### PR TITLE
refactor: split OSTL factory into OSTLRecurrent and OSTLFeedforward

### DIFF
--- a/braintrace/__init__.py
+++ b/braintrace/__init__.py
@@ -30,6 +30,8 @@ from ._etrace_algorithms import (
     pp_prop,
     EProp,
     OSTL,
+    OSTLRecurrent,
+    OSTLFeedforward,
     OTPE,
     OTTT,
     OSTTP,
@@ -145,6 +147,8 @@ __all__ = [
     # SNN online-learning algorithms
     'EProp',
     'OSTL',
+    'OSTLRecurrent',
+    'OSTLFeedforward',
     'OTPE',
     'OTTT',
     'OSTTP',

--- a/braintrace/_etrace_algorithms/__init__.py
+++ b/braintrace/_etrace_algorithms/__init__.py
@@ -25,7 +25,7 @@ from .base import ETraceAlgorithm, EligibilityTrace
 from .d_rtrl import D_RTRL, ParamDimVjpAlgorithm
 from .e_prop import EProp
 from .graph_executor import ETraceGraphExecutor
-from .ostl import OSTL
+from .ostl import OSTL, OSTLFeedforward, OSTLRecurrent
 from .osttp import OSTTP
 from .otpe import OTPE
 from .ottt import OTTT
@@ -49,6 +49,8 @@ __all__ = [
     # SNN
     'EProp',
     'OSTL',
+    'OSTLRecurrent',
+    'OSTLFeedforward',
     'OTPE',
     'OTTT',
     'OSTTP',

--- a/braintrace/_etrace_algorithms/ostl.py
+++ b/braintrace/_etrace_algorithms/ostl.py
@@ -15,8 +15,19 @@
 
 """OSTL — Online Spatio-Temporal Learning (Bohnstingl et al. 2023).
 
-Regime 'with-H'    — RTRL-exact single-layer factorization (delegates to D_RTRL).
-Regime 'without-H' — feedforward / no recurrent Jacobian (delegates to pp_prop with decay≈0).
+The paper defines two regimes that differ in whether the recurrent (hidden-to-
+hidden) Jacobian ``H`` is retained. Each regime is its own class so that it
+inherits the full, separately-tested machinery of an existing VJP algorithm —
+``compile_graph``, ``update``, ``reset_state``, ``get_etrace_of`` — without
+branching:
+
+- :class:`OSTLRecurrent` ('with-H') keeps ``H`` and is RTRL-exact for a single
+  recurrent layer (per-parameter D-RTRL trace, O(P·H)).
+- :class:`OSTLFeedforward` ('without-H') drops ``H``; the temporal term vanishes
+  and the update reduces to pp_prop with negligible decay (feedforward SNN).
+
+:func:`OSTL` is a thin factory selecting between the two by ``regime`` keyword,
+preserving the historical ``OSTL(model, regime=...)`` call site.
 """
 
 from typing import Optional
@@ -26,7 +37,64 @@ import brainstate
 from .d_rtrl import ParamDimVjpAlgorithm
 from .pp_prop import IODimVjpAlgorithm
 
-__all__ = ['OSTL']
+__all__ = ['OSTL', 'OSTLRecurrent', 'OSTLFeedforward']
+
+
+class OSTLRecurrent(ParamDimVjpAlgorithm):
+    """OSTL 'with-H' regime — RTRL-exact single-layer factorization.
+
+    Retains the hidden-to-hidden Jacobian, so the eligibility trace carries the
+    full temporal term ``ε^t = D^t·ε^{t-1} + diag(D_f^t)⊗x^t``. Exact for a
+    single recurrent layer; per-parameter trace with O(P·H) memory. Delegates
+    entirely to :class:`ParamDimVjpAlgorithm` (D-RTRL).
+
+    Parameters
+    ----------
+    model : brainstate.nn.Module
+        The recurrent SNN whose weights are trained online.
+    name, vjp_method, fast_solve, normalize_matrix_spectrum : optional
+        Forwarded verbatim to :class:`ParamDimVjpAlgorithm`.
+    """
+
+    __module__ = 'braintrace'
+
+    #: Identifies the OSTL regime this class implements.
+    regime = 'with-H'
+
+
+class OSTLFeedforward(IODimVjpAlgorithm):
+    """OSTL 'without-H' regime — feedforward / no recurrent Jacobian.
+
+    Drops the hidden-to-hidden Jacobian. With a negligible decay the input-
+    output factorized trace stops accumulating across time, so the update is the
+    purely-spatial (feedforward SNN) approximation. Delegates to
+    :class:`IODimVjpAlgorithm` (pp_prop).
+
+    Parameters
+    ----------
+    model : brainstate.nn.Module
+        The SNN whose weights are trained online.
+    decay_or_rank : float or int, default 1e-6
+        Exponential-smoothing factor of the IO-dim trace. The tiny default makes
+        the temporal contribution negligible, matching the 'without-H' regime. A
+        float must lie in (0, 1); an int is read as an approximation rank.
+    name, vjp_method, fast_solve : optional
+        Forwarded verbatim to :class:`IODimVjpAlgorithm`.
+    """
+
+    __module__ = 'braintrace'
+
+    #: Identifies the OSTL regime this class implements.
+    regime = 'without-H'
+
+    def __init__(
+        self,
+        model: brainstate.nn.Module,
+        decay_or_rank: float | int = 1e-6,
+        name: Optional[str] = None,
+        **kwargs,
+    ):
+        super().__init__(model, decay_or_rank=decay_or_rank, name=name, **kwargs)
 
 
 def OSTL(
@@ -35,30 +103,27 @@ def OSTL(
     name: Optional[str] = None,
     **kwargs,
 ):
-    """Factory returning the appropriate VJP algorithm for the selected regime.
+    """Construct the OSTL algorithm for the selected regime.
 
-    Using a factory (not a subclass with branching) lets each regime inherit
-    everything — compile_graph, update, reset_state, get_etrace_of — from the
-    existing tested algorithm classes without duplication.
+    A convenience dispatcher over :class:`OSTLRecurrent` ('with-H') and
+    :class:`OSTLFeedforward` ('without-H'). Prefer constructing those classes
+    directly when the regime is known at the call site.
 
     Parameters
     ----------
     model : brainstate.nn.Module
-    regime : {'with-H', 'without-H'}
-        'with-H' uses D_RTRL-shape traces (per-parameter, O(P·H)). Exact for
-        single-recurrent-layer networks. 'without-H' drops the temporal term,
-        equivalent to pp_prop with negligible decay (feedforward SNN).
-    name : optional name.
-    **kwargs : forwarded to the base algorithm constructor.
+    regime : {'with-H', 'without-H'}, default 'with-H'
+        'with-H' keeps the recurrent Jacobian (RTRL-exact, per-parameter trace).
+        'without-H' drops it (feedforward SNN, IO-dim trace with tiny decay).
+    name : optional name forwarded to the chosen class.
+    **kwargs : forwarded to the chosen class constructor.
+
+    Returns
+    -------
+    OSTLRecurrent or OSTLFeedforward
     """
-    if regime not in ('with-H', 'without-H'):
-        raise ValueError(f"regime must be 'with-H' or 'without-H'; got {regime!r}")
-
     if regime == 'with-H':
-        algo = ParamDimVjpAlgorithm(model, name=name, **kwargs)
-    else:
-        decay = kwargs.pop('decay_or_rank', 1e-6)
-        algo = IODimVjpAlgorithm(model, decay_or_rank=decay, name=name, **kwargs)
-
-    algo.regime = regime
-    return algo
+        return OSTLRecurrent(model, name=name, **kwargs)
+    if regime == 'without-H':
+        return OSTLFeedforward(model, name=name, **kwargs)
+    raise ValueError(f"regime must be 'with-H' or 'without-H'; got {regime!r}")

--- a/braintrace/_etrace_algorithms/ostl_test.py
+++ b/braintrace/_etrace_algorithms/ostl_test.py
@@ -20,7 +20,13 @@ import jax
 import jax.numpy as jnp
 
 import braintrace
-from braintrace._etrace_algorithms.ostl import OSTL
+from braintrace._etrace_algorithms.d_rtrl import ParamDimVjpAlgorithm
+from braintrace._etrace_algorithms.ostl import (
+    OSTL,
+    OSTLFeedforward,
+    OSTLRecurrent,
+)
+from braintrace._etrace_algorithms.pp_prop import IODimVjpAlgorithm
 
 
 def _tiny_rec_net():
@@ -43,56 +49,164 @@ def _tiny_rec_net():
     return net
 
 
-class TestOSTLConstruction(unittest.TestCase):
-    def test_default_regime_is_with_h(self):
-        algo = OSTL(_tiny_rec_net())
+def _drive(algo, n=3, x=None):
+    """Compile, init, and run ``n`` update steps; return the algo and last out."""
+    x = jnp.ones((1, 3)) if x is None else x
+    algo.compile_graph(x)
+    algo.init_etrace_state()
+    out = None
+    for _ in range(n):
+        out = algo.update(x)
+    return algo, out
+
+
+def _train_loss(algo, n_steps=10, lr=0.05):
+    """Online SGD on a fit-to-ones task; return the per-step loss list."""
+    x = jnp.ones((1, 3))
+    algo.compile_graph(x)
+    algo.init_etrace_state()
+    losses = []
+    for _ in range(n_steps):
+        def loss_fn(x_):
+            out = algo.update(x_)
+            return ((out - jnp.ones_like(out)) ** 2).mean()
+
+        grads, loss_val = brainstate.augment.grad(
+            loss_fn, algo.param_states, return_value=True
+        )(x)
+        for path, st in algo.param_states.items():
+            st.value = st.value - lr * grads[path]
+        losses.append(float(loss_val))
+    return losses
+
+
+class TestOSTLRecurrent(unittest.TestCase):
+    def test_is_param_dim_subclass(self):
+        algo = OSTLRecurrent(_tiny_rec_net())
+        assert isinstance(algo, ParamDimVjpAlgorithm)
         assert algo.regime == 'with-H'
+
+    def test_compiles_and_updates(self):
+        algo, out = _drive(OSTLRecurrent(_tiny_rec_net()), n=1)
+        assert out.shape == (1, 3)
+
+    def test_reset_zeros_traces(self):
+        algo, _ = _drive(OSTLRecurrent(_tiny_rec_net()), n=3)
+        algo.reset_state(batch_size=1)
+        for st in algo.etrace_bwg.values():
+            for arr in jax.tree.leaves(st.value):
+                assert jnp.allclose(arr, jnp.zeros_like(arr))
+        assert algo.running_index.value == 0
+
+    def test_forwards_kwargs_to_base(self):
+        algo = OSTLRecurrent(
+            _tiny_rec_net(),
+            fast_solve=False,
+            normalize_matrix_spectrum=True,
+            vjp_method='single-step',
+        )
+        assert algo.fast_solve is False
+        assert algo.normalize_matrix_spectrum is True
+
+    def test_get_etrace_of_named_weight(self):
+        net = _tiny_rec_net()
+        algo, _ = _drive(OSTLRecurrent(net), n=2)
+        traces = algo.get_etrace_of(net.w_rec)
+        assert len(traces) >= 1
+
+    def test_training_decreases_loss(self):
+        losses = _train_loss(OSTLRecurrent(_tiny_rec_net()))
+        assert losses[-1] < losses[0]
+
+
+class TestOSTLFeedforward(unittest.TestCase):
+    def test_is_io_dim_subclass(self):
+        algo = OSTLFeedforward(_tiny_rec_net())
+        assert isinstance(algo, IODimVjpAlgorithm)
+        assert algo.regime == 'without-H'
+
+    def test_default_decay_is_tiny(self):
+        algo = OSTLFeedforward(_tiny_rec_net())
+        assert algo.decay == 1e-6
+
+    def test_compiles_and_updates(self):
+        algo, out = _drive(OSTLFeedforward(_tiny_rec_net()), n=1)
+        assert out.shape == (1, 3)
+
+    def test_reset_zeros_traces(self):
+        algo, _ = _drive(OSTLFeedforward(_tiny_rec_net()), n=3)
+        algo.reset_state(batch_size=1)
+        for st in algo.etrace_xs.values():
+            assert jnp.allclose(st.value, jnp.zeros_like(st.value))
+        for st in algo.etrace_dfs.values():
+            assert jnp.allclose(st.value, jnp.zeros_like(st.value))
+        assert algo.running_index.value == 0
+
+    def test_custom_float_decay_honored(self):
+        algo = OSTLFeedforward(_tiny_rec_net(), decay_or_rank=0.5)
+        assert algo.decay == 0.5
+
+    def test_int_rank_sets_decay(self):
+        # rank r -> decay = (r-1)/(r+1); rank 3 -> 0.5
+        algo = OSTLFeedforward(_tiny_rec_net(), decay_or_rank=3)
+        assert abs(algo.decay - 0.5) < 1e-9
+
+    def test_out_of_range_float_decay_rejected(self):
+        with self.assertRaises(AssertionError):
+            OSTLFeedforward(_tiny_rec_net(), decay_or_rank=1.5)
+
+    def test_bad_decay_type_rejected(self):
+        with self.assertRaises(ValueError):
+            OSTLFeedforward(_tiny_rec_net(), decay_or_rank='nope')
+
+    def test_training_decreases_loss(self):
+        losses = _train_loss(OSTLFeedforward(_tiny_rec_net()))
+        assert losses[-1] < losses[0]
+
+
+class TestOSTLFactory(unittest.TestCase):
+    def test_default_regime_returns_recurrent(self):
+        algo = OSTL(_tiny_rec_net())
+        assert isinstance(algo, OSTLRecurrent)
+        assert algo.regime == 'with-H'
+
+    def test_without_h_returns_feedforward(self):
+        algo = OSTL(_tiny_rec_net(), regime='without-H')
+        assert isinstance(algo, OSTLFeedforward)
+        assert algo.regime == 'without-H'
 
     def test_invalid_regime_raises(self):
         with self.assertRaises(ValueError):
             OSTL(_tiny_rec_net(), regime='bogus')
 
+    def test_factory_forwards_decay_to_feedforward(self):
+        algo = OSTL(_tiny_rec_net(), regime='without-H', decay_or_rank=0.5)
+        assert algo.decay == 0.5
+
+    def test_factory_forwards_name(self):
+        algo = OSTL(_tiny_rec_net(), name='my_ostl')
+        assert algo.name == 'my_ostl'
+
     def test_with_h_compiles_and_updates(self):
-        net = _tiny_rec_net()
-        algo = OSTL(net, regime='with-H')
-        x = jnp.ones((1, 3))
-        algo.compile_graph(x)
-        algo.init_etrace_state()
-        out = algo.update(x)
+        algo, out = _drive(OSTL(_tiny_rec_net(), regime='with-H'), n=1)
         assert out.shape == (1, 3)
 
     def test_without_h_compiles_and_updates(self):
-        net = _tiny_rec_net()
-        algo = OSTL(net, regime='without-H')
-        x = jnp.ones((1, 3))
-        algo.compile_graph(x)
-        algo.init_etrace_state()
-        out = algo.update(x)
+        algo, out = _drive(OSTL(_tiny_rec_net(), regime='without-H'), n=1)
         assert out.shape == (1, 3)
 
+    def test_exported_from_package(self):
+        assert braintrace.OSTLRecurrent is OSTLRecurrent
+        assert braintrace.OSTLFeedforward is OSTLFeedforward
+        for name in ('OSTL', 'OSTLRecurrent', 'OSTLFeedforward'):
+            assert name in braintrace.__all__
 
-class TestOSTLResetAndKnob(unittest.TestCase):
-    def test_reset_zeros_traces(self):
-        net = _tiny_rec_net()
-        algo = OSTL(net, regime='with-H')
-        x = jnp.ones((1, 3))
-        algo.compile_graph(x)
-        algo.init_etrace_state()
-        # Drive a few steps so traces become non-zero.
-        for _ in range(3):
-            algo.update(x)
-        algo.reset_state(batch_size=1)
-        for k, st in algo.etrace_bwg.items():
-            for arr in jax.tree.leaves(st.value):
-                assert jnp.allclose(arr, jnp.zeros_like(arr))
-        assert algo.running_index.value == 0
 
-    def test_without_h_regime_differs_from_with_h(self):
-        """Drive several recurrent steps; the two regimes must disagree on a non-trivial loss."""
+class TestRegimesDiffer(unittest.TestCase):
+    def test_recurrent_and_feedforward_disagree_on_gradient(self):
+        """With recurrent dynamics, keeping vs dropping H must change the grad."""
 
-        def final_grad(regime):
-            net = _tiny_rec_net()
-            algo = OSTL(net, regime=regime)
+        def final_grad(algo):
             x = jnp.ones((1, 3))
             algo.compile_graph(x)
             algo.init_etrace_state()
@@ -107,6 +221,6 @@ class TestOSTLResetAndKnob(unittest.TestCase):
             )(x)
             return grads[next(iter(grads))]
 
-        g_with = final_grad('with-H')
-        g_without = final_grad('without-H')
+        g_with = final_grad(OSTLRecurrent(_tiny_rec_net()))
+        g_without = final_grad(OSTLFeedforward(_tiny_rec_net()))
         assert not jnp.allclose(g_with, g_without, atol=1e-4)

--- a/docs/apis/algorithms.rst
+++ b/docs/apis/algorithms.rst
@@ -113,6 +113,8 @@ Paper-faithful algorithms tailored to spiking neural networks. All are
 
    EProp
    OSTL
+   OSTLRecurrent
+   OSTLFeedforward
    OTPE
    OTTT
    OSTTP
@@ -152,10 +154,10 @@ Algorithm Comparison
      - :math:`O(B \cdot |\theta|)`
      - :math:`O(B \cdot I \cdot O)`
      - SNNs with κ-filtered / random-feedback learning signals
-   * - ``OSTL``
+   * - ``OSTL`` / ``OSTLRecurrent`` / ``OSTLFeedforward``
      - depends on regime
      - depends on regime
-     - SNN regime-switchable factory (D-RTRL / pp_prop)
+     - ``OSTLRecurrent`` ('with-H', D-RTRL) keeps the recurrent Jacobian; ``OSTLFeedforward`` ('without-H', pp_prop) drops it. ``OSTL`` dispatches between them.
    * - ``OTPE``
      - :math:`O(B \cdot I \cdot O)` (full) / :math:`O(B(I+O))` (approx)
      - :math:`O(B \cdot I \cdot O)`


### PR DESCRIPTION
Replace the OSTL factory's regime branching with two well-scoped
subclasses: OSTLRecurrent (with-H, D-RTRL/ParamDimVjpAlgorithm) keeps the
recurrent Jacobian, and OSTLFeedforward (without-H, pp_prop/IODimVjpAlgorithm)
drops it via a negligible-decay IO-dim trace. OSTL is now a thin dispatcher
over the two, preserving existing OSTL(model, regime=...) call sites.

Export both classes from the package and top-level namespace, document them
in the API reference, and add comprehensive tests covering construction,
updates, reset, kwarg forwarding, decay/rank handling, error cases, factory
dispatch, and regime divergence.
