### PR TITLE
docs: convert public API docstrings to NumPy-doc style

### DIFF
--- a/braintrace/_etrace_algorithms/_common.py
+++ b/braintrace/_etrace_algorithms/_common.py
@@ -56,14 +56,37 @@ class _ZeroResetState(brainstate.ShortTermState):
 
 
 class PresynapticTrace(_ZeroResetState):
-    """Leaky accumulator ``â ← λ·â + x_t`` used by OTTT and OTPE-Approx.
+    r"""Leaky presynaptic accumulator used by OTTT and OTPE-Approx.
+
+    The trace accumulates the presynaptic input with a multiplicative decay,
+    following :math:`\hat{a} \leftarrow \lambda \cdot \hat{a} + x_t`.
 
     Parameters
     ----------
     init_value : jax.Array
-        Initial value; also dictates shape and dtype.
+        Initial value; also dictates the shape and dtype of the trace.
     leak : float
-        Decay factor λ in (0, 1). Pulled from the neuron's membrane leak in SNN usage.
+        Decay factor :math:`\lambda` in ``(0, 1)``. Pulled from the neuron's
+        membrane leak in SNN usage.
+
+    Raises
+    ------
+    ValueError
+        If ``leak`` is not strictly inside the open interval ``(0, 1)``.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        >>> import jax.numpy as jnp
+        >>> import braintrace
+        >>> trace = braintrace.PresynapticTrace(jnp.zeros(3), leak=0.5)
+        >>> out = trace.update(jnp.ones(3))
+        >>> print(out)
+        [1. 1. 1.]
+        >>> out = trace.update(jnp.ones(3))
+        >>> print(out)
+        [1.5 1.5 1.5]
     """
 
     __module__ = 'braintrace'
@@ -75,19 +98,53 @@ class PresynapticTrace(_ZeroResetState):
         self.leak = float(leak)
 
     def update(self, x):
-        """Apply one accumulation step: â ← λ·â + x."""
+        r"""Apply one accumulation step :math:`\hat{a} \leftarrow \lambda \cdot \hat{a} + x`.
+
+        Parameters
+        ----------
+        x : jax.Array
+            The new presynaptic input added to the decayed trace.
+
+        Returns
+        -------
+        jax.Array
+            The updated trace value.
+        """
         self.value = self.leak * self.value + x
         return self.value
 
 
 class KappaFilter(_ZeroResetState):
-    """Low-pass output-side filter ``x_filt ← (1-κ)·x + κ·x_filt`` used by EProp.
+    r"""Low-pass output-side filter used by EProp.
+
+    The filter smooths the output-side signal following
+    :math:`x_{\mathrm{filt}} \leftarrow (1-\kappa) \cdot x + \kappa \cdot x_{\mathrm{filt}}`.
 
     Parameters
     ----------
     init_value : jax.Array
+        Initial value; also dictates the shape and dtype of the filtered state.
     kappa : float
-        Decay factor in [0, 1). 0 disables filtering.
+        Decay factor :math:`\kappa` in ``[0, 1)``. A value of ``0`` disables filtering.
+
+    Raises
+    ------
+    ValueError
+        If ``kappa`` is not inside the half-open interval ``[0, 1)``.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        >>> import jax.numpy as jnp
+        >>> import braintrace
+        >>> filt = braintrace.KappaFilter(jnp.zeros(3), kappa=0.5)
+        >>> out = filt.update(jnp.ones(3))
+        >>> print(out)
+        [0.5 0.5 0.5]
+        >>> out = filt.update(jnp.ones(3))
+        >>> print(out)
+        [0.75 0.75 0.75]
     """
 
     __module__ = 'braintrace'
@@ -105,9 +162,44 @@ class KappaFilter(_ZeroResetState):
 
 
 class FixedRandomFeedback:
-    """Frozen random feedback matrix ``B ∈ ℝ^{n_target × n_layer}`` with stop_gradient guard.
+    r"""Frozen random feedback matrix with a stop-gradient guard.
 
-    Used by OSTTP (per-HiddenGroup target projection) and EProp-random-feedback.
+    The feedback matrix :math:`B \in \mathbb{R}^{n_{\mathrm{target}} \times n_{\mathrm{layer}}}`
+    is sampled once at construction and frozen via :func:`jax.lax.stop_gradient`. It is used by
+    OSTTP (per-HiddenGroup target projection) and EProp-random-feedback.
+
+    Parameters
+    ----------
+    n_target : int
+        Number of target dimensions (the row count of ``B``).
+    n_layer : int
+        Number of layer dimensions (the column count of ``B``).
+    key : jax.Array
+        A JAX PRNG key used to sample the feedback matrix.
+    init_scale : float, optional
+        Standard-deviation scaling applied to the sampled normal entries. Default is ``0.1``.
+
+    Attributes
+    ----------
+    B : jax.Array
+        The frozen feedback matrix of shape ``(n_target, n_layer)``.
+    n_target : int
+        Number of target dimensions.
+    n_layer : int
+        Number of layer dimensions.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        >>> import jax
+        >>> import braintrace
+        >>> fb = braintrace.FixedRandomFeedback(2, 3, jax.random.PRNGKey(0))
+        >>> print(fb.B.shape)
+        (2, 3)
+        >>> y = jax.numpy.ones(2)
+        >>> print(fb.project(y).shape)
+        (3,)
     """
 
     __module__ = 'braintrace'
@@ -120,7 +212,18 @@ class FixedRandomFeedback:
         self.n_layer = int(n_layer)
 
     def project(self, y_target):
-        """Return ``y_target @ B`` with B frozen. Handles batched and unbatched y_target."""
+        """Project the target onto the frozen feedback matrix.
+
+        Parameters
+        ----------
+        y_target : jax.Array
+            The target tensor to project. Both batched and unbatched layouts are handled.
+
+        Returns
+        -------
+        jax.Array
+            The projection ``y_target @ B`` with ``B`` frozen.
+        """
         return y_target @ self.B
 
 

--- a/braintrace/_etrace_algorithms/base.py
+++ b/braintrace/_etrace_algorithms/base.py
@@ -40,12 +40,17 @@ class EligibilityTrace(brainstate.ShortTermState):
 
     Examples
     --------
-    When you are using :class:`braintrace.pp_prop`, you can get
-    the eligibility trace of the weight by calling:
+    An eligibility trace wraps an array-valued state, just like any other
+    :class:`brainstate.ShortTermState`:
 
     .. code-block:: python
 
-        >>> etrace = etrace_algorithm.etrace_of(weight)
+        >>> import jax.numpy as jnp
+        >>> import braintrace
+        >>>
+        >>> trace = braintrace.EligibilityTrace(jnp.zeros((3, 4)))
+        >>> trace.value.shape
+        (3, 4)
 
     """
     __module__ = 'braintrace'

--- a/braintrace/_etrace_algorithms/e_prop.py
+++ b/braintrace/_etrace_algorithms/e_prop.py
@@ -134,7 +134,7 @@ class EProp(ParamDimVjpAlgorithm):
         ...         return x >> self.cell >> self.out
         >>>
         >>> model = RSNN()
-        >>> brainstate.nn.init_all_states(model)
+        >>> _ = brainstate.nn.init_all_states(model)
         >>> learner = braintrace.EProp(model, kappa_filter_decay=0.9)
         >>> x0 = brainstate.random.randn(1)
         >>> learner.compile_graph(x0)   # trace the graph once

--- a/braintrace/_etrace_algorithms/graph_executor.py
+++ b/braintrace/_etrace_algorithms/graph_executor.py
@@ -92,14 +92,18 @@ class ETraceGraphExecutor:
         for the eligibility trace algorithm. It contains various attributes that describe the
         relationships between the model's variables, states, and operations.
 
-        Returns:
-            ETraceGraph: The compiled graph for the model. This graph includes detailed
-            information about the model's structure, such as output variables, state variables,
+        Returns
+        -------
+        ETraceGraph
+            The compiled graph for the model. This graph includes detailed information about
+            the model's structure, such as output variables, state variables,
             hidden-to-hidden variable relationships, and more.
 
-        Raises:
-            ValueError: If the graph has not been compiled yet. Ensure to call the
-            `compile_graph()` method before accessing this property.
+        Raises
+        ------
+        ValueError
+            If the graph has not been compiled yet. Ensure to call the
+            :meth:`compile_graph` method before accessing this property.
         """
         if self._compiled_graph is None:
             raise ValueError('The graph is not compiled yet. Please call ".compile_graph()" first.')
@@ -110,7 +114,9 @@ class ETraceGraphExecutor:
         """
         The states for the model.
 
-        Returns:
+        Returns
+        -------
+        brainstate.util.FlattedDict[Path, brainstate.State]
             The states for the model.
         """
         return self.graph.module_info.retrieved_model_states
@@ -120,7 +126,9 @@ class ETraceGraphExecutor:
         """
         The path to the states.
 
-        Returns:
+        Returns
+        -------
+        brainstate.util.FlattedDict[Path, brainstate.State]
             The path to the states.
         """
         return self.states
@@ -130,8 +138,10 @@ class ETraceGraphExecutor:
         """
         The state id to the path.
 
-        Returns:
-            The state id to the path.
+        Returns
+        -------
+        Dict[int, Path]
+            The mapping from state id to the path.
         """
         if self._state_id_to_path is None:
             self._state_id_to_path = {id(state): path for path, state in self.states.items()}
@@ -255,15 +265,6 @@ class ETraceGraphExecutor:
         part of the eligibility trace algorithm, which helps in understanding the influence of weights
         and previous hidden states on the current hidden state.
 
-        Now we mathematically define what computations are done in this function.
-
-        For the state transition function $y, h^t = f(h^{t-1}, \theta, x)$, this function aims to solve:
-
-        1. The function output: $y$
-        2. The updated hidden states: $h^t$
-        3. The Jacobian matrix of hidden-to-weight, i.e., $\partial h^t / \partial \theta^t$.
-        2. The Jacobian matrix of hidden-to-hidden, i.e., $\partial h^t / \partial h^{t-1}$.
-
         Parameters
         ----------
         *args
@@ -274,10 +275,26 @@ class ETraceGraphExecutor:
         -------
         Any
             A tuple containing the following elements:
+
             - The function output (e.g., model predictions).
             - The updated hidden states after the current computation step.
             - Other states that may be relevant to the model's operation.
             - The spatial gradients of the weights, represented by the hidden-to-weight Jacobian.
+
+        Raises
+        ------
+        NotImplementedError
+            This method must be implemented by subclasses.
+
+        Notes
+        -----
+        For the state transition function :math:`y, h^t = f(h^{t-1}, \theta, x)`, this function aims
+        to solve:
+
+        1. The function output :math:`y`.
+        2. The updated hidden states :math:`h^t`.
+        3. The Jacobian matrix of hidden-to-weight, i.e., :math:`\partial h^t / \partial \theta^t`.
+        4. The Jacobian matrix of hidden-to-hidden, i.e., :math:`\partial h^t / \partial h^{t-1}`.
         """
         raise NotImplementedError('The method "solve_h2w_h2h_jacobian" should be '
                                   'implemented in the subclass.')
@@ -294,15 +311,6 @@ class ETraceGraphExecutor:
         influence of weights and previous hidden states on the current hidden state, as well as the impact
         of the loss on the hidden states.
 
-        Particularly, this function aims to solve:
-
-        1. The Jacobian matrix of hidden-to-weight. That is,
-           :math:`\partial h / \partial w`, where :math:`h` is the hidden state and :math:`w` is the weight.
-        2. The Jacobian matrix of hidden-to-hidden. That is,
-           :math:`\partial h / \partial h`, where :math:`h` is the hidden state.
-        3. The partial gradients of the loss with respect to the hidden states.
-           That is, :math:`\partial L / \partial h`, where :math:`L` is the loss and :math:`h` is the hidden state.
-
         Parameters
         ----------
         *args
@@ -313,11 +321,28 @@ class ETraceGraphExecutor:
         -------
         Any
             A tuple containing the following elements:
+
             - The function output (e.g., model predictions).
             - The updated hidden states after the current computation step.
             - Other states that may be relevant to the model's operation.
             - The spatial gradients of the weights, represented by the hidden-to-weight Jacobian.
             - The residuals, which are the partial gradients of the loss with respect to the hidden states.
+
+        Raises
+        ------
+        NotImplementedError
+            This method must be implemented by subclasses.
+
+        Notes
+        -----
+        Particularly, this function aims to solve:
+
+        1. The Jacobian matrix of hidden-to-weight. That is,
+           :math:`\partial h / \partial w`, where :math:`h` is the hidden state and :math:`w` is the weight.
+        2. The Jacobian matrix of hidden-to-hidden. That is,
+           :math:`\partial h / \partial h`, where :math:`h` is the hidden state.
+        3. The partial gradients of the loss with respect to the hidden states.
+           That is, :math:`\partial L / \partial h`, where :math:`L` is the loss and :math:`h` is the hidden state.
         """
         raise NotImplementedError('The method "solve_h2w_h2h_jacobian_and_l2h_vjp" '
                                   'should be implemented in the subclass.')

--- a/braintrace/_etrace_algorithms/io_dim_vjp.py
+++ b/braintrace/_etrace_algorithms/io_dim_vjp.py
@@ -490,22 +490,48 @@ def _solve_IO_dim_weight_gradients(
 
 
 class IODimVjpAlgorithm(ETraceVjpAlgorithm):
-    r"""
-    The online gradient computation algorithm with the diagonal approximation
-    and the input-output dimensional complexity.
+    r"""Online gradient algorithm with diagonal approximation and input-output-dimension complexity.
 
-    This algrithm computes the gradients of the weights with the diagonal approximation
-    and the input-output dimensional complexity. Its aglritm is based on the RTRL algorithm,
-    and has the following learning rule:
+    This algorithm computes the gradients of the weights with the diagonal
+    approximation and the input-output dimensional complexity. It is based on the
+    RTRL algorithm (Real-Time Recurrent Learning).
 
-    $$
-    \begin{aligned}
-    & \boldsymbol{\epsilon}^t \approx \boldsymbol{\epsilon}_{\mathbf{f}}^t \otimes \boldsymbol{\epsilon}_{\mathbf{x}}^t \\
-    & \boldsymbol{\epsilon}_{\mathbf{x}}^t=\alpha \boldsymbol{\epsilon}_{\mathbf{x}}^{t-1}+\mathbf{x}^t \\
-    & \boldsymbol{\epsilon}_{\mathbf{f}}^t=\alpha \operatorname{diag}\left(\mathbf{D}^t\right) \circ \boldsymbol{\epsilon}_{\mathbf{f}}^{t-1}+(1-\alpha) \operatorname{diag}\left(\mathbf{D}_f^t\right) \\
-    & \nabla_{\boldsymbol{\theta}} \mathcal{L}=\sum_{t^{\prime} \in \mathcal{T}} \frac{\partial \mathcal{L}^{t^{\prime}}}{\partial \mathbf{h}^{t^{\prime}}} \circ \boldsymbol{\epsilon}^{t^{\prime}}
-    \end{aligned}
-    $$
+    Parameters
+    ----------
+    model : brainstate.nn.Module
+        The model function, which receives the input arguments and returns the
+        model output.
+    decay_or_rank : float or int
+        The exponential smoothing factor for the eligibility trace. If a float,
+        it is the decay factor and should be in the range :math:`(0, 1)`. If an
+        integer, it is the number of approximation ranks for the algorithm and
+        should be greater than 0.
+    vjp_method : str, optional
+        The method for computing the VJP. It should be either ``"single-step"``
+        or ``"multi-step"``.
+
+        - ``"single-step"``: the VJP is computed at the current time step, i.e.,
+          :math:`\partial L^t/\partial h^t`.
+        - ``"multi-step"``: the VJP is computed at multiple time steps, i.e.,
+          :math:`\partial L^t/\partial h^{t-k}`, where :math:`k` is determined by
+          the data input.
+    name : str, optional
+        The name of the etrace algorithm.
+    mode : braintrace.mixin.Mode, optional
+        The computing mode, indicating the batching information.
+
+    Notes
+    -----
+    The learning rule is
+
+    .. math::
+
+        \begin{aligned}
+        & \boldsymbol{\epsilon}^t \approx \boldsymbol{\epsilon}_{\mathbf{f}}^t \otimes \boldsymbol{\epsilon}_{\mathbf{x}}^t \\
+        & \boldsymbol{\epsilon}_{\mathbf{x}}^t=\alpha \boldsymbol{\epsilon}_{\mathbf{x}}^{t-1}+\mathbf{x}^t \\
+        & \boldsymbol{\epsilon}_{\mathbf{f}}^t=\alpha \operatorname{diag}\left(\mathbf{D}^t\right) \circ \boldsymbol{\epsilon}_{\mathbf{f}}^{t-1}+(1-\alpha) \operatorname{diag}\left(\mathbf{D}_f^t\right) \\
+        & \nabla_{\boldsymbol{\theta}} \mathcal{L}=\sum_{t^{\prime} \in \mathcal{T}} \frac{\partial \mathcal{L}^{t^{\prime}}}{\partial \mathbf{h}^{t^{\prime}}} \circ \boldsymbol{\epsilon}^{t^{\prime}}
+        \end{aligned}
 
     where :math:`\boldsymbol{\epsilon}_{\mathbf{x}}^t` is the input-side trace,
     :math:`\boldsymbol{\epsilon}_{\mathbf{f}}^t` the output-side trace,
@@ -513,7 +539,7 @@ class IODimVjpAlgorithm(ETraceVjpAlgorithm):
     hidden-to-hidden Jacobian, :math:`\mathbf{D}_f^t` the state-to-output
     Jacobian, and :math:`\mathbf{x}^t` the presynaptic input.
 
-    **How it works.** The full per-parameter D-RTRL trace
+    The full per-parameter D-RTRL trace
     :math:`\boldsymbol{\epsilon}^t \in \mathbb{R}^{I\times O}` is approximated by
     the outer product of two exponentially-smoothed *vectors* — one over the
     input dimension and one over the output dimension. Storing the two factors
@@ -522,35 +548,14 @@ class IODimVjpAlgorithm(ETraceVjpAlgorithm):
     approximation rank) controls how much temporal history the factored trace
     retains; the bias of the exponential estimator is corrected at solve time.
 
+    This algorithm has :math:`O(BI+BO)` memory complexity and :math:`O(BIO)`
+    computational complexity, where :math:`I` and :math:`O` are the number of
+    input and output dimensions, and :math:`B` the batch size. In particular, for
+    a linear transformation layer, the weight gradients are computed with
+    :math:`O(Bn)` memory complexity and :math:`O(Bn^2)` computational complexity,
+    where :math:`n` is the number of hidden dimensions.
+
     For more details, please see `the ES-D-RTRL algorithm presented in our manuscript <https://www.biorxiv.org/content/10.1101/2024.09.24.614728v2>`_.
-
-    This algorithm has the :math:`O(BI+BO)` memory complexity and :math:`O(BIO)` computational
-    complexity, where :math:`I` and :math:`O` are the number of input and output dimensions, and
-    :math:`B` the batch size.
-
-    Particularly, for a Linear transformation layer, the algorithm computes the weight gradients
-    with the :math:`O(Bn)` memory complexity and :math:`O(Bn^2)` computational complexity, where
-    :math:`n` is the number of hidden dimensions.
-
-    Parameters
-    -----------
-    model: brainstate.nn.Module
-        The model function, which receives the input arguments and returns the model output.
-    vjp_method: str, optional
-        The method for computing the VJP. It should be either "single-step" or "multi-step".
-
-        - "single-step": The VJP is computed at the current time step, i.e., $\partial L^t/\partial h^t$.
-        - "multi-step": The VJP is computed at multiple time steps, i.e., $\partial L^t/\partial h^{t-k}$,
-          where $k$ is determined by the data input.
-
-    decay_or_rank: float, int
-        The exponential smoothing factor for the eligibility trace.
-        If it is a float, it is the decay factor, should be in the range of (0, 1).
-        If it is an integer, it is the number of approximation rank for the algorithm, should be greater than 0.
-    name: str, optional
-        The name of the etrace algorithm.
-    mode: braintrace.mixin.Mode
-        The computing mode, indicating the batching information.
 
     Examples
     --------
@@ -568,7 +573,7 @@ class IODimVjpAlgorithm(ETraceVjpAlgorithm):
         ...         return x >> self.cell >> self.out
         >>>
         >>> model = RNN()
-        >>> brainstate.nn.init_all_states(model)
+        >>> _ = brainstate.nn.init_all_states(model)
         >>> learner = braintrace.pp_prop(model, decay_or_rank=0.9)  # or rank: decay_or_rank=19
         >>> x0 = brainstate.random.randn(1)
         >>> learner.compile_graph(x0)   # trace the graph once
@@ -609,10 +614,10 @@ class IODimVjpAlgorithm(ETraceVjpAlgorithm):
         self.fast_solve = fast_solve
 
     def init_etrace_state(self, *args, **kwargs):
-        """
-        Initialize the eligibility trace states of the etrace algorithm.
+        """Initialize the eligibility trace states of the etrace algorithm.
 
-        This method is needed after compiling the etrace graph. See :meth:`.compile_graph()` for the details.
+        This method is needed after compiling the etrace graph. See
+        :meth:`compile_graph` for the details.
         """
         # The states of weight spatial gradients:
         #   1. x
