### PR TITLE
test: add BPTT gradient oracle and prove multi-step D_RTRL matches BPTT

### DIFF
--- a/braintrace/_etrace_algorithms/oracle.py
+++ b/braintrace/_etrace_algorithms/oracle.py
@@ -1,0 +1,157 @@
+# Copyright 2026 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Ground-truth gradient oracle for online-learning algorithms (test support).
+
+The sequence loss is fixed to sum-of-squares over every step and element::
+
+    L = sum_t (model(x_t) ** 2).sum()
+
+BPTT differentiates this through an unrolled ``for_loop``; this is the exact
+total gradient any *exact* online algorithm must reproduce.
+"""
+
+from typing import Callable
+
+import brainstate
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+import braintrace
+
+
+def _sse(y):
+    return (y ** 2).sum()
+
+
+def bptt_param_gradients(model_factory: Callable[[], brainstate.nn.Module], inputs):
+    """Exact BPTT gradient of the sequence sum-of-squares loss w.r.t. all ParamStates."""
+    model = model_factory()
+    brainstate.nn.init_all_states(model, batch_size=1)
+
+    def total_loss():
+        losses = brainstate.transform.for_loop(lambda x: _sse(model(x)), inputs)
+        return losses.sum()
+
+    return brainstate.transform.grad(total_loss, model.states(brainstate.ParamState))()
+
+
+def finite_difference_param_gradients(
+    model_factory: Callable[[], brainstate.nn.Module], inputs, *, eps: float = 1e-3
+):
+    """Central finite-difference gradient of the sequence SSE loss for every ParamState.
+
+    Independent arbiter for the BPTT implementation. O(num_params) loss evals;
+    intended for small toy models only.
+    """
+    template = model_factory()
+    brainstate.nn.init_all_states(template, batch_size=1)
+    base_values = {
+        k: np.asarray(v.value) for k, v in template.states(brainstate.ParamState).items()
+    }
+
+    def loss_with(values):
+        model = model_factory()
+        brainstate.nn.init_all_states(model, batch_size=1)
+        params = model.states(brainstate.ParamState)
+        for k, arr in values.items():
+            params[k].value = jnp.asarray(arr)
+        losses = brainstate.transform.for_loop(lambda x: _sse(model(x)), inputs)
+        return float(losses.sum())
+
+    grads = {}
+    for key, base in base_values.items():
+        g = np.zeros_like(base)
+        flat = base.reshape(-1)
+        gflat = g.reshape(-1)
+        for idx in range(flat.size):
+            plus = {k: v.copy() for k, v in base_values.items()}
+            minus = {k: v.copy() for k, v in base_values.items()}
+            plus[key].reshape(-1)[idx] = flat[idx] + eps
+            minus[key].reshape(-1)[idx] = flat[idx] - eps
+            gflat[idx] = (loss_with(plus) - loss_with(minus)) / (2 * eps)
+        grads[key] = jnp.asarray(g)
+    return grads
+
+
+def online_param_gradients(
+    model_factory: Callable[[], brainstate.nn.Module],
+    inputs,
+    *,
+    algo_factory: Callable[[brainstate.nn.Module], object],
+):
+    """Total sequence gradient from an online algorithm via the multi-step VJP path.
+
+    ``algo_factory(model)`` must return an algorithm whose ``__call__`` accepts a
+    ``braintrace.MultiStepData`` and returns the stacked per-step outputs. The loss
+    ``(out ** 2).sum()`` over the whole stacked output equals the BPTT sequence loss.
+    """
+    model = model_factory()
+    brainstate.nn.init_all_states(model, batch_size=1)
+    algo = algo_factory(model)
+    algo.compile_graph(inputs[0])
+    algo.init_etrace_state()
+
+    return brainstate.transform.grad(
+        lambda seq: (algo(braintrace.MultiStepData(seq)) ** 2).sum(),
+        model.states(brainstate.ParamState),
+    )(inputs)
+
+
+def online_param_gradients_singlestep_naive(
+    model_factory: Callable[[], brainstate.nn.Module],
+    inputs,
+    *,
+    algo_factory: Callable[[brainstate.nn.Module], object],
+):
+    """Naive 'single-step' total gradient: sum of per-step grad((algo(x_t)**2).sum()).
+
+    Kept to document finding F-SINGLESTEP — this recipe does NOT equal BPTT even
+    for the exact D_RTRL algorithm, while the multi-step path does. See
+    dev/superpowers/specs/2026-05-26-comprehensive-test-strategy-design.md.
+    """
+    model = model_factory()
+    brainstate.nn.init_all_states(model, batch_size=1)
+    algo = algo_factory(model)
+    algo.compile_graph(inputs[0])
+    algo.init_etrace_state()
+    params = model.states(brainstate.ParamState)
+
+    total = None
+    for t in range(inputs.shape[0]):
+        g = brainstate.transform.grad(lambda x: (algo(x) ** 2).sum(), params)(inputs[t])
+        total = g if total is None else jax.tree.map(lambda a, b: a + b, total, g)
+    return total
+
+
+def assert_param_gradients_close(actual, expected, *, atol=1e-4, rtol=0.0, keys=None):
+    """Assert two param-gradient dicts match, with a per-key diagnostic on failure.
+
+    ``keys`` restricts the comparison to a subset (e.g. only ETP params). When
+    None, every key present in ``expected`` is compared.
+    """
+    compare_keys = list(expected.keys()) if keys is None else list(keys)
+    failures = []
+    for key in compare_keys:
+        a = jnp.asarray(actual[key])
+        e = jnp.asarray(expected[key])
+        if not bool(jnp.allclose(a, e, atol=atol, rtol=rtol)):
+            failures.append(f"  {key}: maxabsdiff={float(jnp.max(jnp.abs(a - e))):.3e}")
+    if failures:
+        raise AssertionError(
+            "param gradients differ beyond tolerance "
+            f"(atol={atol}, rtol={rtol}):\n" + "\n".join(failures)
+        )

--- a/braintrace/_etrace_algorithms/oracle_models.py
+++ b/braintrace/_etrace_algorithms/oracle_models.py
@@ -1,0 +1,66 @@
+# Copyright 2026 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Deterministic toy models for the gradient oracle (test support)."""
+
+from dataclasses import dataclass
+from typing import Callable, Tuple
+
+import brainstate
+import jax
+import jax.numpy as jnp
+
+import braintrace
+
+
+@dataclass(frozen=True)
+class ModelSpec:
+    """A zero-arg model factory plus metadata about its parameters.
+
+    ``factory()`` returns a freshly constructed, *uninitialized* model with
+    deterministic weights. Callers must call
+    ``brainstate.nn.init_all_states(model, batch_size=...)`` themselves.
+    """
+
+    factory: Callable[[], brainstate.nn.Module]
+    etp_param_keys: Tuple[tuple, ...]    # routed through an ETP primitive
+    plain_param_keys: Tuple[tuple, ...]  # used via plain JAX ops (excluded from ETP)
+
+
+def tanh_rnn(n_in: int = 3, n_rec: int = 4, seed: int = 0) -> ModelSpec:
+    """Batched (batch=1) tanh RNN: recurrent ETP weight ``w``, plain input weight ``win``."""
+
+    def factory():
+        class Net(brainstate.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.w = brainstate.ParamState(
+                    0.1 * jax.random.normal(jax.random.PRNGKey(seed), (n_rec, n_rec))
+                )
+                self.win = brainstate.ParamState(
+                    0.1 * jax.random.normal(jax.random.PRNGKey(seed + 1), (n_in, n_rec))
+                )
+                self.h = brainstate.HiddenState(jnp.zeros((1, n_rec)))
+
+            def update(self, x):
+                inp = x @ self.win.value  # plain op -> excluded from ETP
+                self.h.value = jax.nn.tanh(
+                    inp + braintrace.matmul(self.h.value, self.w.value)
+                )
+                return self.h.value
+
+        return Net()
+
+    return ModelSpec(factory=factory, etp_param_keys=(('w',),), plain_param_keys=(('win',),))

--- a/braintrace/_etrace_algorithms/oracle_test.py
+++ b/braintrace/_etrace_algorithms/oracle_test.py
@@ -1,0 +1,159 @@
+# Copyright 2026 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Tests for the gradient oracle: self-validation (BPTT vs finite-difference),
+the headline exact-correctness proof (multi-step D_RTRL == BPTT), and the
+F-SINGLESTEP finding encoded as a strict xfail."""
+
+import brainstate
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+import braintrace
+from braintrace._etrace_algorithms.oracle import (
+    assert_param_gradients_close,
+    bptt_param_gradients,
+    finite_difference_param_gradients,
+    online_param_gradients,
+    online_param_gradients_singlestep_naive,
+)
+from braintrace._etrace_algorithms.oracle_models import ModelSpec, tanh_rnn
+
+
+def _inputs(T, n_in, seed=42):
+    return jnp.asarray(np.random.RandomState(seed).randn(T, n_in).astype('float32'))
+
+
+# --- Task 1: model factory ---------------------------------------------------
+
+def test_tanh_rnn_factory_builds_runnable_model():
+    spec = tanh_rnn(n_in=3, n_rec=4, seed=0)
+    assert isinstance(spec, ModelSpec)
+    assert spec.etp_param_keys == (('w',),)
+    assert spec.plain_param_keys == (('win',),)
+
+    model = spec.factory()
+    brainstate.nn.init_all_states(model, batch_size=1)
+    keys = set(model.states(brainstate.ParamState).keys())
+    assert keys == {('w',), ('win',)}
+
+    y = model(jnp.ones((3,), dtype='float32'))
+    assert y.shape == (1, 4)
+    assert bool(jnp.all(jnp.isfinite(y)))
+
+
+def test_tanh_rnn_factory_is_deterministic():
+    m1 = tanh_rnn(seed=0).factory(); brainstate.nn.init_all_states(m1, batch_size=1)
+    m2 = tanh_rnn(seed=0).factory(); brainstate.nn.init_all_states(m2, batch_size=1)
+    w1 = m1.states(brainstate.ParamState)[('w',)].value
+    w2 = m2.states(brainstate.ParamState)[('w',)].value
+    assert bool(jnp.allclose(w1, w2))
+
+
+# --- Task 2: BPTT reference --------------------------------------------------
+
+def test_bptt_param_gradients_shapes_and_finiteness():
+    spec = tanh_rnn(n_in=3, n_rec=4, seed=0)
+    grads = bptt_param_gradients(spec.factory, _inputs(6, 3))
+    assert set(grads.keys()) == {('w',), ('win',)}
+    assert grads[('w',)].shape == (4, 4)
+    assert grads[('win',)].shape == (3, 4)
+    for v in grads.values():
+        assert bool(jnp.all(jnp.isfinite(v)))
+    # win is upstream of the loss every step -> its gradient is non-trivial
+    assert float(jnp.abs(grads[('win',)]).sum()) > 1e-3
+
+
+# --- Task 3: finite-difference arbiter (validates BPTT) ----------------------
+
+def test_finite_difference_matches_bptt():
+    spec = tanh_rnn(n_in=3, n_rec=4, seed=0)
+    inputs = _inputs(6, 3)
+    g_bptt = bptt_param_gradients(spec.factory, inputs)
+    g_fd = finite_difference_param_gradients(spec.factory, inputs, eps=1e-3)
+    for key in g_bptt:
+        diff = float(jnp.max(jnp.abs(jnp.asarray(g_bptt[key]) - jnp.asarray(g_fd[key]))))
+        assert diff < 1e-3, f"{key}: BPTT vs FD maxdiff={diff:.3e}"
+
+
+# --- Task 4: multi-step online gradients -------------------------------------
+
+def test_online_multistep_gradients_shapes():
+    spec = tanh_rnn(n_in=3, n_rec=4, seed=0)
+    grads = online_param_gradients(
+        spec.factory, _inputs(6, 3),
+        algo_factory=lambda m: braintrace.ParamDimVjpAlgorithm(m, vjp_method='multi-step'),
+    )
+    assert set(grads.keys()) == {('w',), ('win',)}
+    assert grads[('w',)].shape == (4, 4)
+    for v in grads.values():
+        assert bool(jnp.all(jnp.isfinite(v)))
+
+
+# --- Task 5: comparison assertion helper -------------------------------------
+
+def test_assert_close_passes_for_equal_trees():
+    a = {('w',): jnp.ones((2, 2))}
+    b = {('w',): jnp.ones((2, 2)) + 1e-7}
+    assert_param_gradients_close(a, b, atol=1e-4)  # must not raise
+
+
+def test_assert_close_reports_offending_key():
+    a = {('w',): jnp.zeros((2, 2)), ('v',): jnp.zeros((2, 2))}
+    b = {('w',): jnp.zeros((2, 2)), ('v',): jnp.ones((2, 2))}
+    with pytest.raises(AssertionError, match=r"\('v',\)"):
+        assert_param_gradients_close(a, b, atol=1e-4)
+
+
+def test_assert_close_can_restrict_to_subset_of_keys():
+    a = {('w',): jnp.zeros((2, 2)), ('v',): jnp.zeros((2, 2))}
+    b = {('w',): jnp.zeros((2, 2)), ('v',): jnp.ones((2, 2))}
+    assert_param_gradients_close(a, b, atol=1e-4, keys=[('w',)])  # ('v',) ignored
+
+
+# --- Task 6: HEADLINE — multi-step D_RTRL == BPTT ----------------------------
+
+def test_d_rtrl_multistep_matches_bptt():
+    """Exact algorithm: multi-step D_RTRL must reproduce the BPTT gradient exactly."""
+    spec = tanh_rnn(n_in=3, n_rec=4, seed=0)
+    inputs = _inputs(6, 3)
+    g_bptt = bptt_param_gradients(spec.factory, inputs)
+    g_online = online_param_gradients(
+        spec.factory, inputs,
+        algo_factory=lambda m: braintrace.ParamDimVjpAlgorithm(m, vjp_method='multi-step'),
+    )
+    # multi-step reproduces BPTT for ALL params (observed maxdiff 0.0 in the spike)
+    assert_param_gradients_close(g_online, g_bptt, atol=1e-4)
+
+
+# --- Task 7: finding F-SINGLESTEP encoded as strict xfail --------------------
+
+@pytest.mark.xfail(
+    reason="F-SINGLESTEP: naive single-step per-step-grad summation diverges from "
+           "BPTT (ETP weight ~1.65e-2 off at T=6) though multi-step is exact; "
+           "accumulation recipe / single-step semantics need investigation",
+    strict=True,
+)
+def test_singlestep_naive_matches_bptt_KNOWN_DIVERGENCE():
+    spec = tanh_rnn(n_in=3, n_rec=4, seed=0)
+    inputs = _inputs(6, 3)
+    g_bptt = bptt_param_gradients(spec.factory, inputs)
+    g_naive = online_param_gradients_singlestep_naive(
+        spec.factory, inputs,
+        algo_factory=lambda m: braintrace.ParamDimVjpAlgorithm(m, vjp_method='single-step'),
+    )
+    # Compare only the ETP weight; this is expected to FAIL (hence xfail strict).
+    assert_param_gradients_close(g_naive, g_bptt, atol=1e-4, keys=list(spec.etp_param_keys))


### PR DESCRIPTION
Add a ground-truth gradient oracle for online-learning algorithms:
- oracle_models.py: deterministic tanh-RNN model factory (ETP recurrent
  weight + plain input weight) with ETP/plain param metadata.
- oracle.py: BPTT reference gradients, central finite-difference arbiter,
  multi-step online-algorithm gradients, naive single-step accumulation,
  and a per-key comparison assertion.
- oracle_test.py: validates BPTT against finite differences, proves
  multi-step D_RTRL reproduces BPTT exactly, and encodes finding
  F-SINGLESTEP (naive single-step accumulation diverges) as a strict xfail.

## Summary by Sourcery

Introduce a gradient oracle and toy RNN model to validate online ETP algorithms against BPTT, including tests that prove multi-step D_RTRL matches BPTT and capture known single-step divergence as an expected failure.

New Features:
- Add a deterministic tanh RNN ModelSpec with metadata separating ETP and plain parameters for use in gradient-oracle tests.
- Provide a gradient oracle module exposing BPTT, finite-difference, and online gradient computations, plus a helper to compare parameter-gradient dicts.

Tests:
- Add tests that validate BPTT gradients against finite differences, verify multi-step online gradients reproduce BPTT, exercise the tanh RNN factory, and encode the known naive single-step divergence as a strict xfail.