### PR TITLE
docs: complete algorithm docstrings with math, references, and examples

### DIFF
--- a/braintrace/_etrace_algorithms/d_rtrl.py
+++ b/braintrace/_etrace_algorithms/d_rtrl.py
@@ -506,6 +506,20 @@ class ParamDimVjpAlgorithm(ETraceVjpAlgorithm):
     \end{aligned}
     $$
 
+    where :math:`\boldsymbol{\epsilon}^t` is the per-parameter eligibility
+    trace, :math:`\mathbf{D}^t` the hidden-to-hidden Jacobian, :math:`\mathbf{D}_f^t`
+    the state-to-output Jacobian, :math:`\mathbf{x}^t` the presynaptic input, and
+    :math:`\partial \mathcal{L}^{t'}/\partial \mathbf{h}^{t'}` the learning
+    signal back-propagated from the loss at each step.
+
+    **How it works.** Real-Time Recurrent Learning (RTRL) propagates the full
+    sensitivity :math:`\partial \mathbf{h}^t/\partial \boldsymbol{\theta}`
+    forward in time, which costs :math:`O(|\theta| \cdot H)` memory. D-RTRL
+    keeps only the *diagonal* of the hidden-to-hidden Jacobian, collapsing the
+    trace to one value per parameter. The trace is then contracted with the
+    instantaneous learning signal at each step to accumulate the gradient — no
+    backward pass through time and memory linear in the parameter count.
+
     For more details, please see `the D-RTRL algorithm presented in our manuscript <https://www.biorxiv.org/content/10.1101/2024.09.24.614728v2>`_.
 
     Note than the :py:class:`ParamDimVjpAlgorithm` is a subclass of :py:class:`brainstate.nn.Module`,
@@ -535,6 +549,39 @@ class ParamDimVjpAlgorithm(ETraceVjpAlgorithm):
         The name of the etrace algorithm.
     mode: braintrace.mixin.Mode
         The computing mode, indicating the batching behavior.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        >>> import brainstate
+        >>> import braintrace
+        >>>
+        >>> class RNN(brainstate.nn.Module):
+        ...     def __init__(self):
+        ...         super().__init__()
+        ...         self.cell = braintrace.nn.ValinaRNNCell(1, 20, activation='tanh')
+        ...         self.out = braintrace.nn.Linear(20, 1)
+        ...     def update(self, x):
+        ...         return x >> self.cell >> self.out
+        >>>
+        >>> model = RNN()
+        >>> brainstate.nn.init_all_states(model)
+        >>> learner = braintrace.D_RTRL(model)  # alias of ParamDimVjpAlgorithm
+        >>> x0 = brainstate.random.randn(1)
+        >>> learner.compile_graph(x0)   # trace the graph once
+        >>> y = learner(x0)             # forward pass + eligibility-trace update
+
+    References
+    ----------
+    .. [1] Wang, C., Dong, X., Ji, Z., Xiao, M., Jiang, J., Liu, X., Huan, Y., &
+       Wu, S. (2026). "Model-agnostic linear-memory online learning in spiking
+       neural networks." *Nature Communications*.
+       https://doi.org/10.1038/s41467-026-68453-w
+       (preprint: bioRxiv 2024.09.24.614728)
+    .. [2] Williams, R. J., & Zipser, D. (1989). "A Learning Algorithm for
+       Continually Running Fully Recurrent Neural Networks" (RTRL). *Neural
+       Computation*, 1(2), 270-280. https://doi.org/10.1162/neco.1989.1.2.270
     """
 
     # batch of weight gradients
@@ -812,5 +859,18 @@ class D_RTRL(ParamDimVjpAlgorithm):
     For more details, please see `the D-RTRL algorithm presented in our manuscript <https://www.biorxiv.org/content/10.1101/2024.09.24.614728v2>`_.
 
     This subclass inherits all behavior from :py:class:`ParamDimVjpAlgorithm`
-    without modification; it exists to provide the canonical ``D_RTRL`` name.
+    without modification; it exists to provide the canonical ``D_RTRL`` name. See
+    :py:class:`ParamDimVjpAlgorithm` for the full parameter list and a usage
+    example.
+
+    References
+    ----------
+    .. [1] Wang, C., Dong, X., Ji, Z., Xiao, M., Jiang, J., Liu, X., Huan, Y., &
+       Wu, S. (2026). "Model-agnostic linear-memory online learning in spiking
+       neural networks." *Nature Communications*.
+       https://doi.org/10.1038/s41467-026-68453-w
+       (preprint: bioRxiv 2024.09.24.614728)
+    .. [2] Williams, R. J., & Zipser, D. (1989). "A Learning Algorithm for
+       Continually Running Fully Recurrent Neural Networks" (RTRL). *Neural
+       Computation*, 1(2), 270-280. https://doi.org/10.1162/neco.1989.1.2.270
     """

--- a/braintrace/_etrace_algorithms/e_prop.py
+++ b/braintrace/_etrace_algorithms/e_prop.py
@@ -13,13 +13,20 @@
 # limitations under the License.
 # ==============================================================================
 
-"""E-Prop — Eligibility Propagation (Bellec et al. 2020).
+"""E-Prop — Eligibility Propagation (Bellec et al., 2020).
 