@@ -624,19 +629,38 @@ class IODimVjpAlgorithm(ETraceVjpAlgorithm):
             _init_IO_dim_state(self.etrace_xs, self.etrace_dfs, relation)
 
     def reset_state(self, batch_size: int = None, **kwargs):
-        """
-        Reset the eligibility trace states.
+        """Reset the eligibility trace states.
+
+        Parameters
+        ----------
+        batch_size : int, optional
+            The batch size used to reshape the reset trace states. Default ``None``.
         """
         self.running_index.value = 0
         _reset_state_in_a_dict(self.etrace_xs, batch_size)
         _reset_state_in_a_dict(self.etrace_dfs, batch_size)
 
     def get_etrace_of(self, weight: brainstate.ParamState | Path) -> Tuple[Dict, Dict]:
-        """
-        Get the eligibility trace of the given weight.
+        """Get the eligibility trace of the given weight.
 
-        The eligibility trace contains the following structures:
+        Parameters
+        ----------
+        weight : brainstate.ParamState or Path
+            The weight whose eligibility trace is requested, given either as a
+            :class:`brainstate.ParamState` instance or as its path in the model.
 
+        Returns
+        -------
+        etrace_xs : dict
+            The input-side eligibility traces keyed by the weight-input variable.
+        etrace_dfs : dict
+            The output-side eligibility traces keyed by
+            ``(y_var, hidden-group index)``.
+
+        Raises
+        ------
+        ValueError
+            If no eligibility trace is found for the given weight.
         """
         self._assert_compiled()
 

--- a/braintrace/_etrace_algorithms/oracle.py
+++ b/braintrace/_etrace_algorithms/oracle.py
@@ -91,7 +91,7 @@ def online_param_gradients(
     model_factory: Callable[[], brainstate.nn.Module],
     inputs,
     *,
-    algo_factory: Callable[[brainstate.nn.Module], object],
+    algo_factory: Callable[[brainstate.nn.Module], braintrace.ETraceAlgorithm],
 ):
     """Total sequence gradient from an online algorithm via the multi-step VJP path.
 
@@ -115,7 +115,7 @@ def online_param_gradients_singlestep_naive(
     model_factory: Callable[[], brainstate.nn.Module],
     inputs,
     *,
-    algo_factory: Callable[[brainstate.nn.Module], object],
+    algo_factory: Callable[[brainstate.nn.Module], braintrace.ETraceAlgorithm],
 ):
     """Naive 'single-step' total gradient: sum of per-step grad((algo(x_t)**2).sum()).
 

--- a/braintrace/_etrace_algorithms/ostl.py
+++ b/braintrace/_etrace_algorithms/ostl.py
@@ -90,7 +90,7 @@ class OSTLRecurrent(ParamDimVjpAlgorithm):
         ...         return x >> self.cell >> self.out
         >>>
         >>> model = Net()
-        >>> brainstate.nn.init_all_states(model)
+        >>> _ = brainstate.nn.init_all_states(model)
         >>> learner = braintrace.OSTLRecurrent(model)
         >>> x0 = brainstate.random.randn(1)
         >>> learner.compile_graph(x0)
@@ -158,7 +158,7 @@ class OSTLFeedforward(pp_prop):
         ...         return x >> self.cell >> self.out
         >>>
         >>> model = Net()
-        >>> brainstate.nn.init_all_states(model)
+        >>> _ = brainstate.nn.init_all_states(model)
         >>> learner = braintrace.OSTLFeedforward(model)
         >>> x0 = brainstate.random.randn(1)
         >>> learner.compile_graph(x0)

--- a/braintrace/_etrace_algorithms/osttp.py
+++ b/braintrace/_etrace_algorithms/osttp.py
@@ -108,13 +108,13 @@ class OSTTP(ParamDimVjpAlgorithm):
         ...         return x >> self.cell >> self.out
         >>>
         >>> model = Net()
-        >>> brainstate.nn.init_all_states(model)
+        >>> _ = brainstate.nn.init_all_states(model)
         >>> # one (n_target, n_l) feedback matrix per HiddenGroup (here n_l = 20)
         >>> B = jax.random.normal(jax.random.PRNGKey(0), (1, 20))
         >>> learner = braintrace.OSTTP(model, B_list=[B])
         >>> x0 = brainstate.random.randn(1)
         >>> learner.compile_graph(x0)
-        >>> y = learner(x0, y_target=brainstate.random.randn(1))
+        >>> y = learner.update(x0, y_target=brainstate.random.randn(1))
 
     References
     ----------

--- a/braintrace/_etrace_algorithms/otpe.py
+++ b/braintrace/_etrace_algorithms/otpe.py
@@ -173,7 +173,7 @@ class OTPE(ETraceVjpAlgorithm):
         ...         return x >> self.cell >> self.out
         >>>
         >>> model = Net()
-        >>> brainstate.nn.init_all_states(model)
+        >>> _ = brainstate.nn.init_all_states(model)
         >>> # ``leak`` is the postsynaptic membrane leak and must be passed
         >>> # explicitly; it is never inferred from the model.
         >>> learner = braintrace.OTPE(model, mode='full', leak=0.9)

--- a/braintrace/_etrace_algorithms/ottt.py
+++ b/braintrace/_etrace_algorithms/ottt.py
@@ -138,7 +138,7 @@ class OTTT(ETraceVjpAlgorithm):
         ...         return x >> self.cell >> self.out
         >>>
         >>> model = Net()
-        >>> brainstate.nn.init_all_states(model)
+        >>> _ = brainstate.nn.init_all_states(model)
         >>> # ``leak`` is the postsynaptic membrane leak and must be passed
         >>> # explicitly; it is never inferred from the model.
         >>> learner = braintrace.OTTT(model, mode='A', leak=0.9)

--- a/braintrace/_etrace_algorithms/param_dim_vjp.py
+++ b/braintrace/_etrace_algorithms/param_dim_vjp.py
@@ -492,18 +492,41 @@ def _remove_units(xs_maybe_quantity: brainstate.typing.PyTree):
 
 
 class ParamDimVjpAlgorithm(ETraceVjpAlgorithm):
-    r"""
-    The online gradient computation algorithm with the diagonal approximation and the parameter dimension complexity.
+    r"""Online gradient algorithm with diagonal approximation and parameter-dimension complexity.
 
-    This algorithm computes the gradients of the weights with the diagonal approximation and the parameter dimension complexity.
-    Its algorithm is based on the RTRL algorithm, and has the following learning rule:
+    This algorithm computes the gradients of the weights with the diagonal
+    approximation and the parameter-dimension complexity. It is based on the RTRL
+    algorithm (Real-Time Recurrent Learning).
 
-    $$
-    \begin{aligned}
-    &\boldsymbol{\epsilon}^t \approx \mathbf{D}^t \boldsymbol{\epsilon}^{t-1}+\operatorname{diag}\left(\mathbf{D}_f^t\right) \otimes \mathbf{x}^t \\
-    & \nabla_{\boldsymbol{\theta}} \mathcal{L}=\sum_{t^{\prime} \in \mathcal{T}} \frac{\partial \mathcal{L}^{t^{\prime}}}{\partial \mathbf{h}^{t^{\prime}}} \circ \boldsymbol{\epsilon}^{t^{\prime}}
-    \end{aligned}
-    $$
+    Parameters
+    ----------
+    model : brainstate.nn.Module
+        The model function, which receives the input arguments and returns the
+        model output.
+    vjp_method : str, optional
+        The method for computing the VJP. It should be either ``"single-step"``
+        or ``"multi-step"``.
+
+        - ``"single-step"``: the VJP is computed at the current time step, i.e.,
+          :math:`\partial L^t/\partial h^t`.
+        - ``"multi-step"``: the VJP is computed at multiple time steps, i.e.,
+          :math:`\partial L^t/\partial h^{t-k}`, where :math:`k` is determined by
+          the data input.
+    name : str, optional
+        The name of the etrace algorithm.
+    mode : braintrace.mixin.Mode, optional
+        The computing mode, indicating the batching behavior.
+
+    Notes
+    -----
+    The learning rule is
+
+    .. math::
+
+        \begin{aligned}
+        &\boldsymbol{\epsilon}^t \approx \mathbf{D}^t \boldsymbol{\epsilon}^{t-1}+\operatorname{diag}\left(\mathbf{D}_f^t\right) \otimes \mathbf{x}^t \\
+        & \nabla_{\boldsymbol{\theta}} \mathcal{L}=\sum_{t^{\prime} \in \mathcal{T}} \frac{\partial \mathcal{L}^{t^{\prime}}}{\partial \mathbf{h}^{t^{\prime}}} \circ \boldsymbol{\epsilon}^{t^{\prime}}
+        \end{aligned}
 
     where :math:`\boldsymbol{\epsilon}^t` is the per-parameter eligibility
     trace, :math:`\mathbf{D}^t` the hidden-to-hidden Jacobian, :math:`\mathbf{D}_f^t`
@@ -511,43 +534,27 @@ class ParamDimVjpAlgorithm(ETraceVjpAlgorithm):
     :math:`\partial \mathcal{L}^{t'}/\partial \mathbf{h}^{t'}` the learning
     signal back-propagated from the loss at each step.
 
-    **How it works.** Real-Time Recurrent Learning (RTRL) propagates the full
-    sensitivity :math:`\partial \mathbf{h}^t/\partial \boldsymbol{\theta}`
-    forward in time, which costs :math:`O(|\theta| \cdot H)` memory. D-RTRL
-    keeps only the *diagonal* of the hidden-to-hidden Jacobian, collapsing the
-    trace to one value per parameter. The trace is then contracted with the
-    instantaneous learning signal at each step to accumulate the gradient — no
-    backward pass through time and memory linear in the parameter count.
+    Real-Time Recurrent Learning (RTRL) propagates the full sensitivity
+    :math:`\partial \mathbf{h}^t/\partial \boldsymbol{\theta}` forward in time,
+    which costs :math:`O(|\theta| \cdot H)` memory. D-RTRL keeps only the
+    *diagonal* of the hidden-to-hidden Jacobian, collapsing the trace to one
+    value per parameter. The trace is then contracted with the instantaneous
+    learning signal at each step to accumulate the gradient — no backward pass
+    through time and memory linear in the parameter count.
+
+    :class:`ParamDimVjpAlgorithm` is a subclass of :class:`brainstate.nn.Module`
+    and is sensitive to the context/mode of the computation. In particular, it is
+    sensitive to ``brainstate.mixin.Batching`` behavior.
+
+    This algorithm has :math:`O(B\theta)` memory complexity, where
+    :math:`\theta` is the number of parameters and :math:`B` the batch size.
+    For a convolutional layer, the weight gradients are computed with
+    :math:`O(B\theta)` memory complexity, where :math:`\theta` is the dimension
+    of the convolutional kernel. For a linear transformation layer, the weight
+    gradients are computed with :math:`O(BIO)` computational complexity, where
+    :math:`I` and :math:`O` are the number of input and output dimensions.
 
     For more details, please see `the D-RTRL algorithm presented in our manuscript <https://www.biorxiv.org/content/10.1101/2024.09.24.614728v2>`_.
