### PR TITLE
refactor: make D_RTRL a subclass of ParamDimVjpAlgorithm

### DIFF
--- a/braintrace/_etrace_algorithms/d_rtrl.py
+++ b/braintrace/_etrace_algorithms/d_rtrl.py
@@ -793,4 +793,24 @@ class ParamDimVjpAlgorithm(ETraceVjpAlgorithm):
         return dG_weights
 
 
-D_RTRL = ParamDimVjpAlgorithm
+class D_RTRL(ParamDimVjpAlgorithm):
+    r"""
+    The Diagonal RTRL (D-RTRL) online gradient computation algorithm.
+
+    ``D_RTRL`` is the canonical name for the parameter-dimension eligibility
+    trace algorithm implemented by :py:class:`ParamDimVjpAlgorithm`. It computes
+    the gradients of the weights with the diagonal approximation and the
+    parameter dimension complexity, following the learning rule:
+
+    $$
+    \begin{aligned}
+    &\boldsymbol{\epsilon}^t \approx \mathbf{D}^t \boldsymbol{\epsilon}^{t-1}+\operatorname{diag}\left(\mathbf{D}_f^t\right) \otimes \mathbf{x}^t \\
+    & \nabla_{\boldsymbol{\theta}} \mathcal{L}=\sum_{t^{\prime} \in \mathcal{T}} \frac{\partial \mathcal{L}^{t^{\prime}}}{\partial \mathbf{h}^{t^{\prime}}} \circ \boldsymbol{\epsilon}^{t^{\prime}}
+    \end{aligned}
+    $$
+
+    For more details, please see `the D-RTRL algorithm presented in our manuscript <https://www.biorxiv.org/content/10.1101/2024.09.24.614728v2>`_.
+
+    This subclass inherits all behavior from :py:class:`ParamDimVjpAlgorithm`
+    without modification; it exists to provide the canonical ``D_RTRL`` name.
+    """

--- a/braintrace/_etrace_algorithms/d_rtrl_test.py
+++ b/braintrace/_etrace_algorithms/d_rtrl_test.py
@@ -297,10 +297,21 @@ class TestRemoveUnits:
 # ---------------------------------------------------------------------------
 
 class TestParamDimVjpAlgorithmAlias:
-    """Check that D_RTRL is indeed an alias for ParamDimVjpAlgorithm."""
+    """Check that D_RTRL is a subclass of ParamDimVjpAlgorithm."""
 
     def test_d_rtrl_is_param_dim_vjp_algorithm(self):
-        assert D_RTRL is ParamDimVjpAlgorithm
+        assert issubclass(D_RTRL, ParamDimVjpAlgorithm)
+
+    def test_d_rtrl_instance_is_param_dim_vjp_algorithm(self):
+        model = braintrace.nn.GRUCell(3, 4)
+        brainstate.nn.init_all_states(model)
+        algo = D_RTRL(model)
+        assert isinstance(algo, D_RTRL)
+        assert isinstance(algo, ParamDimVjpAlgorithm)
+        # Constructor defaults preserved through inheritance.
+        assert algo.vjp_method == 'single-step'
+        assert algo.fast_solve is True
+        assert algo.normalize_matrix_spectrum is False
 
 
 class TestParamDimVjpAlgorithmInit:


### PR DESCRIPTION
Convert the ``D_RTRL = ParamDimVjpAlgorithm`` alias into a proper
subclass. ParamDimVjpAlgorithm remains the standalone implementation
class; D_RTRL now inherits all behavior, constructor defaults, and
runtime semantics unchanged, providing the canonical user-facing name.

Update the alias test to assert the subclass/instance relationship and
that constructor defaults are preserved through inheritance.