-``D_RTRL``'s per-parameter trace plus:
-- An optional κ-filter on each HiddenGroup's eligibility signal (ē = F_κ(L))
-  matching the paper's readout-side low-pass.
-- An optional random-feedback variant (feedback='random') that replaces the
-  readout's symmetric gradient with a fixed random projection.
+E-prop factorizes the BPTT gradient of a recurrent SNN into a *local*
+eligibility trace and a *learning signal* broadcast from the readout. This
+module builds on ``D_RTRL``'s per-parameter trace and adds the two ingredients
+that make the rule biologically plausible:
+
+- An optional κ-filter on each HiddenGroup's learning signal
+  (:math:`\\bar L = F_\\kappa(L)`), matching the paper's readout-side low-pass.
+- An optional random-feedback variant (``feedback='random'``) that replaces the
+  readout's symmetric gradient with a fixed random projection, removing the
+  weight-transport requirement.
+
+See :class:`EProp` for the mathematical formulation, references, and an example.
 """
 
 from typing import Dict, Optional
@@ -35,20 +42,110 @@ __all__ = ['EProp']
 
 
 class EProp(ParamDimVjpAlgorithm):
-    """Eligibility Propagation.
+    r"""Eligibility Propagation (e-prop) for recurrent spiking networks.
+
+    E-prop approximates the gradient of a loss :math:`\mathcal{L}` with respect
+    to a recurrent weight :math:`W_{ji}` by the product of a *local* eligibility
+    trace and a *global* learning signal, dropping the temporally non-local
+    terms of BPTT:
+
+    .. math::
+
+        \frac{d\mathcal{L}}{dW_{ji}}
+        = \sum_t L_j^t \, \bar{e}_{ji}^t ,
+
+    where
+
+    .. math::
+
+        e_{ji}^t = \frac{\partial h_j^t}{\partial W_{ji}}
+                 \approx D_j^t \, e_{ji}^{t-1}
+                 + \big[\operatorname{diag}(D_{f,j}^t)\big]\, x_i^t ,
+        \qquad
+        \bar{e}_{ji}^t = \kappa\,\bar{e}_{ji}^{t-1} + e_{ji}^t .
+
+    Here :math:`h_j^t` is the hidden state of neuron :math:`j` at time
+    :math:`t`, :math:`x_i^t` the presynaptic input, :math:`D_j^t` the
+    hidden-to-hidden (recurrent) Jacobian diagonal, :math:`D_{f,j}^t` the
+    state-to-output Jacobian, and :math:`\kappa \in [0, 1)` the readout-side
+    low-pass factor. The learning signal is
+
+    .. math::
+
+        L_j^t =
+        \begin{cases}
+          \dfrac{\partial \mathcal{L}}{\partial h_j^t}
+            & \text{(symmetric feedback, standard backprop through readout)} \\[2ex]
+          \big(B\,e^t\big)_j
+            & \text{(random feedback: a fixed random projection } B\text{)} .
+        \end{cases}
+
+    **How it works.** The eligibility trace :math:`e_{ji}^t` is exactly the
+    per-parameter trace maintained by :class:`~braintrace.D_RTRL`; it depends
+    only on quantities local to the synapse and is updated forward in time. The
+    learning signal :math:`L_j^t` is broadcast from the readout. E-prop is
+    therefore *online* (no backward pass through time) and uses memory linear in
+    the number of parameters. With ``kappa_filter_decay > 0`` the learning
+    signal is additionally low-pass filtered; with ``feedback='random'`` the
+    symmetric readout gradient is replaced by a frozen random matrix, removing
+    the biologically implausible weight-transport requirement.
 
     Parameters
     ----------
     model : brainstate.nn.Module
-    feedback : {'symmetric', 'random'}
-        'symmetric' uses reverse-AD's ∂L/∂h (standard backprop through readout).
-        'random' replaces the readout gradient with a frozen random projection.
-    kappa_filter_decay : float in [0, 1)
-        If > 0, apply an output-side low-pass to each HiddenGroup's learning
-        signal each step. 0 disables (paper default for hard tasks).
+        The recurrent SNN whose weights are trained online.
+    feedback : {'symmetric', 'random'}, default 'symmetric'
+        ``'symmetric'`` uses reverse-AD's :math:`\partial \mathcal{L}/\partial h`
+        (standard backprop through the readout). ``'random'`` replaces the
+        readout gradient with a frozen random projection (requires
+        ``random_feedback_key``).
+    kappa_filter_decay : float in [0, 1), default 0.0
+        Readout-side low-pass factor :math:`\kappa`. If ``> 0``, each
+        HiddenGroup's learning signal is filtered each step
+        (:math:`\bar L^t = (1-\kappa)L^t + \kappa\bar L^{t-1}`). ``0`` disables
+        filtering.
     random_feedback_key : jax.random.PRNGKey, optional
-        Seed for the random-feedback matrices when feedback='random'.
-    name, vjp_method, fast_solve, normalize_matrix_spectrum : forwarded to D_RTRL.
+        Seed for the random-feedback matrices. Required when
+        ``feedback='random'``; ignored otherwise.
+    name : str, optional
+        Name of the algorithm instance.
+    vjp_method, fast_solve, normalize_matrix_spectrum
+        Forwarded verbatim to :class:`~braintrace.D_RTRL`.
+
+    Raises
+    ------
+    ValueError
+        If ``feedback`` is not one of ``{'symmetric', 'random'}``, or if
+        ``feedback='random'`` is given without ``random_feedback_key``.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        >>> import brainstate
+        >>> import braintrace
+        >>>
+        >>> class RSNN(brainstate.nn.Module):
+        ...     def __init__(self):
+        ...         super().__init__()
+        ...         self.cell = braintrace.nn.ValinaRNNCell(1, 20, activation='tanh')
+        ...         self.out = braintrace.nn.Linear(20, 1)
+        ...     def update(self, x):
+        ...         return x >> self.cell >> self.out
+        >>>
+        >>> model = RSNN()
+        >>> brainstate.nn.init_all_states(model)
+        >>> learner = braintrace.EProp(model, kappa_filter_decay=0.9)
+        >>> x0 = brainstate.random.randn(1)
+        >>> learner.compile_graph(x0)   # trace the graph once
+        >>> y = learner(x0)             # forward pass + eligibility-trace update
+
+    References
+    ----------
+    .. [1] Bellec, G., Scherr, F., Subramoney, A., Hajek, E., Salaj, D.,
+       Legenstein, R., & Maass, W. (2020). "A solution to the learning dilemma
+       for recurrent networks of spiking neurons." *Nature Communications*,
+       11, 3625. https://doi.org/10.1038/s41467-020-17236-y
     """
 
     __module__ = 'braintrace'