-
-    Note than the :py:class:`ParamDimVjpAlgorithm` is a subclass of :py:class:`brainstate.nn.Module`,
-    and it is sensitive to the context/mode of the computation. Particularly,
-    the :py:class:`ParamDimVjpAlgorithm` is sensitive to ``brainstate.mixin.Batching`` behavior.
-
-    This algorithm has the :math:`O(B\theta)` memory complexity, where :math:`\theta` is the number of parameters,
-    and :math:`B` the batch size.
-
-    For a convolutional layer, the algorithm computes the weight gradients with the :math:`O(B\theta)`
-    memory complexity, where :math:`\theta` is the dimension of the convolutional kernel.
-
-    For a Linear transformation layer, the algorithm computes the weight gradients with the :math:`O(BIO)``
-    computational complexity, where :math:`I` and :math:`O` are the number of input and output dimensions.
-
-    Parameters
-    -----------
-    model: brainstate.nn.Module
-        The model function, which receives the input arguments and returns the model output.
-    vjp_method: str, optional
-        The method for computing the VJP. It should be either "single-step" or "multi-step".
-
-        - "single-step": The VJP is computed at the current time step, i.e., $\partial L^t/\partial h^t$.
-        - "multi-step": The VJP is computed at multiple time steps, i.e., $\partial L^t/\partial h^{t-k}$,
-          where $k$ is determined by the data input.
-    name: str, optional
-        The name of the etrace algorithm.
-    mode: braintrace.mixin.Mode
-        The computing mode, indicating the batching behavior.
 
     Examples
     --------
@@ -565,7 +572,7 @@ class ParamDimVjpAlgorithm(ETraceVjpAlgorithm):
         ...         return x >> self.cell >> self.out
         >>>
         >>> model = RNN()
-        >>> brainstate.nn.init_all_states(model)
+        >>> _ = brainstate.nn.init_all_states(model)
         >>> learner = braintrace.D_RTRL(model)  # alias of ParamDimVjpAlgorithm
         >>> x0 = brainstate.random.randn(1)
         >>> learner.compile_graph(x0)   # trace the graph once
@@ -607,11 +614,10 @@ class ParamDimVjpAlgorithm(ETraceVjpAlgorithm):
         self.normalize_matrix_spectrum = normalize_matrix_spectrum
 
     def init_etrace_state(self, *args, **kwargs):
-        """
-        Initialize the eligibility trace states of the etrace algorithm.
+        """Initialize the eligibility trace states of the etrace algorithm.
 
         This method is needed after compiling the etrace graph. See
-        `.compile_graph()` for the details.
+        :meth:`compile_graph` for the details.
         """
         # The states of batched weight gradients
         self.etrace_bwg = dict()
@@ -619,18 +625,35 @@ class ParamDimVjpAlgorithm(ETraceVjpAlgorithm):
             _init_param_dim_state(self.etrace_bwg, relation)
 
     def reset_state(self, batch_size: int = None, **kwargs):
-        """
-        Reset the eligibility trace states.
+        """Reset the eligibility trace states.
+
+        Parameters
+        ----------
+        batch_size : int, optional
+            The batch size used to reshape the reset trace states. Default ``None``.
         """
         self.running_index.value = 0
         _reset_state_in_a_dict(self.etrace_bwg, batch_size)
 
     def get_etrace_of(self, weight: brainstate.ParamState | Path) -> Dict:
-        """
-        Get the eligibility trace of the given weight.
+        """Get the eligibility trace of the given weight.
 
-        The eligibility trace contains the following structures:
+        Parameters
+        ----------
+        weight : brainstate.ParamState or Path
+            The weight whose eligibility trace is requested, given either as a
+            :class:`brainstate.ParamState` instance or as its path in the model.
 
+        Returns
+        -------
+        dict
+            A dictionary mapping ``(y_var id, hidden-group index)`` keys to the
+            eligibility-trace values associated with the given weight.
+
+        Raises
+        ------
+        ValueError
+            If no eligibility trace is found for the given weight.
         """
 
         self._assert_compiled()

--- a/braintrace/_etrace_algorithms/pp_prop.py
+++ b/braintrace/_etrace_algorithms/pp_prop.py
@@ -22,29 +22,57 @@ __all__ = [
 
 
 class pp_prop(IODimVjpAlgorithm):
-    r"""
-    The online gradient computation algorithm with the diagonal approximation
-    and the input-output dimensional complexity.
+    r"""Online gradient algorithm with diagonal approximation and input-output-dimension complexity.
 
     ``pp_prop`` is the canonical name for the input-output-dimension eligibility
-    trace algorithm implemented by :py:class:`IODimVjpAlgorithm`. It computes the
+    trace algorithm implemented by :class:`IODimVjpAlgorithm`. It computes the
     gradients of the weights with the diagonal approximation and the
-    input-output dimensional complexity, following the learning rule:
+    input-output dimensional complexity.
 
-    $$
-    \begin{aligned}
-    & \boldsymbol{\epsilon}^t \approx \boldsymbol{\epsilon}_{\mathbf{f}}^t \otimes \boldsymbol{\epsilon}_{\mathbf{x}}^t \\
-    & \boldsymbol{\epsilon}_{\mathbf{x}}^t=\alpha \boldsymbol{\epsilon}_{\mathbf{x}}^{t-1}+\mathbf{x}^t \\
-    & \boldsymbol{\epsilon}_{\mathbf{f}}^t=\alpha \operatorname{diag}\left(\mathbf{D}^t\right) \circ \boldsymbol{\epsilon}_{\mathbf{f}}^{t-1}+(1-\alpha) \operatorname{diag}\left(\mathbf{D}_f^t\right) \\
-    & \nabla_{\boldsymbol{\theta}} \mathcal{L}=\sum_{t^{\prime} \in \mathcal{T}} \frac{\partial \mathcal{L}^{t^{\prime}}}{\partial \mathbf{h}^{t^{\prime}}} \circ \boldsymbol{\epsilon}^{t^{\prime}}
-    \end{aligned}
-    $$
+    This subclass inherits all behavior from :class:`IODimVjpAlgorithm` without
+    modification; it exists to provide the canonical ``pp_prop`` name. See
+    :class:`IODimVjpAlgorithm` for the full parameter list.
+
+    See Also
+    --------
+    IODimVjpAlgorithm : The implementing class with the full parameter list.
+
+    Notes
+    -----
+    The learning rule is
+
+    .. math::
+
+        \begin{aligned}
+        & \boldsymbol{\epsilon}^t \approx \boldsymbol{\epsilon}_{\mathbf{f}}^t \otimes \boldsymbol{\epsilon}_{\mathbf{x}}^t \\
+        & \boldsymbol{\epsilon}_{\mathbf{x}}^t=\alpha \boldsymbol{\epsilon}_{\mathbf{x}}^{t-1}+\mathbf{x}^t \\
+        & \boldsymbol{\epsilon}_{\mathbf{f}}^t=\alpha \operatorname{diag}\left(\mathbf{D}^t\right) \circ \boldsymbol{\epsilon}_{\mathbf{f}}^{t-1}+(1-\alpha) \operatorname{diag}\left(\mathbf{D}_f^t\right) \\
+        & \nabla_{\boldsymbol{\theta}} \mathcal{L}=\sum_{t^{\prime} \in \mathcal{T}} \frac{\partial \mathcal{L}^{t^{\prime}}}{\partial \mathbf{h}^{t^{\prime}}} \circ \boldsymbol{\epsilon}^{t^{\prime}}
+        \end{aligned}
 
     For more details, please see `the ES-D-RTRL algorithm presented in our manuscript <https://www.biorxiv.org/content/10.1101/2024.09.24.614728v2>`_.
 
-    This subclass inherits all behavior from :py:class:`IODimVjpAlgorithm` without
-    modification; it exists to provide the canonical ``pp_prop`` name. See
-    :py:class:`IODimVjpAlgorithm` for the full parameter list and a usage example.
+    Examples
+    --------
+    .. code-block:: python
+
+        >>> import brainstate
+        >>> import braintrace
+        >>>
+        >>> class RNN(brainstate.nn.Module):
+        ...     def __init__(self):
+        ...         super().__init__()
+        ...         self.cell = braintrace.nn.ValinaRNNCell(1, 20, activation='tanh')
+        ...         self.out = braintrace.nn.Linear(20, 1)
+        ...     def update(self, x):
+        ...         return x >> self.cell >> self.out
+        >>>
+        >>> model = RNN()
+        >>> _ = brainstate.nn.init_all_states(model)
+        >>> learner = braintrace.pp_prop(model, decay_or_rank=0.9)  # or rank: decay_or_rank=19
+        >>> x0 = brainstate.random.randn(1)
+        >>> learner.compile_graph(x0)   # trace the graph once
+        >>> y = learner(x0)             # forward pass + eligibility-trace update
 
     References
     ----------

