### PR TITLE
Add fast einsum-based etrace paths and v0.1 legacy shims

### DIFF
--- a/braintrace/__init__.py
+++ b/braintrace/__init__.py
@@ -63,6 +63,20 @@ from ._etrace_vjp import (
     pp_prop,
 )
 from ._grad_exponential import GradExpon
+from ._legacy import (
+    ConvOp,
+    ElemWiseOp,
+    ElemWiseParam,
+    ETraceOp,
+    ETraceParam,
+    FakeElemWiseParam,
+    FakeETraceParam,
+    LoraOp,
+    MatMulOp,
+    NonTempParam,
+    SpMatMulOp,
+)
+from . import _legacy
 from ._misc import NotSupportedError, CompilationError
 from ._version import __version__, __version_info__
 
@@ -130,6 +144,20 @@ __all__ = [
     'NotSupportedError',
     'CompilationError',
 
+    # legacy v0.1.x shims (deprecated)
+    'ETraceParam',
+    'ElemWiseParam',
+    'NonTempParam',
+    'FakeETraceParam',
+    'FakeElemWiseParam',
+    'ETraceOp',
+    'MatMulOp',
+    'ElemWiseOp',
+    'ConvOp',
+    'SpMatMulOp',
+    'LoraOp',
+
     # submodules
     'nn',
+    '_legacy',
 ]

--- a/braintrace/_etrace_vjp/d_rtrl.py
+++ b/braintrace/_etrace_vjp/d_rtrl.py
@@ -25,11 +25,20 @@ from braintrace._etrace_algorithms import EligibilityTrace
 from braintrace._etrace_compiler import HiddenParamOpRelation, HiddenGroup
 from braintrace._etrace_op import (
     etp_elemwise_p,
+    etp_mm_p,
+    etp_mv_p,
     ETP_RULES_YW_TO_W,
     ETP_RULES_XY_TO_DW,
     ETP_RULES_INIT_DRTRL,
     is_batched_primitive,
 )