--- a/braintrace/_etrace_algorithms/ostl.py
+++ b/braintrace/_etrace_algorithms/ostl.py
@@ -28,6 +28,13 @@ branching:
 
 :func:`OSTL` is a thin factory selecting between the two by ``regime`` keyword,
 preserving the historical ``OSTL(model, regime=...)`` call site.
+
+Reference
+---------
+Bohnstingl, T., Woźniak, S., Pantazi, A., & Eleftheriou, E. (2023). "Online
+Spatio-Temporal Learning in Deep Neural Networks." *IEEE Transactions on Neural
+Networks and Learning Systems*, 34(11), 8894-8908.
+https://doi.org/10.1109/TNNLS.2022.3153985 (arXiv:2007.12723)
 """
 
 from typing import Optional
@@ -41,19 +48,63 @@ __all__ = ['OSTL', 'OSTLRecurrent', 'OSTLFeedforward']
 
 
 class OSTLRecurrent(ParamDimVjpAlgorithm):
-    """OSTL 'with-H' regime — RTRL-exact single-layer factorization.
+    r"""OSTL 'with-H' regime — RTRL-exact single-layer factorization.
 
-    Retains the hidden-to-hidden Jacobian, so the eligibility trace carries the
-    full temporal term ``ε^t = D^t·ε^{t-1} + diag(D_f^t)⊗x^t``. Exact for a
-    single recurrent layer; per-parameter trace with O(P·H) memory. Delegates
-    entirely to :class:`ParamDimVjpAlgorithm` (D-RTRL).
+    OSTL derives an online rule by cleanly separating the gradient into a
+    *temporal* eligibility trace and a *spatial* learning signal. The 'with-H'
+    regime retains the hidden-to-hidden Jacobian, so the trace carries the full
+    temporal term and the rule is gradient-equivalent to BPTT for a single
+    recurrent layer:
+
+    .. math::
+
+        \boldsymbol{\epsilon}^t = \mathbf{D}^t\,\boldsymbol{\epsilon}^{t-1}
+        + \operatorname{diag}(\mathbf{D}_f^t)\otimes \mathbf{x}^t ,
+        \qquad
+        \nabla_{\boldsymbol{\theta}}\mathcal{L}
+        = \sum_t \frac{\partial \mathcal{L}^t}{\partial \mathbf{h}^t}
+          \circ \boldsymbol{\epsilon}^t ,
+
+    where :math:`\mathbf{D}^t` is the hidden-to-hidden Jacobian, :math:`\mathbf{D}_f^t`
+    the state-to-output Jacobian, and :math:`\mathbf{x}^t` the presynaptic input.
+    This is exactly the per-parameter D-RTRL trace (memory :math:`O(P\cdot H)`),
+    so the class delegates entirely to :class:`~braintrace.ParamDimVjpAlgorithm`.
 
     Parameters
     ----------
     model : brainstate.nn.Module
         The recurrent SNN whose weights are trained online.
     name, vjp_method, fast_solve, normalize_matrix_spectrum : optional
-        Forwarded verbatim to :class:`ParamDimVjpAlgorithm`.
+        Forwarded verbatim to :class:`~braintrace.ParamDimVjpAlgorithm`.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        >>> import brainstate
+        >>> import braintrace
+        >>>
+        >>> class Net(brainstate.nn.Module):
+        ...     def __init__(self):
+        ...         super().__init__()
+        ...         self.cell = braintrace.nn.ValinaRNNCell(1, 20, activation='tanh')
+        ...         self.out = braintrace.nn.Linear(20, 1)
+        ...     def update(self, x):
+        ...         return x >> self.cell >> self.out
+        >>>
+        >>> model = Net()
+        >>> brainstate.nn.init_all_states(model)
+        >>> learner = braintrace.OSTLRecurrent(model)   # or braintrace.OSTL(model, regime='with-H')
+        >>> x0 = brainstate.random.randn(1)
+        >>> learner.compile_graph(x0)
+        >>> y = learner(x0)
+
+    References
+    ----------
+    .. [1] Bohnstingl, T., Woźniak, S., Pantazi, A., & Eleftheriou, E. (2023).
+       "Online Spatio-Temporal Learning in Deep Neural Networks." *IEEE
+       Transactions on Neural Networks and Learning Systems*, 34(11), 8894-8908.
+       https://doi.org/10.1109/TNNLS.2022.3153985 (arXiv:2007.12723)
     """
 
     __module__ = 'braintrace'
