### PR TITLE
test: add operator-rule oracle (P2) and public-API contract (P3)

### DIFF
--- a/braintrace/_etrace_op/op_rule_oracle.py
+++ b/braintrace/_etrace_op/op_rule_oracle.py
@@ -1,0 +1,60 @@
+# Copyright 2026 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Ground-truth checks for ETP-primitive rules (test support).
+
+The defining property of a primitive's ``xy_to_dw`` rule is that it equals the
+JAX vector-Jacobian product of that primitive's ``impl`` with respect to the
+trainable weights, evaluated at the learning-signal cotangent ``hidden_dim``.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+
+def xy_to_dw_and_vjp(*, rule, impl, x, hidden_dim, weights, params=None):
+    """Return ``(rule_dw, vjp_dw)`` — the rule's weight gradient and the JAX vjp.
+
+    ``impl`` must be a single-argument callable of the weights tree (closing over
+    ``x`` and any static params), returning the primitive output ``y``.
+    """
+    params = params or {}
+    rule_dw = rule(x, hidden_dim, weights, **params)
+    _, vjp_fn = jax.vjp(impl, weights)
+    vjp_dw = vjp_fn(hidden_dim)[0]
+    return rule_dw, vjp_dw
+
+
+def assert_xy_to_dw_matches_vjp(*, rule, impl, x, hidden_dim, weights, params=None, atol=1e-5, keys=None):
+    """Assert the rule's weight gradient equals vjp(impl)(hidden_dim).
+
+    ``keys`` restricts the comparison to a subset of weight leaves. This matters
+    for primitives that *defer* part of a gradient's reduction (e.g. conv defers
+    the spatial summation of the bias gradient) — those leaves are checked
+    separately by the caller rather than compared element-wise here.
+    """
+    rule_dw, vjp_dw = xy_to_dw_and_vjp(
+        rule=rule, impl=impl, x=x, hidden_dim=hidden_dim, weights=weights, params=params
+    )
+    compare = list(rule_dw.keys()) if keys is None else list(keys)
+    if keys is None:
+        assert set(rule_dw.keys()) == set(vjp_dw.keys()), (
+            f"key mismatch: rule={set(rule_dw.keys())} vjp={set(vjp_dw.keys())}"
+        )
+    for key in compare:
+        a = jnp.asarray(rule_dw[key])
+        e = jnp.asarray(vjp_dw[key])
+        np.testing.assert_allclose(a, e, atol=atol, err_msg=f"xy_to_dw mismatch on {key!r}")