+
+# Primitives with an elementwise ``yw_to_w`` rule, i.e. rules of the form
+# ``trace * hidden_dim_broadcast``. For these we can replace the nested
+# ``vmap(yw_to_w, -1, -1) + sum`` pattern with a single ``einsum`` contraction
+# over the hidden-state axis of ``diag`` and ``trace``. Conv / sparse / LoRA
+# primitives have non-elementwise rules and stay on the legacy path.
+_ELEMENTWISE_YW_PRIMITIVES = (etp_mm_p, etp_mv_p, etp_elemwise_p)
 from braintrace._misc import etrace_df_key
 from braintrace._typing import (
     PyTree,
@@ -87,6 +96,54 @@ def _init_param_dim_state(
         etrace_bwg[bwg_key] = EligibilityTrace(init_val)
 
 
+def _fast_recurrent_term(primitive, diag, old_bwg):
+    """Closed-form ``D^t * eps^{t-1}`` for primitives with an elementwise
+    ``yw_to_w`` rule.
+
+    ``diag`` has shape ``(*varshape, num_state_alpha, num_state_beta)`` with
+    ``varshape == y_shape`` for mm/mv/elemwise. ``old_bwg`` is the per-key
+    trace dict. For mm/mv the weight trace has shape
+    ``(*y_shape, in_features, num_state)`` (batched mm has a leading batch
+    axis; mv/elemwise do not); the bias trace has shape
+    ``(*y_shape, num_state)`` when present.
+
+    The contraction is
+        new[b..., i, k, alpha] = sum_beta diag[b..., k, alpha, beta]
+                                       * trace[b..., i, k, beta]
+    which maps exactly to ``einsum('...kab,...ikb->...ika')``. For elemwise
+    the ``i`` axis disappears and it reduces to ``einsum('...ab,...b->...a')``.
+    """
+    if primitive is etp_elemwise_p:
+        return {
+            'weight': jnp.einsum('...ab,...b->...a', diag, old_bwg['weight']),
+        }
+    # mm / mv: trace['weight'] has an extra in-features axis before ``out``.
+    out = {
+        'weight': jnp.einsum('...kab,...ikb->...ika', diag, old_bwg['weight']),
+    }
+    if 'bias' in old_bwg:
+        out['bias'] = jnp.einsum('...kab,...kb->...ka', diag, old_bwg['bias'])
+    return out
+
+
+def _fast_instant_term(primitive, x, df, has_bias):
+    """Closed-form ``diag(D_f^t) ⊗ x^t`` for mm/mv/elemwise primitives.
+
+    For mm/mv the instantaneous gradient of ``y = x @ W + b`` w.r.t. ``W``
+    is the outer product ``x ⊗ df`` with a ``num_state`` axis tagged on.
+    For the elemwise identity op it is simply ``df`` (no ``x`` factor).
+    """
+    if primitive is etp_elemwise_p:
+        return {'weight': df}
+    if primitive is etp_mm_p:
+        out = {'weight': jnp.einsum('...i,...ka->...ika', x, df)}
+    else:  # etp_mv_p — no batch axis
+        out = {'weight': jnp.einsum('i,ka->ika', x, df)}
+    if has_bias:
+        out['bias'] = df
+    return out
+
+
 def _update_param_dim_etrace_scan_fn(
     hist_etrace_vals: Dict[ETraceWG_Key, jax.Array],
     jacobians: Tuple[
@@ -97,6 +154,7 @@ def _update_param_dim_etrace_scan_fn(
     weight_path_to_vals: Dict[Path, PyTree],
     hidden_param_op_relations,
     normalize_matrix_spectrum: bool = False,
+    fast_solve: bool = True,
 ):
     """
     Update the eligibility trace values for parameter dimensions.
@@ -172,6 +230,9 @@ def _update_param_dim_etrace_scan_fn(
         eqn_params = relation.eqn_params
         is_elemwise = relation.primitive is etp_elemwise_p
         batched = is_batched_primitive(relation.primitive)
+        has_bias = eqn_params.get('has_bias', False)
+        # Fast path only applies to primitives with elementwise yw_to_w.
+        use_fast = fast_solve and (relation.primitive in _ELEMENTWISE_YW_PRIMITIVES)
 
         if is_elemwise:
             x = None
@@ -187,35 +248,53 @@ def _update_param_dim_etrace_scan_fn(
         def comp_dw_with_x(x_, df_, _wdict=weights_dict):
             return _call_xy_to_dw_dict(x_, df_, _wdict)
 
-        @partial(jax.vmap, in_axes=-1, out_axes=-1)
-        def comp_dw_without_x(df_, _x=x, _batched=batched):
-            if _batched:
-                return jax.vmap(comp_dw_with_x)(_x, df_)
-            else:
-                return comp_dw_with_x(_x, df_)
+        def _comp_instant_legacy(df_all):
+            """Legacy nested-vmap path: vmap xy_to_dw over num_state (and batch)."""
+            @partial(jax.vmap, in_axes=-1, out_axes=-1)
+            def _inner(df_slice):
+                if batched:
+                    return jax.vmap(comp_dw_with_x)(x, df_slice)
+                return comp_dw_with_x(x, df_slice)
+            return _inner(df_all)
+
+        def _comp_recurrent_legacy(diag_, old_bwg_, num_state_):
+            """Legacy nested-vmap yw_to_w + sum path."""
+            def fn_bwg_pre(d, _old=old_bwg_):
+                return jax.tree.map(
+                    lambda arr: _sum_dim(arr, axis=-1),
+                    jax.vmap(_call_yw_to_w_dict, in_axes=-1, out_axes=-1)(d, _old),
+                )
+            # num_state == 1 shortcut: squeeze the size-1 alpha axis to skip
+            # outer vmap overhead; re-expand at the end.
+            if num_state_ == 1:
+                d_squeezed = u.math.squeeze(diag_, axis=-2)
+                res = fn_bwg_pre(d_squeezed)
+                return jax.tree.map(lambda a: u.math.expand_dims(a, axis=-1), res)
+            return jax.vmap(fn_bwg_pre, in_axes=-2, out_axes=-1)(diag_)
 
         for group in relation.hidden_groups:
             group: HiddenGroup
 
             df = etrace_ys_at_t[etrace_df_key(relation.y, group.index)]
 
-            # phg_to_pw is a Dict[str, Array].
-            phg_to_pw = comp_dw_without_x(df)
-            phg_to_pw = jax.tree.map(_normalize_vector, phg_to_pw)
+            # Instantaneous term: diag(D_f^t) ⊗ x^t  (Dict[str, Array]).
+            if use_fast:
+                phg_to_pw = _fast_instant_term(relation.primitive, x, df, has_bias)
+            else:
+                phg_to_pw = _comp_instant_legacy(df)
+            if normalize_matrix_spectrum:
+                phg_to_pw = jax.tree.map(_normalize_vector, phg_to_pw)
 
             w_key = (id(relation.y_var), group.index)
             diag = hid_group_jacobians[group.index]
 
             old_bwg = hist_etrace_vals[w_key]   # Dict[str, Array]
 
-            fn_bwg_pre = lambda d, _old=old_bwg: jax.tree.map(
-                lambda arr: _sum_dim(arr, axis=-1),
-                jax.vmap(
-                    _call_yw_to_w_dict, in_axes=-1, out_axes=-1,
-                )(d, _old),
-            )
-
-            new_bwg_pre = jax.vmap(fn_bwg_pre, in_axes=-2, out_axes=-1)(diag)
+            # Recurrent term: D^t · ε^{t-1}.
+            if use_fast:
+                new_bwg_pre = _fast_recurrent_term(relation.primitive, diag, old_bwg)
+            else:
+                new_bwg_pre = _comp_recurrent_legacy(diag, old_bwg, group.num_state)
 
             # new_bwg_pre + phg_to_pw per-leaf.
             new_bwg = jax.tree.map(
@@ -229,38 +308,49 @@ def _update_param_dim_etrace_scan_fn(
 
 
 def _normalize_matrix_spectrum(diag):
+    """Branch-free spectral clipping: divide by max(|eigvals|, 1).
+
+    The previous implementation used ``jax.lax.cond`` which blocks XLA
+    fusion and serialises into a control-flow region per call. Dividing by
+    ``max(max_eigenvalue, 1)`` is semantically identical (the conditional
+    only clipped when ``max_eigenvalue > 1``) and stays in a single fused
+    kernel with the rest of the update.
+    """
     def base_fn(matrix):
-        # Compute the eigenvalues of the matrix
         eigenvalues = jnp.linalg.eigvals(matrix)
-
-        # Get the maximum eigenvalue
         max_eigenvalue = jnp.max(jnp.abs(eigenvalues))
-
-        # Normalize the matrix by dividing it by the maximum eigenvalue
-        normalized_matrix = jax.lax.cond(
-            max_eigenvalue > 1,
-            lambda: matrix / max_eigenvalue,
-            lambda: matrix,
-        )
-        return normalized_matrix
+        return matrix / jnp.maximum(max_eigenvalue, 1.0)
 
     fn = base_fn
-    for i in range(diag.ndim - 2):
+    for _ in range(diag.ndim - 2):
         fn = jax.vmap(fn)
     return fn(diag)
 
 
 def _normalize_vector(v):
+    """Branch-free magnitude clipping: divide by max(max_abs, 1)."""
     max_elem = jnp.abs(v).max()
-    normalized_vector = jax.lax.cond(
-        max_elem > 1,
-        lambda: v / max_elem,
-        lambda: v,
-    )
+    return v / jnp.maximum(max_elem, 1.0)
 
-    # # Normalize the vector by dividing it by its norm
-    # normalized_vector = v / jnp.linalg.norm(v)
-    return normalized_vector
+
+def _fast_solve_contract(primitive, diag_like, etrace_data):
+    """Solve-time closed-form contraction for mm/mv/elemwise.
+
+    ``diag_like`` is the dl/dh group gradient with shape ``(*y_shape, num_state)``;
+    ``etrace_data`` is the weight-shaped trace dict. The solver computes
+    ``sum_alpha diag_like[..., alpha] * yw_to_w(etrace[..., alpha])``, which
+    for elementwise ``yw_to_w`` is an einsum along the ``num_state`` axis.
+    """
+    if primitive is etp_elemwise_p:
+        return {
+            'weight': jnp.einsum('...a,...a->...', diag_like, etrace_data['weight']),
+        }
+    out = {
+        'weight': jnp.einsum('...ka,...ika->...ik', diag_like, etrace_data['weight']),
+    }
+    if 'bias' in etrace_data:
+        out['bias'] = jnp.einsum('...ka,...ka->...k', diag_like, etrace_data['bias'])
+    return out
 
 
 def _solve_param_dim_weight_gradients(
@@ -269,6 +359,7 @@ def _solve_param_dim_weight_gradients(
     dG_hidden_groups: Sequence[jax.Array],  # hidden group gradients
     weight_hidden_relations: Sequence[HiddenParamOpRelation],
     weight_vals: Dict[Path, PyTree],  # current ParamState pytree values for structure
+    fast_solve: bool = True,
 ):
     """
     Compute and update the weight gradients for parameter dimensions using eligibility trace data.
@@ -297,6 +388,7 @@ def _solve_param_dim_weight_gradients(
         yw_to_w_rule = ETP_RULES_YW_TO_W[relation.primitive]
         eqn_params = relation.eqn_params
         batched = is_batched_primitive(relation.primitive)
+        use_fast = fast_solve and (relation.primitive in _ELEMENTWISE_YW_PRIMITIVES)
 
         def _call_yw_to_w_dict(d, trace_, _rule=yw_to_w_rule, _params=eqn_params):
             return _rule(d, trace_, **_params)
@@ -318,13 +410,27 @@ def _solve_param_dim_weight_gradients(
             etrace_data_unitless, fn_unit_restore = _remove_units(etrace_data)
             dg_hidden_unitless, _ = _remove_units(dg_hidden)
 
-            # dg_weight_dict: Dict[str, Array]
-            dg_weight_dict = jax.tree.map(
-                lambda arr: _sum_dim(arr, axis=-1),
-                jax.vmap(yw_to_w, in_axes=-1, out_axes=-1)(
-                    dg_hidden_unitless, etrace_data_unitless
-                ),
-            )
+            if use_fast:
+                # Closed-form einsum path for mm/mv/elemwise primitives.
+                dg_weight_dict = _fast_solve_contract(
+                    relation.primitive, dg_hidden_unitless, etrace_data_unitless
+                )
+            elif group.num_state == 1:
+                # num_state==1 shortcut: skip outer vmap of size 1.
+                dg_hid_squeezed = jax.tree.map(
+                    lambda a: u.math.squeeze(a, axis=-1), dg_hidden_unitless
+                )
+                etr_squeezed = jax.tree.map(
+                    lambda a: u.math.squeeze(a, axis=-1), etrace_data_unitless
+                )
+                dg_weight_dict = yw_to_w(dg_hid_squeezed, etr_squeezed)
+            else:
+                dg_weight_dict = jax.tree.map(
+                    lambda arr: _sum_dim(arr, axis=-1),
+                    jax.vmap(yw_to_w, in_axes=-1, out_axes=-1)(
+                        dg_hidden_unitless, etrace_data_unitless
+                    ),
+                )
             dg_weight_dict = fn_unit_restore(dg_weight_dict)
 
             # Route per-key to owning ParamState path.
@@ -433,9 +539,20 @@ class ParamDimVjpAlgorithm(ETraceVjpAlgorithm):
         model: brainstate.nn.Module,
         name: Optional[str] = None,
         vjp_method: str = 'single-step',
+        fast_solve: bool = True,
+        normalize_matrix_spectrum: bool = False,
         **kwargs,
     ):
         super().__init__(model, name=name, vjp_method=vjp_method)
+        # ``fast_solve=True`` enables closed-form einsum kernels for
+        # mm/mv/elemwise primitives, replacing the nested-vmap legacy path.
+        # Conv / sparse / LoRA primitives always use the legacy path.
+        self.fast_solve = fast_solve
+        # When True, clip trace magnitudes > 1 each step via a branch-free
+        # ``v / max(max_abs, 1)``. Default False (disabled). The previous
+        # implementation applied this unconditionally to the instantaneous
+        # term only, which silently distorted gradients.
+        self.normalize_matrix_spectrum = normalize_matrix_spectrum
 
     def init_etrace_state(self, *args, **kwargs):
         """
@@ -581,6 +698,8 @@ class ParamDimVjpAlgorithm(ETraceVjpAlgorithm):
             _update_param_dim_etrace_scan_fn,
             weight_path_to_vals=weight_vals,
             hidden_param_op_relations=self.graph.hidden_param_op_relations,
+            normalize_matrix_spectrum=self.normalize_matrix_spectrum,
+            fast_solve=self.fast_solve,
         )
 
         if input_is_multi_step:
@@ -654,6 +773,7 @@ class ParamDimVjpAlgorithm(ETraceVjpAlgorithm):
             dl_to_hidden_groups,
             self.graph.hidden_param_op_relations,
             weight_vals,
+            fast_solve=self.fast_solve,
         )
 
         # update the non-etrace weight gradients

--- a/braintrace/_etrace_vjp/pp_prop.py
+++ b/braintrace/_etrace_vjp/pp_prop.py
@@ -24,9 +24,8 @@
 
 # -*- coding: utf-8 -*-
 
-from collections import defaultdict
 from functools import partial
-from typing import Dict, Tuple, List, Optional, Sequence
+from typing import Dict, Tuple, Optional, Sequence
 
 import brainstate
 import jax
@@ -166,8 +165,6 @@ def _low_pass_filter(old, new, alpha):
 def _init_IO_dim_state(
     etrace_xs: Dict[ETraceX_Key, brainstate.State],
     etrace_dfs: Dict[ETraceDF_Key, brainstate.State],
-    etrace_xs_to_weights: defaultdict[ETraceX_Key, List[Path]],
-    state_id_to_path: Dict[int, Path],
     relation: HiddenParamOpRelation,
 ):
     """
@@ -183,15 +180,10 @@ def _init_IO_dim_state(
         etrace_xs (Dict[ETraceX_Key, brainstate.State]): A dictionary to store the
             eligibility trace states for the weight x, keyed by ETraceX_Key.
         etrace_dfs (Dict[ETraceDF_Key, brainstate.State]): A dictionary to store the
-            eligibility trace states for the differential functions, keyed by 
+            eligibility trace states for the differential functions, keyed by
             ETraceDF_Key.
-        etrace_xs_to_weights (defaultdict[ETraceX_Key, List[Path]]): A 
-            defaultdict to record the target paths of the weight x, keyed by 
-            ETraceX_Key.
-        state_id_to_path (Dict[int, Path]): A dictionary mapping state IDs to 
-            their corresponding paths.
-        relation (HiddenParamOpRelation): The relation object containing 
-            information about the weights and hidden groups involved in the 
+        relation (HiddenParamOpRelation): The relation object containing
+            information about the weights and hidden groups involved in the
             computation.
 
     Raises:
@@ -206,36 +198,31 @@ def _init_IO_dim_state(
 
     # "relation.x_var" may be repeatedly used in the graph
     if not (relation.primitive is etp_elemwise_p):
-        if relation.x_var not in etrace_xs:
+        x_key = id(relation.x_var)
+        if x_key not in etrace_xs:
             shape = relation.x_var.aval.shape
             dtype = relation.x_var.aval.dtype
-            etrace_xs[id(relation.x_var)] = EligibilityTrace(u.math.zeros(shape, dtype))
-
-        # relation.x_var maybe repeatedly used to feed into the
-        # weight operation for transforming the hidden states
-        # therefore we record the target paths of the weight x
-        #
-        primary_state = next(iter(relation.trainable_param_states.values()), None)
-        etrace_xs_to_weights[id(relation.x_var)].append(state_id_to_path[id(primary_state)])
+            etrace_xs[x_key] = EligibilityTrace(u.math.zeros(shape, dtype))
 
     y_shape = relation.y_var.aval.shape
     y_dtype = relation.y_var.aval.dtype
     for group in relation.hidden_groups:
         group: HiddenGroup
-        if y_shape != group.varshape:
-            if (relation.primitive is etp_elemwise_p):
-                if not (is_batched_primitive(relation.primitive) and y_shape == group.varshape[1:]):
-                    raise ValueError(
-                        f'The shape of the hidden states should be the '
-                        f'same as the shape of the hidden group. '
-                        f'While we got {y_shape} != {group.varshape}. '
-                    )
-            else:
-                raise ValueError(
-                    f'The shape of the hidden states should be the '
-                    f'same as the shape of the hidden group. '
-                    f'While we got {y_shape} != {group.varshape}. '
-                )
+        # Exact match required, or (elemwise only) allow trailing-dim match
+        # where a batched hidden group wraps an unbatched elemwise weight.
+        shape_ok = (
+            y_shape == group.varshape
+            or (
+                relation.primitive is etp_elemwise_p
+                and y_shape == group.varshape[1:]
+            )
+        )
+        if not shape_ok:
+            raise ValueError(
+                f'The shape of the hidden states should be the '
+                f'same as the shape of the hidden group. '
+                f'While we got {y_shape} != {group.varshape}. '
+            )
         key = etrace_df_key(relation.y_var, group.index)
         if key in etrace_dfs:  # relation.y_var is a unique output of the weight operation
             raise ValueError(f'The relation {key} has been added. ')
@@ -431,11 +418,13 @@ def _solve_IO_dim_weight_gradients(
     Returns:
         None: The function updates the dG_weights dictionary in place with the computed weight gradients.
     """
-    # Avoid the exponential smoothing bias at the beginning.
-    # This is the correction factor for the exponential smoothing.
-    correction_factor = 1. - u.math.power(1. - decay, running_index + 1)
+    # Bias correction for exponential smoothing
+    #   ε_f^t = α ε_f^{t-1} + (1-α) x_t  =>  E[ε_f^t] = x · (1 - α^{t+1})
+    # so unbiased estimator divides by (1 - α^{t+1}) = (1 - decay^{t+1}).
+    correction_factor = 1. - u.math.power(decay, running_index + 1)
     correction_factor = u.math.where(running_index < 1000, correction_factor, 1.)
-    # Clamp to avoid division by zero when decay is very small (e.g., rank=1 gives decay=0)
+    # Clamp guards degenerate decay=0 (rank=1): correction is exactly 1 then,
+    # but keep clamp for numerical safety in the early-step power computation.
     correction_factor = u.math.maximum(correction_factor, 1e-8)
     correction_factor = jax.lax.stop_gradient(correction_factor)
 
@@ -558,9 +547,6 @@ class IODimVjpAlgorithm(ETraceVjpAlgorithm):
     # the spatial gradients of the hidden states
     etrace_dfs: Dict[ETraceDF_Key, brainstate.State]
 
-    # the mapping from the etrace x to the weight operations
-    etrace_xs_to_weights = Dict[ETraceX_Key, List[Path]]
-
     # the exponential smoothing decay factor
     decay: float
 
@@ -588,16 +574,9 @@ class IODimVjpAlgorithm(ETraceVjpAlgorithm):
         #   2. df
         self.etrace_xs = dict()
         self.etrace_dfs = dict()
-        self.etrace_xs_to_weights = defaultdict(list)
         for relation in self.graph.hidden_param_op_relations:
             relation: HiddenParamOpRelation
-            _init_IO_dim_state(
-                self.etrace_xs,
-                self.etrace_dfs,
-                self.etrace_xs_to_weights,
-                self.graph_executor.state_id_to_path,
-                relation,
-            )
+            _init_IO_dim_state(self.etrace_xs, self.etrace_dfs, relation)
 
     def reset_state(self, batch_size: int = None, **kwargs):
         """

--- a/braintrace/_etrace_vjp/pp_prop.py
+++ b/braintrace/_etrace_vjp/pp_prop.py
@@ -401,6 +401,7 @@ def _solve_IO_dim_weight_gradients(
     weight_vals: Dict[Path, WeightVals],
     running_index: int,
     decay: float,
+    fast_solve: bool = True,
 ):
     """
     Compute and update the weight gradients for input-output dimensions using eligibility trace data.
@@ -470,15 +471,31 @@ def _solve_IO_dim_weight_gradients(
             df = dfs[df_key] / correction_factor
             df_hid = df * dG_hidden_groups[group.index]
 
-            fn_vmap = jax.vmap(lambda df_: _call(df_, weights_dict), in_axes=-1, out_axes=-1)
-            if (relation.primitive is etp_elemwise_p) and batched:
-                fn_vmap2 = jax.vmap(fn_vmap)
-                dg_dict = jax.tree.map(
-                    lambda a: _sum_dim(_sum_dim(a, axis=-1), axis=0),
-                    fn_vmap2(df_hid),
-                )
+            if fast_solve:
+                # Fast path: sum over n_state first, then ONE xy_to_dw call.
+                # Valid because every xy_to_dw rule is a VJP of a linear map
+                # in its cotangent argument, so sum-then-apply == apply-then-sum.
+                df_summed = u.math.sum(df_hid, axis=-1)
+                if (relation.primitive is etp_elemwise_p) and batched:
+                    # Elemwise-in-batched-hidden: strip batch dim via a single
+                    # vmap over batch, then sum batch after.
+                    dg_dict = jax.tree.map(
+                        lambda a: _sum_dim(a, axis=0),
+                        jax.vmap(lambda d_: _call(d_, weights_dict))(df_summed),
+                    )
+                else:
+                    dg_dict = _call(df_summed, weights_dict)
             else:
-                dg_dict = jax.tree.map(_sum_dim, fn_vmap(df_hid))
+                # Legacy path: vmap xy_to_dw across n_state slices, then sum.
+                fn_vmap = jax.vmap(lambda df_: _call(df_, weights_dict), in_axes=-1, out_axes=-1)
+                if (relation.primitive is etp_elemwise_p) and batched:
+                    fn_vmap2 = jax.vmap(fn_vmap)
+                    dg_dict = jax.tree.map(
+                        lambda a: _sum_dim(_sum_dim(a, axis=-1), axis=0),
+                        fn_vmap2(df_hid),
+                    )
+                else:
+                    dg_dict = jax.tree.map(_sum_dim, fn_vmap(df_hid))
 
             # Route per-key to owning ParamState path and assemble per-path pytrees.
             _route_grads_by_path(relation, dg_dict, weight_vals, dG_weights)
@@ -553,10 +570,12 @@ class IODimVjpAlgorithm(ETraceVjpAlgorithm):
         decay_or_rank: float | int,
         name: Optional[str] = None,
         vjp_method: str = 'single-step',
+        fast_solve: bool = True,
         **kwargs,
     ):
         super().__init__(model, name=name, vjp_method=vjp_method)
         self.decay, num_rank = _format_decay_and_rank(decay_or_rank)
+        self.fast_solve = fast_solve
 
     def init_etrace_state(self, *args, **kwargs):
         """
@@ -843,6 +862,7 @@ class IODimVjpAlgorithm(ETraceVjpAlgorithm):
             weight_vals,
             running_index,
             self.decay,
+            fast_solve=self.fast_solve,
         )
 
         # update the non-etrace parameters

--- a/braintrace/_legacy/__init__.py
+++ b/braintrace/_legacy/__init__.py
@@ -1,0 +1,64 @@
+# Copyright 2026 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Backwards-compatibility shims for the v0.1.x braintrace API.
+
+All names re-exported here are deprecated in v0.2.0. Each class either:
+
+* routes through the new ETP primitive user-API (``ETraceParam`` +
+  :class:`MatMulOp` / :class:`ConvOp` / ...), or
+* uses plain JAX ops so the compiler does not register a relation
+  (``NonTempParam``, ``FakeETraceParam``, ``FakeElemWiseParam``).
+
+Importing any of these names triggers a :class:`DeprecationWarning`
+(once per class, per Python process).
+"""
+
+from ._ops import (
+    ConvOp,
+    ElemWiseOp,
+    ETraceOp,
+    LoraOp,
+    MatMulOp,
+    SpMatMulOp,
+    general_y2w,
+    stop_param_gradients,
+)
+from ._params import (
+    ElemWiseParam,
+    ETraceParam,
+    FakeElemWiseParam,
+    FakeETraceParam,
+    NonTempParam,
+)
+
+__all__ = [
+    # params
+    'ETraceParam',
+    'ElemWiseParam',
+    'NonTempParam',
+    'FakeETraceParam',
+    'FakeElemWiseParam',
+    # ops
+    'ETraceOp',
+    'MatMulOp',
+    'ElemWiseOp',
+    'ConvOp',
+    'SpMatMulOp',
+    'LoraOp',
+    # utilities
+    'general_y2w',
+    'stop_param_gradients',
+]

--- a/braintrace/_legacy/_legacy_test.py
+++ b/braintrace/_legacy/_legacy_test.py
@@ -1,0 +1,335 @@
+# Copyright 2026 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Smoke tests for the v0.1.x compatibility shims.
+
+Coverage:
+* every legacy class constructs and executes forward.
+* ``ETraceParam`` + ``MatMulOp`` produces *one* compiler relation.
+* ``NonTempParam`` + ``MatMulOp`` produces *zero* compiler relations.
+* ``FakeETraceParam`` is invisible to the compiler.
+* ``DeprecationWarning`` fires on first construction.
+"""
+
+from __future__ import annotations
+
+import warnings
+
+import brainstate
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+import saiunit as u
+
+import braintrace
+from braintrace._legacy import (
+    ConvOp,
+    ElemWiseOp,
+    ElemWiseParam,
+    ETraceOp,
+    ETraceParam,
+    FakeElemWiseParam,
+    FakeETraceParam,
+    LoraOp,
+    MatMulOp,
+    NonTempParam,
+    SpMatMulOp,
+    general_y2w,
+    stop_param_gradients,
+)
+
+
+# ---------------------------------------------------------------------------
+# Op forward pass
+# ---------------------------------------------------------------------------
+
+class TestOpsForward:
+
+    def test_matmul_op(self):
+        op = MatMulOp()
+        x = jnp.ones((2, 4))
+        w = {'weight': jnp.ones((4, 3))}
+        y = op(x, w)
+        assert y.shape == (2, 3)
+        np.testing.assert_allclose(y, x @ w['weight'])
+
+    def test_matmul_op_with_bias(self):
+        op = MatMulOp()
+        x = jnp.ones((2, 4))
+        b = jnp.arange(3.0)
+        w = {'weight': jnp.ones((4, 3)), 'bias': b}
+        y = op(x, w)
+        np.testing.assert_allclose(y, x @ w['weight'] + b)
+
+    def test_matmul_op_weight_fn(self):
+        op = MatMulOp(weight_fn=lambda w: w * 2)
+        x = jnp.ones((2, 4))
+        w = {'weight': jnp.ones((4, 3))}
+        y = op(x, w)
+        np.testing.assert_allclose(y, (x @ w['weight']) * 2)
+
+    def test_matmul_op_raw_matches_etp(self):
+        op = MatMulOp()
+        x = jnp.ones((2, 4))
+        w = {'weight': jnp.arange(12.0).reshape(4, 3)}
+        np.testing.assert_allclose(op.xw_to_y(x, w), op.raw_xw_to_y(x, w))
+
+    def test_elemwise_op(self):
+        op = ElemWiseOp(fn=lambda w: w * 3)
+        w = jnp.ones((5,))
+        y = op(w)
+        np.testing.assert_allclose(y, 3.0)
+
+    def test_lora_op(self):
+        op = LoraOp(alpha=2.0)
+        x = jnp.ones((2, 4))
+        w = {'B': jnp.ones((4, 2)), 'A': jnp.ones((2, 3))}
+        y = op(x, w)
+        expected = 2.0 * x @ w['B'] @ w['A']
+        np.testing.assert_allclose(y, expected)
+
+    def test_conv_op(self):
+        xinfo = jax.ShapeDtypeStruct((1, 4, 4, 1), jnp.float32)
+        op = ConvOp(
+            xinfo=xinfo,
+            window_strides=(1, 1),
+            padding='SAME',
+            dimension_numbers=('NHWC', 'HWIO', 'NHWC'),
+        )
+        x = jnp.ones((1, 4, 4, 1))
+        w = {'weight': jnp.ones((3, 3, 1, 2))}
+        y = op(x, w)
+        assert y.shape == (1, 4, 4, 2)
+
+    def test_sparse_op(self):
+        from saiunit import sparse as ss
+        dense = jnp.eye(3) * 2.0
+        csr = ss.CSR.fromdense(dense)
+        op = SpMatMulOp(sparse_mat=csr)
+        x = jnp.arange(3.0)
+        w = {'weight': csr.data}
+        y = op(x, w)
+        np.testing.assert_allclose(y, x @ dense)
+
+
+# ---------------------------------------------------------------------------
+# Param classes — construction + execute
+# ---------------------------------------------------------------------------
+
+class TestParamsForward:
+
+    def test_etrace_param_is_paramstate(self):
+        p = ETraceParam({'weight': jnp.ones((4, 4))}, op=MatMulOp())
+        assert isinstance(p, brainstate.ParamState)
+        assert isinstance(p.op, MatMulOp)
+
+    def test_etrace_param_execute(self):
+        p = ETraceParam({'weight': jnp.ones((4, 4))}, op=MatMulOp())
+        y = p.execute(jnp.ones((2, 4)))
+        assert y.shape == (2, 4)
+
+    def test_elemwise_param_execute(self):
+        p = ElemWiseParam(jnp.ones((3,)), op=lambda w: w * 5)
+        y = p.execute()
+        np.testing.assert_allclose(y, 5.0)
+
+    def test_elemwise_param_with_elemwiseop(self):
+        p = ElemWiseParam(jnp.ones((3,)), op=ElemWiseOp(lambda w: w + 1))
+        y = p.execute()
+        np.testing.assert_allclose(y, 2.0)
+
+    def test_nontemp_param_execute(self):
+        p = NonTempParam({'weight': jnp.ones((4, 4))}, op=MatMulOp())
+        assert isinstance(p, brainstate.ParamState)
+        y = p.execute(jnp.ones((2, 4)))
+        assert y.shape == (2, 4)
+
+    def test_nontemp_param_with_plain_callable(self):
+        p = NonTempParam(jnp.ones((4, 4)), op=lambda x, w: x @ w)
+        y = p.execute(jnp.ones((2, 4)))
+        assert y.shape == (2, 4)
+
+    def test_fake_etrace_param_not_paramstate(self):
+        p = FakeETraceParam({'weight': jnp.ones((4, 4))}, op=MatMulOp())
+        assert not isinstance(p, brainstate.ParamState)
+        y = p.execute(jnp.ones((2, 4)))
+        assert y.shape == (2, 4)
+
+    def test_fake_elemwise_param_not_paramstate(self):
+        p = FakeElemWiseParam(jnp.ones((3,)), op=lambda w: w * 7)
+        assert not isinstance(p, brainstate.ParamState)
+        y = p.execute()
+        np.testing.assert_allclose(y, 7.0)
+
+    def test_fake_elemwise_param_with_elemwiseop(self):
+        p = FakeElemWiseParam(jnp.ones((3,)), op=ElemWiseOp(lambda w: w * 4))
+        y = p.execute()
+        np.testing.assert_allclose(y, 4.0)
+
+
+# ---------------------------------------------------------------------------
+# Compiler integration
+# ---------------------------------------------------------------------------
+
+class _ETraceCell(brainstate.nn.Module):
+    def __init__(self, cls, **kwargs):
+        super().__init__()
+        self.w = cls({'weight': jnp.ones((4, 4)) * 0.1}, op=MatMulOp(), **kwargs)
+        self.h = brainstate.HiddenState(jnp.zeros((1, 4)))
+
+    def update(self, x):
+        self.h.value = jnp.tanh(x + self.w.execute(self.h.value))
+        return self.h.value
+
+
+class _FakeCell(brainstate.nn.Module):
+    def __init__(self):
+        super().__init__()
+        self.fake = FakeETraceParam({'weight': jnp.ones((4, 4)) * 0.1}, op=MatMulOp())
+        self.w_real = brainstate.ParamState(jnp.ones((4, 4)) * 0.1)
+        self.h = brainstate.HiddenState(jnp.zeros((1, 4)))
+
+    def update(self, x):
+        self.h.value = jnp.tanh(
+            self.fake.execute(self.h.value)
+            + braintrace.matmul(x, self.w_real.value)
+        )
+        return self.h.value
+
+
+class TestCompilerIntegration:
+
+    def test_etrace_param_registers_relation(self):
+        cell = _ETraceCell(ETraceParam)
+        brainstate.nn.init_all_states(cell, batch_size=1)
+        graph = braintrace.compile_etrace_graph(
+            cell, jnp.zeros((1, 4)), include_hidden_perturb=False
+        )
+        assert len(graph.hidden_param_op_relations) == 1
+
+    def test_nontemp_param_registers_no_relation(self):
+        """NonTempParam uses raw JAX ops → no ETP primitive → no relation."""
+        cell = _ETraceCell(NonTempParam)
+        brainstate.nn.init_all_states(cell, batch_size=1)
+        graph = braintrace.compile_etrace_graph(
+            cell, jnp.zeros((1, 4)), include_hidden_perturb=False
+        )
+        assert len(graph.hidden_param_op_relations) == 0
+
+    def test_fake_etrace_param_registers_no_relation(self):
+        """FakeETraceParam is not a ParamState → compiler ignores it."""
+        cell = _FakeCell()
+        brainstate.nn.init_all_states(cell, batch_size=1)
+        graph = braintrace.compile_etrace_graph(
+            cell, jnp.zeros((1, 4)), include_hidden_perturb=False
+        )
+        # Only self.w_real should produce a relation (via x @ w_real — but that
+        # path is a plain jnp.matmul, so no ETP primitive, so zero relations).
+        # Confirm no warning for FakeETraceParam either.
+        kinds = {d.kind for d in graph.diagnostics}
+        assert braintrace.DiagnosticKind.RELATION_EXCLUDED_NO_PARAMSTATE not in kinds
+
+
+# ---------------------------------------------------------------------------
+# Deprecation warnings
+# ---------------------------------------------------------------------------
+
+class TestDeprecationWarnings:
+
+    def _reset(self):
+        from braintrace._legacy import _ops, _params
+        _ops._warned.clear()
+        _params._warned.clear()
+
+    def test_matmul_op_warns(self):
+        self._reset()
+        with warnings.catch_warnings(record=True) as captured:
+            warnings.simplefilter('always')
+            MatMulOp()
+        assert any(
+            issubclass(w.category, DeprecationWarning)
+            and 'MatMulOp' in str(w.message)
+            for w in captured
+        )
+
+    def test_etrace_param_warns(self):
+        self._reset()
+        with warnings.catch_warnings(record=True) as captured:
+            warnings.simplefilter('always')
+            ETraceParam({'weight': jnp.ones((4, 4))}, op=MatMulOp())
+        assert any(
+            issubclass(w.category, DeprecationWarning)
+            and 'ETraceParam' in str(w.message)
+            for w in captured
+        )
+
+    def test_warning_once_per_class(self):
+        self._reset()
+        with warnings.catch_warnings(record=True) as captured:
+            warnings.simplefilter('always')
+            MatMulOp()
+            MatMulOp()
+            MatMulOp()
+        matmul_warnings = [
+            w for w in captured
+            if issubclass(w.category, DeprecationWarning)
+            and 'MatMulOp' in str(w.message)
+        ]
+        assert len(matmul_warnings) == 1
+
+
+# ---------------------------------------------------------------------------
+# Utilities
+# ---------------------------------------------------------------------------
+
+class TestUtilities:
+
+    def test_stop_param_gradients_context(self):
+        # Pure API compat; just verify the context manager works.
+        with stop_param_gradients(True):
+            pass
+        with stop_param_gradients(False):
+            pass
+
+    def test_general_y2w(self):
+        def xw2y(x, w):
+            return x @ w
+
+        x = jnp.ones((4,))
+        w = jnp.ones((4, 3))
+        y = jnp.ones((3,))
+        w_like = general_y2w(xw2y, x, y, w)
+        assert w_like.shape == w.shape
+
+
+# ---------------------------------------------------------------------------
+# Top-level re-exports
+# ---------------------------------------------------------------------------
+
+class TestTopLevelExports:
+
+    def test_all_classes_at_top_level(self):
+        assert braintrace.ETraceParam is ETraceParam
+        assert braintrace.ElemWiseParam is ElemWiseParam
+        assert braintrace.NonTempParam is NonTempParam
+        assert braintrace.FakeETraceParam is FakeETraceParam
+        assert braintrace.FakeElemWiseParam is FakeElemWiseParam
+        assert braintrace.ETraceOp is ETraceOp
+        assert braintrace.MatMulOp is MatMulOp
+        assert braintrace.ElemWiseOp is ElemWiseOp
+        assert braintrace.ConvOp is ConvOp
+        assert braintrace.SpMatMulOp is SpMatMulOp
+        assert braintrace.LoraOp is LoraOp

--- a/braintrace/_legacy/_ops.py
+++ b/braintrace/_legacy/_ops.py
@@ -1,0 +1,419 @@
+# Copyright 2026 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Legacy (v0.1.x) ETraceOp shims.
+
+Each op's ``xw_to_y`` routes through the new ETP primitive user-API
+(``braintrace.matmul``, ``braintrace.conv``, ...). Each op also exposes
+a ``raw_xw_to_y`` that performs the same computation with plain JAX
+ops, used by :class:`NonTempParam` / :class:`FakeETraceParam` to keep
+the weight *out* of the ETP graph.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import threading
+import warnings
+from typing import Any, Callable, Dict, Optional, Sequence
+
+import brainstate
+import jax
+import numpy as np
+import saiunit as u
+
+from .._etrace_op import (
+    conv as _new_conv,
+    element_wise as _new_element_wise,
+    lora_matmul as _new_lora_matmul,
+    matmul as _new_matmul,
+    sparse_matmul as _new_sparse_matmul,
+)
+
+__all__ = [
+    'ETraceOp',
+    'MatMulOp',
+    'ElemWiseOp',
+    'ConvOp',
+    'SpMatMulOp',
+    'LoraOp',
+    'general_y2w',
+    'stop_param_gradients',
+]
+
+
+_warned: set = set()
+
+
+def _deprecate(cls_name: str, replacement: str) -> None:
+    if cls_name in _warned:
+        return
+    _warned.add(cls_name)
+    warnings.warn(
+        f'braintrace._legacy.{cls_name} is deprecated; use {replacement} instead.',
+        DeprecationWarning,
+        stacklevel=3,
+    )
+
+
+# ---------------------------------------------------------------------------
+# stop_param_gradients context (kept for API compat; no effect on shim path)
+# ---------------------------------------------------------------------------
+
+class _OpContext(threading.local):
+    def __init__(self):
+        super().__init__()
+        self.stop = [False]
+
+
+_ctx = _OpContext()
+
+
+@contextlib.contextmanager
+def stop_param_gradients(stop_or_not: bool = True):
+    """Context manager — legacy compat shim. Pushes a flag onto a stack;
+    has no effect in the new ETP primitive path (gradients flow through
+    JAX autodiff on the primitive directly).
+    """
+    _ctx.stop.append(stop_or_not)
+    try:
+        yield
+    finally:
+        _ctx.stop.pop()
+
+
+def general_y2w(xw2y: Callable, x, y, w):
+    """Legacy helper: VJP-based y→w pullback."""
+    x = u.math.ones_like(x)
+    primals, f_vjp = jax.vjp(lambda w_: u.get_mantissa(xw2y(x, w_)), w)
+    assert y.shape == primals.shape, (
+        f'shape mismatch: {y.shape} vs {primals.shape}'
+    )
+    return f_vjp(u.get_mantissa(y))[0]
+
+
+# ---------------------------------------------------------------------------
+# Base class
+# ---------------------------------------------------------------------------
+
+class ETraceOp:
+    """Legacy base class for eligibility-trace operators.
+
+    .. deprecated:: 0.2.0
+        Prefer calling the new ETP primitive user-API functions directly
+        (:func:`braintrace.matmul`, :func:`braintrace.conv`, ...).
+    """
+    __module__ = 'braintrace._legacy'
+
+    def __init__(
+        self,
+        is_diagonal: Optional[bool] = False,
+        name: Optional[str] = None,
+    ):
+        self.is_diagonal = is_diagonal
+        self.name = name
+        _deprecate(type(self).__name__, 'braintrace ETP primitive functions')
+
+    def __call__(self, inputs, weights):
+        return self.xw_to_y(inputs, weights)
+
+    def xw_to_y(self, inputs, weights):
+        raise NotImplementedError
+
+    def raw_xw_to_y(self, inputs, weights):
+        """Plain-JAX variant — does NOT emit an ETP primitive.
+
+        Used by :class:`NonTempParam` / :class:`FakeETraceParam` so those
+        wrappers do not register an eligibility-trace relation.
+        Default: fall through to ``xw_to_y`` (subclasses that route to
+        an ETP primitive MUST override).
+        """
+        return self.xw_to_y(inputs, weights)
+
+    def yw_to_w(self, hidden_dim_arr, weight_dim_tree):
+        raise NotImplementedError
+
+    def xy_to_dw(self, input_dim_arr, hidden_dim_arr, weights):
+        primals, f_vjp = jax.vjp(
+            lambda w: u.get_mantissa(self.xw_to_y(input_dim_arr, w)),
+            weights,
+        )
+        assert hidden_dim_arr.shape == primals.shape, (
+            f'shape mismatch: {hidden_dim_arr.shape} vs {primals.shape}'
+        )
+        return f_vjp(u.get_mantissa(hidden_dim_arr))[0]
+
+
+# ---------------------------------------------------------------------------
+# MatMulOp
+# ---------------------------------------------------------------------------
+
+class MatMulOp(ETraceOp):
+    r"""Legacy dense-matmul op. Routes to :func:`braintrace.matmul`.
+
+    Weight is supplied as ``{'weight': ..., 'bias': <optional>}``.
+    """
+    __module__ = 'braintrace._legacy'
+
+    def __init__(
+        self,
+        weight_mask: Optional[Any] = None,
+        weight_fn: Callable = lambda w: w,
+        apply_weight_fn_before_mask: bool = False,
+    ):
+        super().__init__(is_diagonal=False)
+        if weight_mask is None:
+            pass
+        elif isinstance(weight_mask, (np.ndarray, jax.Array, u.Quantity)):
+            weight_mask = u.math.asarray(weight_mask)
+        else:
+            raise TypeError(
+                f'weight_mask must be array-like, got {type(weight_mask)}'
+            )
+        self.weight_mask = weight_mask
+        assert callable(weight_fn), f'weight_fn must be callable, got {type(weight_fn)}'
+        self.weight_fn = weight_fn
+        assert isinstance(apply_weight_fn_before_mask, bool)
+        self.apply_weight_fn_before_mask = apply_weight_fn_before_mask
+
+    def _check(self, w):
+        if not isinstance(w, dict):
+            raise TypeError(f'MatMulOp weight must be dict, got {type(w)}')
+        if 'weight' not in w:
+            raise ValueError("MatMulOp weight dict must contain 'weight'")
+
+    def _process_weight(self, w):
+        if self.apply_weight_fn_before_mask:
+            W = self.weight_fn(w['weight'])
+            if self.weight_mask is not None:
+                W = W * self.weight_mask
+        else:
+            W = w['weight']
+            if self.weight_mask is not None:
+                W = W * self.weight_mask
+            W = self.weight_fn(W)
+        return W
+
+    def xw_to_y(self, x, w):
+        self._check(w)
+        return _new_matmul(x, self._process_weight(w), bias=w.get('bias'))
+
+    def raw_xw_to_y(self, x, w):
+        self._check(w)
+        y = u.math.matmul(x, self._process_weight(w))
+        if 'bias' in w:
+            y = y + w['bias']
+        return y
+
+
+# ---------------------------------------------------------------------------
+# ElemWiseOp
+# ---------------------------------------------------------------------------
+
+class ElemWiseOp(ETraceOp):
+    r"""Legacy element-wise op. Routes to :func:`braintrace.element_wise`."""
+    __module__ = 'braintrace._legacy'
+
+    def __init__(self, fn: Callable = lambda w: w):
+        super().__init__(is_diagonal=True)
+        self._raw_fn = fn
+
+    def __call__(self, weights):
+        return self.xw_to_y(None, weights)
+
+    def xw_to_y(self, inputs, weights):
+        return _new_element_wise(weights, self._raw_fn)
+
+    def raw_xw_to_y(self, inputs, weights):
+        return self._raw_fn(weights)
+
+
+# ---------------------------------------------------------------------------
+# ConvOp
+# ---------------------------------------------------------------------------
+
+class ConvOp(ETraceOp):
+    r"""Legacy convolution op. Routes to :func:`braintrace.conv`.
+
+    Weight is supplied as ``{'weight': ..., 'bias': <optional>}``.
+    """
+    __module__ = 'braintrace._legacy'
+
+    def __init__(
+        self,
+        xinfo: jax.ShapeDtypeStruct,
+        window_strides: Sequence[int],
+        padding,
+        lhs_dilation: Optional[Sequence[int]] = None,
+        rhs_dilation: Optional[Sequence[int]] = None,
+        feature_group_count: int = 1,
+        batch_group_count: int = 1,
+        dimension_numbers: Any = None,
+        weight_mask: Optional[Any] = None,
+        weight_fn: Callable = lambda w: w,
+    ):
+        super().__init__(is_diagonal=False)
+        self.xinfo = xinfo
+        self.window_strides = window_strides
+        self.padding = padding
+        self.lhs_dilation = lhs_dilation
+        self.rhs_dilation = rhs_dilation
+        self.feature_group_count = feature_group_count
+        self.batch_group_count = batch_group_count
+        self.dimension_numbers = dimension_numbers
+        if weight_mask is None:
+            pass
+        elif isinstance(weight_mask, (np.ndarray, jax.Array, u.Quantity)):
+            weight_mask = u.math.asarray(weight_mask)
+        else:
+            raise TypeError(
+                f'weight_mask must be array-like, got {type(weight_mask)}'
+            )
+        self.weight_mask = weight_mask
+        assert callable(weight_fn)
+        self.weight_fn = weight_fn
+
+    def _check(self, w):
+        if not isinstance(w, dict):
+            raise TypeError(f'ConvOp weight must be dict, got {type(w)}')
+        if 'weight' not in w:
+            raise ValueError("ConvOp weight dict must contain 'weight'")
+
+    def _process_weight(self, w):
+        W = w['weight']
+        if self.weight_mask is not None:
+            W = W * self.weight_mask
+        return self.weight_fn(W)
+
+    def _conv_kwargs(self):
+        return dict(
+            strides=self.window_strides,
+            padding=self.padding,
+            lhs_dilation=self.lhs_dilation,
+            rhs_dilation=self.rhs_dilation,
+            feature_group_count=self.feature_group_count,
+            batch_group_count=self.batch_group_count,
+            dimension_numbers=self.dimension_numbers,
+        )
+
+    def xw_to_y(self, x, w):
+        self._check(w)
+        return _new_conv(
+            x, self._process_weight(w), bias=w.get('bias'), **self._conv_kwargs()
+        )
+
+    def raw_xw_to_y(self, x, w):
+        self._check(w)
+        W = self._process_weight(w)
+        y = jax.lax.conv_general_dilated(
+            lhs=x,
+            rhs=W,
+            window_strides=self.window_strides,
+            padding=self.padding,
+            lhs_dilation=self.lhs_dilation,
+            rhs_dilation=self.rhs_dilation,
+            feature_group_count=self.feature_group_count,
+            batch_group_count=self.batch_group_count,
+            dimension_numbers=self.dimension_numbers,
+        )
+        if 'bias' in w:
+            y = y + w['bias']
+        return y
+
+
+# ---------------------------------------------------------------------------
+# SpMatMulOp
+# ---------------------------------------------------------------------------
+
+class SpMatMulOp(ETraceOp):
+    r"""Legacy sparse-matmul op. Routes to :func:`braintrace.sparse_matmul`.
+
+    Weight is supplied as ``{'weight': data, 'bias': <optional>}``.
+    """
+    __module__ = 'braintrace._legacy'
+
+    def __init__(
+        self,
+        sparse_mat,
+        weight_fn: Callable = lambda w: w,
+    ):
+        super().__init__(is_diagonal=False)
+        if not isinstance(sparse_mat, u.sparse.SparseMatrix):
+            raise TypeError(
+                f'sparse_mat must be a saiunit SparseMatrix, got {type(sparse_mat)}'
+            )
+        self.sparse_mat = sparse_mat
+        assert callable(weight_fn)
+        self.weight_fn = weight_fn
+
+    def _check(self, w):
+        if not isinstance(w, dict):
+            raise TypeError(f'SpMatMulOp weight must be dict, got {type(w)}')
+        if 'weight' not in w:
+            raise ValueError("SpMatMulOp weight dict must contain 'weight'")
+
+    def xw_to_y(self, x, w):
+        self._check(w)
+        data = self.weight_fn(w['weight'])
+        return _new_sparse_matmul(
+            x, data, sparse_mat=self.sparse_mat, bias=w.get('bias')
+        )
+
+    def raw_xw_to_y(self, x, w):
+        self._check(w)
+        data = self.weight_fn(w['weight'])
+        mat = self.sparse_mat.with_data(data)
+        y = x @ mat
+        if 'bias' in w:
+            y = y + w['bias']
+        return y
+
+
+# ---------------------------------------------------------------------------
+# LoraOp
+# ---------------------------------------------------------------------------
+
+class LoraOp(ETraceOp):
+    r"""Legacy LoRA op. Routes to :func:`braintrace.lora_matmul`.
+
+    Weight is supplied as ``{'B': ..., 'A': ..., 'bias': <optional>}``.
+    """
+    __module__ = 'braintrace._legacy'
+
+    def __init__(self, alpha: Optional[Any] = None):
+        super().__init__(is_diagonal=False)
+        if alpha is not None:
+            alpha = u.math.asarray(alpha)
+        self.alpha = alpha
+
+    def _check(self, w):
+        if not isinstance(w, dict):
+            raise TypeError(f'LoraOp weight must be dict, got {type(w)}')
+        if 'B' not in w or 'A' not in w:
+            raise ValueError("LoraOp weight dict must contain 'B' and 'A'")
+
+    def xw_to_y(self, x, w):
+        self._check(w)
+        alpha = 1.0 if self.alpha is None else self.alpha
+        return _new_lora_matmul(x, w['B'], w['A'], alpha=alpha, bias=w.get('bias'))
+
+    def raw_xw_to_y(self, x, w):
+        self._check(w)
+        if self.alpha is not None:
+            x = self.alpha * x
+        y = x @ w['B'] @ w['A']
+        if 'bias' in w:
+            y = y + w['bias']
+        return y

--- a/braintrace/_legacy/_params.py
+++ b/braintrace/_legacy/_params.py
@@ -1,0 +1,252 @@
+# Copyright 2026 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Legacy (v0.1.x) parameter-state shims.
+
+* :class:`ETraceParam` — ``ParamState`` subclass that routes
+  :meth:`execute` through an ETP primitive; picked up by the compiler.
+* :class:`ElemWiseParam` — element-wise variant.
+* :class:`NonTempParam` — ``ParamState`` subclass that routes through
+  *plain* JAX ops (no ETP primitive), so the compiler registers no
+  eligibility-trace relation for this weight.
+* :class:`FakeETraceParam`, :class:`FakeElemWiseParam` — plain ``object``
+  wrappers (NOT ``ParamState``), invisible to the compiler.
+"""
+
+from __future__ import annotations
+
+import warnings
+from enum import Enum
+from typing import Callable, Optional
+
+import brainstate
+
+from ._ops import ElemWiseOp, ETraceOp
+
+__all__ = [
+    'ETraceParam',
+    'ElemWiseParam',
+    'NonTempParam',
+    'FakeETraceParam',
+    'FakeElemWiseParam',
+]
+
+
+_warned: set = set()
+
+
+def _deprecate(cls_name: str, replacement: str) -> None:
+    if cls_name in _warned:
+        return
+    _warned.add(cls_name)
+    warnings.warn(
+        f'braintrace._legacy.{cls_name} is deprecated; use {replacement} instead.',
+        DeprecationWarning,
+        stacklevel=3,
+    )
+
+
+class ETraceGrad(str, Enum):
+    """Legacy gradient-type enum. Kept for API compatibility; no effect
+    on the new primitive-based compiler."""
+    full = 'full'
+    approx = 'approx'
+    adaptive = 'adaptive'
+
+
+# ---------------------------------------------------------------------------
+# ETraceParam
+# ---------------------------------------------------------------------------
+
+class ETraceParam(brainstate.ParamState):
+    """Legacy eligibility-trace parameter.
+
+    Wraps a pytree weight (typically ``{'weight': ..., 'bias': ...}``)
+    and an :class:`ETraceOp`. :meth:`execute` routes through the op's
+    ETP-primitive path, so the compiler will register an eligibility-
+    trace relation when this parameter flows into a hidden state.
+
+    .. deprecated:: 0.2.0
+        Use :class:`brainstate.ParamState` + the new ETP primitive
+        functions (:func:`braintrace.matmul` etc.) directly.
+    """
+    __module__ = 'braintrace._legacy'
+
+    def __init__(
+        self,
+        weight,
+        op: ETraceOp,
+        grad: Optional[object] = None,
+        name: Optional[str] = None,
+    ):
+        super().__init__(weight, name=name)
+        if not isinstance(op, ETraceOp):
+            raise TypeError(f'op must be ETraceOp, got {type(op)}')
+        self.op = op
+        if grad is None:
+            grad = ETraceGrad.adaptive
+        elif isinstance(grad, str):
+            grad = ETraceGrad(grad)
+        self.gradient = grad
+        self.is_etrace = True
+        _deprecate(
+            'ETraceParam',
+            'brainstate.ParamState + braintrace.matmul/conv/...',
+        )
+
+    def execute(self, x):
+        return self.op(x, self.value)
+
+
+# ---------------------------------------------------------------------------
+# ElemWiseParam
+# ---------------------------------------------------------------------------
+
+class ElemWiseParam(ETraceParam):
+    """Legacy element-wise trace parameter."""
+    __module__ = 'braintrace._legacy'
+
+    def __init__(
+        self,
+        weight,
+        op=(lambda w: w),
+        name: Optional[str] = None,
+    ):
+        if not isinstance(op, ElemWiseOp):
+            op = ElemWiseOp(op)
+        super().__init__(weight, op=op, grad=ETraceGrad.full, name=name)
+
+    def execute(self):  # type: ignore[override]
+        return self.op(self.value)
+
+
+# ---------------------------------------------------------------------------
+# NonTempParam
+# ---------------------------------------------------------------------------
+
+class NonTempParam(brainstate.ParamState):
+    """Legacy parameter — spatial gradient only, no eligibility trace.
+
+    ``execute`` calls the op's plain-JAX path (``raw_xw_to_y``), so no
+    ETP primitive appears in the jaxpr for this weight. The compiler
+    therefore registers zero relations for this ``ParamState``.
+
+    .. deprecated:: 0.2.0
+        Use :class:`brainstate.ParamState` with plain JAX ops (``x @ w``)
+        directly.
+    """
+    __module__ = 'braintrace._legacy'
+
+    def __init__(
+        self,
+        value,
+        op,
+        name: Optional[str] = None,
+        **_kwargs,
+    ):
+        super().__init__(value, name=name)
+        if isinstance(op, ETraceOp):
+            self._etrace_op = op
+            self.op = op.raw_xw_to_y
+        else:
+            if not callable(op):
+                raise TypeError(f'op must be callable, got {type(op)}')
+            self._etrace_op = None
+            self.op = op
+        _deprecate(
+            'NonTempParam',
+            'brainstate.ParamState with plain JAX ops',
+        )
+
+    def execute(self, x):
+        return self.op(x, self.value)
+
+
+# ---------------------------------------------------------------------------
+# FakeETraceParam — non-ParamState wrapper
+# ---------------------------------------------------------------------------
+
+class FakeETraceParam(object):
+    """Legacy fake parameter — NOT a ``ParamState``.
+
+    Stores a value + callable and exposes :meth:`execute`. Since this is
+    not a ``ParamState``, the compiler never sees it — no gradient will
+    be produced for this weight.
+
+    Routes through the op's plain-JAX path to avoid emitting any ETP
+    primitive (which would trigger
+    :attr:`DiagnosticKind.RELATION_EXCLUDED_NO_PARAMSTATE` warnings).
+
+    .. deprecated:: 0.2.0
+        Use :class:`brainstate.FakeState` with plain JAX ops.
+    """
+    __module__ = 'braintrace._legacy'
+
+    def __init__(self, value, op):
+        self.value = value
+        if isinstance(op, ETraceOp):
+            self._etrace_op = op
+            self.op = op.raw_xw_to_y
+        else:
+            if not callable(op):
+                raise TypeError(f'op must be callable, got {type(op)}')
+            self._etrace_op = None
+            self.op = op
+        _deprecate('FakeETraceParam', 'brainstate.FakeState')
+
+    def execute(self, x):
+        return self.op(x, self.value)
+
+
+# ---------------------------------------------------------------------------
+# FakeElemWiseParam — non-ParamState wrapper
+# ---------------------------------------------------------------------------
+
+class FakeElemWiseParam(object):
+    """Legacy fake element-wise parameter — NOT a ``ParamState``.
+
+    .. deprecated:: 0.2.0
+        Use :class:`brainstate.FakeState` with plain JAX ops.
+    """
+    __module__ = 'braintrace._legacy'
+
+    def __init__(
+        self,
+        weight,
+        op=(lambda w: w),
+        name: Optional[str] = None,
+    ):
+        self._is_etrace_op = False
+        if isinstance(op, ETraceOp):
+            if not isinstance(op, ElemWiseOp):
+                raise TypeError(
+                    f'op must be ElemWiseOp when an ETraceOp is supplied, got {type(op)}'
+                )
+            self._etrace_op = op
+            self.op = op.raw_xw_to_y
+            self._is_etrace_op = True
+        else:
+            if not callable(op):
+                raise TypeError(f'op must be callable, got {type(op)}')
+            self._etrace_op = None
+            self.op = op
+        self.value = weight
+        self.name = name
+        _deprecate('FakeElemWiseParam', 'brainstate.FakeState')
+
+    def execute(self):
+        if self._is_etrace_op:
+            return self.op(None, self.value)
+        return self.op(self.value)

--- a/braintrace/_version.py
+++ b/braintrace/_version.py
@@ -13,5 +13,5 @@
 # limitations under the License.
 # ==============================================================================
 
-__version__ = "0.1.3"
+__version__ = "0.2.0"
 __version_info__ = tuple(map(int, __version__.split('.')))

--- a/braintrace/nn/_normalizations.py
+++ b/braintrace/nn/_normalizations.py
@@ -15,17 +15,13 @@
 
 # -*- coding: utf-8 -*-
 
-from functools import partial
 from typing import Callable, Union, Sequence, Optional, Any
 
 import brainstate
 import braintools
-import saiunit as u
-import jax
 from brainstate import BatchState
 from brainstate.nn._normalizations import _BatchNorm
 
-pass  # old imports removed
 from braintrace._typing import ArrayLike, Size, Axes
 
 __all__ = [

--- a/examples/101-integrator-rnn.py
+++ b/examples/101-integrator-rnn.py
@@ -135,7 +135,7 @@ def train_online(n_epochs=5):
     model = RNN(1, num_hidden)
     weights = model.states(brainstate.ParamState)
 
-    lr = braintools.optim.ExponentialDecayLR(1e-3, decay_steps=1, decay_rate=0.99975)
+    lr = braintools.optim.ExponentialDecayLR(5e-3, decay_steps=1, decay_rate=0.99975)
     opt = braintools.optim.Adam(lr=lr, eps=1e-1)
     opt.register_trainable_weights(weights)
 
@@ -211,7 +211,7 @@ def train_online(n_epochs=5):
 print("=" * 60)
 print("Training with BPTT")
 print("=" * 60)
-bptt_model, bptt_predict, bptt_losses = train_bptt(n_epochs=5)
+# bptt_model, bptt_predict, bptt_losses = train_bptt(n_epochs=5)
 
 print()
 print("=" * 60)

--- a/examples/101-integrator-rnn.py
+++ b/examples/101-integrator-rnn.py
@@ -30,13 +30,13 @@ which internally use ETP primitives (``braintrace.matmul``) so the compiler
 can automatically build eligibility trace graphs for online learning.
 """
 
+import brainstate
+import braintools
 import jax
 import jax.numpy as jnp
 import matplotlib.pyplot as plt
 import numpy as np
 
-import brainstate
-import braintools
 import braintrace
 
 # ---------------------------------------------------------------------------
@@ -77,11 +77,7 @@ def train_data():
 class RNN(brainstate.nn.Module):
     def __init__(self, num_in, num_hidden):
         super().__init__()
-        self.rnn = braintrace.nn.ValinaRNNCell(
-            in_size=num_in,
-            out_size=num_hidden,
-            activation='relu',
-        )
+        self.rnn = braintrace.nn.MiniGRU(in_size=num_in, out_size=num_hidden)
         self.out = braintrace.nn.Linear(num_hidden, 1)
 
     def update(self, x):
@@ -139,7 +135,7 @@ def train_online(n_epochs=5):
     model = RNN(1, num_hidden)
     weights = model.states(brainstate.ParamState)
 
-    lr = braintools.optim.ExponentialDecayLR(0.025, decay_steps=1, decay_rate=0.99975)
+    lr = braintools.optim.ExponentialDecayLR(1e-3, decay_steps=1, decay_rate=0.99975)
     opt = braintools.optim.Adam(lr=lr, eps=1e-1)
     opt.register_trainable_weights(weights)
 


### PR DESCRIPTION
## Summary by Sourcery

Introduce fast closed-form einsum paths for eligibility-trace updates and solves, add configurable normalization and decay handling, and provide a v0.1.x compatibility layer with legacy ops/params and tests while updating examples and versioning.

Enhancements:
- Add fast einsum-based paths for recurrent and instantaneous eligibility-trace terms with a feature flag to fall back to legacy nested-vmap implementations.
- Replace branchy normalization of matrix spectra and vectors with branch-free clipping and make spectrum normalization optional and consistently applied.
- Refine IO-dimension trace initialization shape checks and simplify IO trace state bookkeeping by removing unused x-to-weight mappings.
- Adjust exponential smoothing bias correction for IO-dimension traces to use the decay factor directly and guard numerical edge cases.
- Introduce fast-solve contraction for weight gradients using closed-form einsums and special-case small state dimensions for efficiency.
- Expose fast-solve and normalization controls through ETrace VJP algorithm constructors and propagate them into update/solve calls.
- Update the integrator RNN example to use MiniGRU, retune optimizer hyperparameters, and skip the BPTT training run by default.
- Clean up unused imports and stubs in the normalization module.

Documentation:
- Export legacy v0.1.x shim classes from the top-level package and add a dedicated legacy submodule for their documentation surface.

Tests:
- Add comprehensive smoke tests for legacy ops and parameter shims, including compiler integration behavior, deprecation warnings, utilities, and top-level re-exports.

Chores:
- Add a _legacy subpackage implementing deprecated v0.1.x ops/params shims that wrap the new ETP primitive API or plain JAX paths as appropriate.
- Re-export legacy shim symbols from the main package for backwards compatibility and bump the library version to 0.2.0.