@@ -63,12 +114,25 @@ class OSTLRecurrent(ParamDimVjpAlgorithm):
 
 
 class OSTLFeedforward(pp_prop):
-    """OSTL 'without-H' regime — feedforward / no recurrent Jacobian.
+    r"""OSTL 'without-H' regime — feedforward / no recurrent Jacobian.
 
-    Drops the hidden-to-hidden Jacobian. With a negligible decay the input-
-    output factorized trace stops accumulating across time, so the update is the
-    purely-spatial (feedforward SNN) approximation. Delegates to
-    :class:`pp_prop`.
+    The 'without-H' regime drops the hidden-to-hidden Jacobian
+    :math:`\mathbf{D}^t`, so the temporal term of the eligibility trace
+    vanishes and only the instantaneous (spatial) contribution survives:
+
+    .. math::
+
+        \boldsymbol{\epsilon}^t \approx \operatorname{diag}(\mathbf{D}_f^t)
+        \otimes \mathbf{x}^t ,
+        \qquad
+        \nabla_{\boldsymbol{\theta}}\mathcal{L}
+        = \sum_t \frac{\partial \mathcal{L}^t}{\partial \mathbf{h}^t}
+          \circ \boldsymbol{\epsilon}^t .
+
+    This is the appropriate (and exact) approximation for feed-forward SNNs. It
+    is realized by delegating to :class:`~braintrace.pp_prop` (the input-output
+    factorized trace) with a *negligible* decay, so the trace does not
+    accumulate across time.
 
     Parameters
     ----------
@@ -79,7 +143,36 @@ class OSTLFeedforward(pp_prop):
         the temporal contribution negligible, matching the 'without-H' regime. A
         float must lie in (0, 1); an int is read as an approximation rank.
     name, vjp_method, fast_solve : optional
-        Forwarded verbatim to :class:`pp_prop`.
+        Forwarded verbatim to :class:`~braintrace.pp_prop`.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        >>> import brainstate
+        >>> import braintrace
+        >>>
+        >>> class Net(brainstate.nn.Module):
+        ...     def __init__(self):
+        ...         super().__init__()
+        ...         self.cell = braintrace.nn.ValinaRNNCell(1, 20, activation='tanh')
+        ...         self.out = braintrace.nn.Linear(20, 1)
+        ...     def update(self, x):
+        ...         return x >> self.cell >> self.out
+        >>>
+        >>> model = Net()
+        >>> brainstate.nn.init_all_states(model)
+        >>> learner = braintrace.OSTLFeedforward(model)  # or braintrace.OSTL(model, regime='without-H')
+        >>> x0 = brainstate.random.randn(1)
+        >>> learner.compile_graph(x0)
+        >>> y = learner(x0)
+
+    References
+    ----------
+    .. [1] Bohnstingl, T., Woźniak, S., Pantazi, A., & Eleftheriou, E. (2023).
+       "Online Spatio-Temporal Learning in Deep Neural Networks." *IEEE
+       Transactions on Neural Networks and Learning Systems*, 34(11), 8894-8908.
+       https://doi.org/10.1109/TNNLS.2022.3153985 (arXiv:2007.12723)
     """
 
     __module__ = 'braintrace'

--- a/braintrace/_etrace_algorithms/osttp.py
+++ b/braintrace/_etrace_algorithms/osttp.py
@@ -13,11 +13,16 @@
 # limitations under the License.
 # ==============================================================================
 
-"""OSTTP — Online Spatio-Temporal Target Projection (Ortner et al. 2023).
+"""OSTTP — Online Spatio-Temporal Learning with Target Projection
+(Ortner et al., 2023).
 
-D_RTRL trace machinery + DRTP-style target projection replacing reverse-AD's
-``∂L/∂h``. Each HiddenGroup receives a signal ``B_l @ y_target`` instead of the
-autodiff gradient.
+OSTTP combines the OSTL / D-RTRL eligibility trace with a DRTP-style *target
+projection*: instead of back-propagating :math:`\\partial \\mathcal{L}/\\partial
+h` from the readout, each HiddenGroup receives a learning signal formed by a
+fixed random projection of the task target, :math:`y^{*}\\,B_l`. This removes the
+weight-transport requirement and the backward pass, so learning is forward-only.
+
+See :class:`OSTTP` for the mathematical formulation, references, and an example.
 """
 
 from typing import Optional, Sequence
@@ -32,19 +37,96 @@ __all__ = ['OSTTP']
 
 
 class OSTTP(ParamDimVjpAlgorithm):