--- a/braintrace/_etrace_algorithms/vjp_base.py
+++ b/braintrace/_etrace_algorithms/vjp_base.py
@@ -48,54 +48,54 @@ __all__ = [
 
 class ETraceVjpAlgorithm(ETraceAlgorithm):
     r"""
-    The base class for the eligibility trace algorithm which supporting the VJP gradient
+    The base class for the eligibility trace algorithm supporting the VJP gradient
     computation (reverse-mode differentiation).
 
-    The term ``VJP`` comes from the following two aspects:
+    The term ``VJP`` comes from two aspects. First, this module is designed to be
+    compatible with JAX's VJP mechanism, so the gradient is computed according to the
+    reverse-mode differentiation interface, like :func:`jax.grad`, :func:`jax.vjp`, or
+    :func:`jax.jacrev`. The true update function is defined as a custom VJP function
+    ``._true_update_fun()``, which receives the inputs, the hidden states, other states,
+    and etrace variables at the last time step, and returns the outputs, the hidden
+    states, other states, and etrace variables at the current time step. Second, the
+    algorithm computes the spatial gradient :math:`\partial L^t / \partial H^t` using the
+    standard back-propagation algorithm, which enhances the accuracy and the stability of
+    the gradient computation.
 
-    **First**, this module is designed to be compatible with the JAX's VJP mechanism.
-    This means that the gradient is computed according to the reverse-mode differentiation
-    interface, like the ``jax.grad()`` function, the ``jax.vjp()`` function,
-    or the ``jax.jacrev()`` function. The true update function is defined as a custom
-    VJP function ``._true_update_fun()``, which receives the inputs, the hidden states,
-    other states, and etrace variables at the last time step, and returns the outputs,
-    the hidden states, other states, and etrace variables at the current time step.
+    Parameters
+    ----------
+    model : brainstate.nn.Module
+        The model function, which receives the input arguments and returns the model output.
+    name : str, optional
+        The name of the etrace algorithm.
+    vjp_method : str, optional
+        The method for computing the VJP. It should be either ``"single-step"`` or
+        ``"multi-step"``. Default is ``"single-step"``.
 
-    For each subclass (or the instance of an etrace algorithm), we should define the
-    following methods:
+        - ``"single-step"``: The VJP is computed at the current time step, i.e.,
+          :math:`\partial L^t/\partial h^t`.
+        - ``"multi-step"``: The VJP is computed at multiple time steps, i.e.,
+          :math:`\partial L^t/\partial h^{t-k}`, where :math:`k` is determined by the
+          data input.
 
-    - ``._update()``: update the eligibility trace states and return the outputs, hidden states, other states, and etrace data.
+    Notes
+    -----
+    For each subclass (or the instance of an etrace algorithm), the following methods
+    define the custom VJP rule:
+
+    - ``._update()``: update the eligibility trace states and return the outputs, hidden
+      states, other states, and etrace data.
     - ``._update_fwd()``: the forward pass of the custom VJP rule.
     - ``._update_bwd()``: the backward pass of the custom VJP rule.
 
-    However, this class has provided a default implementation for the ``._update()``,
-    ``._update_fwd()``, and ``._update_bwd()`` methods.
-
-    To implement a new etrace algorithm, users just need to override the following methods:
+    This class provides a default implementation for the ``._update()``,
+    ``._update_fwd()``, and ``._update_bwd()`` methods. To implement a new etrace
+    algorithm, users just need to override the following methods:
 
     - ``._solve_weight_gradients()``: solve the gradients of the learnable weights / parameters.
     - ``._update_etrace_data()``: update the eligibility trace data.
     - ``._assign_etrace_data()``: assign the eligibility trace data to the states.
     - ``._get_etrace_data()``: get the eligibility trace data.
-
-    **Second**, the algorithm computes the spatial gradient $\partial L^t / \partial H^t$ using the standard
-    back-propagation algorithm. This design can enhance the accuracy and the stability of the algorithm for
-    computing gradients.
-
-
-    Parameters
-    ----------
-    model: brainstate.nn.Module
-        The model function, which receives the input arguments and returns the model output.
-    name: str, optional
-        The name of the etrace algorithm.
-    vjp_method: str
-        The method for computing the VJP. It should be either "single-step" or "multi-step".
-
-        - "single-step": The VJP is computed at the current time step, i.e., $\partial L^t/\partial h^t$.
-        - "multi-step": The VJP is computed at multiple time steps, i.e., $\partial L^t/\partial h^{t-k}$,
-          where $k$ is determined by the data input.
-
     """
 
     __module__ = 'braintrace'
@@ -133,15 +133,29 @@ class ETraceVjpAlgorithm(ETraceAlgorithm):
             raise ValueError('The etrace algorithm has not been compiled. Please call `compile_graph()` first. ')
 
     def update(self, *args) -> Any:
-        """
+        r"""
         Update the model states and the eligibility trace.
 
-        The input arguments ``args`` here supports very complex data structures, including
+        The input arguments ``args`` here support very complex data structures, including
         the combination of :py:class:`SingleStepData` and :py:class:`MultiStepData`.
 
-        - :py:class:`SingleStepData`: indicating the data at the single time step, $x_t$.
-        - :py:class:`MultiStepData`: indicating the data at multiple time steps, $[x_{t-k}, ..., x_t]$.
+        - :py:class:`SingleStepData`: indicating the data at the single time step,
+          :math:`x_t`.
+        - :py:class:`MultiStepData`: indicating the data at multiple time steps,
+          :math:`[x_{t-k}, ..., x_t]`.
 
+        Parameters
+        ----------
+        *args
+            The input arguments.
+
+        Returns
+        -------
+        Any
+            The model output.
+
+        Notes
+        -----
         Suppose all inputs have the shape of ``(10,)``.
 
         If the input arguments are given by:
@@ -178,9 +192,6 @@ class ETraceVjpAlgorithm(ETraceAlgorithm):
         Then, the first input argument is considered as the :py:class:`MultiStepData`, and its data will
         be fed into the model within five consecutive steps, and the second input argument will be fed
         into the model at each time of this five consecutive steps.
-
-        Args:
-            *args: the input arguments.
         """
 
         # ----------------------------------------------------------------------------------------------

--- a/braintrace/_etrace_algorithms/vjp_graph_executor.py
+++ b/braintrace/_etrace_algorithms/vjp_graph_executor.py
@@ -140,14 +140,17 @@ class ETraceVjpGraphExecutor(ETraceGraphExecutor):
 
     Parameters
     ----------
-    model: brainstate.nn.Module
+    model : brainstate.nn.Module
         The model to build the eligibility trace graph. The models should only define the one-step behavior.
-    vjp_method: str
-        The method for computing the VJP. It should be either "single-step" or "multi-step".
+    vjp_method : str, optional
+        The method for computing the VJP. It should be either ``"single-step"`` or
+        ``"multi-step"``. Default is ``"single-step"``.
 
-        - "single-step": The VJP is computed at the current time step, i.e., $\partial L^t/\partial h^t$.
-        - "multi-step": The VJP is computed at multiple time steps, i.e., $\partial L^t/\partial h^{t-k}$,
-          where $k$ is determined by the data input.
+        - ``"single-step"``: The VJP is computed at the current time step, i.e.,
+          :math:`\partial L^t/\partial h^t`.
+        - ``"multi-step"``: The VJP is computed at multiple time steps, i.e.,
+          :math:`\partial L^t/\partial h^{t-k}`, where :math:`k` is determined by the
+          data input.
     """
     __module__ = 'braintrace'
 
@@ -170,8 +173,10 @@ class ETraceVjpGraphExecutor(ETraceGraphExecutor):
         """
         Whether the VJP method is ``single-step``.
 
-        Returns:
-            bool: Whether the VJP method is ``single-step``.
+        Returns
+        -------
+        bool
+            Whether the VJP method is ``single-step``.
         """
         return self.vjp_method == 'single-step'
 
@@ -180,8 +185,10 @@ class ETraceVjpGraphExecutor(ETraceGraphExecutor):
         """
         Whether the VJP method is ``multi-step``.
 
-        Returns:
-            bool: Whether the VJP method is ``multi-step``.
+        Returns
+        -------
+        bool
+            Whether the VJP method is ``multi-step``.
         """
         return self.vjp_method == 'multi-step'
 
@@ -193,8 +200,10 @@ class ETraceVjpGraphExecutor(ETraceGraphExecutor):
         graph for the model, which is used for computing the weight spatial gradients and
         the hidden state Jacobian.
 
-        Args:
-            *args: The positional arguments for the model.
+        Parameters
+        ----------
+        *args
+            The positional arguments for the model.
         """
 
         # process the inputs
@@ -316,22 +325,27 @@ class ETraceVjpGraphExecutor(ETraceGraphExecutor):
 
         This function is typically used for computing the forward propagation of hidden-to-weight Jacobian.
 
-        Now we mathematically define what computations are done in this function.
+        Parameters
+        ----------
+        *args
+            The positional arguments for the model.
 
-        For the state transition function $y, h^t = f(h^{t-1}, \theta, x)$, this function aims to solve:
-
-        1. The function output: $y$
-        2. The updated hidden states: $h^t$
-        3. The Jacobian matrix of hidden-to-weight, i.e., $\partial h^t / \partial \theta^t$.
-        2. The Jacobian matrix of hidden-to-hidden, i.e., $\partial h^t / \partial h^{t-1}$.
-
-        Args:
-            *args: The positional arguments for the model.
-
-        Returns:
+        Returns
+        -------
+        tuple
             The outputs, hidden states, other states, and the spatial gradients of the weights.
             Return the single-step results if inputs do not contain multiple-step data,
             otherwise return the multi-step data.
+
+        Notes
+        -----
+        For the state transition function :math:`y, h^t = f(h^{t-1}, \theta, x)`, this function aims
+        to solve:
+
+        1. The function output :math:`y`.
+        2. The updated hidden states :math:`h^t`.
+        3. The Jacobian matrix of hidden-to-weight, i.e., :math:`\partial h^t / \partial \theta^t`.
+        4. The Jacobian matrix of hidden-to-hidden, i.e., :math:`\partial h^t / \partial h^{t-1}`.
         """
 
         input_is_multi_step = has_multistep_data(*args)
@@ -452,6 +466,18 @@ class ETraceVjpGraphExecutor(ETraceGraphExecutor):
         This function is typically used for computing both the forward propagation of hidden-to-weight Jacobian
         and the loss-to-hidden gradients at the current time-step.
 
+        Parameters
+        ----------
+        *args
+            The positional arguments for the model.
+
+        Returns
+        -------
+        tuple
+            The outputs, hidden states, other states, the spatial gradients of the weights, and the residuals.
+
+        Notes
+        -----
         Particularly, this function aims to solve:
 
         1. The Jacobian matrix of hidden-to-weight. That is,
@@ -460,12 +486,6 @@ class ETraceVjpGraphExecutor(ETraceGraphExecutor):
            :math:`\partial h / \partial h`, where :math:`h` is the hidden state.
         3. The partial gradients of the loss with respect to the hidden states.
            That is, :math:`\partial L / \partial h`, where :math:`L` is the loss and :math:`h` is the hidden state.
-
-        Args:
-          *args: The positional arguments for the model.
-
-        Returns:
-          The outputs, hidden states, other states, the spatial gradients of the weights, and the residuals.
         """
         input_is_multi_step = has_multistep_data(*args)
 

--- a/braintrace/_etrace_compiler/diagnostics.py
+++ b/braintrace/_etrace_compiler/diagnostics.py
@@ -46,7 +46,20 @@ __all__ = [
 
 
 class DiagnosticLevel(str, Enum):
-    """Severity of a :class:`CompilationRecord`."""
+    """Severity of a :class:`CompilationRecord`.
+
+    A string-valued enumeration ordering compiler diagnostics by severity.
+
+    Attributes
+    ----------
+    INFO
+        Informational record; not surfaced through :func:`warnings.warn`.
+    WARNING
+        A potential problem (e.g. an excluded relation) that is also emitted
+        as a Python warning.
+    ERROR
+        A serious problem that is also emitted as a Python warning.
+    """
 
     INFO = 'info'
     WARNING = 'warning'
@@ -56,8 +69,17 @@ class DiagnosticLevel(str, Enum):
 class DiagnosticKind(str, Enum):
     """Machine-readable reason for a :class:`CompilationRecord`.
 
-    Every decision the ETrace compiler makes maps to exactly one ``DiagnosticKind``
-    so tests can assert on ``.kind`` rather than parsing message strings.
+    A string-valued enumeration naming the exact decision the ETrace compiler
+    made. Every decision maps to exactly one ``DiagnosticKind`` so tests can
+    assert on ``CompilationRecord.kind`` rather than parsing message strings.
+
+    Notes
+    -----
+    The members fall into a few families: an inclusion marker
+    (``RELATION_INCLUDED``), exclusion reasons (the ``RELATION_EXCLUDED_*``
+    members), a path-classification marker (``RELATION_PARTIAL_PATH``), and a
+    set of structural observations about the jaxpr (nested ``jit``, control
+    flow, multi-output primitives, state mismatches, and so on).
     """
 
     # Inclusion
@@ -90,8 +112,30 @@ class DiagnosticKind(str, Enum):
 class CompilationRecord:
     """A single compiler decision, captured with structured context.
 
-    ``context`` is an open dict keyed by the emitting site; see the
-    :class:`DiagnosticKind` documentation for the schema of each kind.
+    A frozen dataclass recording one decision made by the ETrace compiler,
+    together with enough structured context to query *why* the decision was
+    made without parsing the human-readable ``message``.
+
+    Parameters
+    ----------
+    kind : DiagnosticKind
+        Machine-readable reason for the record.
+    level : DiagnosticLevel
+        Severity of the record.
+    message : str
+        Human-readable description of the decision.
+    primitive : object or None, optional
+        The JAX primitive the decision concerns, if any. Default ``None``.
+    weight_path : tuple of object or None, optional
+        Module path of the weight ``ParamState`` the decision concerns, if
+        any. Default ``None``.
+    hidden_paths : tuple of tuple of object, optional
+        Module paths of the hidden states the decision concerns. Default
+        ``()``.
+    context : dict or None, optional
+        Open dict of extra context keyed by the emitting site; see the
+        :class:`DiagnosticKind` documentation for the schema of each kind.
+        Default ``None``.
     """
 
     kind: DiagnosticKind

--- a/braintrace/_etrace_compiler/graph.py
+++ b/braintrace/_etrace_compiler/graph.py
@@ -74,31 +74,45 @@ def order_hidden_group_index(
 
 
 class ETraceGraph(NamedTuple):
-    """
-    The overall compiled graph for the eligibility trace.
+    """The overall compiled graph for the eligibility trace.
 
-    The eligibility trace graph, tracking the relationship between the etrace weights
-    ParamState, the etrace variables HiddenState, and the etrace
-    operations :pyETP primitives.
+    Tracks the relationship between the eligibility-trace weights
+    (``ParamState``), the eligibility-trace variables (``HiddenState``), and
+    the eligibility-trace operations (ETP primitives). It is the object
+    returned by :func:`compile_etrace_graph` and consumed by the online-learning
+    algorithms.
 
-    The following fields are included:
+    Attributes
+    ----------
+    module_info : ModuleInfo
+        The model information.
+    hidden_groups : sequence of HiddenGroup
+        The hidden groups.
+    hid_path_to_group : dict
+        Mapping from each hidden-state path to its :class:`HiddenGroup`.
+    hidden_param_op_relations : sequence of HiddenParamOpRelation
+        The hidden parameter-operation relations.
+    hidden_perturb : HiddenPerturbation or None
+        The hidden perturbation, or ``None`` when perturbations are excluded.
+    diagnostics : tuple of CompilationRecord
+        The structured compilation records emitted while building the graph.
 
-    - ``module_info``: The model information, instance of :class:`ModuleInfo`.
-    - ``hidden_groups``: The hidden groups, sequence of :class:`HiddenGroup`.
-    - ``hid_path_to_group``: The mapping from the hidden path to the hidden group :class:`HiddenGroup`.
-    - ``hidden_param_op_relations``: The hidden parameter operation relations, sequence of :class:`HiddenParamOpRelation`.
-    - ``hidden_perturb``: The hidden perturbation, instance of :class:`HiddenPerturbation`, or None.
+    See Also
+    --------
+    compile_etrace_graph : Build an ``ETraceGraph`` from a model.
 
-    Example::
+    Examples
+    --------
+    .. code-block:: python
 
-        >>> import braintrace
         >>> import brainstate
-        >>> gru = braintrace.nn.GRUCell(10, 20)
-        >>> gru.init_state()
-        >>> inputs = brainstate.random.randn(10)
-        >>> compiled_graph = braintrace.compile_etrace_graph(gru, inputs)
-        >>> compiled_graph.dict().keys()
-
+        >>> import braintrace
+        >>> gru = braintrace.nn.GRUCell(3, 4)
+        >>> _ = brainstate.nn.init_all_states(gru)
+        >>> inputs = brainstate.random.randn(3)
+        >>> graph = braintrace.compile_etrace_graph(gru, inputs)
+        >>> isinstance(graph, braintrace.ETraceGraph)
+        True
     """
 
     module_info: ModuleInfo
@@ -119,8 +133,25 @@ class ETraceGraph(NamedTuple):
 
         ``weight_path`` and ``hidden_path`` match the record's ``weight_path``
         exactly and ``hidden_paths`` membership respectively. ``kind`` matches
-        ``CompilationRecord.kind``. All are optional; with no filters the full
-        diagnostic log is returned.
+        ``CompilationRecord.kind``. All filters are optional; with no filters
+        the full diagnostic log is returned.
+
+        Parameters
+        ----------
+        weight_path : Path or None, optional
+            If given, keep only records whose ``weight_path`` equals this
+            value. Default ``None``.
+        hidden_path : Path or None, optional
+            If given, keep only records whose ``hidden_paths`` contain this
+            value. Default ``None``.
+        kind : DiagnosticKind or None, optional
+            If given, keep only records whose ``kind`` is this value. Default
+            ``None``.
+
+        Returns
+        -------
+        tuple of CompilationRecord
+            The matching records, in emission order.
         """
         result = []
         for record in self.diagnostics:
@@ -218,29 +249,52 @@ def compile_etrace_graph(
     *model_args: Tuple,
     include_hidden_perturb: bool = True,
 ) -> ETraceGraph:
-    """
-    Constructs the eligibility trace graph for a given model based on the provided inputs.
+    """Construct the eligibility-trace graph for a given model and inputs.
 
-    This is the most important method for the eligibility trace graph. It builds the
-    graph for the model, tracking the relationship between the etrace weights
-    ParamState, the etrace state HiddenState, and the etrace
-    operations ETP primitives, which will be used for computing the weight
-    spatial gradients, the hidden state Jacobian, and the hidden state-weight Jacobian.
+    This is the primary entry point of the ETrace compiler. It builds the graph
+    for the model, tracking the relationship between the eligibility-trace
+    weights (``ParamState``), the eligibility-trace states (``HiddenState``),
+    and the eligibility-trace operations (ETP primitives). These relationships
+    are later used to compute the weight spatial gradients, the hidden-state
+    Jacobian, and the hidden-state-to-weight Jacobian.
 
-    This function is crucial for building the eligibility trace graph, which tracks the
-    relationships between eligibility trace weights, states, and operations. These relationships
-    are used to compute weight spatial gradients, hidden state Jacobians, and hidden state-weight
-    Jacobians.
+    Parameters
+    ----------
+    model : brainstate.nn.Module
+        The model for which the eligibility-trace graph is built.
+    *model_args : tuple
+        The positional arguments required by the model.
+    include_hidden_perturb : bool, optional
+        Whether to include hidden perturbations in the graph. Default ``True``.
 
-    Args:
-        model (brainstate.nn.Module): The model for which the eligibility trace graph is to be built.
-        model_args (Tuple): The arguments required by the model.
-        include_hidden_perturb (bool): Indicates whether to include hidden perturbations in the graph.
-            Defaults to True.
+    Returns
+    -------
+    ETraceGraph
+        The compiled eligibility-trace graph containing module information,
+        hidden groups, hidden parameter-operation relations, and optional
+        hidden perturbations.
 
-    Returns:
-        ETraceGraph: The compiled eligibility trace graph containing module information, hidden groups,
-        hidden parameter operation relations, and optional hidden perturbations.
+    Raises
+    ------
+    NotImplementedError
+        If a recursive call to the compiler is detected.
+
+    See Also
+    --------
+    ETraceGraph : The returned compiled-graph data structure.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        >>> import brainstate
+        >>> import braintrace
+        >>> gru = braintrace.nn.GRUCell(3, 4)
+        >>> _ = brainstate.nn.init_all_states(gru)
+        >>> inputs = brainstate.random.randn(3)
+        >>> graph = braintrace.compile_etrace_graph(gru, inputs)
+        >>> len(graph.hidden_groups)
+        1
     """
 
     with compiler_context('compile_graph'), diagnostic_context() as reporter:

--- a/braintrace/_etrace_compiler/hid_param_op.py
+++ b/braintrace/_etrace_compiler/hid_param_op.py
@@ -124,36 +124,50 @@ class PathClassification:
 class HiddenParamOpRelation(NamedTuple):
     r"""Connection between an ETP primitive, its trainable parameters, and hidden states.
 
-    Records the structural relationship:
+    Records the structural relationship
 
     .. math::
-        h^t = f(y), \quad y = \text{primitive}(x, \theta)
 
-    Attributes:
-        primitive: The JAX primitive (``etp_mm_p``, ``etp_mv_p``, etc.).
-        x_var: Jaxpr ``Var`` for the input (``None`` for element-wise ops).
-        y_var: Jaxpr ``Var`` for the primitive output.
-        hidden_groups: Hidden groups that this op feeds into.
-        y_to_hidden_group_jaxprs: Transition Jaxpr from *y* to each hidden group.
-        connected_hidden_paths: Hidden-state paths connected to this op.
-        eqn_params: Static parameters of the primitive equation.
-        path_classification: ``{hidden_path: PathClassification.*}`` for each
-            connected hidden state. Populated by the path-classification pass.
-        trainable_vars: Per-key dict mapping a primitive-chosen key name
-            (e.g. ``'weight'``, ``'bias'``, ``'lora_b'``, ``'lora_a'``) to its
-            jaxpr ``Var``. Populated by the compiler with one entry per declared
-            trainable input.
-        trainable_paths: Per-key dict mapping each key to the owning
-            ``ParamState``'s module path. When the primitive has two keys
-            whose invars trace to the same ``ParamState`` (e.g. merged
-            ``{weight, bias}`` Linear), the entries share a path.
-        trainable_leaf_indices: Per-key dict mapping each key to the leaf
-            index in ``jax.tree.leaves`` of the owning ``ParamState``.
-        trainable_param_states: Per-key dict mapping each key to the actual
-            ``ParamState`` object.
-        trainable_processing_chains: Per-key dict mapping each key to the
-            backward-trace processing chain (primitives traversed from the
-            trainable invar back to the originating ``ParamState`` invar).
+        h^t = f(y), \quad y = \mathrm{primitive}(x, \theta)
+
+    discovered by the compiler for a single ETP primitive equation.
+
+    Attributes
+    ----------
+    primitive : Primitive
+        The JAX primitive (``etp_mm_p``, ``etp_mv_p``, etc.).
+    x_var : Var or None
+        Jaxpr ``Var`` for the input (``None`` for element-wise ops).
+    y_var : Var
+        Jaxpr ``Var`` for the primitive output.
+    hidden_groups : list of HiddenGroup
+        Hidden groups that this op feeds into.
+    y_to_hidden_group_jaxprs : list of Jaxpr
+        Transition jaxpr from ``y`` to each hidden group.
+    connected_hidden_paths : list of Path
+        Hidden-state paths connected to this op.
+    eqn_params : dict
+        Static parameters of the primitive equation.
+    path_classification : dict
+        Mapping ``{hidden_path: PathClassification.*}`` for each connected
+        hidden state. Populated by the path-classification pass.
+    trainable_vars : dict
+        Per-key dict mapping a primitive-chosen key name (e.g. ``'weight'``,
+        ``'bias'``, ``'lora_b'``, ``'lora_a'``) to its jaxpr ``Var``, with one
+        entry per declared trainable input.
+    trainable_paths : dict
+        Per-key dict mapping each key to the owning ``ParamState``'s module
+        path. When two keys trace to the same ``ParamState`` (e.g. a merged
+        ``{weight, bias}`` Linear), the entries share a path.
+    trainable_leaf_indices : dict
+        Per-key dict mapping each key to the leaf index in
+        ``jax.tree.leaves`` of the owning ``ParamState``.
+    trainable_param_states : dict
+        Per-key dict mapping each key to the actual ``ParamState`` object.
+    trainable_processing_chains : dict
+        Per-key dict mapping each key to the backward-trace processing chain
+        (primitives traversed from the trainable invar back to the originating
+        ``ParamState`` invar).
     """
     primitive: Primitive
     x_var: Optional[Var]
@@ -183,7 +197,25 @@ class HiddenParamOpRelation(NamedTuple):
         return next(iter(self.trainable_paths.values()), None)
 
     def y_to_hidden_groups(self, y_val, const_vals, concat_hidden_vals=True):
-        """Evaluate transition jaxprs: y -> hidden group values."""
+        """Evaluate the transition jaxprs mapping ``y`` to hidden-group values.
+
+        Parameters
+        ----------
+        y_val : jax.Array
+            The value of the primitive output ``y``.
+        const_vals : dict
+            Mapping from each transition-jaxpr constvar to its value.
+        concat_hidden_vals : bool, optional
+            If ``True``, concatenate each group's hidden values into a single
+            array via :meth:`HiddenGroup.concat_hidden`. Default ``True``.
+
+        Returns
+        -------
+        list
+            One entry per hidden group: either a list of per-state arrays
+            (when ``concat_hidden_vals`` is ``False``) or a single concatenated
+            array (when ``True``).
+        """
         vals_of_hidden_groups = []
         for jaxpr, group in zip(self.y_to_hidden_group_jaxprs, self.hidden_groups):
             consts = [const_vals[var] for var in jaxpr.constvars]
@@ -951,8 +983,24 @@ def find_hidden_param_op_relations_from_minfo(
 ) -> Sequence[HiddenParamOpRelation]:
     """Find ETP relations from a ``ModuleInfo``.
 
-    Builds a mapping from ALL ``brainstate.ParamState`` invars so that
-    plain ``ParamState`` weights used with ETP primitives are recognised.
+    Builds a mapping from all ``brainstate.ParamState`` invars so that plain
+    ``ParamState`` weights used with ETP primitives are recognised.
+
+    Parameters
+    ----------
+    minfo : ModuleInfo
+        The model information.
+    hid_path_to_group : dict
+        Mapping from each hidden-state path to its :class:`HiddenGroup`.
+
+    Returns
+    -------
+    sequence of HiddenParamOpRelation
+        The discovered ETP-primitive-to-hidden-state relations.
+
+    See Also
+    --------
+    find_hidden_param_op_relations_from_module : Equivalent helper starting from a model.
     """
     invar_to_weight_path: Dict[Var, Path] = {}
     weight_path_to_invars: Dict[Path, List[Var]] = {}
@@ -986,7 +1034,39 @@ def find_hidden_param_op_relations_from_module(
     *model_args,
     **model_kwargs,
 ) -> Sequence[HiddenParamOpRelation]:
-    """Find ETP relations from a model."""
+    """Find ETP relations from a model.
+
+    Parameters
+    ----------
+    model : brainstate.nn.Module
+        The model.
+    *model_args
+        The positional arguments of the model.
+    **model_kwargs
+        The keyword arguments of the model.
+
+    Returns
+    -------
+    sequence of HiddenParamOpRelation
+        The discovered ETP-primitive-to-hidden-state relations.
+
+    See Also
+    --------
+    find_hidden_param_op_relations_from_minfo : Equivalent helper starting from ``ModuleInfo``.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        >>> import brainstate
+        >>> import braintrace
+        >>> gru = braintrace.nn.GRUCell(3, 4)
+        >>> _ = brainstate.nn.init_all_states(gru)
+        >>> inputs = brainstate.random.randn(3)
+        >>> relations = braintrace.find_hidden_param_op_relations_from_module(gru, inputs)
+        >>> len(relations)
+        2
+    """
     minfo = extract_module_info(model, *model_args, **model_kwargs)
     hidden_groups, hid_path_to_group = find_hidden_groups_from_minfo(minfo)
     return find_hidden_param_op_relations_from_minfo(minfo, hid_path_to_group)

--- a/braintrace/_etrace_compiler/hidden_group.py
+++ b/braintrace/_etrace_compiler/hidden_group.py
@@ -72,30 +72,49 @@ __all__ = [
 
 
 class HiddenGroup(NamedTuple):
-    r"""
-    The data structure for recording the hidden group relation.
+    r"""The data structure recording a hidden-group relation.
 
-    The following fields are included:
+    A hidden group bundles the hidden states that are mutually connected through
+    a recurrence transition, together with the jaxpr that computes that
+    transition
 
-    - ``hidden_paths``: the path to each hidden state
-    - ``hidden_states``: the hidden states
-    - ``hidden_invars``: the input jax Var of hidden states
-    - ``hidden_outvars``: the output jax Var of hidden states
-    - ``transition_jaxpr``: the jaxpr for computing hidden state transitions, i.e.,
-      $h_1^t, h_2^t, ... = f(h_1^{t-1}, h_2^{t-1}, ..., x_t)$
-    - ``transition_jaxpr_constvars``: the other input variables for jaxpr evaluation of ``transition_jaxpr``
+    .. math::
 
+        h_1^t, h_2^t, \ldots = f(h_1^{t-1}, h_2^{t-1}, \ldots, x^t).
 
-    Example::
+    Attributes
+    ----------
+    index : int
+        Position of this group in the compiled group sequence.
+    hidden_paths : list of Path
+        The module path to each hidden state in the group.
+    hidden_states : list of brainstate.HiddenState
+        The hidden states in the group.
+    hidden_invars : list of HiddenInVar
+        The input jaxpr ``Var`` of each hidden state (at the previous step).
+    hidden_outvars : list of HiddenOutVar
+        The output jaxpr ``Var`` of each hidden state (at the current step).
+    transition_jaxpr : Jaxpr
+        The jaxpr computing the hidden-state transition for the group.
+    transition_jaxpr_constvars : list of Var
+        The other input variables required to evaluate ``transition_jaxpr``.
 
-        >>> import braintrace
+    See Also
+    --------
+    find_hidden_groups_from_module : Build hidden groups directly from a model.
+
+    Examples
+    --------
+    .. code-block:: python
+
         >>> import brainstate
-        >>> gru = braintrace.nn.GRUCell(10, 20)
-        >>> gru.init_state()
-        >>> inputs = brainstate.random.randn(10)
+        >>> import braintrace
+        >>> gru = braintrace.nn.GRUCell(3, 4)
+        >>> _ = brainstate.nn.init_all_states(gru)
+        >>> inputs = brainstate.random.randn(3)
         >>> hidden_groups, _ = braintrace.find_hidden_groups_from_module(gru, inputs)
-        >>> for group in hidden_groups:
-        ...     print(group.hidden_paths)
+        >>> len(hidden_groups)
+        1
     """
 
     index: int  # type: ignore[assignment]  # intentional NamedTuple field; shadows tuple.index
@@ -121,24 +140,33 @@ class HiddenGroup(NamedTuple):
 
     @property
     def varshape(self) -> Tuple[int, ...]:
-        """
-        The shape of each state variable.
+        """The shape of each state variable.
+
+        Returns
+        -------
+        tuple of int
+            The variable shape shared by the hidden states in the group.
         """
         return self.hidden_states[0].varshape
 
     @property
     def num_state(self) -> int:
-        """
-        The number of hidden states.
+        """The number of hidden states.
+
+        Returns
+        -------
+        int
+            The total number of hidden states across the group.
         """
         return sum([st.num_state for st in self.hidden_states])
 
     def check_consistent_varshape(self):
-        """
-        Checking whether the shapes of the hidden states are consistent.
+        """Check whether the shapes of the hidden states are consistent.
 
-        Raises:
-            NotSupportedError: If the shapes of the hidden states are not consistent.
+        Raises
+        ------
+        NotSupportedError
+            If the shapes of the hidden states are not consistent.
         """
 
         varshapes = set([tuple(st.varshape) for st in self.hidden_states])
@@ -153,15 +181,25 @@ class HiddenGroup(NamedTuple):
         hidden_vals: Sequence[jax.Array],
         input_vals: PyTree,
     ) -> List[jax.Array]:
-        r"""
-        Computing the hidden state transitions $h_1^t, h_2^t, \cdots = f(h_1^{t-1}, h_2^{t-1}, \cdots, x^t)$.
+        r"""Compute the hidden-state transitions.
 
-        Args:
-            hidden_vals: The old hidden state value.
-            input_vals: The input values.
+        Evaluates the group transition jaxpr
 
-        Returns:
-            The new hidden state values.
+        .. math::
+
+            h_1^t, h_2^t, \cdots = f(h_1^{t-1}, h_2^{t-1}, \cdots, x^t).
+
+        Parameters
+        ----------
+        hidden_vals : sequence of jax.Array
+            The old hidden-state values.
+        input_vals : PyTree
+            The input values.
+
+        Returns
+        -------
+        list of jax.Array
+            The new hidden-state values.
         """
         return jax.core.eval_jaxpr(self.transition_jaxpr, input_vals, *hidden_vals)
 
@@ -170,15 +208,19 @@ class HiddenGroup(NamedTuple):
         hidden_vals: Sequence[jax.Array],
         input_vals: PyTree,
     ):
-        """
-        Computing the diagonal Jacobian matrix along the last dimension.
+        """Compute the diagonal Jacobian matrix along the last dimension.
 
-        Args:
-            hidden_vals: The hidden state values.
-            input_vals: The input values.
+        Parameters
+        ----------
+        hidden_vals : sequence of jax.Array
+            The hidden-state values.
+        input_vals : PyTree
+            The input values.
 
-        Returns:
-            The diagonal Jacobian matrix, which has the shape of
+        Returns
+        -------
+        jax.Array
+            The diagonal Jacobian matrix, with shape
             ``(*varshape, num_states, num_states)``.
         """
         return jacrev_last_dim(
@@ -187,20 +229,23 @@ class HiddenGroup(NamedTuple):
         )
 
     def concat_hidden(self, splitted_hid_vals: Sequence[jax.Array]):
-        """
-        Concatenate split hidden state values into a single array.
+        """Concatenate split hidden-state values into a single array.
 
-        This function takes a sequence of split hidden state values and concatenates them
-        along the last axis. For non-HiddenGroupState values, it adds an extra dimension
-        before concatenation.
+        Concatenates a sequence of split hidden-state values along the last
+        axis. For non-``HiddenGroupState`` values, an extra trailing dimension
+        is added before concatenation.
 
-        Args:
-            splitted_hid_vals (Sequence[jax.Array]): A sequence of split hidden state
-                values, each corresponding to a hidden state in the group.
+        Parameters
+        ----------
+        splitted_hid_vals : sequence of jax.Array
+            A sequence of split hidden-state values, each corresponding to a
+            hidden state in the group.
 
-        Returns:
-            jax.Array: A single concatenated array containing all hidden state values.
-                The concatenation is performed along the last axis.
+        Returns
+        -------
+        jax.Array
+            A single array containing all hidden-state values concatenated
+            along the last axis.
         """
         splitted_hid_vals = [
             val
@@ -211,19 +256,22 @@ class HiddenGroup(NamedTuple):
         return u.math.concatenate(splitted_hid_vals, axis=-1)
 
     def split_hidden(self, concat_hid_vals: jax.Array):
-        """
-        Split concatenated hidden state values into individual arrays.
+        """Split a concatenated hidden-state array into individual arrays.
 
-        This function takes a concatenated array of hidden state values and splits it
-        into separate arrays for each hidden state in the group. It handles both
-        HiddenGroupState and non-HiddenGroupState values differently.
+        Splits a concatenated array of hidden-state values into separate arrays,
+        one per hidden state in the group. ``HiddenGroupState`` and
+        non-``HiddenGroupState`` values are handled differently.
 
-        Args:
-            concat_hid_vals (jax.Array): A concatenated array of hidden state values.
-                The last dimension is assumed to contain the concatenated states.
+        Parameters
+        ----------
+        concat_hid_vals : jax.Array
+            A concatenated array of hidden-state values. The last dimension is
+            assumed to contain the concatenated states.
 
-        Returns:
-            List[jax.Array]: A list of split hidden state arrays. For non-HiddenGroupState
+        Returns
+        -------
+        list of jax.Array
+            A list of split hidden-state arrays. For non-``HiddenGroupState``
             values, the last dimension is squeezed.
         """
         num_states = [st.num_state for st in self.hidden_states]
@@ -926,15 +974,23 @@ def find_hidden_groups_from_jaxpr(
 def find_hidden_groups_from_minfo(
     minfo: ModuleInfo
 ):
-    """
-    Finding the hidden groups from the model.
+    """Find the hidden groups from the model information.
 
-    Args:
-        minfo: The model information.
+    Parameters
+    ----------
+    minfo : ModuleInfo
+        The model information.
 
-    Returns:
-        The hidden groups,
-        and the mapping from the hidden state path to the hidden group.
+    Returns
+    -------
+    hidden_groups : sequence of HiddenGroup
+        The hidden groups.
+    hid_path_to_group : dict
+        Mapping from each hidden-state path to its :class:`HiddenGroup`.
+
+    See Also
+    --------
+    find_hidden_groups_from_module : Equivalent helper starting from a model.
     """
     (
         hidden_groups,
@@ -955,18 +1011,40 @@ def find_hidden_groups_from_module(
     *model_args,
     **model_kwargs,
 ) -> Tuple[Sequence[HiddenGroup], brainstate.util.PrettyDict]:
-    """
-    Find hidden groups from the model.
+    """Find hidden groups from a model.
 
-    Args:
-        model: The model.
-        model_args: The model arguments.
-        model_kwargs: The model keyword arguments.
+    Parameters
+    ----------
+    model : brainstate.nn.Module
+        The model.
+    *model_args
+        The positional arguments of the model.
+    **model_kwargs
+        The keyword arguments of the model.
 
-    Returns:
-        A tuple containing:
-        - Sequence of HiddenGroup objects
-        - PrettyDict mapping hidden state paths to hidden groups
+    Returns
+    -------
+    hidden_groups : sequence of HiddenGroup
+        The hidden groups.
+    hid_path_to_group : brainstate.util.PrettyDict
+        Mapping from each hidden-state path to its :class:`HiddenGroup`.
+
+    See Also
+    --------
+    find_hidden_groups_from_minfo : Equivalent helper starting from ``ModuleInfo``.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        >>> import brainstate
+        >>> import braintrace
+        >>> gru = braintrace.nn.GRUCell(3, 4)
+        >>> _ = brainstate.nn.init_all_states(gru)
+        >>> inputs = brainstate.random.randn(3)
+        >>> hidden_groups, hid_path_to_group = braintrace.find_hidden_groups_from_module(gru, inputs)
+        >>> len(hidden_groups)
+        1
     """
     minfo = extract_module_info(model, *model_args, **model_kwargs)
     return find_hidden_groups_from_minfo(minfo)

--- a/braintrace/_etrace_compiler/hidden_pertubation.py
+++ b/braintrace/_etrace_compiler/hidden_pertubation.py
@@ -54,43 +54,57 @@ __all__ = [
 
 
 class HiddenPerturbation(NamedTuple):
-    r"""
-    The hidden perturbation information.
+    r"""The hidden-perturbation information.
 
-    Hidden perturbation means that we add perturbations to the hidden states in the jaxpr,
-    and replace the hidden states with the perturbed states.
-    
-    Mathematically, we have the following equation:
-    
-    $$
-    h^t = f(x)  \Rightarrow  h^t = f(x) + \text{perturb_var}
-    $$
-    
-    where $h$ is the hidden state, $f$ is the function, $x$ is the input, and $\text{perturb_var}$
-    is the perturbation variable.
+    Hidden perturbation adds a perturbation variable to each hidden state in the
+    jaxpr and replaces the hidden states with the perturbed states:
 
-    Technically, we first define a new variable $\hat{h}^t = f(x)$, and then add a new equation:
+    .. math::
 
-    $$
-    h^t = \hat{h}^t + \text{perturb_var}
-    $$
+        h^t = f(x) \;\Rightarrow\; h^t = f(x) + \mathrm{perturb\_var},
 
-    Actually, we add the perturbation to the hidden states in the jaxpr for computing the hidden state gradients:
+    where :math:`h` is the hidden state, :math:`f` is the function, :math:`x` is
+    the input, and :math:`\mathrm{perturb\_var}` is the perturbation variable.
 
-    $$
-    \frac{\partial L^t}{\partial h^t} = \frac{\partial L^t}{\partial \text{perturb_var}}
-    $$
+    Attributes
+    ----------
+    perturb_vars : sequence of Var
+        The perturbation variables.
+    perturb_hidden_paths : sequence of Path
+        The hidden-state paths that are perturbed.
+    perturb_hidden_states : sequence of brainstate.HiddenState
+        The hidden states that are perturbed.
+    perturb_jaxpr : ClosedJaxpr
+        The perturbed jaxpr.
 
-    Example::
+    See Also
+    --------
+    add_hidden_perturbation_in_module : Build perturbations directly from a model.
 
-        >>> import braintrace
+    Notes
+    -----
+    Internally a new variable :math:`\hat{h}^t = f(x)` is defined and an extra
+    equation :math:`h^t = \hat{h}^t + \mathrm{perturb\_var}` is added. The
+    perturbation lets the hidden-state gradient be read off the perturbation
+    variable
+
+    .. math::
+
+        \frac{\partial L^t}{\partial h^t}
+        = \frac{\partial L^t}{\partial \mathrm{perturb\_var}}.
+
+    Examples
+    --------
+    .. code-block:: python
+
         >>> import brainstate
-        >>> gru = braintrace.nn.GRUCell(10, 20)
-        >>> gru.init_state()
-        >>> inputs = brainstate.random.randn(10)
+        >>> import braintrace
+        >>> gru = braintrace.nn.GRUCell(3, 4)
+        >>> _ = brainstate.nn.init_all_states(gru)
+        >>> inputs = brainstate.random.randn(3)
         >>> hidden_perturb = braintrace.add_hidden_perturbation_in_module(gru, inputs)
-
-
+        >>> isinstance(hidden_perturb, braintrace.HiddenPerturbation)
+        True
     """
     perturb_vars: Sequence[Var]  # the perturbation variables
     perturb_hidden_paths: Sequence[Path]  # the hidden state paths that are perturbed
@@ -102,8 +116,19 @@ class HiddenPerturbation(NamedTuple):
         inputs: Sequence[jax.Array],
         perturb_data: Sequence[jax.Array]
     ) -> Sequence[jax.Array]:
-        """
-        Evaluate the perturbed jaxpr.
+        """Evaluate the perturbed jaxpr.
+
+        Parameters
+        ----------
+        inputs : sequence of jax.Array
+            The flat input values of the original jaxpr.
+        perturb_data : sequence of jax.Array
+            The perturbation values, one per entry of ``perturb_vars``.
+
+        Returns
+        -------
+        sequence of jax.Array
+            The outputs of the perturbed jaxpr.
         """
         return jax.core.eval_jaxpr(
             self.perturb_jaxpr.jaxpr,
@@ -112,8 +137,13 @@ class HiddenPerturbation(NamedTuple):
         )
 
     def init_perturb_data(self) -> Sequence[jax.Array]:
-        """
-        Initialize the perturbation data.
+        """Initialize the perturbation data to zeros.
+
+        Returns
+        -------
+        sequence of jax.Array
+            One zero array per perturbation variable, matching its shape and
+            dtype.
         """
         return [jax.numpy.zeros(v.aval.shape, dtype=v.aval.dtype) for v in self.perturb_vars]
 
@@ -122,8 +152,25 @@ class HiddenPerturbation(NamedTuple):
         perturb_data: Sequence[jax.Array],
         hidden_groups: Sequence[HiddenGroup],
     ) -> Sequence[jax.Array]:
-        """
-        Convert the perturbation data to the hidden group data.
+        """Convert the perturbation data to per-hidden-group data.
+
+        Parameters
+        ----------
+        perturb_data : sequence of jax.Array
+            The perturbation values, one per entry of ``perturb_vars``.
+        hidden_groups : sequence of HiddenGroup
+            The hidden groups to map the perturbation data onto.
+
+        Returns
+        -------
+        sequence of jax.Array
+            One concatenated perturbation array per hidden group.
+
+        Raises
+        ------
+        AssertionError
+            If ``perturb_data`` does not have the same length as
+            ``perturb_vars``.
         """
         assert len(perturb_data) == len(self.perturb_vars), (
             f'The length of the perturb data is not correct. '
@@ -350,15 +397,24 @@ def add_hidden_perturbation_in_jaxpr(
 def add_hidden_perturbation_from_minfo(
     minfo: ModuleInfo,
 ) -> HiddenPerturbation:
-    """
-    Adding perturbations to the hidden states in the module,
-    and replacing the hidden states with the perturbed states.
+    """Add hidden-state perturbations from a ``ModuleInfo``.
 
-    Args:
-        minfo: The model information.
+    Adds perturbations to the hidden states in the module jaxpr and replaces
+    the hidden states with the perturbed states.
 
-    Returns:
-        The hidden perturbation information.
+    Parameters
+    ----------
+    minfo : ModuleInfo
+        The model information.
+
+    Returns
+    -------
+    HiddenPerturbation
+        The hidden-perturbation information.
+
+    See Also
+    --------
+    add_hidden_perturbation_in_module : Equivalent helper starting from a model.
     """
     return add_hidden_perturbation_in_jaxpr(
         closed_jaxpr=minfo.closed_jaxpr,
@@ -375,18 +431,43 @@ def add_hidden_perturbation_in_module(
     *model_args,
     **model_kwargs,
 ) -> HiddenPerturbation:
-    """
-    Adds perturbations to the hidden states in the given module and replaces the hidden states with the perturbed states.
+    """Add hidden-state perturbations from a model.
+
+    Adds perturbations to the hidden states of the given module and replaces the
+    hidden states with the perturbed states.
 
     Parameters
     ----------
-    model (brainstate.nn.Module): The neural network module to which hidden state perturbations will be added.
-    *model_args: Additional positional arguments to be passed to the model.
-    **model_kwargs: Additional keyword arguments to be passed to the model.
+    model : brainstate.nn.Module
+        The neural-network module to which hidden-state perturbations are added.
+    *model_args
+        Additional positional arguments passed to the model.
+    **model_kwargs
+        Additional keyword arguments passed to the model.
 
     Returns
     -------
-    HiddenPerturbation: An object containing information about the perturbations added to the hidden states, including the perturbed variables, paths, states, and the revised jaxpr.
+    HiddenPerturbation
+        Information about the perturbations added to the hidden states,
+        including the perturbed variables, paths, states, and the revised
+        jaxpr.
+
+    See Also
+    --------
+    add_hidden_perturbation_from_minfo : Equivalent helper starting from ``ModuleInfo``.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        >>> import brainstate
+        >>> import braintrace
+        >>> gru = braintrace.nn.GRUCell(3, 4)
+        >>> _ = brainstate.nn.init_all_states(gru)
+        >>> inputs = brainstate.random.randn(3)
+        >>> hidden_perturb = braintrace.add_hidden_perturbation_in_module(gru, inputs)
+        >>> len(hidden_perturb.perturb_vars)
+        1
     """
     minfo = extract_module_info(model, *model_args, **model_kwargs)
     return add_hidden_perturbation_from_minfo(minfo)

--- a/braintrace/_etrace_compiler/module_info.py
+++ b/braintrace/_etrace_compiler/module_info.py
@@ -199,54 +199,68 @@ def abstractify_model(
 
 
 class ModuleInfo(NamedTuple):
-    """
-    The model information for the etrace compiler.
+    """The model information for the ETrace compiler.
 
-    The model information contains the at least five categories of information:
+    Bundles the abstract representation of a model and all the lookup tables the
+    compiler needs. It groups information into five categories: the stateful
+    model, the jaxpr, the states, the hidden states, and the parameter weights.
 
-    1. The stateful model.
+    Attributes
+    ----------
+    stateful_model : brainstate.transform.StatefulFunction
+        The stateful function that compiles the model into an abstract jaxpr
+        representation.
+    closed_jaxpr : ClosedJaxpr
+        The closed-jaxpr representation of the model.
+    retrieved_model_states : brainstate.util.FlattedDict
+        The model states retrieved from ``model.states()``, with well-defined
+        paths and structures.
+    compiled_model_states : sequence of brainstate.State
+        The model states compiled from the stateful model; accurate and
+        consistent with the model jaxpr but lacking path information.
+    state_id_to_path : dict
+        Mapping from each state id to its state path.
+    state_tree_invars : PyTree of Var
+        The input jaxpr variables of the states, as a pytree.
+    state_tree_outvars : PyTree of Var
+        The output jaxpr variables of the states, as a pytree.
+    hidden_path_to_invar : dict
+        Mapping from each hidden path to its input variable.
+    hidden_path_to_outvar : dict
+        Mapping from each hidden path to its output variable.
+    invar_to_hidden_path : dict
+        Mapping from each input variable to its hidden path.
+    outvar_to_hidden_path : dict
+        Mapping from each output variable to its hidden path.
+    hidden_outvar_to_invar : dict
+        Mapping from each output variable to its input variable.
+    weight_invars : list of Var
+        The weight input variables.
+    weight_path_to_invars : dict
+        Mapping from each weight path to its input variables.
+    invar_to_weight_path : dict
+        Mapping from each input variable to its weight path.
+    num_var_out : int
+        Number of original output variables.
+    num_var_state : int
+        Number of state-variable outputs.
 
-        - ``stateful_model``: The stateful model is the model that compiles the model
-          into abstract jaxpr representation.
+    See Also
+    --------
+    extract_module_info : Build a ``ModuleInfo`` from a model.
 
-    2. The jaxpr.
+    Examples
+    --------
+    .. code-block:: python
 
-        The jaxpr is the abstract representation of the model.
-
-        - ``closed_jaxpr``: The closed jaxpr is the closed jaxpr representation of the model.
-
-    3. The states.
-
-        - ``retrieved_model_states``: The model states that are retrieved from the ``model.states()`` function,
-          which has well-defined paths and structures.
-        - ``compiled_model_states``: The model states that are compiled from the stateful model, which is
-          accurate and consistent with the model jaxpr, but loss the path information.
-        - ``state_id_to_path``: The mapping from the state id to the state path.
-
-    4. The hidden states.
-
-        - ``hidden_path_to_invar``: The mapping from the hidden path to the input variable.
-        - ``hidden_path_to_outvar``: The mapping from the hidden path to the output variable.
-        - ``invar_to_hidden_path``: The mapping from the input variable to the hidden path.
-        - ``outvar_to_hidden_path``: The mapping from the output variable to the hidden path.
-        - ``hidden_outvar_to_invar``: The mapping from the output variable to the input variable.
-
-    5. The parameter weights.
-
-        - ``weight_invars``: The weight input variables.
-        - ``weight_path_to_invars``: The mapping from the weight path to the input variables.
-        - ``invar_to_weight_path``: The mapping from the input variable to the weight path.
-
-
-    Example::
-
-        >>> import braintrace
         >>> import brainstate
-        >>> gru = braintrace.nn.GRUCell(10, 20)
-        >>> gru.init_state()
-        >>> inputs = brainstate.random.randn(10)
+        >>> import braintrace
+        >>> gru = braintrace.nn.GRUCell(3, 4)
+        >>> _ = brainstate.nn.init_all_states(gru)
+        >>> inputs = brainstate.random.randn(3)
         >>> module_info = braintrace.extract_module_info(gru, inputs)
-
+        >>> isinstance(module_info, braintrace.ModuleInfo)
+        True
     """
     # stateful model
     stateful_model: brainstate.transform.StatefulFunction
@@ -279,8 +293,12 @@ class ModuleInfo(NamedTuple):
 
     @property
     def jaxpr(self) -> Jaxpr:
-        """
-        The jaxpr of the model.
+        """The jaxpr of the model.
+
+        Returns
+        -------
+        Jaxpr
+            The jaxpr extracted from ``closed_jaxpr``.
         """
         return self.closed_jaxpr.jaxpr
 
@@ -288,9 +306,20 @@ class ModuleInfo(NamedTuple):
         self,
         jax_vars: Sequence[Var],
     ) -> 'ModuleInfo':
-        """
-        Adding the jaxpr outputs to the model jaxpr, so that it can return the additional variables which
-        needed for the etrace compiler.
+        """Add extra jaxpr outputs to the model jaxpr.
+
+        Returns a new ``ModuleInfo`` whose jaxpr additionally outputs the given
+        variables, so the compiler can recover the intermediate values it needs.
+
+        Parameters
+        ----------
+        jax_vars : sequence of Var
+            The extra jaxpr variables to append to the jaxpr outputs.
+
+        Returns
+        -------
+        ModuleInfo
+            A new ``ModuleInfo`` with the extended jaxpr.
         """
         assert all(isinstance(v, Var) for v in jax_vars), 'The jax_vars should be the instance of Var.'
 
@@ -316,13 +345,16 @@ class ModuleInfo(NamedTuple):
         return ModuleInfo(**items)
 
     def split_state_outvars(self):
-        """
-        Splitting the state outvars into three parts: weight, hidden, and other states.
+        """Split the state outvars into weight, hidden, and other states.
 
-        Returns:
-            weight_jaxvar_tree: The weight tree of jax Var.
-            hidden_jaxvar: The hidden tree of jax Var.
-            other_state_jaxvar_tree: The other state tree of jax Var.
+        Returns
+        -------
+        weight_jaxvar_tree : PyTree of Var
+            The weight tree of jaxpr variables.
+        hidden_jaxvar : PyTree of Var
+            The hidden tree of jaxpr variables.
+        other_state_jaxvar_tree : PyTree of Var
+            The other-state tree of jaxpr variables.
         """
         (
             weight_jaxvar_tree,
@@ -341,18 +373,26 @@ class ModuleInfo(NamedTuple):
         StateVals,
         TempData,
     ]:
-        """
-        Computing the model according to the given inputs and parameters by using the compiled jaxpr.
+        """Evaluate the model on the given inputs using the compiled jaxpr.
 
-        Args:
-            args: The inputs of the model.
-            old_state_vals: The old state values.
+        Parameters
+        ----------
+        *args : Inputs
+            The inputs of the model.
+        old_state_vals : sequence of jax.Array or None, optional
+            The old state values. When ``None``, the current values of the
+            compiled model states are used. Default ``None``.
 
-        Returns:
-            out: The output of the model.
-            etrace_vals: The values for etrace states.
-            oth_state_vals: The other state values.
-            temps: The temporary intermediate values.
+        Returns
+        -------
+        out : Outputs
+            The output of the model.
+        etrace_vals : ETraceVals
+            The values for the eligibility-trace (hidden) states.
+        oth_state_vals : StateVals
+            The other state values.
+        temps : TempData
+            The temporary intermediate values.
         """
 
         # state checking
@@ -431,16 +471,38 @@ def extract_module_info(
     *model_args,
     **model_kwargs
 ) -> ModuleInfo:
-    """
-    Extracting the model information for the etrace compiler.
+    """Extract the model information for the ETrace compiler.
 
-    Args:
-        model: The model to extract the information.
-        model_args: The arguments of the model.
-        model_kwargs: The keyword arguments of the model.
+    Parameters
+    ----------
+    model : brainstate.nn.Module
+        The model from which to extract the information.
+    *model_args
+        The positional arguments of the model.
+    **model_kwargs
+        The keyword arguments of the model.
 
-    Returns:
-        The model information, instance of :class:`ModuleInfo`.
+    Returns
+    -------
+    ModuleInfo
+        The model information.
+
+    See Also
+    --------
+    ModuleInfo : The returned data structure.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        >>> import brainstate
+        >>> import braintrace
+        >>> gru = braintrace.nn.GRUCell(3, 4)
+        >>> _ = brainstate.nn.init_all_states(gru)
+        >>> inputs = brainstate.random.randn(3)
+        >>> module_info = braintrace.extract_module_info(gru, inputs)
+        >>> module_info.num_var_out
+        1
     """
 
     # abstract the model

--- a/braintrace/_etrace_op/_primitive.py
+++ b/braintrace/_etrace_op/_primitive.py
@@ -58,40 +58,65 @@ class ETPPrimitive(Primitive):
     convenience methods for installing ETP-specific rules into the global
     registries.
 
-    Example::
+    See Also
+    --------
+    register_primitive : Factory that creates and returns an instance.
 
-        my_p = register_primitive('etp_my_op', _my_impl, batched=True)
-        my_p.register_yw_to_w(my_yw_to_w_fn)
-        my_p.register_xy_to_dw(my_xy_to_dw_fn)
-        my_p.register_init_drtrl(my_init_drtrl_fn)
-        my_p.register_init_pp(my_init_pp_fn)
+    Examples
+    --------
+    .. code-block:: python
+
+        >>> import jax.numpy as jnp
+        >>> import braintrace
+        >>>
+        >>> # Register a primitive whose forward delegates to a standard op.
+        >>> def my_impl(x, w):
+        ...     return x @ w
+        >>> my_p = braintrace.register_primitive('etp_demo_mm', my_impl, batched=True)
+        >>> y = my_p.bind(jnp.ones((2, 3)), jnp.ones((3, 4)))
+        >>> print(y.shape)
+        (2, 4)
     """
 
     def register_yw_to_w(self, fn: Callable):
         """Install a D-RTRL trace propagation rule.
 
-        Signature: ``(hidden_dim, trace, **params) -> trace``.
+        Parameters
+        ----------
+        fn : Callable
+            Rule with signature ``(hidden_dim, trace, **params) -> trace``.
         """
         ETP_RULES_YW_TO_W[self] = fn
 
     def register_xy_to_dw(self, fn: Callable):
         """Install a weight-gradient rule.
 
-        Signature: ``(x, hidden_dim, w, **params) -> dw``.
+        Parameters
+        ----------
+        fn : Callable
+            Rule with signature ``(x, hidden_dim, w, **params) -> dw``.
         """
         ETP_RULES_XY_TO_DW[self] = fn
 
     def register_init_drtrl(self, fn: Callable):
         """Install a D-RTRL trace initialiser.
 
-        Signature: ``(x_var, y_var, weight_var, num_hidden_state) -> zeros``.
+        Parameters
+        ----------
+        fn : Callable
+            Rule with signature
+            ``(x_var, y_var, weight_var, num_hidden_state) -> zeros``.
         """
         ETP_RULES_INIT_DRTRL[self] = fn
 
     def register_init_pp(self, fn: Callable):
         """Install a pp_prop (IO-dim) df trace initialiser.
 
-        Signature: ``(x_var, y_var, weight_var, num_hidden_state) -> zeros``.
+        Parameters
+        ----------
+        fn : Callable
+            Rule with signature
+            ``(x_var, y_var, weight_var, num_hidden_state) -> zeros``.
         """
         ETP_RULES_INIT_PP[self] = fn
 
@@ -103,7 +128,21 @@ class ETPPrimitive(Primitive):
         init_drtrl: Callable = None,
         init_pp: Callable = None,
     ):
-        """Install multiple ETP rules in one call. Skips any ``None`` argument."""
+        """Install multiple ETP rules in one call.
+
+        Any argument left as ``None`` is skipped.
+
+        Parameters
+        ----------
+        yw_to_w : Callable, optional
+            D-RTRL trace propagation rule. Default ``None``.
+        xy_to_dw : Callable, optional
+            Weight-gradient rule. Default ``None``.
+        init_drtrl : Callable, optional
+            D-RTRL trace initialiser. Default ``None``.
+        init_pp : Callable, optional
+            pp_prop (IO-dim) df trace initialiser. Default ``None``.
+        """
         if yw_to_w is not None:
             ETP_RULES_YW_TO_W[self] = yw_to_w
         if xy_to_dw is not None:
@@ -126,38 +165,50 @@ def register_primitive(
 ):
     """Create an :class:`ETPPrimitive` with all JAX rules auto-derived.
 
-    The following rules are installed automatically:
-
-    - **impl** — eager execution
-    - **abstract_eval** — via ``jax.eval_shape(impl)``
-    - **lowering** — via ``mlir.lower_fun(impl)``
-    - **JVP** — via ``jax.jvp(impl)``
-    - **transpose** — derived by JAX from the JVP
-    - **batching** — via ``jax.vmap(impl)``
-
     Only the four ETP-specific rules need hand-writing — call the returned
     primitive's ``register_*`` methods.
 
-    Args:
-        name: Primitive name (e.g. ``'etp_mm'``).
-        impl_fn: Implementation function.
-        batched: Whether this primitive operates on batched inputs.
-        gradient_enabled: If True, the compiler will *evaluate* this primitive
-            when walking ``y -> h`` (identity-like ops such as
-            ``etp_elemwise_p``).
-        trainable_invars_fn: Function ``eqn.params -> {key: invar_index}``
-            declaring the primitive's full trainable-input layout. Used by the
-            compiler and executors to support N-trainable-input primitives
-            (e.g. ``{weight, bias}`` for Linear, ``{B, A, bias}`` for LoRA). If
-            ``None``, the compiler falls back to the single-weight
-            ``{'weight': 1}`` layout.
-        x_invar_index: Position of the input ``x`` in ``eqn.invars``, or
-            ``None`` for primitives with no external input (currently only
-            ``etp_elemwise_p``).
-        y_outvar_index: Position of the output ``y`` in ``eqn.outvars``.
+    Parameters
+    ----------
+    name : str
+        Primitive name (e.g. ``'etp_mm'``).
+    impl_fn : Callable
+        Implementation function.
+    batched : bool, optional
+        Whether this primitive operates on batched inputs. Default ``False``.
+    gradient_enabled : bool, optional
+        If ``True``, the compiler will *evaluate* this primitive when walking
+        ``y -> h`` (identity-like ops such as ``etp_elemwise_p``). Default
+        ``False``.
+    trainable_invars_fn : Callable or None, optional
+        Function ``eqn.params -> {key: invar_index}`` declaring the
+        primitive's full trainable-input layout. Used by the compiler and
+        executors to support N-trainable-input primitives (e.g.
+        ``{weight, bias}`` for Linear, ``{B, A, bias}`` for LoRA). If
+        ``None``, the compiler falls back to the single-weight
+        ``{'weight': 1}`` layout. Default ``None``.
+    x_invar_index : int or None, optional
+        Position of the input ``x`` in ``eqn.invars``, or ``None`` for
+        primitives with no external input (currently only ``etp_elemwise_p``).
+        Default ``0``.
+    y_outvar_index : int, optional
+        Position of the output ``y`` in ``eqn.outvars``. Default ``0``.
 
-    Returns:
-        :class:`ETPPrimitive`: the registered primitive.
+    Returns
+    -------
+    ETPPrimitive
+        The registered primitive.
+
+    Notes
+    -----
+    The following standard JAX rules are installed automatically:
+
+    - **impl** — eager execution.
+    - **abstract_eval** — via ``jax.eval_shape(impl)``.
+    - **lowering** — via ``mlir.lower_fun(impl)``.
+    - **JVP** — via ``jax.jvp(impl)``.
+    - **transpose** — derived by JAX from the JVP.
+    - **batching** — via ``jax.vmap(impl)``.
     """
     p = ETPPrimitive(name)
     ETP_PRIMITIVES.add(p)

--- a/braintrace/_etrace_op/conv.py
+++ b/braintrace/_etrace_op/conv.py
@@ -458,23 +458,55 @@ def conv(
 ):
     r"""ETP-aware convolution.
 
-    Computes :math:`y = \mathrm{conv}(x, kernel) \; (+ b)`.
-    Always expects a batch dimension on ``x``.
+    Computes :math:`y = \mathrm{conv}(x, kernel) \; (+ b)` by routing the
+    kernel (and optional bias) through an ETP primitive so they participate
+    in eligibility-trace computation. The full keyword surface of
+    :func:`jax.lax.conv_general_dilated` is preserved. Always expects a
+    batch dimension on ``x``.
 
-    Args:
-        x: Input tensor with batch dimension.
-        kernel: Convolution kernel.
-        bias: Optional bias.
-        strides: Window strides.
-        padding: Padding mode.
-        lhs_dilation: Left-hand-side dilation.
-        rhs_dilation: Right-hand-side dilation.
-        feature_group_count: Feature group count.
-        batch_group_count: Batch group count.
-        dimension_numbers: Convolution dimension numbers.
+    Parameters
+    ----------
+    x : ArrayLike
+        Input tensor with a leading batch dimension.
+    kernel : ArrayLike
+        Convolution kernel, with layout governed by ``dimension_numbers``.
+    bias : ArrayLike or None, optional
+        Per-output-channel bias. Default ``None``.
+    strides : Sequence[int], optional
+        Window strides. Default ``(1,)``.
+    padding : str, optional
+        Padding mode (e.g. ``'SAME'`` or ``'VALID'``). Default ``'SAME'``.
+    lhs_dilation : Sequence[int] or None, optional
+        Left-hand-side (input) dilation factors. Default ``None``.
+    rhs_dilation : Sequence[int] or None, optional
+        Right-hand-side (kernel) dilation factors. Default ``None``.
+    feature_group_count : int, optional
+        Number of feature groups. Default ``1``.
+    batch_group_count : int, optional
+        Number of batch groups. Default ``1``.
+    dimension_numbers : Any, optional
+        Convolution dimension numbers (e.g. ``('NHWC', 'HWIO', 'NHWC')``).
+        Default ``None``, which uses the JAX default layout.
 
-    Returns:
-        Convolution output.
+    Returns
+    -------
+    ArrayLike
+        Convolution output tensor.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        >>> import brainstate
+        >>> import braintrace
+        >>>
+        >>> brainstate.environ.set(precision=64)
+        >>> # 1-D conv, NCH input and OIH kernel (JAX defaults)
+        >>> x = brainstate.random.randn(8, 3, 16)
+        >>> kernel = brainstate.random.randn(4, 3, 5)
+        >>> y = braintrace.conv(x, kernel, strides=(1,), padding='SAME')
+        >>> print(y.shape)
+        (8, 4, 16)
     """
     conv_kwargs = dict(
         strides=tuple(strides),

--- a/braintrace/_etrace_op/dense.py
+++ b/braintrace/_etrace_op/dense.py
@@ -393,18 +393,45 @@ etp_mv_p.register_etp_rules(
 def matmul(x, weight, bias=None):
     r"""ETP-aware matrix multiplication.
 
-    Computes :math:`y = x \mathbin{@} w \; (+ b)`.
+    Computes :math:`y = x \mathbin{@} w \; (+ b)`. The operation is routed
+    through an ETP primitive so the weight (and optional bias) participates
+    in eligibility-trace computation. Auto-dispatches to ``etp_mm_p``
+    (batched) or ``etp_mv_p`` (unbatched) based on ``x.ndim``.
 
-    Auto-dispatches to ``etp_mm_p`` (batched) or ``etp_mv_p`` (unbatched)
-    based on ``x.ndim``.
+    Parameters
+    ----------
+    x : ArrayLike
+        Input array, shape ``(..., in_features)`` or ``(in_features,)``.
+    weight : ArrayLike
+        Weight matrix, shape ``(in_features, out_features)``.
+    bias : ArrayLike or None, optional
+        Bias vector, shape ``(out_features,)``. Default ``None``.
 
-    Args:
-        x: Input array, shape ``(..., in_features)`` or ``(in_features,)``.
-        weight: Weight matrix, shape ``(in_features, out_features)``.
-        bias: Optional bias vector, shape ``(out_features,)``.
+    Returns
+    -------
+    ArrayLike
+        Output array, shape ``(..., out_features)`` or ``(out_features,)``.
 
-    Returns:
-        Output array.
+    Examples
+    --------
+    .. code-block:: python
+
+        >>> import brainstate
+        >>> import braintrace
+        >>>
+        >>> brainstate.environ.set(precision=64)
+        >>> x = brainstate.random.randn(16, 3)
+        >>> w = brainstate.random.randn(3, 4)
+        >>> y = braintrace.matmul(x, w)
+        >>> print(y.shape)
+        (16, 4)
+        >>>
+        >>> # Unbatched input with a bias term
+        >>> x1 = brainstate.random.randn(3)
+        >>> b = brainstate.random.randn(4)
+        >>> y1 = braintrace.matmul(x1, w, bias=b)
+        >>> print(y1.shape)
+        (4,)
     """
     p = etp_mm_p if x.ndim >= 2 else etp_mv_p
     x_v, x_u = u.split_mantissa_unit(x)

--- a/braintrace/_etrace_op/elemwise.py
+++ b/braintrace/_etrace_op/elemwise.py
@@ -196,15 +196,42 @@ etp_elemwise_p.register_etp_rules(
 def element_wise(weight, fn=lambda w: w):
     r"""ETP-aware element-wise operation.
 
-    Applies ``fn`` to ``weight`` and passes through a marker primitive.
-    The operation is treated as *diagonal* in the hidden-state space.
+    Applies ``fn`` to ``weight`` and passes the result through a marker
+    primitive. The operation is treated as *diagonal* in the hidden-state
+    space, so the weight participates in eligibility-trace computation as a
+    per-element trainable parameter.
 
-    Args:
-        weight: Weight parameter.
-        fn: Element-wise function. Defaults to identity.
+    Parameters
+    ----------
+    weight : ArrayLike
+        Weight parameter.
+    fn : Callable, optional
+        Element-wise function applied to ``weight`` before the primitive
+        binds. Default is the identity ``lambda w: w``.
 
-    Returns:
-        ``fn(weight)``.
+    Returns
+    -------
+    ArrayLike
+        ``fn(weight)``, with the same shape as ``weight``.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        >>> import brainstate
+        >>> import braintrace
+        >>>
+        >>> brainstate.environ.set(precision=64)
+        >>> w = brainstate.random.randn(5)
+        >>> y = braintrace.element_wise(w)
+        >>> print(y.shape)
+        (5,)
+        >>>
+        >>> # Apply a non-linearity to the weight
+        >>> import jax.numpy as jnp
+        >>> y1 = braintrace.element_wise(w, fn=jnp.tanh)
+        >>> print(y1.shape)
+        (5,)
     """
     y = fn(weight)
     y_v, y_u = u.split_mantissa_unit(y)

--- a/braintrace/_etrace_op/lora.py
+++ b/braintrace/_etrace_op/lora.py
@@ -338,19 +338,43 @@ etp_lora_mv_p.register_etp_rules(
 def lora_matmul(x, B, A, *, alpha=1.0, bias=None):
     r"""ETP-aware LoRA (Low-Rank Adaptation) matrix multiplication.
 
-    Computes :math:`y = \alpha \cdot x \mathbin{@} B \mathbin{@} A \; (+ b)`.
-
+    Computes :math:`y = \alpha \cdot x \mathbin{@} B \mathbin{@} A \; (+ b)`,
+    routing both low-rank factors (and the optional bias) through an ETP
+    primitive so they participate in eligibility-trace computation.
     Auto-dispatches batched/unbatched based on ``x.ndim``.
 
-    Args:
-        x: Input array.
-        B: Low-rank matrix B, shape ``(in_features, rank)``.
-        A: Low-rank matrix A, shape ``(rank, out_features)``.
-        alpha: Scaling factor.
-        bias: Optional bias.
+    Parameters
+    ----------
+    x : ArrayLike
+        Input array, shape ``(..., in_features)`` or ``(in_features,)``.
+    B : ArrayLike
+        Low-rank matrix :math:`B`, shape ``(in_features, rank)``.
+    A : ArrayLike
+        Low-rank matrix :math:`A`, shape ``(rank, out_features)``.
+    alpha : float, optional
+        Scalar scaling factor :math:`\alpha`. Default ``1.0``.
+    bias : ArrayLike or None, optional
+        Bias vector, shape ``(out_features,)``. Default ``None``.
 
-    Returns:
-        Output array.
+    Returns
+    -------
+    ArrayLike
+        Output array, shape ``(..., out_features)`` or ``(out_features,)``.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        >>> import brainstate
+        >>> import braintrace
+        >>>
+        >>> brainstate.environ.set(precision=64)
+        >>> x = brainstate.random.randn(16, 8)
+        >>> B = brainstate.random.randn(8, 2)
+        >>> A = brainstate.random.randn(2, 4)
+        >>> y = braintrace.lora_matmul(x, B, A, alpha=0.5)
+        >>> print(y.shape)
+        (16, 4)
     """
     p = etp_lora_mm_p if x.ndim >= 2 else etp_lora_mv_p
     x_v, x_u = u.split_mantissa_unit(x)

--- a/braintrace/_etrace_op/sparse.py
+++ b/braintrace/_etrace_op/sparse.py
@@ -318,19 +318,28 @@ etp_sp_mv_p.register_etp_rules(
 def sparse_matmul(x, weight_data, *, sparse_mat, bias=None):
     r"""ETP-aware sparse matrix multiplication.
 
-    Computes :math:`y = x \mathbin{@} \mathrm{sparse}(w) \; (+ b)`.
-
+    Computes :math:`y = x \mathbin{@} \mathrm{sparse}(w) \; (+ b)`, where
+    only the non-zero entries (``weight_data``) of the fixed sparse pattern
+    are trainable and participate in eligibility-trace computation.
     Auto-dispatches batched/unbatched based on ``x.ndim``.
 
-    Args:
-        x: Input array.
-        weight_data: Sparse-matrix data (non-zero values).
-        sparse_mat: The sparse-matrix structure (e.g. a
-            ``saiunit.sparse`` matrix object) — must expose ``with_data``
-            and ``yw_to_w_transposed``.
-        bias: Optional bias.
+    Parameters
+    ----------
+    x : ArrayLike
+        Input array.
+    weight_data : ArrayLike
+        Sparse-matrix data, i.e. the non-zero values, shape ``(nnz,)``.
+    sparse_mat : object
+        Sparse-matrix structure (e.g. a ``saiunit.sparse`` matrix object).
+        Must expose ``with_data`` (substitute new data into the structure)
+        and ``yw_to_w_transposed`` (apply the transposed sparse pattern to
+        a trace).
+    bias : ArrayLike or None, optional
+        Bias vector. Default ``None``.
 
-    Returns:
+    Returns
+    -------
+    ArrayLike
         Output array.
     """
     p = etp_sp_mm_p if x.ndim >= 2 else etp_sp_mv_p

--- a/braintrace/_grad_exponential.py
+++ b/braintrace/_grad_exponential.py
@@ -24,21 +24,47 @@ __all__ = [
 
 
 class GradExpon(brainstate.nn.Module):
-    r"""
-    Accumulates gradients exponentially.
+    r"""Accumulate gradients with an exponential (leaky) running sum.
 
-    Mathematically, the update rule is:
+    Maintains a decaying accumulator over a pytree of gradients, useful for
+    smoothing online-learning gradient signals across time steps.
 
-        $$
-        g_{t+1} = \text{decay} \cdot g_t + \text{grads} \\
-        $$
+    Parameters
+    ----------
+    grad_shape : brainstate.typing.PyTree
+        A pytree whose leaves give the shape and dtype of the gradients to
+        accumulate. The accumulator is initialised to zeros matching each
+        leaf.
+    tau_or_decay : saiunit.Quantity or float
+        Either a decay time constant (as a :class:`~saiunit.Quantity`), from
+        which the decay factor is computed as
+        :math:`\exp(-1 / (\tau / \mathrm{dt}))`, or the decay factor itself
+        (a ``float`` in the open interval :math:`(0, 1)`).
 
-    where $g_t$ is the accumulated gradient at time $t$, $\text{grads}$ is the gradient at time
-    $t$, and $\text{decay}$ is the decay factor.
+    Notes
+    -----
+    The update rule is
 
-    Args:
-        grad_shape: The shape of the gradients.
-        tau_or_decay: The decay time constant or the decay factor.
+    .. math::
+
+        g_{t+1} = \mathrm{decay} \cdot g_t + \mathrm{grads},
+
+    where :math:`g_t` is the accumulated gradient at time :math:`t`,
+    :math:`\mathrm{grads}` is the new gradient at time :math:`t`, and
+    :math:`\mathrm{decay}` is the decay factor.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        >>> import brainstate
+        >>> import jax.numpy as jnp
+        >>> import braintrace
+        >>> acc = braintrace.GradExpon(jnp.zeros((3,)), 0.9)
+        >>> acc.update(jnp.ones((3,)))
+        >>> acc.update(jnp.ones((3,)))
+        >>> print(acc.gradients.value)
+        [1.9 1.9 1.9]
     """
 
     def __init__(
@@ -65,17 +91,23 @@ class GradExpon(brainstate.nn.Module):
         self.decay = decay
 
     def update(self, grads: brainstate.typing.PyTree):
-        """
-        Updates the accumulated gradients using the exponential decay rule.
+        r"""Update the accumulated gradients with the exponential decay rule.
 
-        This method applies the update rule g_{t+1} = decay * g_t + grads, where g_t is the
-        accumulated gradient at time t, grads is the new gradient, and decay is the decay factor.
+        Applies :math:`g_{t+1} = \mathrm{decay} \cdot g_t + \mathrm{grads}`,
+        where :math:`g_t` is the accumulated gradient, ``grads`` the new
+        gradient, and :math:`\mathrm{decay}` the decay factor. The
+        accumulator stored in ``self.gradients`` is updated in place.
 
-        Args:
-            grads (brainstate.typing.PyTree): The new gradients to be incorporated into the accumulated gradients.
+        Parameters
+        ----------
+        grads : brainstate.typing.PyTree
+            The new gradients to incorporate into the accumulated gradients.
+            Must match the pytree structure of the accumulator.
 
-        Returns:
-            None. The method updates the `self.gradients` attribute in-place.
+        Returns
+        -------
+        None
+            The ``self.gradients`` attribute is updated in place.
         """
         self.gradients.value = jax.tree.map(
             lambda x, y: x * self.decay + y,

--- a/braintrace/_input_data.py
+++ b/braintrace/_input_data.py
@@ -63,40 +63,64 @@ class ETraceInputData:
 
 @register_pytree_node_class
 class SingleStepData(ETraceInputData):
-    """
-    The data at a single time step.
+    """A container marking input data as belonging to a single time step.
 
-    Examples::
+    Wraps an arbitrary pytree of arrays so the online-learning machinery
+    can distinguish per-step inputs (which are reused at every step) from
+    time-major inputs. Registered as a JAX pytree node, so instances can
+    cross ``jit``/``grad`` boundaries transparently.
 
-        >>> import brainstate as brainstate
-        >>> data = SingleStepData(brainstate.random.randn(2, 3))
+    Parameters
+    ----------
+    data : Any
+        The pytree of arrays to store for a single time step.
 
+    See Also
+    --------
+    MultiStepData : Container for inputs spanning multiple time steps.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        >>> import brainstate
+        >>> import braintrace
+        >>> data = braintrace.SingleStepData(brainstate.random.randn(2, 3))
+        >>> print(data.data.shape)
+        (2, 3)
     """
     __module__ = 'braintrace'
 
 
 @register_pytree_node_class
 class MultiStepData(ETraceInputData):
-    """
-    The data at multiple time steps.
+    """A container marking input data as spanning multiple time steps.
 
-    The first dimension of the data represents the time steps.
+    Wraps an arbitrary pytree of arrays whose leading axis is the time
+    dimension, so the online-learning machinery can iterate over time
+    steps. Registered as a JAX pytree node, so instances can cross
+    ``jit``/``grad`` boundaries transparently.
 
-    Examples::
+    Parameters
+    ----------
+    data : Any
+        The pytree of arrays to store. The first dimension of each array
+        represents the time steps.
 
-        >>> import brainstate as brainstate
-        # data at 10 time steps, each time step has 2 samples, each sample has 3 features
-        >>> data = MultiStepData(brainstate.random.randn(10, 2, 3))
+    See Also
+    --------
+    SingleStepData : Container for an input at a single time step.
 
+    Examples
+    --------
+    .. code-block:: python
 
-    Another example::
-
-        >>> import brainstate as brainstate
-        >>> data = MultiStepData(
-        ...     brainstate.random.randn(10, 2, 3),
-        ...     brainstate.random.randn(10, 5),
-        ... )
-
+        >>> import brainstate
+        >>> import braintrace
+        >>> # data at 10 time steps, 2 samples each, 3 features per sample
+        >>> data = braintrace.MultiStepData(brainstate.random.randn(10, 2, 3))
+        >>> print(data.data.shape)
+        (10, 2, 3)
     """
     __module__ = 'braintrace'
 

--- a/braintrace/_legacy/_ops.py
+++ b/braintrace/_legacy/_ops.py
@@ -107,11 +107,27 @@ def general_y2w(xw2y: Callable, x, y, w):
 # ---------------------------------------------------------------------------
 
 class ETraceOp:
-    """Legacy base class for eligibility-trace operators.
+    r"""Legacy base class for eligibility-trace operators.
+
+    Defines the operator interface used by the legacy parameter shims: a
+    forward map from inputs and weights to outputs (``xw_to_y``), a
+    plain-JAX variant (``raw_xw_to_y``), and gradient helpers.
 
     .. deprecated:: 0.2.0
         Prefer calling the new ETP primitive user-API functions directly
-        (:func:`braintrace.matmul`, :func:`braintrace.conv`, ...).
+        (:func:`braintrace.matmul`, :func:`braintrace.conv`, etc.).
+
+    Parameters
+    ----------
+    is_diagonal : bool, optional
+        Whether the operator is element-wise (diagonal). Default ``False``.
+    name : str, optional
+        Optional operator name.
+
+    Notes
+    -----
+    This class is a deprecated back-compatibility shim. New code should
+    call the ETP primitive functions directly.
     """
     __module__ = 'braintrace'
 
@@ -131,12 +147,25 @@ class ETraceOp:
         raise NotImplementedError
 
     def raw_xw_to_y(self, inputs, weights):
-        """Plain-JAX variant — does NOT emit an ETP primitive.
+        """Compute the forward map without emitting an ETP primitive.
 
-        Used by :class:`NonTempParam` / :class:`FakeETraceParam` so those
-        wrappers do not register an eligibility-trace relation.
-        Default: fall through to ``xw_to_y`` (subclasses that route to
-        an ETP primitive MUST override).
+        Plain-JAX variant of :meth:`xw_to_y`, used by
+        :class:`NonTempParam` and :class:`FakeETraceParam` so those
+        wrappers do not register an eligibility-trace relation. The base
+        implementation falls through to :meth:`xw_to_y`; subclasses that
+        route to an ETP primitive must override this.
+
+        Parameters
+        ----------
+        inputs : Any
+            The input array(s) to the operator.
+        weights : Any
+            The weight pytree.
+
+        Returns
+        -------
+        Any
+            The operator output computed with plain JAX ops.
         """
         return self.xw_to_y(inputs, weights)
 
@@ -159,9 +188,29 @@ class ETraceOp:
 # ---------------------------------------------------------------------------
 
 class MatMulOp(ETraceOp):
-    r"""Legacy dense-matmul op. Routes to :func:`braintrace.matmul`.
+    r"""Legacy dense matrix-multiplication operator.
 
-    Weight is supplied as ``{'weight': ..., 'bias': <optional>}``.
+    Routes :meth:`xw_to_y` to :func:`braintrace.matmul`. The weight is
+    supplied as a dict ``{'weight': ..., 'bias': <optional>}``.
+
+    .. deprecated:: 0.2.0
+        Use :func:`braintrace.matmul` directly.
+
+    Parameters
+    ----------
+    weight_mask : array_like, optional
+        Optional multiplicative mask applied to the weight. Default
+        ``None``.
+    weight_fn : Callable, optional
+        Function applied to the (possibly masked) weight before the
+        matmul. Default is the identity ``lambda w: w``.
+    apply_weight_fn_before_mask : bool, optional
+        If ``True``, ``weight_fn`` is applied before the mask; otherwise
+        after. Default ``False``.
+
+    Notes
+    -----
+    This class is a deprecated back-compatibility shim.
     """
     __module__ = 'braintrace'
 
@@ -221,7 +270,24 @@ class MatMulOp(ETraceOp):
 # ---------------------------------------------------------------------------
 
 class ElemWiseOp(ETraceOp):
-    r"""Legacy element-wise op. Routes to :func:`braintrace.element_wise`."""
+    r"""Legacy element-wise operator.
+
+    Routes :meth:`xw_to_y` to :func:`braintrace.element_wise`, applying a
+    callable element-wise to the weight.
+
+    .. deprecated:: 0.2.0
+        Use :func:`braintrace.element_wise` directly.
+
+    Parameters
+    ----------
+    fn : Callable, optional
+        The element-wise function applied to the weight. Default is the
+        identity ``lambda w: w``.
+
+    Notes
+    -----
+    This class is a deprecated back-compatibility shim.
+    """
     __module__ = 'braintrace'
 
     def __init__(self, fn: Callable = lambda w: w):
@@ -243,9 +309,42 @@ class ElemWiseOp(ETraceOp):
 # ---------------------------------------------------------------------------
 
 class ConvOp(ETraceOp):
-    r"""Legacy convolution op. Routes to :func:`braintrace.conv`.
+    r"""Legacy convolution operator.
 
-    Weight is supplied as ``{'weight': ..., 'bias': <optional>}``.
+    Routes :meth:`xw_to_y` to :func:`braintrace.conv`. The weight is
+    supplied as a dict ``{'weight': ..., 'bias': <optional>}``.
+
+    .. deprecated:: 0.2.0
+        Use :func:`braintrace.conv` directly.
+
+    Parameters
+    ----------
+    xinfo : jax.ShapeDtypeStruct
+        Shape/dtype information describing the convolution input.
+    window_strides : Sequence[int]
+        Strides of the convolution window.
+    padding : Any
+        Padding specification passed to the convolution.
+    lhs_dilation : Sequence[int], optional
+        Dilation factor for the input. Default ``None``.
+    rhs_dilation : Sequence[int], optional
+        Dilation factor for the kernel. Default ``None``.
+    feature_group_count : int, optional
+        Number of feature groups. Default ``1``.
+    batch_group_count : int, optional
+        Number of batch groups. Default ``1``.
+    dimension_numbers : Any, optional
+        Convolution dimension-numbers specification. Default ``None``.
+    weight_mask : array_like, optional
+        Optional multiplicative mask applied to the weight. Default
+        ``None``.
+    weight_fn : Callable, optional
+        Function applied to the (possibly masked) weight. Default is the
+        identity ``lambda w: w``.
+
+    Notes
+    -----
+    This class is a deprecated back-compatibility shim.
     """
     __module__ = 'braintrace'
 
@@ -336,9 +435,27 @@ class ConvOp(ETraceOp):
 # ---------------------------------------------------------------------------
 
 class SpMatMulOp(ETraceOp):
-    r"""Legacy sparse-matmul op. Routes to :func:`braintrace.sparse_matmul`.
+    r"""Legacy sparse matrix-multiplication operator.
 
-    Weight is supplied as ``{'weight': data, 'bias': <optional>}``.
+    Routes :meth:`xw_to_y` to :func:`braintrace.sparse_matmul`. The weight
+    is supplied as a dict ``{'weight': data, 'bias': <optional>}``, where
+    ``data`` holds the values of the sparse matrix.
+
+    .. deprecated:: 0.2.0
+        Use :func:`braintrace.sparse_matmul` directly.
+
+    Parameters
+    ----------
+    sparse_mat : saiunit.sparse.SparseMatrix
+        The sparse matrix whose structure is reused; its data is replaced
+        by the weight values.
+    weight_fn : Callable, optional
+        Function applied to the weight data before the matmul. Default is
+        the identity ``lambda w: w``.
+
+    Notes
+    -----
+    This class is a deprecated back-compatibility shim.
     """
     __module__ = 'braintrace'
 
@@ -384,9 +501,24 @@ class SpMatMulOp(ETraceOp):
 # ---------------------------------------------------------------------------
 
 class LoraOp(ETraceOp):
-    r"""Legacy LoRA op. Routes to :func:`braintrace.lora_matmul`.
+    r"""Legacy LoRA (low-rank adaptation) operator.
 
-    Weight is supplied as ``{'B': ..., 'A': ..., 'bias': <optional>}``.
+    Routes :meth:`xw_to_y` to :func:`braintrace.lora_matmul`. The weight is
+    supplied as a dict ``{'B': ..., 'A': ..., 'bias': <optional>}`` holding
+    the two low-rank factors.
+
+    .. deprecated:: 0.2.0
+        Use :func:`braintrace.lora_matmul` directly.
+
+    Parameters
+    ----------
+    alpha : array_like, optional
+        Scaling factor applied to the low-rank product. Defaults to
+        ``1.0`` when ``None``.
+
+    Notes
+    -----
+    This class is a deprecated back-compatibility shim.
     """
     __module__ = 'braintrace'
 

--- a/braintrace/_legacy/_params.py
+++ b/braintrace/_legacy/_params.py
@@ -70,16 +70,36 @@ class ETraceGrad(str, Enum):
 # ---------------------------------------------------------------------------
 
 class ETraceParam(brainstate.ParamState):
-    """Legacy eligibility-trace parameter.
+    r"""Legacy eligibility-trace parameter.
 
-    Wraps a pytree weight (typically ``{'weight': ..., 'bias': ...}``)
-    and an :class:`ETraceOp`. :meth:`execute` routes through the op's
-    ETP-primitive path, so the compiler will register an eligibility-
-    trace relation when this parameter flows into a hidden state.
+    Wraps a pytree weight (typically ``{'weight': ..., 'bias': ...}``) and
+    an :class:`ETraceOp`. :meth:`execute` routes through the op's
+    ETP-primitive path, so the compiler registers an eligibility-trace
+    relation when this parameter flows into a hidden state.
 
     .. deprecated:: 0.2.0
-        Use :class:`brainstate.ParamState` + the new ETP primitive
-        functions (:func:`braintrace.matmul` etc.) directly.
+        Use :class:`brainstate.ParamState` together with the new ETP
+        primitive functions (:func:`braintrace.matmul`, etc.) directly.
+
+    Parameters
+    ----------
+    weight : Any
+        The pytree weight to wrap, typically a dict such as
+        ``{'weight': ..., 'bias': ...}``.
+    op : ETraceOp
+        The eligibility-trace operator used to combine inputs with the
+        weight.
+    grad : object, optional
+        Legacy gradient type. Defaults to the adaptive mode; kept for API
+        compatibility and has no effect on the new primitive-based
+        compiler.
+    name : str, optional
+        Optional name forwarded to :class:`brainstate.ParamState`.
+
+    Notes
+    -----
+    This class is a deprecated back-compatibility shim. New code should
+    use :class:`brainstate.ParamState` with the ETP primitive functions.
     """
     __module__ = 'braintrace'
 
@@ -114,7 +134,31 @@ class ETraceParam(brainstate.ParamState):
 # ---------------------------------------------------------------------------
 
 class ElemWiseParam(ETraceParam):
-    """Legacy element-wise trace parameter."""
+    r"""Legacy element-wise eligibility-trace parameter.
+
+    Element-wise variant of :class:`ETraceParam`: wraps a weight together
+    with an :class:`ElemWiseOp` and routes :meth:`execute` through the
+    element-wise ETP-primitive path.
+
+    .. deprecated:: 0.2.0
+        Use :class:`brainstate.ParamState` together with
+        :func:`braintrace.element_wise` directly.
+
+    Parameters
+    ----------
+    weight : Any
+        The pytree weight to wrap.
+    op : ElemWiseOp or Callable, optional
+        Element-wise operator (or a callable wrapped into one). Defaults to
+        the identity ``lambda w: w``.
+    name : str, optional
+        Optional name forwarded to :class:`brainstate.ParamState`.
+
+    Notes
+    -----
+    This class is a deprecated back-compatibility shim. New code should
+    use :class:`brainstate.ParamState` with :func:`braintrace.element_wise`.
+    """
     __module__ = 'braintrace'
 
     def __init__(
@@ -136,15 +180,32 @@ class ElemWiseParam(ETraceParam):
 # ---------------------------------------------------------------------------
 
 class NonTempParam(brainstate.ParamState):
-    """Legacy parameter — spatial gradient only, no eligibility trace.
+    r"""Legacy parameter with spatial gradient only and no eligibility trace.
 
-    ``execute`` calls the op's plain-JAX path (``raw_xw_to_y``), so no
+    :meth:`execute` calls the op's plain-JAX path (``raw_xw_to_y``), so no
     ETP primitive appears in the jaxpr for this weight. The compiler
-    therefore registers zero relations for this ``ParamState``.
+    therefore registers zero eligibility-trace relations for this
+    ``ParamState``.
 
     .. deprecated:: 0.2.0
         Use :class:`brainstate.ParamState` with plain JAX ops (``x @ w``)
         directly.
+
+    Parameters
+    ----------
+    value : Any
+        The pytree weight to wrap.
+    op : ETraceOp or Callable
+        Operator used in :meth:`execute`. If an :class:`ETraceOp` is given,
+        its plain-JAX ``raw_xw_to_y`` path is used so no ETP primitive is
+        emitted; otherwise a plain callable is used directly.
+    name : str, optional
+        Optional name forwarded to :class:`brainstate.ParamState`.
+
+    Notes
+    -----
+    This class is a deprecated back-compatibility shim. New code should
+    use :class:`brainstate.ParamState` with plain JAX ops.
     """
     __module__ = 'braintrace'
 
@@ -178,18 +239,30 @@ class NonTempParam(brainstate.ParamState):
 # ---------------------------------------------------------------------------
 
 class FakeETraceParam(object):
-    """Legacy fake parameter — NOT a ``ParamState``.
+    r"""Legacy fake parameter that is NOT a ``ParamState``.
 
-    Stores a value + callable and exposes :meth:`execute`. Since this is
-    not a ``ParamState``, the compiler never sees it — no gradient will
-    be produced for this weight.
-
-    Routes through the op's plain-JAX path to avoid emitting any ETP
-    primitive (which would trigger
+    Stores a value and a callable and exposes :meth:`execute`. Because it
+    is not a ``ParamState``, the compiler never sees it, so no gradient is
+    produced for this weight. The op is routed through its plain-JAX path
+    to avoid emitting any ETP primitive (which would otherwise trigger
     :attr:`DiagnosticKind.RELATION_EXCLUDED_NO_PARAMSTATE` warnings).
 
     .. deprecated:: 0.2.0
         Use :class:`brainstate.FakeState` with plain JAX ops.
+
+    Parameters
+    ----------
+    value : Any
+        The pytree weight to store.
+    op : ETraceOp or Callable
+        Operator used in :meth:`execute`. An :class:`ETraceOp` is routed
+        through its plain-JAX ``raw_xw_to_y`` path; otherwise a plain
+        callable is used directly.
+
+    Notes
+    -----
+    This class is a deprecated back-compatibility shim. New code should
+    use :class:`brainstate.FakeState` with plain JAX ops.
     """
     __module__ = 'braintrace'
 
@@ -214,10 +287,30 @@ class FakeETraceParam(object):
 # ---------------------------------------------------------------------------
 
 class FakeElemWiseParam(object):
-    """Legacy fake element-wise parameter — NOT a ``ParamState``.
+    r"""Legacy fake element-wise parameter that is NOT a ``ParamState``.
+
+    Element-wise variant of :class:`FakeETraceParam`. Because it is not a
+    ``ParamState``, the compiler never sees it and produces no gradient for
+    this weight.
 
     .. deprecated:: 0.2.0
         Use :class:`brainstate.FakeState` with plain JAX ops.
+
+    Parameters
+    ----------
+    weight : Any
+        The pytree weight to store.
+    op : ElemWiseOp or Callable, optional
+        Element-wise operator. An :class:`ElemWiseOp` is routed through its
+        plain-JAX path; otherwise a plain callable is used directly.
+        Defaults to the identity ``lambda w: w``.
+    name : str, optional
+        Optional name stored on the instance.
+
+    Notes
+    -----
+    This class is a deprecated back-compatibility shim. New code should
+    use :class:`brainstate.FakeState` with plain JAX ops.
     """
     __module__ = 'braintrace'
 

--- a/braintrace/_misc.py
+++ b/braintrace/_misc.py
@@ -221,22 +221,21 @@ def deprecation_getattr(module, deprecations):
 
 
 class NotSupportedError(Exception):
-    """
-    Exception raised for operations that are not supported.
+    """Exception raised for operations that are not supported.
 
-    This exception is used to indicate that a particular operation or
-    functionality is not supported within the context of the application.
-
+    Signals that a particular operation or functionality is not supported
+    within the eligibility-trace compilation and execution machinery, for
+    example an ETP primitive used in an unsupported configuration.
     """
     __module__ = 'braintrace'
 
 
 class CompilationError(Exception):
-    """
-    Exception raised for errors that occur during the compilation process.
+    """Exception raised for errors that occur during compilation.
 
-    This exception is used to indicate that a compilation error has occurred
-    within the context of the application.
+    Signals that the jaxpr-analysis / graph-building stage of the
+    eligibility-trace compiler failed, for example when parameters cannot
+    be connected to the hidden states they influence.
     """
     __module__ = 'braintrace'
 

--- a/braintrace/nn/_readout.py
+++ b/braintrace/nn/_readout.py
@@ -83,6 +83,7 @@ class LeakyRateReadout(brainstate.nn.Module):
         >>> import brainstate
         >>> import saiunit as u
         >>>
+        >>> brainstate.environ.set(dt=0.1 * u.ms)
         >>> # Create a leaky rate readout layer
         >>> readout = braintrace.nn.LeakyRateReadout(
         ...     in_size=256,


### PR DESCRIPTION
## Summary
- Convert all public-API docstrings (`braintrace.__all__` and `braintrace.nn.__all__`) to NumPy-doc style with the canonical section order: Short summary → Extended summary → Parameters → Returns/Yields → Raises → See Also → Notes → References → Examples.
- Examples use the `.. code-block:: python` directive with doctest-style `>>>` prompts, self-contained imports, and expected output. All **310** authored examples were verified runnable via `doctest` (ELLIPSIS).
- Scope covered: ETP ops (`matmul`, `element_wise`, `conv`, `sparse_matmul`, `lora_matmul`), `ETPPrimitive`/`register_primitive`, algorithms (D_RTRL, pp_prop/ES_D_RTRL, EProp, OSTL*, OTPE, OTTT, OSTTP) and their base/executor classes, the compiler public API (graph, hidden groups, hid-param-op relations, module info, perturbation, diagnostics), `nn` cells/readout, input-data containers, `GradExpon`, error classes, and the deprecated legacy shims (with `.. deprecated::` directives).
- Inherited-from-upstream docstrings (`Linear`, `SignedWLinear`, `SparseLinear`, `Conv1d/2d/3d`, which set `__doc__` from `brainstate`) are intentionally left as-is — not authored here.
- Drive-by fix: annotate `oracle.py`'s `algo_factory` return type as `ETraceAlgorithm` instead of `object`. This resolves a pre-existing `mypy` failure on `main` (introduced by #88) that was blocking `typecheck_and_build`.

## Test plan
- [x] `python -m mypy braintrace` — passes (exit 0)
- [x] `python -m pytest braintrace/` — 1209 passed, 1 xfailed
- [x] doctest sweep over all public objects — 310 examples, 0 failures
- [ ] CI `typecheck_and_build` green