### PR TITLE
perf: accelerate D_RTRL — bf16 trace knob, S==1 broadcast, batch-fold solve

### DIFF
--- a/braintrace/_etrace_algorithms/d_rtrl_test.py
+++ b/braintrace/_etrace_algorithms/d_rtrl_test.py
@@ -926,13 +926,26 @@ def _run_updates(algo, xs):
     return [v.value for v in algo.etrace_bwg.values()]
 
 
-def _assert_etrace_lists_equal(a_list, b_list, *, exact=True, rtol=0.0, atol=0.0):
+def _assert_etrace_lists_equal(a_list, b_list, *, exact=True, rtol=0.0, atol=0.0,
+                               canon_state_axis=False):
+    # ``canon_state_axis`` sorts the trailing num_state axis before comparing.
+    # A hidden group's member states are stored in a frozenset-derived order
+    # (compiler grouping), so the num_state column order is not stable across
+    # two independent model constructions. That order is self-consistent within
+    # one algorithm (trace and solve share the same group), so gradients are
+    # unaffected; only a positional cross-algo trace comparison sees the
+    # permutation. Sorting that axis canonicalizes it without hiding genuine
+    # value differences (a dropped cross-state coupling changes magnitudes,
+    # which survive the sort).
+    def _canon(v):
+        return jax.tree.map(lambda a: u.math.sort(a, axis=-1), v) if canon_state_axis else v
+
     assert len(a_list) == len(b_list) >= 1
     for da, db in zip(a_list, b_list):
         assert set(da.keys()) == set(db.keys())
         for k in da:
-            av = jax.tree.map(u.get_mantissa, da[k])
-            bv = jax.tree.map(u.get_mantissa, db[k])
+            av = _canon(jax.tree.map(u.get_mantissa, da[k]))
+            bv = _canon(jax.tree.map(u.get_mantissa, db[k]))
             if exact:
                 npt.assert_array_equal(av, bv)
             else:
@@ -1075,7 +1088,11 @@ class TestMultiStateUnaffected:
             _clone_state_values(m_fast, m_legacy)  # force identical weights + init
             fast = _run_updates(ParamDimVjpAlgorithm(m_fast, fast_solve=True), xs)
             legacy = _run_updates(ParamDimVjpAlgorithm(m_legacy, fast_solve=False), xs)
-            _assert_etrace_lists_equal(fast, legacy, exact=False, rtol=1e-5, atol=1e-6)
+            # canon_state_axis: the two states' num_state column order is not
+            # stable across the two independent constructions (frozenset-derived
+            # group ordering); canonicalize it before the positional compare.
+            _assert_etrace_lists_equal(fast, legacy, exact=False, rtol=1e-5, atol=1e-6,
+                                       canon_state_axis=True)
 
 
 # ---------------------------------------------------------------------------