-    """Online Spatio-Temporal Target Projection.
+    r"""Online Spatio-Temporal Learning with Target Projection.
+
+    OSTTP reuses the OSTL / D-RTRL per-parameter eligibility trace but replaces
+    the back-propagated learning signal with a **direct random target
+    projection** (DRTP):
+
+    .. math::
+
+        \boldsymbol{\epsilon}^t \approx \mathbf{D}^t\,\boldsymbol{\epsilon}^{t-1}
+        + \operatorname{diag}(\mathbf{D}_f^t)\otimes \mathbf{x}^t ,
+        \qquad
+        L_l^t = y^{*\,t}\, B_l ,
+        \qquad
+        \nabla_{W}\mathcal{L} = \sum_t L^t \circ \boldsymbol{\epsilon}^t ,
+
+    where :math:`y^{*\,t}` is the task target at time :math:`t`, :math:`B_l \in
+    \mathbb{R}^{n_\text{target}\times n_l}` is a fixed random feedback matrix for
+    HiddenGroup :math:`l` (frozen via ``stop_gradient``), :math:`\mathbf{D}^t` is
+    the hidden-to-hidden Jacobian, :math:`\mathbf{D}_f^t` the state-to-output
+    Jacobian, and :math:`\mathbf{x}^t` the presynaptic input.
+
+    **How it works.** The eligibility trace carries the temporal credit exactly
+    as in :class:`~braintrace.OSTL` ('with-H'), but the spatial credit normally
+    obtained by back-propagating :math:`\partial \mathcal{L}/\partial h` is
+    replaced by a frozen random projection of the target. Because the projection
+    matrices :math:`B_l` are fixed, there is no weight transport and no backward
+    pass — the rule is fully forward and update-unlocked in both space and time.
 
     Parameters
     ----------
     model : brainstate.nn.Module
+        The SNN whose weights are trained online.
     B_list : Sequence[jax.Array]
-        One feedback matrix per HiddenGroup, each of shape ``(n_target, n_l)``.
-        Frozen via ``stop_gradient`` at construction.
-    target_timing : {'per-step', 'sequence-end'}
-        'per-step' requires ``y_target`` at every ``update()`` call.
-        'sequence-end' zeros the signal on intermediate steps and only applies
-        the projection when ``y_target`` is supplied.
-    name, vjp_method, fast_solve : forwarded to ``ParamDimVjpAlgorithm``.
+        One feedback matrix per HiddenGroup, each of shape
+        ``(n_target, n_l)``. Frozen via ``stop_gradient`` at construction; the
+        count and trailing dimension are validated against the compiled graph.
+    target_timing : {'per-step', 'sequence-end'}, default 'per-step'
+        ``'per-step'`` requires ``y_target`` at every :meth:`update` call.
+        ``'sequence-end'`` zeros the learning signal on intermediate steps (the
+        trace still accumulates) and applies the projection only when
+        ``y_target`` is supplied.
+    name : str, optional
+        Name of the algorithm instance.
+    vjp_method, fast_solve
+        Forwarded verbatim to :class:`~braintrace.ParamDimVjpAlgorithm`.
+
+    Raises
+    ------
+    ValueError
+        If ``target_timing`` is invalid; if ``len(B_list)`` differs from the
+        number of HiddenGroups; if a matrix's trailing dimension does not match
+        its HiddenGroup width; or if ``target_timing='per-step'`` and
+        ``y_target`` is omitted from an :meth:`update` call.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        >>> import brainstate
+        >>> import jax
+        >>> import braintrace
+        >>>
+        >>> class Net(brainstate.nn.Module):
+        ...     def __init__(self):
+        ...         super().__init__()
+        ...         self.cell = braintrace.nn.ValinaRNNCell(1, 20, activation='tanh')
+        ...         self.out = braintrace.nn.Linear(20, 1)
+        ...     def update(self, x):
+        ...         return x >> self.cell >> self.out
+        >>>
+        >>> model = Net()
+        >>> brainstate.nn.init_all_states(model)
+        >>> # one (n_target, n_l) feedback matrix per HiddenGroup (here n_l = 20)
+        >>> B = jax.random.normal(jax.random.PRNGKey(0), (1, 20))
+        >>> learner = braintrace.OSTTP(model, B_list=[B])
+        >>> x0 = brainstate.random.randn(1)
+        >>> learner.compile_graph(x0)
+        >>> y = learner(x0, y_target=brainstate.random.randn(1))
+
+    References
+    ----------
+    .. [1] Ortner, T., Pes, L., Gentinetta, J., Frenkel, C., & Pantazi, A.
+       (2023). "Online Spatio-Temporal Learning with Target Projection."
+       *2023 IEEE 5th International Conference on Artificial Intelligence
+       Circuits and Systems (AICAS)*, 1-5.
+       https://doi.org/10.1109/AICAS57966.2023.10168623 (arXiv:2304.05124)
+    .. [2] Frenkel, C., Lefebvre, M., & Bol, D. (2021). "Learning Without
+       Feedback: Fixed Random Learning Signals Allow for Feedforward Training of
+       Deep Neural Networks" (DRTP). *Frontiers in Neuroscience*, 15, 629892.
+       https://doi.org/10.3389/fnins.2021.629892
     """
 
     __module__ = 'braintrace'

--- a/braintrace/_etrace_algorithms/otpe.py
+++ b/braintrace/_etrace_algorithms/otpe.py
@@ -13,12 +13,17 @@
 # limitations under the License.
 # ==============================================================================
 
-"""OTPE — Online Training with Postsynaptic Estimates (Summe et al. 2024).
+"""OTPE — Online Training with Postsynaptic Estimates (Summe et al., 2023).
 
-Replaces RTRL's full Jacobian with a leaky-additive per-parameter accumulator
-``R_hat ← λ·R_hat + ∂s/∂θ_local``. Cross-layer coupling is handled inside
-``_solve_weight_gradients`` without relaxing the compiler's "no W→W→h"
+OTPE replaces RTRL's full Jacobian with a leaky-additive per-parameter
+accumulator :math:`\\hat R \\leftarrow \\lambda\\,\\hat R + \\partial s/\\partial
+\\theta_\\text{local}` that estimates how a parameter's influence persists in the
+postsynaptic membrane across several time steps — temporal structure that the
+single-step approximations OTTT and OSTL drop. Cross-layer coupling is handled
+inside ``_solve_weight_gradients`` without relaxing the compiler's "no W→W→h"
 invariant.
+
+See :class:`OTPE` for the mathematical formulation, references, and an example.
 """
 
 import warnings