--- a/braintrace/_etrace_op/op_rule_oracle_test.py
+++ b/braintrace/_etrace_op/op_rule_oracle_test.py
@@ -1,0 +1,171 @@
+# Copyright 2026 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Operator-rule correctness: each primitive's xy_to_dw must equal jax.vjp of its
+impl; init_drtrl/init_pp shape contract; lora partial-propagation; multi-primitive
+composition gradients. Fills gaps left by dense_test/elemwise_test."""
+
+from collections import namedtuple
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+import braintrace
+from braintrace._etrace_op import (
+    ETP_RULES_INIT_DRTRL,
+    ETP_RULES_INIT_PP,
+    ETP_RULES_XY_TO_DW,
+    ETP_RULES_YW_TO_W,
+)
+from braintrace._etrace_op.dense import etp_mm_p, _etp_matmul_impl
+from braintrace._etrace_op.conv import etp_conv_p, _etp_conv_impl
+from braintrace._etrace_op.sparse import etp_sp_mm_p, _etp_sp_matmul_impl
+from braintrace._etrace_op.lora import etp_lora_mm_p, _etp_lora_impl
+from braintrace._etrace_op.op_rule_oracle import assert_xy_to_dw_matches_vjp, xy_to_dw_and_vjp
+from braintrace._etrace_op.sparse_test import _StubSparseMat
+
+_FakeVar = namedtuple('_FakeVar', ['aval'])
+_FakeAval = namedtuple('_FakeAval', ['shape', 'dtype'])
+
+
+def _fake_var(shape, dtype=jnp.float32):
+    return _FakeVar(aval=_FakeAval(shape=shape, dtype=dtype))
+
+
+# --- Task 1: dense mm xy_to_dw == jax.vjp ------------------------------------
+
+def test_mm_xy_to_dw_matches_vjp():
+    x = jnp.arange(6.0).reshape(2, 3)
+    w = jnp.arange(12.0).reshape(3, 4)
+    hidden = jnp.ones((2, 4))
+    assert_xy_to_dw_matches_vjp(
+        rule=ETP_RULES_XY_TO_DW[etp_mm_p],
+        impl=lambda weights: _etp_matmul_impl(x, weights['weight'], has_bias=False),
+        x=x, hidden_dim=hidden, weights={'weight': w}, params={'has_bias': False},
+    )
+
+
+# --- Task 2: conv xy_to_dw == jax.vjp (with bias) ----------------------------
+
+def test_conv_xy_to_dw_matches_vjp_with_bias():
+    # NCW layout: x=(batch, in_ch, L), kernel=(out_ch, in_ch, width)
+    x = jnp.asarray(np.random.RandomState(0).randn(1, 2, 8).astype('float32'))
+    kernel = jnp.asarray(np.random.RandomState(1).randn(4, 2, 3).astype('float32'))
+    bias = jnp.zeros((1, 4, 1), dtype='float32')
+    conv_params = dict(has_bias=True, strides=(1,), padding='SAME', dimension_numbers=None)
+    y = _etp_conv_impl(x, kernel, bias, **conv_params)
+    hidden = jnp.ones_like(y)
+    impl = lambda w: _etp_conv_impl(x, w['weight'], w['bias'], **conv_params)
+    weights = {'weight': kernel, 'bias': bias}
+    # The kernel gradient must match jax.vjp exactly.
+    assert_xy_to_dw_matches_vjp(
+        rule=ETP_RULES_XY_TO_DW[etp_conv_p], impl=impl,
+        x=x, hidden_dim=hidden, weights=weights, params=conv_params,
+        atol=1e-4, keys=['weight'],
+    )
+    # The bias gradient is DEFERRED: the rule returns the un-summed cotangent
+    # (batch, out_ch, L); summing over the spatial axis recovers the jax.vjp bias.
+    rule_dw, vjp_dw = xy_to_dw_and_vjp(
+        rule=ETP_RULES_XY_TO_DW[etp_conv_p], impl=impl,
+        x=x, hidden_dim=hidden, weights=weights, params=conv_params,
+    )
+    summed_bias = jnp.asarray(rule_dw['bias']).sum(axis=2, keepdims=True)
+    np.testing.assert_allclose(summed_bias, jnp.asarray(vjp_dw['bias']), atol=1e-4)
+
+
+# --- Task 3: sparse xy_to_dw == jax.vjp --------------------------------------
+
+def test_sparse_xy_to_dw_matches_vjp():
+    in_dim, out_dim = 3, 4
+    rng = np.random.RandomState(0)
+    x = jnp.asarray(rng.randn(2, in_dim).astype('float32'))
+    weight_data = jnp.asarray(rng.randn(in_dim * out_dim).astype('float32'))
+    sparse_mat = _StubSparseMat(jnp.zeros((in_dim, out_dim)))
+    sp_params = dict(sparse_mat=sparse_mat, has_bias=False)
+    y = _etp_sp_matmul_impl(x, weight_data, **sp_params)
+    hidden = jnp.ones_like(y)
+    assert_xy_to_dw_matches_vjp(
+        rule=ETP_RULES_XY_TO_DW[etp_sp_mm_p],
+        impl=lambda w: _etp_sp_matmul_impl(x, w['weight'], **sp_params),
+        x=x, hidden_dim=hidden, weights={'weight': weight_data},
+        params=sp_params, atol=1e-4,
+    )
+
+
+# --- Task 4: lora xy_to_dw == jax.vjp + partial propagation ------------------
+
+def test_lora_xy_to_dw_matches_vjp():
+    rng = np.random.RandomState(0)
+    x = jnp.asarray(rng.randn(2, 6).astype('float32'))
+    B = jnp.asarray(rng.randn(6, 3).astype('float32'))   # (in, rank)
+    A = jnp.asarray(rng.randn(3, 4).astype('float32'))   # (rank, out)
+    lora_params = dict(alpha=1.0, has_bias=False)
+    y = _etp_lora_impl(x, B, A, **lora_params)
+    hidden = jnp.ones_like(y)
+    assert_xy_to_dw_matches_vjp(
+        rule=ETP_RULES_XY_TO_DW[etp_lora_mm_p],
+        impl=lambda w: _etp_lora_impl(x, w['lora_b'], w['lora_a'], **lora_params),
+        x=x, hidden_dim=hidden, weights={'lora_b': B, 'lora_a': A},
+        params=lora_params, atol=1e-4,
+    )
+
+
+def test_lora_yw_to_w_leaves_B_trace_unchanged():
+    """yw_to_w propagates hidden through lora_a only; lora_b trace passes through."""
+    rule = ETP_RULES_YW_TO_W[etp_lora_mm_p]
+    rank, out_dim = 3, 4
+    hidden = jnp.arange(1.0, out_dim + 1.0)            # (out,)
+    trace = {'lora_b': jnp.ones((6, rank)), 'lora_a': jnp.ones((rank, out_dim))}
+    out = rule(hidden, trace)
+    np.testing.assert_allclose(out['lora_b'], trace['lora_b'])
+
+
+# --- Task 5: init_drtrl / init_pp shape contract -----------------------------
+
+def test_init_drtrl_and_pp_shapes_consistent_for_mm():
+    n_state = 2
+    x_var = _fake_var((4, 3))           # (batch, in)
+    y_var = _fake_var((4, 5))           # (batch, out)
+    weight_vars = {'weight': _fake_var((3, 5))}
+    drtrl = ETP_RULES_INIT_DRTRL[etp_mm_p](x_var, y_var, weight_vars, num_hidden_state=n_state)
+    pp = ETP_RULES_INIT_PP[etp_mm_p](x_var, y_var, weight_vars, num_hidden_state=n_state)
+    assert drtrl['weight'].shape == (4, 3, 5, n_state)   # batch + weight + state
+    assert pp.shape == (4, 5, n_state)                   # y + state
+
+
+# --- Task 6: multi-primitive composition gradients ---------------------------
+
+def test_matmul_then_elementwise_grad_flows_through_both():
+    rng = np.random.RandomState(0)
+    x = jnp.asarray(rng.randn(2, 3).astype('float32'))
+    w = jnp.asarray(rng.randn(3, 4).astype('float32'))
+    scale = jnp.asarray(rng.randn(4).astype('float32'))
+
+    def f(w_, scale_):
+        y = braintrace.matmul(x, w_)                     # etp_mm_p
+        z = braintrace.element_wise(scale_, fn=lambda s: s) * y  # etp_elemwise_p marker
+        return (z ** 2).sum()
+
+    def f_ref(w_, scale_):
+        y = x @ w_
+        z = scale_ * y
+        return (z ** 2).sum()
+
+    gw, gs = jax.grad(f, argnums=(0, 1))(w, scale)
+    gw_ref, gs_ref = jax.grad(f_ref, argnums=(0, 1))(w, scale)
+    np.testing.assert_allclose(gw, gw_ref, atol=1e-4)
+    np.testing.assert_allclose(gs, gs_ref, atol=1e-4)

--- a/braintrace/api_contract_test.py
+++ b/braintrace/api_contract_test.py
@@ -1,0 +1,222 @@
+# Copyright 2026 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""L0 public-API contract: every ``braintrace.__all__`` symbol resolves to a
+usable object; public algorithms run a minimal end-to-end step; documented error
+paths fire on their real triggers; legacy/nn deprecations warn. Also pins the
+implementation facts that drifted from CLAUDE.md (F-17)."""
+
+import brainstate
+import jax
+import jax.numpy as jnp
+import pytest
+
+import braintrace
+from braintrace._etrace_algorithms.oracle_models import tanh_rnn
+
+
+# --- Task 1: every __all__ symbol resolves to a non-None object --------------
+
+def test_all_symbols_are_resolvable():
+    missing = [name for name in braintrace.__all__ if not hasattr(braintrace, name)]
+    assert not missing, f"__all__ names with no attribute: {missing}"
+
+
+def test_all_symbols_are_non_none():
+    none_valued = [name for name in braintrace.__all__ if getattr(braintrace, name) is None]
+    assert not none_valued, f"__all__ names resolving to None: {none_valued}"
+
+
+def test_marker_sentinel_fails_first():
+    # Guard against an empty/trivial __all__ silently passing the above.
+    assert len(braintrace.__all__) > 30
+
+
+# --- Task 2: rate-model algorithms instantiate and run a minimal step --------
+
+def _algo_constructors():
+    """Map name -> callable(model)->algo for each public algorithm that works on
+    a plain rate model (SNN-specific algos needing leak are covered separately)."""
+    return {
+        'D_RTRL': lambda m: braintrace.D_RTRL(m),
+        'ParamDimVjpAlgorithm': lambda m: braintrace.ParamDimVjpAlgorithm(m),
+        'pp_prop': lambda m: braintrace.pp_prop(m, decay_or_rank=0.9),
+        'ES_D_RTRL': lambda m: braintrace.ES_D_RTRL(m, decay_or_rank=0.9),
+        'IODimVjpAlgorithm': lambda m: braintrace.IODimVjpAlgorithm(m, decay_or_rank=0.9),
+        'EProp': lambda m: braintrace.EProp(m),
+        'OSTLRecurrent': lambda m: braintrace.OSTLRecurrent(m),
+        'OSTLFeedforward': lambda m: braintrace.OSTLFeedforward(m, decay_or_rank=0.9),
+    }
+
+
+@pytest.mark.parametrize('name', list(_algo_constructors().keys()))
+def test_algorithm_is_usable_end_to_end(name):
+    model = tanh_rnn(n_in=3, n_rec=4, seed=0).factory()
+    brainstate.nn.init_all_states(model, batch_size=1)
+    algo = _algo_constructors()[name](model)
+    x0 = jnp.ones((3,), dtype='float32')
+    algo.compile_graph(x0)
+    algo.init_etrace_state()
+    y = algo(x0)
+    assert y.shape == (1, 4)
+    assert bool(jnp.all(jnp.isfinite(y)))
+
+
+# --- Task 3: SNN algos requiring leak + OSTTP B_list contract ----------------
+
+def test_ottt_otpe_require_explicit_leak():
+    model = tanh_rnn(seed=0).factory()
+    brainstate.nn.init_all_states(model, batch_size=1)
+    with pytest.raises(TypeError):
+        braintrace.OTTT(model)          # leak is keyword-only & required
+    with pytest.raises(TypeError):
+        braintrace.OTPE(model)
+
+
+def test_ottt_otpe_construct_with_leak():
+    for ctor in (lambda m: braintrace.OTTT(m, leak=0.9),
+                 lambda m: braintrace.OTPE(m, leak=0.9)):
+        model = tanh_rnn(seed=0).factory()
+        brainstate.nn.init_all_states(model, batch_size=1)
+        algo = ctor(model)
+        assert algo is not None
+
+
+def test_osttp_constructs_with_B_list():
+    model = tanh_rnn(n_in=3, n_rec=4, seed=0).factory()
+    brainstate.nn.init_all_states(model, batch_size=1)
+    # OSTTP needs one random-feedback matrix per HiddenGroup; B.shape[1] == n_l (=4).
+    B_list = [jnp.eye(4, dtype='float32')]
+    algo = braintrace.OSTTP(model, B_list)
+    assert algo is not None
+
+
+# --- Task 4: dynamic weight assignment raises NotSupportedError --------------
+
+def test_dynamic_weight_assignment_raises_not_supported():
+    """Writing a ParamState during the forward pass is unsupported and must
+    raise braintrace.NotSupportedError at graph compile time."""
+
+    class BadModel(brainstate.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.w = brainstate.ParamState(
+                0.1 * jax.random.normal(jax.random.PRNGKey(0), (4, 4)))
+            self.h = brainstate.HiddenState(jnp.zeros((1, 4)))
+
+        def update(self, x):
+            self.w.value = self.w.value * 1.001   # illegal: rewriting a ParamState
+            self.h.value = jax.nn.tanh(braintrace.matmul(self.h.value, self.w.value))
+            return self.h.value
+
+    model = BadModel()
+    brainstate.nn.init_all_states(model, batch_size=1)
+    algo = braintrace.D_RTRL(model)
+    with pytest.raises(braintrace.NotSupportedError):
+        algo.compile_graph(jnp.ones((1, 4), dtype='float32'))
+
+
+# --- Task 5: weight inside control flow raises NotImplementedError -----------
+
+@pytest.mark.xfail(
+    strict=True,
+    reason="F-SCAN-WEIGHT: the weight-in-control-flow guard intends to raise "
+           "NotImplementedError, but its error-message construction at "
+           "base.py:133 indexes invar_to_hidden_path with the *weight* var "
+           "(absent from that hidden-path map), so a KeyError escapes instead. "
+           "The guard fires, but the wrong exception type surfaces.",
+)
+def test_weight_used_inside_scan_raises_not_implemented():
+    """check_unsupported_op should raise NotImplementedError when a weight var is
+    used within a control-flow op. Today it raises KeyError while building the
+    message (F-SCAN-WEIGHT) — this test pins the intended contract via xfail."""
+
+    class ScanModel(brainstate.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.w = brainstate.ParamState(
+                0.1 * jax.random.normal(jax.random.PRNGKey(0), (4, 4)))
+            self.h = brainstate.HiddenState(jnp.zeros((1, 4)))
+
+        def update(self, x):
+            def body(carry, _):
+                return braintrace.matmul(carry, self.w.value), None  # weight inside scan
+            out, _ = jax.lax.scan(body, self.h.value, xs=None, length=2)
+            self.h.value = jax.nn.tanh(out)
+            return self.h.value
+
+    model = ScanModel()
+    brainstate.nn.init_all_states(model, batch_size=1)
+    algo = braintrace.D_RTRL(model)
+    with pytest.raises(NotImplementedError):
+        algo.compile_graph(jnp.ones((1, 4), dtype='float32'))
+
+
+# --- Task 6: legacy + nn deprecations emit DeprecationWarning ----------------
+
+def _reset_legacy_warned():
+    # Legacy ops/params warn once per class (cached in a module-level set); reset
+    # so the warning fires regardless of earlier construction this session.
+    from braintrace._legacy import _ops, _params
+    _ops._warned.clear()
+    _params._warned.clear()
+
+
+def test_legacy_op_construction_warns():
+    _reset_legacy_warned()
+    with pytest.warns(DeprecationWarning):
+        braintrace.MatMulOp()
+
+
+def test_legacy_param_construction_warns():
+    _reset_legacy_warned()
+    with pytest.warns(DeprecationWarning):
+        braintrace.ETraceParam({'weight': jnp.ones((4, 4))}, op=braintrace.MatMulOp())
+
+
+def test_nn_forwarded_name_warns():
+    import braintrace.nn as nn
+    with pytest.warns(DeprecationWarning):
+        _ = nn.LayerNorm
+
+
+def test_nn_unknown_name_raises_attribute_error():
+    import braintrace.nn as nn
+    with pytest.raises(AttributeError):
+        _ = nn.ThisNameDoesNotExist
+
+
+# --- Task 7: lock the drifted implementation facts (F-17) --------------------
+
+def test_ostl_is_two_classes_not_a_factory():
+    from braintrace._etrace_algorithms.param_dim_vjp import ParamDimVjpAlgorithm
+    from braintrace._etrace_algorithms.io_dim_vjp import IODimVjpAlgorithm
+    assert isinstance(braintrace.OSTLRecurrent, type)
+    assert isinstance(braintrace.OSTLFeedforward, type)
+    assert issubclass(braintrace.OSTLRecurrent, ParamDimVjpAlgorithm)
+    assert issubclass(braintrace.OSTLFeedforward, IODimVjpAlgorithm)
+
+
+def test_iodim_lives_in_io_dim_vjp_module():
+    from braintrace._etrace_algorithms.io_dim_vjp import IODimVjpAlgorithm
+    assert braintrace.IODimVjpAlgorithm is IODimVjpAlgorithm
+    assert braintrace.pp_prop is braintrace.ES_D_RTRL  # aliases
+
+
+def test_expected_rnn_cells_exist():
+    import braintrace.nn as nn
+    for cell in ('ValinaRNNCell', 'GRUCell', 'MGUCell', 'LSTMCell', 'URLSTMCell',
+                 'MinimalRNNCell', 'MiniGRU', 'MiniLSTM', 'LRUCell'):
+        assert hasattr(nn, cell), f"missing cell: {cell}"


### PR DESCRIPTION
P2: op_rule_oracle proves each ETP primitive's xy_to_dw equals jax.vjp of
its impl (dense/conv/sparse/lora), pins conv's deferred bias summation, lora
partial-propagation, init_drtrl/init_pp shape contract, and multi-primitive
composition gradients.

P3: api_contract pins the public surface — every __all__ symbol resolves and
is non-None, rate-model algorithms run end-to-end, OTTT/OTPE require keyword
leak, OSTTP B_list contract, dynamic-weight NotSupportedError, legacy/nn
DeprecationWarnings, and OSTL two-class / IODim-module / cell-roster facts.

xfail F-SCAN-WEIGHT: weight-in-control-flow guard raises KeyError while
building its NotImplementedError message (base.py:133 indexes the hidden-path
map with a weight var).

## Summary by Sourcery

Add oracle-based gradient rule checks for ETP primitives and codify the public API and behavioral contracts via end-to-end tests.

Enhancements:
- Introduce a reusable oracle helper that compares xy_to_dw operator rules against JAX vjp for ETP primitives.

Tests:
- Add public API contract tests ensuring __all__ symbols resolve, key algorithms run end-to-end, and documented error and deprecation behaviors are pinned.
- Add operator-rule oracle tests that validate dense/conv/sparse/LoRA xy_to_dw gradients, shape contracts, partial propagation, and multi-primitive composition gradients.
- Mark the known weight-in-control-flow guard bug as an xfail that encodes the intended NotImplementedError contract.