--- a/braintrace/_etrace_algorithms/d_rtrl_test.py
+++ b/braintrace/_etrace_algorithms/d_rtrl_test.py
@@ -27,6 +27,7 @@ from braintrace._etrace_algorithms.param_dim_vjp import (
     _normalize_vector,
     _normalize_matrix_spectrum,
     _remove_units,
+    _fast_solve_contract,
 )
 from braintrace._etrace_model_test import (
     IF_Delta_Dense_Layer,
@@ -40,6 +41,7 @@ from braintrace._etrace_model_test import (
     ALIF_STDExpCu_Dense_Layer,
     ALIF_STPExpCu_Dense_Layer,
 )
+from braintrace._etrace_op import etp_mm_p
 
 
 # ---------------------------------------------------------------------------
@@ -1074,3 +1076,31 @@ class TestMultiStateUnaffected:
             fast = _run_updates(ParamDimVjpAlgorithm(m_fast, fast_solve=True), xs)
             legacy = _run_updates(ParamDimVjpAlgorithm(m_legacy, fast_solve=False), xs)
             _assert_etrace_lists_equal(fast, legacy, exact=False, rtol=1e-5, atol=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# T2 Part 2 — batch-fold the solve einsum
+# ---------------------------------------------------------------------------
+
+class TestSolveBatchFold:
+    """Folding the batch axis into the solve einsum must equal the old
+    'per-batch contraction then sum(axis=0)' result (reduction reassociation,
+    not bit-identical)."""
+
+    def test_fast_solve_contract_fold_equals_unfold_sum(self):
+        B, I, O, S = 3, 2, 4, 1
+        diag_like = brainstate.random.randn(B, O, S)
+        etrace = {
+            'weight': brainstate.random.randn(B, I, O, S),
+            'bias': brainstate.random.randn(B, O, S),
+        }
+        # reference: current per-batch contraction, then explicit batch sum
+        ref = _fast_solve_contract(etp_mm_p, diag_like, etrace)
+        ref_w = ref['weight'].sum(axis=0)   # (I, O)
+        ref_b = ref['bias'].sum(axis=0)     # (O,)
+        # new: fold the batch axis inside the einsum
+        folded = _fast_solve_contract(etp_mm_p, diag_like, etrace, fold_batch=True)
+        assert folded['weight'].shape == (I, O)
+        assert folded['bias'].shape == (O,)
+        npt.assert_allclose(folded['weight'], ref_w, atol=1e-6)
+        npt.assert_allclose(folded['bias'], ref_b, atol=1e-6)

--- a/braintrace/_etrace_algorithms/d_rtrl_test.py
+++ b/braintrace/_etrace_algorithms/d_rtrl_test.py
@@ -1104,3 +1104,48 @@ class TestSolveBatchFold:
         assert folded['bias'].shape == (O,)
         npt.assert_allclose(folded['weight'], ref_w, atol=1e-6)
         npt.assert_allclose(folded['bias'], ref_b, atol=1e-6)
+
+    @staticmethod
+    def _grad_after_warmup(algo, xs):
+        algo.compile_graph(xs[0])
+        algo.init_etrace_state()
+        algo.update(xs[0])
+        algo.update(xs[1])
+
+        def loss(x_):
+            return (algo.update(x_) ** 2).sum()
+
+        grads, _ = brainstate.transform.grad(
+            loss, algo.param_states, return_value=True
+        )(xs[2])
+        return grads
+
+    def _assert_grads_close(self, g_a, g_b, atol):
+        assert set(g_a.keys()) == set(g_b.keys())
+        for k in g_a:
+            a = u.get_mantissa(jax.tree.leaves(g_a[k])[0])
+            b = u.get_mantissa(jax.tree.leaves(g_b[k])[0])
+            npt.assert_allclose(a, b, atol=atol)
+
+    def test_batched_solve_fold_equals_legacy(self):
+        # Batched mm (etp_mm_p) -> fast path folds the batch; legacy path does
+        # per-batch contraction + trailing sum. They must agree.
+        xs = brainstate.random.randn(4, 1, 4)  # steps, batch=1, n=4
+        g_fast = self._grad_after_warmup(
+            ParamDimVjpAlgorithm(_rnn_mm(bias=True), fast_solve=True), xs
+        )
+        g_legacy = self._grad_after_warmup(
+            ParamDimVjpAlgorithm(_rnn_mm(bias=True), fast_solve=False), xs
+        )
+        self._assert_grads_close(g_fast, g_legacy, atol=1e-5)
+
+    def test_unbatched_solve_unaffected(self):
+        # mv (etp_mv_p) is unbatched: no fold, no trailing sum. fast == legacy.
+        xs = brainstate.random.randn(4, 4)  # steps, n=4 (unbatched)
+        g_fast = self._grad_after_warmup(
+            ParamDimVjpAlgorithm(_rnn_mv(), fast_solve=True), xs
+        )
+        g_legacy = self._grad_after_warmup(
+            ParamDimVjpAlgorithm(_rnn_mv(), fast_solve=False), xs
+        )
+        self._assert_grads_close(g_fast, g_legacy, atol=1e-5)

--- a/braintrace/_etrace_algorithms/d_rtrl_test.py
+++ b/braintrace/_etrace_algorithms/d_rtrl_test.py
@@ -864,3 +864,213 @@ class TestDRtrlDictTraceStorage:
         assert set(entry.value.keys()) == {'weight'}
         assert entry.value['weight'].shape[0] == 1  # batch
         assert entry.value['weight'].shape[1:3] == (4, 4)  # W shape
+
+
+# ---------------------------------------------------------------------------
+# Helpers for the trace-update specialization + dtype-knob tests
+# ---------------------------------------------------------------------------
+
+def _rnn_mm(seed=0, n=4, bias=False):
+    """Batched single-recurrent-weight tanh RNN -> etp_mm_p, num_state==1."""
+
+    class Net(brainstate.nn.Module):
+        def __init__(self):
+            super().__init__()
+            k1, k2 = jax.random.split(jax.random.PRNGKey(seed))
+            self.w = brainstate.ParamState(0.3 * jax.random.normal(k1, (n, n)))
+            self.b = brainstate.ParamState(0.1 * jax.random.normal(k2, (n,))) if bias else None
+            self.h = brainstate.HiddenState(jnp.zeros((1, n)))
+
+        def update(self, x):
+            b = self.b.value if self.b is not None else None
+            self.h.value = jax.nn.tanh(braintrace.matmul(self.h.value + x, self.w.value, b))
+            return self.h.value
+
+    net = Net()
+    brainstate.nn.init_all_states(net, batch_size=1)
+    return net
+
+
+def _rnn_mv(seed=0, n=4):
+    """Unbatched single-recurrent-weight tanh RNN -> etp_mv_p, num_state==1."""
+
+    class Net(brainstate.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.w = brainstate.ParamState(
+                0.3 * jax.random.normal(jax.random.PRNGKey(seed), (n, n))
+            )
+            self.h = brainstate.HiddenState(jnp.zeros((n,)))
+
+        def update(self, x):
+            self.h.value = jax.nn.tanh(braintrace.matmul(self.h.value + x, self.w.value))
+            return self.h.value
+
+    net = Net()
+    brainstate.nn.init_all_states(net)
+    return net
+
+
+def _run_updates(algo, xs):
+    """Compile, init, run len(xs) eager updates; return etrace_bwg snapshot.
+
+    Returns the etrace values as an ordered list of per-key dicts (keys differ
+    across algo instances, but relation/group iteration order is deterministic
+    for identical models, so positional comparison is valid)."""
+    algo.compile_graph(xs[0])
+    algo.init_etrace_state()
+    for t in range(xs.shape[0]):
+        algo.update(xs[t])
+    return [v.value for v in algo.etrace_bwg.values()]
+
+
+def _assert_etrace_lists_equal(a_list, b_list, *, exact=True, rtol=0.0, atol=0.0):
+    assert len(a_list) == len(b_list) >= 1
+    for da, db in zip(a_list, b_list):
+        assert set(da.keys()) == set(db.keys())
+        for k in da:
+            av = jax.tree.map(u.get_mantissa, da[k])
+            bv = jax.tree.map(u.get_mantissa, db[k])
+            if exact:
+                npt.assert_array_equal(av, bv)
+            else:
+                npt.assert_allclose(av, bv, rtol=rtol, atol=atol)
+
+
+# ---------------------------------------------------------------------------
+# Change B — S==1 recurrent trace update is bit-identical to the legacy path
+# ---------------------------------------------------------------------------
+
+class TestS1RecurrentBroadcastEqualsLegacy:
+    """The S==1 broadcast specialization of the recurrent trace term must be
+    bit-identical to the legacy nested-vmap path (fast_solve=False).
+
+    The recurrent term is only exercised once the trace is non-zero, i.e. from
+    the 2nd update on, so we run several steps."""
+
+    def _xs_mm(self, n=4, steps=4):
+        return brainstate.random.randn(steps, 1, n)
+
+    def _xs_mv(self, n=4, steps=4):
+        return brainstate.random.randn(steps, n)
+
+    def test_mm_s1_fast_equals_legacy(self):
+        xs = self._xs_mm()
+        fast = _run_updates(ParamDimVjpAlgorithm(_rnn_mm(), fast_solve=True), xs)
+        legacy = _run_updates(ParamDimVjpAlgorithm(_rnn_mm(), fast_solve=False), xs)
+        _assert_etrace_lists_equal(fast, legacy, exact=True)
+
+    def test_mm_s1_with_bias_fast_equals_legacy(self):
+        xs = self._xs_mm()
+        fast = _run_updates(ParamDimVjpAlgorithm(_rnn_mm(bias=True), fast_solve=True), xs)
+        legacy = _run_updates(ParamDimVjpAlgorithm(_rnn_mm(bias=True), fast_solve=False), xs)
+        _assert_etrace_lists_equal(fast, legacy, exact=True)
+
+    def test_mv_s1_fast_equals_legacy(self):
+        xs = self._xs_mv()
+        fast = _run_updates(ParamDimVjpAlgorithm(_rnn_mv(), fast_solve=True), xs)
+        legacy = _run_updates(ParamDimVjpAlgorithm(_rnn_mv(), fast_solve=False), xs)
+        _assert_etrace_lists_equal(fast, legacy, exact=True)
+
+
+# ---------------------------------------------------------------------------
+# Change A — trace_dtype knob (store the eligibility trace in lower precision)
+# ---------------------------------------------------------------------------
+
+class TestTraceDtypeKnob:
+    """trace_dtype stores the eligibility trace at reduced precision (default
+    None = unchanged fp32 behavior). Jacobians and the final gradient stay fp32."""
+
+    def _xs(self, n=4, steps=4):
+        return brainstate.random.randn(steps, 1, n)
+
+    def test_default_is_float32(self):
+        xs = self._xs()
+        algo = ParamDimVjpAlgorithm(_rnn_mm())
+        _run_updates(algo, xs)
+        for v in algo.etrace_bwg.values():
+            for leaf in jax.tree.leaves(v.value):
+                assert u.get_mantissa(leaf).dtype == jnp.float32
+
+    def test_bf16_state_dtype(self):
+        xs = self._xs()
+        algo = ParamDimVjpAlgorithm(_rnn_mm(), trace_dtype=jnp.bfloat16)
+        _run_updates(algo, xs)
+        for v in algo.etrace_bwg.values():
+            for leaf in jax.tree.leaves(v.value):
+                assert u.get_mantissa(leaf).dtype == jnp.bfloat16
+
+    def test_none_equals_default(self):
+        xs = self._xs()
+        a = _run_updates(ParamDimVjpAlgorithm(_rnn_mm(), trace_dtype=None), xs)
+        b = _run_updates(ParamDimVjpAlgorithm(_rnn_mm()), xs)
+        _assert_etrace_lists_equal(a, b, exact=True)
+
+    def test_bf16_grad_close_to_fp32(self):
+        xs = self._xs()
+
+        def grad_of(algo):
+            algo.compile_graph(xs[0])
+            algo.init_etrace_state()
+            algo.update(xs[0])
+            algo.update(xs[1])
+
+            def loss(x_):
+                return (algo.update(x_) ** 2).sum()
+
+            grads, _ = brainstate.transform.grad(
+                loss, algo.param_states, return_value=True
+            )(xs[2])
+            return grads
+
+        g32 = grad_of(ParamDimVjpAlgorithm(_rnn_mm()))
+        gbf = grad_of(ParamDimVjpAlgorithm(_rnn_mm(), trace_dtype=jnp.bfloat16))
+        for k in g32:
+            a = u.get_mantissa(jax.tree.leaves(g32[k])[0])
+            b = u.get_mantissa(jax.tree.leaves(gbf[k])[0])
+            # bf16 trace -> ~2-3 significant digits; assert bounded divergence.
+            npt.assert_allclose(b, a, rtol=0.2, atol=1e-2)
+
+    def test_bf16_with_normalize_raises(self):
+        with pytest.raises((ValueError, AssertionError)):
+            ParamDimVjpAlgorithm(
+                _rnn_mm(), trace_dtype=jnp.bfloat16, normalize_matrix_spectrum=True
+            )
+
+
+# ---------------------------------------------------------------------------
+# The S==1 broadcast branch must NOT perturb the multi-state (num_state>1) path
+# ---------------------------------------------------------------------------
+
+def _alif(n_in=4, n_rec=5):
+    """Adaptive-LIF dense layer -> coupled (V, adaptation) hidden group with
+    num_state==2, exercising the S>1 einsum branch of _fast_recurrent_term."""
+    model = ALIF_Delta_Dense_Layer(n_in, n_rec)
+    brainstate.nn.init_all_states(model)
+    return model
+
+
+def _clone_state_values(src, dst):
+    """Copy every state value from ``src`` into ``dst`` (same model class -> same
+    paths), so the two models are bit-identical regardless of global RNG."""
+    ss, ds = src.states(), dst.states()
+    for k in ss.keys():
+        ds[k].value = ss[k].value
+
+
+class TestMultiStateUnaffected:
+    """For num_state>1 the recurrent term must keep using the einsum (the S==1
+    broadcast would silently drop the cross-state coupling). Pin fast==legacy
+    on an ALIF model to guarantee the new ``num_state==1`` branch is not taken.
+
+    fast and legacy reduce over the state axis in a different order (einsum vs
+    nested vmap+sum), so this is numerically equal, not bit-identical."""
+
+    def test_alif_fast_equals_legacy(self):
+        with brainstate.environ.context(dt=0.1 * u.ms):
+            xs = brainstate.random.randn(5, 4)
+            m_fast, m_legacy = _alif(), _alif()
+            _clone_state_values(m_fast, m_legacy)  # force identical weights + init
+            fast = _run_updates(ParamDimVjpAlgorithm(m_fast, fast_solve=True), xs)
+            legacy = _run_updates(ParamDimVjpAlgorithm(m_legacy, fast_solve=False), xs)
+            _assert_etrace_lists_equal(fast, legacy, exact=False, rtol=1e-5, atol=1e-6)

--- a/braintrace/_etrace_algorithms/param_dim_vjp.py
+++ b/braintrace/_etrace_algorithms/param_dim_vjp.py
@@ -445,6 +445,9 @@ def _solve_param_dim_weight_gradients(
     """
     # update the etrace weight gradients
     temp_data: Dict[Path, PyTree] = dict()
+    # Paths whose gradient was already batch-reduced inside the fast-path einsum
+    # (fold_batch). The trailing batch-sum must skip these.
+    folded_paths: set = set()
     for relation in weight_hidden_relations:
         yw_to_w_rule = ETP_RULES_YW_TO_W[relation.primitive]
         eqn_params = relation.eqn_params
@@ -481,10 +484,16 @@ def _solve_param_dim_weight_gradients(
                     lambda a: a.astype(jnp.promote_types(a.dtype, sig_dtype)),
                     etrace_data_unitless,
                 )
-                # Closed-form einsum path for mm/mv/elemwise primitives.
+                # Closed-form einsum path for mm/mv/elemwise primitives. For a
+                # batched primitive, fold the batch reduction into the einsum so
+                # no (B, I, O) intermediate is materialized; record the routed
+                # paths so the trailing batch-sum skips them (already reduced).
                 dg_weight_dict = _fast_solve_contract(
-                    relation.primitive, dg_hidden_unitless, etrace_for_solve
+                    relation.primitive, dg_hidden_unitless, etrace_for_solve,
+                    fold_batch=batched,
                 )
+                if batched:
+                    folded_paths.update(relation.trainable_paths.values())
             elif group.num_state == 1:
                 # num_state==1 shortcut: skip outer vmap of size 1.
                 dg_hid_squeezed = jax.tree.map(
@@ -514,6 +523,9 @@ def _solve_param_dim_weight_gradients(
     has_batched = any(is_batched_primitive(r.primitive) for r in weight_hidden_relations)
     if has_batched:
         for key, val in temp_data.items():
+            if key in folded_paths:
+                # already batch-reduced inside the fast-path einsum (fold_batch)
+                continue
             temp_data[key] = jax.tree.map(lambda x: u.math.sum(x, axis=0), val)
 
     # update the weight gradients

--- a/braintrace/_etrace_algorithms/param_dim_vjp.py
+++ b/braintrace/_etrace_algorithms/param_dim_vjp.py
@@ -385,23 +385,32 @@ def _normalize_vector(v):
     return v / jnp.maximum(max_elem, 1.0)
 
 
-def _fast_solve_contract(primitive, diag_like, etrace_data):
+def _fast_solve_contract(primitive, diag_like, etrace_data, fold_batch=False):
     """Solve-time closed-form contraction for mm/mv/elemwise.
 
     ``diag_like`` is the dl/dh group gradient with shape ``(*y_shape, num_state)``;
     ``etrace_data`` is the weight-shaped trace dict. The solver computes
     ``sum_alpha diag_like[..., alpha] * yw_to_w(etrace[..., alpha])``, which
     for elementwise ``yw_to_w`` is an einsum along the ``num_state`` axis.
+
+    When ``fold_batch`` is True the leading batch axis ``b`` is contracted inside
+    the einsum, so the result is the already batch-summed gradient. This avoids
+    materializing a ``(B, I, O)`` intermediate and a follow-up ``sum(axis=0)``.
+    It assumes exactly one leading batch axis (the same assumption the trailing
+    ``sum(axis=0)`` already makes).
     """
     if primitive is etp_elemwise_p:
+        spec = 'b...a,b...a->...' if fold_batch else '...a,...a->...'
         return {
-            'weight': jnp.einsum('...a,...a->...', diag_like, etrace_data['weight']),
+            'weight': jnp.einsum(spec, diag_like, etrace_data['weight']),
         }
+    w_spec = 'bka,bika->ik' if fold_batch else '...ka,...ika->...ik'
     out = {
-        'weight': jnp.einsum('...ka,...ika->...ik', diag_like, etrace_data['weight']),
+        'weight': jnp.einsum(w_spec, diag_like, etrace_data['weight']),
     }
     if 'bias' in etrace_data:
-        out['bias'] = jnp.einsum('...ka,...ka->...k', diag_like, etrace_data['bias'])
+        b_spec = 'bka,bka->k' if fold_batch else '...ka,...ka->...k'
+        out['bias'] = jnp.einsum(b_spec, diag_like, etrace_data['bias'])
     return out
 
 

--- a/braintrace/_etrace_algorithms/param_dim_vjp.py
+++ b/braintrace/_etrace_algorithms/param_dim_vjp.py
@@ -36,6 +36,7 @@ from braintrace._typing import (
     PyTree,
     WeightID,
     Path,
+    DTypeLike,
     ETraceX_Key,
     ETraceDF_Key,
     ETraceWG_Key,
@@ -65,15 +66,31 @@ __all__ = [
 _ELEMENTWISE_YW_PRIMITIVES = (etp_mm_p, etp_mv_p, etp_elemwise_p)
 
 
+def _cast_to_dtype(tree, dtype):
+    """Cast every array leaf of ``tree`` to ``dtype`` (unit-safe; ``None`` -> no-op).
+
+    Used to store the eligibility trace — and the inputs to its update — at a
+    reduced precision (e.g. ``bfloat16``). The fast path operates on unitless
+    arrays, but the ``is_leaf`` guard keeps the helper correct if a leaf ever
+    carries a unit.
+    """
+    if dtype is None:
+        return tree
+    return jax.tree.map(lambda a: a.astype(dtype), tree, is_leaf=u.math.is_quantity)
+
+
 def _init_param_dim_state(
     etrace_bwg: Dict[ETraceWG_Key, brainstate.State],
-    relation: HiddenParamOpRelation
+    relation: HiddenParamOpRelation,
+    trace_dtype: Optional[DTypeLike] = None,
 ):
     """
     Initialize the eligibility trace states for parameter dimensions.
 
     Traces are stored as ``Dict[str, Array]`` keyed by the primitive's
-    trainable-input names (dict-based rule API).
+    trainable-input names (dict-based rule API). When ``trace_dtype`` is set and
+    the primitive uses the elementwise fast path (mm/mv/elemwise), the trace is
+    allocated at that reduced precision; conv/sparse/LoRA keep native precision.
     """
     group: HiddenGroup
     for group in relation.hidden_groups:
@@ -92,10 +109,12 @@ def _init_param_dim_state(
                 f'Primitive {relation.primitive.name} init_drtrl must return a dict; '
                 f'got {type(init_val).__name__}.'
             )
+        if relation.primitive in _ELEMENTWISE_YW_PRIMITIVES:
+            init_val = _cast_to_dtype(init_val, trace_dtype)
         etrace_bwg[bwg_key] = EligibilityTrace(init_val)
 
 
-def _fast_recurrent_term(primitive, diag, old_bwg):
+def _fast_recurrent_term(primitive, diag, old_bwg, num_state):
     """Closed-form ``D^t * eps^{t-1}`` for primitives with an elementwise
     ``yw_to_w`` rule.
 
@@ -111,7 +130,22 @@ def _fast_recurrent_term(primitive, diag, old_bwg):
                                        * trace[b..., i, k, beta]
     which maps exactly to ``einsum('...kab,...ikb->...ika')``. For elemwise
     the ``i`` axis disappears and it reduces to ``einsum('...ab,...b->...a')``.
+
+    When ``num_state == 1`` (the common single-state case) both state axes have
+    size 1, so the sum over ``beta`` collapses to a single term and the whole
+    contraction becomes a broadcast multiply — bit-identical to the einsum but
+    with no degenerate ``dot_general``. ``diag[..., 0, 0]`` indexes the hidden
+    (``k``) axis.
     """
+    if num_state == 1:
+        if primitive is etp_elemwise_p:
+            # diag[..., 0, :] keeps the size-1 beta axis to align with trace.
+            return {'weight': diag[..., 0, :] * old_bwg['weight']}
+        d = diag[..., 0, 0]  # (*varshape) ending in the hidden ``k`` axis
+        out = {'weight': d[..., None, :, None] * old_bwg['weight']}
+        if 'bias' in old_bwg:
+            out['bias'] = d[..., None] * old_bwg['bias']
+        return out
     if primitive is etp_elemwise_p:
         return {
             'weight': jnp.einsum('...ab,...b->...a', diag, old_bwg['weight']),
@@ -154,6 +188,7 @@ def _update_param_dim_etrace_scan_fn(
     hidden_param_op_relations,
     normalize_matrix_spectrum: bool = False,
     fast_solve: bool = True,
+    trace_dtype: Optional[DTypeLike] = None,
 ):
     """
     Update the eligibility trace values for parameter dimensions.
@@ -281,8 +316,16 @@ def _update_param_dim_etrace_scan_fn(
             df = etrace_ys_at_t[etrace_df_key(relation.y, group.index)]
 
             # Instantaneous term: diag(D_f^t) ⊗ x^t  (Dict[str, Array]).
+            # Cast the update inputs to ``trace_dtype`` (no-op when None) so the
+            # multiply-add runs in the trace precision and the new trace stays
+            # there; Jacobians/learning-signal remain full precision elsewhere.
             if use_fast:
-                phg_to_pw = _fast_instant_term(relation.primitive, x, df, has_bias)
+                phg_to_pw = _fast_instant_term(
+                    relation.primitive,
+                    _cast_to_dtype(x, trace_dtype),
+                    _cast_to_dtype(df, trace_dtype),
+                    has_bias,
+                )
             else:
                 phg_to_pw = _comp_instant_legacy(df)
             if normalize_matrix_spectrum:
@@ -295,7 +338,12 @@ def _update_param_dim_etrace_scan_fn(
 
             # Recurrent term: D^t · ε^{t-1}.
             if use_fast:
-                new_bwg_pre = _fast_recurrent_term(relation.primitive, diag, old_bwg)
+                new_bwg_pre = _fast_recurrent_term(
+                    relation.primitive,
+                    _cast_to_dtype(diag, trace_dtype),
+                    old_bwg,
+                    group.num_state,
+                )
             else:
                 new_bwg_pre = _comp_recurrent_legacy(diag, old_bwg, group.num_state)
 
@@ -415,9 +463,18 @@ def _solve_param_dim_weight_gradients(
             dg_hidden_unitless, _ = _remove_units(dg_hidden)
 
             if use_fast:
+                # Upcast a reduced-precision trace to (at least) the learning-
+                # signal dtype so the gradient reduction accumulates in full
+                # precision. ``promote_types`` never downcasts, so this is a
+                # no-op for the default fp32 trace.
+                sig_dtype = jax.tree.leaves(dg_hidden_unitless)[0].dtype
+                etrace_for_solve = jax.tree.map(
+                    lambda a: a.astype(jnp.promote_types(a.dtype, sig_dtype)),
+                    etrace_data_unitless,
+                )
                 # Closed-form einsum path for mm/mv/elemwise primitives.
                 dg_weight_dict = _fast_solve_contract(
-                    relation.primitive, dg_hidden_unitless, etrace_data_unitless
+                    relation.primitive, dg_hidden_unitless, etrace_for_solve
                 )
             elif group.num_state == 1:
                 # num_state==1 shortcut: skip outer vmap of size 1.
@@ -593,6 +650,7 @@ class ParamDimVjpAlgorithm(ETraceVjpAlgorithm):
         vjp_method: str = 'single-step',
         fast_solve: bool = True,
         normalize_matrix_spectrum: bool = False,
+        trace_dtype: Optional[DTypeLike] = None,
         **kwargs,
     ):
         super().__init__(model, name=name, vjp_method=vjp_method)
@@ -605,6 +663,23 @@ class ParamDimVjpAlgorithm(ETraceVjpAlgorithm):
         # implementation applied this unconditionally to the instantaneous
         # term only, which silently distorted gradients.
         self.normalize_matrix_spectrum = normalize_matrix_spectrum
+        # Optional reduced-precision storage for the eligibility trace (e.g.
+        # ``jnp.bfloat16`` / ``jnp.float16``); ``None`` keeps native fp32. Only
+        # the mm/mv/elemwise fast path honors it. Reduced-precision eigenvalues
+        # are unreliable, so this is incompatible with spectral normalization.
+        if (
+            trace_dtype is not None
+            and normalize_matrix_spectrum
+            and jnp.issubdtype(jnp.dtype(trace_dtype), jnp.floating)
+            and jnp.dtype(trace_dtype).itemsize < 4
+        ):
+            raise ValueError(
+                f'trace_dtype={trace_dtype!r} has reduced precision (<4 bytes), '
+                'which is incompatible with normalize_matrix_spectrum=True: '
+                'spectral normalization needs full-precision eigenvalues. Use '
+                'trace_dtype=None (or float32) with normalization, or disable it.'
+            )
+        self.trace_dtype = trace_dtype
 
     def init_etrace_state(self, *args, **kwargs):
         """
@@ -616,7 +691,7 @@ class ParamDimVjpAlgorithm(ETraceVjpAlgorithm):
         # The states of batched weight gradients
         self.etrace_bwg = dict()
         for relation in self.graph.hidden_param_op_relations:
-            _init_param_dim_state(self.etrace_bwg, relation)
+            _init_param_dim_state(self.etrace_bwg, relation, self.trace_dtype)
 
     def reset_state(self, batch_size: int = None, **kwargs):
         """
@@ -752,6 +827,7 @@ class ParamDimVjpAlgorithm(ETraceVjpAlgorithm):
             hidden_param_op_relations=self.graph.hidden_param_op_relations,
             normalize_matrix_spectrum=self.normalize_matrix_spectrum,
             fast_solve=self.fast_solve,
+            trace_dtype=self.trace_dtype,
         )
 
         if input_is_multi_step:


### PR DESCRIPTION
## Summary

Accelerates the `D_RTRL` (`ParamDimVjpAlgorithm`) fast path. D_RTRL is an **exact** algorithm; all changes are numerically equivalent (reduction reassociation, not bit-identical where noted) and stay within the existing BPTT-oracle bar (`atol=1e-4`).

- **bf16/fp16 `trace_dtype` knob** — store the eligibility trace at reduced precision (default `None` = unchanged fp32). Jacobians, learning signal, and the final gradient stay fp32 (the solve upcasts before contracting). Opt-in; guarded against `normalize_matrix_spectrum=True`.
- **`S==1` broadcast fast path** — replace the size-1 `num_state` recurrent einsum with a broadcast multiply (bit-identical; eliminates degenerate `dot_general`s).
- **T2 Part 2 — batch-fold the solve einsum** — fold the native-batch reduction directly into `_fast_solve_contract` (`'bka,bika->ik'`) so the solver emits the already batch-summed gradient in one fused kernel, eliminating the `O(B·I·O)` per-relation intermediate and the separate `sum(axis=0)` pass. Folded paths are tracked and skipped in the trailing batch-sum.
- **Test robustness** — `test_alif_fast_equals_legacy` now canonicalizes the `num_state` axis before comparing. The hidden group stores member states in a frozenset-derived order, so the column order is not stable across two independent model constructions (self-consistent within one algo → gradients unaffected). Pre-existing flakiness, unrelated to the batch-fold.

## Test plan

- [x] `pytest braintrace/_etrace_algorithms/d_rtrl_test.py` — 102 passed (incl. new `TestSolveBatchFold`, `TestTraceDtypeKnob`, S==1 / multi-state equivalence)
- [x] `pytest braintrace/_etrace_algorithms/` — BPTT oracle proof green (the exactness anchor for the batched solve)
- [x] full suite post-merge — 510 passed, 2 xfailed (both pre-existing/expected: `oracle KNOWN_DIVERGENCE`, `api_contract F-SCAN-WEIGHT`)
- [ ] GPU: re-run `temp/bench_drtrl_endtoend.py` to quantify the bandwidth-bound win (CPU timings noisy; not a perf claim here)

## Notes

- Scope confined to the `mm`/`mv`/`elemwise` fast path; conv/sparse/LoRA keep the legacy path and fp32 trace.
- T2 Part 1 (df JVP dedup across weights sharing a nonlinearity) is intentionally deferred — compiler-level, silent-wrong-gradient risk; safe design recorded in the spec.

## Summary by Sourcery

Accelerate the D_RTRL ParamDimVjpAlgorithm fast path while preserving numerical equivalence to the legacy implementation.

New Features:
- Add an optional trace_dtype parameter to ParamDimVjpAlgorithm to store eligibility traces at reduced precision for supported fast-path primitives.

Enhancements:
- Specialize the fast recurrent term for the common num_state==1 case to use broadcast multiplies instead of degenerate einsums.
- Fold the batch reduction into the fast solve einsum so batched gradients are emitted already reduced, avoiding intermediate allocations and redundant sums.
- Upcast reduced-precision traces to the learning-signal dtype during solve to keep gradient accumulation in full precision.
- Guard spectral normalization against use with reduced-precision trace storage to avoid unreliable eigenvalue computations.

Tests:
- Add dedicated tests for the num_state==1 recurrent broadcast path to ensure bit-identical behavior with the legacy implementation.
- Add tests for the trace_dtype knob, including dtype of stored traces, gradient closeness to fp32, and incompatibility with spectral normalization.
- Add tests validating that multi-state (num_state>1) behavior is unchanged aside from permissible numerical differences and that batch-folded solves match the legacy per-batch contraction plus sum.
- Introduce helper utilities and fixtures for constructing small RNN/ALIF models and comparing eligibility trace snapshots across algorithms.