@@ -37,20 +42,108 @@ __all__ = ['OTPE']
 
 
 class OTPE(ETraceVjpAlgorithm):
-    """Online Training with Postsynaptic Estimates.
+    r"""Online Training with Postsynaptic Estimates for spiking networks.
+
+    OTPE maintains a leaky, additive estimate :math:`\hat R^t` of each
+    parameter's accumulated influence on the postsynaptic state, then contracts
+    it with the learning signal :math:`L^t` to obtain the weight gradient:
+
+    .. math::
+
+        \hat R^t = \lambda\,\hat R^{t-1}
+                   + \frac{\partial s^t}{\partial \theta}
+                 = \lambda\,\hat R^{t-1}
+                   + x^t \otimes \operatorname{diag}(D_f^t) ,
+        \qquad
+        \nabla_{W}\mathcal{L}^t = L^t \cdot \hat R^t ,
+
+    where :math:`x^t` is the presynaptic input, :math:`D_f^t` the
+    state-to-output Jacobian (surrogate gradient of the spike), :math:`\lambda
+    \in (0, 1)` the membrane leak, and :math:`L^t = \partial \mathcal{L}^t /
+    \partial s^t` the learning signal. The contraction runs over the output
+    dimension, leaving a gradient with the weight's shape.
+
+    In the low-rank ``'approx'`` mode (**F-OTPE**) the estimate is factorized as
+    an outer product, reducing memory from :math:`O(I\cdot O)` to :math:`O(I+O)`
+    per layer:
+
+    .. math::
+
+        \hat R^t \approx \hat z_\text{in}^t \otimes \bar g_\text{out}^t ,
+        \quad
+        \hat z_\text{in}^t = \lambda\,\hat z_\text{in}^{t-1} + x^t ,
+        \quad
+        \bar g_\text{out}^t = \lambda\,\bar g_\text{out}^{t-1}
+                              + \operatorname{diag}(D_f^t) ,
+
+    with gradient :math:`\nabla_{W}\mathcal{L}^t
+    = \hat z_\text{in}^t \otimes (L^t \cdot \bar g_\text{out}^t)`.
+
+    **How it works.** Unlike OTTT/OSTL, which assign temporal credit only within
+    the current layer's output, OTPE keeps a per-parameter trace that decays
+    with the membrane leak, approximating the *entire* temporal effect of a
+    weight on downstream activity while staying local to each layer. This
+    improves gradient alignment with BPTT in deep feed-forward SNNs at modest
+    extra cost.
 
     Parameters
     ----------
     model : brainstate.nn.Module
-    mode : {'full', 'approx'}
-        'full' keeps the ``(batch, I, O)`` ``R_hat`` per layer.
-        'approx' factors ``R_hat`` as ``outer(ḡ_out, ẑ_in)`` for O(I+O) memory
-        (F-OTPE variant); issues a UserWarning for depth > 1.
+        The SNN whose weights are trained online.
+    mode : {'full', 'approx'}, default 'full'
+        ``'full'`` keeps the full ``(batch, I, O)`` estimate :math:`\hat R` per
+        layer. ``'approx'`` (F-OTPE) factorizes it as an outer product for
+        :math:`O(I+O)` memory; emits a :class:`UserWarning` when the network has
+        more than one HiddenGroup, because the factorization bias compounds with
+        depth.
     leak : float, optional
-        λ factor. If None, resolved via ``_resolve_leak``.
-    trace_clip_abs : float or None
-        Elementwise clip on ``R_hat`` each step. None disables.
-    name, vjp_method : forwarded to base.
+        Decay factor :math:`\lambda`. If ``None``, it is resolved from the
+        model's neuron states (the first state exposing a ``leak`` attribute).
+    trace_clip_abs : float, optional
+        Elementwise clip applied to :math:`\hat R` each step (full mode only).
+        ``None`` disables clipping.
+    name : str, optional
+        Name of the algorithm instance.
+    vjp_method : str, optional
+        Forwarded to the base algorithm. Only ``'single-step'`` is supported by
+        OTPE v1; multi-step inputs raise :class:`NotImplementedError`.
+
+    Raises
+    ------
+    ValueError
+        If ``mode`` is not ``'full'`` or ``'approx'``, if ``leak`` cannot be
+        resolved, or if a weight-to-hidden relation reaches more than one
+        HiddenGroup (OTPE v1 requires one-hop per-layer relations).
+
+    Examples
+    --------
+    .. code-block:: python
+
+        >>> import brainstate
+        >>> import braintrace
+        >>>
+        >>> class Net(brainstate.nn.Module):
+        ...     def __init__(self):
+        ...         super().__init__()
+        ...         self.cell = braintrace.nn.ValinaRNNCell(1, 20, activation='tanh')
+        ...         self.out = braintrace.nn.Linear(20, 1)
+        ...     def update(self, x):
+        ...         return x >> self.cell >> self.out
+        >>>
+        >>> model = Net()
+        >>> brainstate.nn.init_all_states(model)
+        >>> # In a real SNN the hidden layer is a spiking neuron exposing a
+        >>> # ``leak`` attribute, in which case ``leak`` can be omitted.
+        >>> learner = braintrace.OTPE(model, mode='full', leak=0.9)
+        >>> x0 = brainstate.random.randn(1)
+        >>> learner.compile_graph(x0)
+        >>> y = learner(x0)
+
+    References
+    ----------
+    .. [1] Summe, T. M., Schaefer, C. J. S., & Joshi, S. (2023). "Estimating
+       Post-Synaptic Effects for Online Training of Feed-Forward SNNs."
+       *arXiv preprint* arXiv:2311.16151. https://arxiv.org/abs/2311.16151
     """
 
     __module__ = 'braintrace'

--- a/braintrace/_etrace_algorithms/ottt.py
+++ b/braintrace/_etrace_algorithms/ottt.py
@@ -13,11 +13,16 @@
 # limitations under the License.
 # ==============================================================================
 
-"""OTTT — Online Training Through Time (Xiao et al. 2022).
+"""OTTT — Online Training Through Time (Xiao et al., 2022).
 
-Drops both the hidden-to-hidden and hidden-to-weight Jacobians; maintains only a
-presynaptic eligibility trace ``â ← λ·â + x_t`` and computes weight gradients as
-``ΔW = outer(â, L · σ'(u))`` per step.
+OTTT is derived from BPTT but discards the hidden-to-hidden recurrent Jacobian,
+so it keeps only a leaky presynaptic eligibility trace
+:math:`\\hat a^t \\leftarrow \\lambda\\,\\hat a^{t-1} + x^t` and forms the weight
+gradient at each step as the outer product of that trace with the (instantaneous)
+learning signal, :math:`\\Delta W = \\hat a^t \\otimes (L \\cdot \\sigma'(u))`.
+This yields constant training memory, independent of the number of time steps.
+
+See :class:`OTTT` for the mathematical formulation, references, and an example.
 """
 
 from typing import Dict, Optional
@@ -34,18 +39,93 @@ __all__ = ['OTTT']
 
 
 class OTTT(ETraceVjpAlgorithm):
-    """Online Training Through Time.
+    r"""Online Training Through Time for spiking neural networks.
+
+    OTTT tracks only a leaky **presynaptic trace** and forms the weight gradient
+    each step as an outer product with the local learning signal:
+
+    .. math::
+
+        \hat{a}^t =
+        \begin{cases}
+          \lambda\,\hat{a}^{t-1} + x^t & \text{(mode='A', accumulated)} \\
+          x^t                           & \text{(mode='O', instantaneous)}
+        \end{cases}
+
+    .. math::
+
+        \nabla_{W}\mathcal{L}^t
+        = \hat{a}^t \otimes
+          \Big( \frac{\partial \mathcal{L}^t}{\partial s^t}\,\sigma'(u^t) \Big)
+        \;=\; \hat{a}^t \otimes L^t ,
+
+    where :math:`x^t` is the presynaptic input, :math:`u^t` the membrane
+    potential, :math:`s^t = \sigma(u^t)` the (surrogate) spike, :math:`\sigma'`
+    the surrogate-gradient function, :math:`\lambda \in (0, 1)` the membrane
+    leak, and :math:`L^t` the learning signal already propagated through the
+    spike nonlinearity.
+
+    **How it works.** Starting from BPTT, OTTT keeps the spatial credit
+    assignment but **drops the hidden-to-hidden recurrent Jacobian**. The only
+    state it carries forward in time is the rank-1 presynaptic trace
+    :math:`\hat{a}^t`, so the per-step gradient is the outer product of that
+    trace with the instantaneous learning signal. Training memory is therefore
+    :math:`O(B \cdot I)` per layer and **independent of the sequence length** —
+    the cheapest of the algorithms here, at the cost of ignoring longer-range
+    temporal credit.
 
     Parameters
     ----------
     model : brainstate.nn.Module
-    mode : {'A', 'O'}
-        'A' (default) accumulates â over time (â ← λ·â + x). 'O' uses the
-        instantaneous presynaptic spike only (â := x_t).
+        The SNN whose weights are trained online.
+    mode : {'A', 'O'}, default 'A'
+        ``'A'`` accumulates the presynaptic trace over time
+        (:math:`\hat a \leftarrow \lambda\,\hat a + x`). ``'O'`` uses the
+        instantaneous presynaptic spike only (:math:`\hat a := x^t`).
     leak : float, optional
-        Presynaptic leak λ. If None, discovered from the model via
-        ``_resolve_leak``.
-    name, vjp_method : forwarded to base.
+        Presynaptic leak :math:`\lambda`. If ``None``, it is discovered from the
+        model's neuron states (the first state exposing a ``leak`` attribute).
+    name : str, optional
+        Name of the algorithm instance.
+    vjp_method : str, optional
+        Forwarded to the base algorithm. Only ``'single-step'`` is supported by
+        OTTT v1; multi-step inputs raise :class:`NotImplementedError`.
+
+    Raises
+    ------
+    ValueError
+        If ``mode`` is not ``'A'`` or ``'O'``, or if ``leak`` cannot be resolved.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        >>> import brainstate
+        >>> import braintrace
+        >>>
+        >>> class Net(brainstate.nn.Module):
+        ...     def __init__(self):
+        ...         super().__init__()
+        ...         self.cell = braintrace.nn.ValinaRNNCell(1, 20, activation='tanh')
+        ...         self.out = braintrace.nn.Linear(20, 1)
+        ...     def update(self, x):
+        ...         return x >> self.cell >> self.out
+        >>>
+        >>> model = Net()
+        >>> brainstate.nn.init_all_states(model)
+        >>> # In a real SNN the hidden layer is a spiking neuron that exposes a
+        >>> # ``leak`` attribute, in which case ``leak`` can be omitted.
+        >>> learner = braintrace.OTTT(model, mode='A', leak=0.9)
+        >>> x0 = brainstate.random.randn(1)
+        >>> learner.compile_graph(x0)
+        >>> y = learner(x0)
+
+    References
+    ----------
+    .. [1] Xiao, M., Meng, Q., Zhang, Z., He, D., & Lin, Z. (2022). "Online
+       Training Through Time for Spiking Neural Networks." *Advances in Neural
+       Information Processing Systems (NeurIPS)* 35.
+       https://arxiv.org/abs/2210.04195
     """
 
     __module__ = 'braintrace'

--- a/braintrace/_etrace_algorithms/pp_prop.py
+++ b/braintrace/_etrace_algorithms/pp_prop.py
@@ -509,6 +509,21 @@ class pp_prop(ETraceVjpAlgorithm):
     \end{aligned}
     $$
 
+    where :math:`\boldsymbol{\epsilon}_{\mathbf{x}}^t` is the input-side trace,
+    :math:`\boldsymbol{\epsilon}_{\mathbf{f}}^t` the output-side trace,
+    :math:`\alpha` the exponential-smoothing factor, :math:`\mathbf{D}^t` the
+    hidden-to-hidden Jacobian, :math:`\mathbf{D}_f^t` the state-to-output
+    Jacobian, and :math:`\mathbf{x}^t` the presynaptic input.
+
+    **How it works.** The full per-parameter D-RTRL trace
+    :math:`\boldsymbol{\epsilon}^t \in \mathbb{R}^{I\times O}` is approximated by
+    the outer product of two exponentially-smoothed *vectors* — one over the
+    input dimension and one over the output dimension. Storing the two factors
+    instead of the full matrix drops the memory from :math:`O(I\cdot O)` to
+    :math:`O(I+O)` per layer. The decay :math:`\alpha` (equivalently an
+    approximation rank) controls how much temporal history the factored trace
+    retains; the bias of the exponential estimator is corrected at solve time.
+
     For more details, please see `the ES-D-RTRL algorithm presented in our manuscript <https://www.biorxiv.org/content/10.1101/2024.09.24.614728v2>`_.
 
     This algorithm has the :math:`O(BI+BO)` memory complexity and :math:`O(BIO)` computational
@@ -538,6 +553,39 @@ class pp_prop(ETraceVjpAlgorithm):
         The name of the etrace algorithm.
     mode: braintrace.mixin.Mode
         The computing mode, indicating the batching information.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        >>> import brainstate
+        >>> import braintrace
+        >>>
+        >>> class RNN(brainstate.nn.Module):
+        ...     def __init__(self):
+        ...         super().__init__()
+        ...         self.cell = braintrace.nn.ValinaRNNCell(1, 20, activation='tanh')
+        ...         self.out = braintrace.nn.Linear(20, 1)
+        ...     def update(self, x):
+        ...         return x >> self.cell >> self.out
+        >>>
+        >>> model = RNN()
+        >>> brainstate.nn.init_all_states(model)
+        >>> learner = braintrace.pp_prop(model, decay_or_rank=0.9)  # or rank: decay_or_rank=19
+        >>> x0 = brainstate.random.randn(1)
+        >>> learner.compile_graph(x0)   # trace the graph once
+        >>> y = learner(x0)             # forward pass + eligibility-trace update
+
+    References
+    ----------
+    .. [1] Wang, C., Dong, X., Ji, Z., Xiao, M., Jiang, J., Liu, X., Huan, Y., &
+       Wu, S. (2026). "Model-agnostic linear-memory online learning in spiking
+       neural networks." *Nature Communications*.
+       https://doi.org/10.1038/s41467-026-68453-w
+       (preprint: bioRxiv 2024.09.24.614728)
+    .. [2] Williams, R. J., & Zipser, D. (1989). "A Learning Algorithm for
+       Continually Running Fully Recurrent Neural Networks" (RTRL). *Neural
+       Computation*, 1(2), 270-280. https://doi.org/10.1162/neco.1989.1.2.270
     """
 
     __module__ = 'braintrace'


### PR DESCRIPTION
Expand the docstrings of every online-learning algorithm (D_RTRL/
ParamDimVjpAlgorithm, pp_prop, EProp, OSTL/OSTLRecurrent/OSTLFeedforward,
OTPE, OTTT, OSTTP) to include a concise mathematical formulation, a
plain-language explanation, the original paper reference (DOI/arXiv),
a minimal usage example, and documented parameters/edge cases.

Documentation-only; no behavior, API, or default changes.
