### PR TITLE
perf: fuse multi-step eligibility-trace roll into the forward scan

### DIFF
--- a/braintrace/_etrace_algorithms/io_dim_vjp.py
+++ b/braintrace/_etrace_algorithms/io_dim_vjp.py
@@ -25,7 +25,7 @@
 # -*- coding: utf-8 -*-
 
 from functools import partial
-from typing import Dict, Tuple, Optional, Sequence, Any
+from typing import Callable, Dict, Tuple, Optional, Sequence, Any
 
 import brainstate
 import jax
@@ -749,6 +749,22 @@ class IODimVjpAlgorithm(ETraceVjpAlgorithm):
         for df, val in etrace_dfs.items():
             self.etrace_dfs[df].value = val
 
+    def _make_etrace_stepper(self, weight_vals: WeightVals) -> Callable:
+        """Build the per-step ES-D-RTRL eligibility-trace stepper.
+
+        Returns the ``partial`` of :func:`_update_IO_dim_etrace_scan_fn` that serves
+        as the body of the trace scan. ``weight_vals`` is accepted for a uniform
+        hook signature but unused (this algorithm's trace roll does not read the
+        weights). Exposing the stepper lets the graph executor fuse the roll into
+        its over-time scan for multi-step input (see the base-class
+        :meth:`_make_etrace_stepper`).
+        """
+        return partial(
+            _update_IO_dim_etrace_scan_fn,
+            hid_weight_op_relations=self.graph.hidden_param_op_relations,
+            decay=self.decay,
+        )
+
     def _update_etrace_data(
         self,
         running_index: Optional[int],
@@ -810,11 +826,7 @@ class IODimVjpAlgorithm(ETraceVjpAlgorithm):
         #           the weight values.
         #
 
-        scan_fn = partial(
-            _update_IO_dim_etrace_scan_fn,
-            hid_weight_op_relations=self.graph.hidden_param_op_relations,
-            decay=self.decay,
-        )
+        scan_fn = self._make_etrace_stepper(weight_vals)
 
         if input_is_multi_step:
             hist_etrace_vals = jax.lax.scan(

--- a/braintrace/_etrace_algorithms/param_dim_vjp.py
+++ b/braintrace/_etrace_algorithms/param_dim_vjp.py
@@ -14,7 +14,7 @@
 # ==============================================================================
 
 from functools import partial
-from typing import Dict, Tuple, Optional, Sequence, Any
+from typing import Callable, Dict, Tuple, Optional, Sequence, Any
 
 import brainstate
 import jax
@@ -827,6 +827,23 @@ class ParamDimVjpAlgorithm(ETraceVjpAlgorithm):
         for x, val in etrace_vals.items():
             self.etrace_bwg[x].value = val
 
+    def _make_etrace_stepper(self, weight_vals: Dict[Path, PyTree]) -> Callable:
+        """Build the per-step D-RTRL eligibility-trace stepper.
+
+        Returns the ``partial`` of :func:`_update_param_dim_etrace_scan_fn` that
+        serves as the body of the trace scan. Exposing it lets the graph executor
+        fuse the roll into its over-time scan for multi-step input (see the
+        base-class :meth:`_make_etrace_stepper`).
+        """
+        return partial(
+            _update_param_dim_etrace_scan_fn,
+            weight_path_to_vals=weight_vals,
+            hidden_param_op_relations=self.graph.hidden_param_op_relations,
+            normalize_matrix_spectrum=self.normalize_matrix_spectrum,
+            fast_solve=self.fast_solve,
+            trace_dtype=self.trace_dtype,
+        )
+
     def _update_etrace_data(
         self,
         running_index: Optional[int],
@@ -865,14 +882,7 @@ class ParamDimVjpAlgorithm(ETraceVjpAlgorithm):
                 same structure as hist_etrace_vals but containing new values for the current timestep.
         """
 
-        scan_fn = partial(
-            _update_param_dim_etrace_scan_fn,
-            weight_path_to_vals=weight_vals,
-            hidden_param_op_relations=self.graph.hidden_param_op_relations,
-            normalize_matrix_spectrum=self.normalize_matrix_spectrum,
-            fast_solve=self.fast_solve,
-            trace_dtype=self.trace_dtype,
-        )
+        scan_fn = self._make_etrace_stepper(weight_vals)
 
         if input_is_multi_step:
             new_etrace = jax.lax.scan(

--- a/braintrace/_etrace_algorithms/scan_fusion_test.py
+++ b/braintrace/_etrace_algorithms/scan_fusion_test.py
@@ -1,0 +1,141 @@
+# Copyright 2026 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Equivalence tests for the fused multi-step eligibility-trace scan.
+
+For multi-step (``MultiStepData``) input the graph executor can fuse the
+per-step eligibility-trace roll into its over-time scan (one ``lax.scan``
+instead of two), driven by the subclass hook ``_make_etrace_stepper``. Fusing
+must be a pure performance change: the model outputs, the final eligibility
+trace, and the weight gradients must match the legacy two-scan path. The legacy
+path is forced here by stubbing ``_make_etrace_stepper`` to return ``None``.
+
+``test_fused_*`` exercises both fused executor entry points:
+  * the forward outputs / final trace go through ``solve_h2w_h2h_jacobian``
+    (the non-differentiated ``_update_fn``), and
+  * the gradients go through ``solve_h2w_h2h_l2h_jacobian`` (the custom-VJP
+    ``_update_fn_fwd`` / ``_update_fn_bwd``), which is where the trace carry is
+    threaded through a ``jax.vjp``-traced scan.
+"""
+
+import brainstate
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+import braintrace
+from braintrace._etrace_algorithms.oracle import (
+    assert_param_gradients_close,
+    bptt_param_gradients,
+)
+from braintrace._etrace_algorithms.oracle_models import tanh_rnn
+
+
+def _inputs(T, n_in, seed=42):
+    return jnp.asarray(np.random.RandomState(seed).randn(T, n_in).astype('float32'))
+
+
+# Both exact/diagonal algorithms that use the canonical scan-based trace roll.
+_ALGOS = {
+    'D_RTRL': lambda m: braintrace.ParamDimVjpAlgorithm(m, vjp_method='multi-step'),
+    'pp_prop': lambda m: braintrace.pp_prop(m, decay_or_rank=0.9, vjp_method='multi-step'),
+}
+
+
+def _build(algo_factory, inputs, *, fuse):
+    # The factory is deterministic (fixed seed), so the fused and legacy builds
+    # start from identical weights and states.
+    model = tanh_rnn(n_in=3, n_rec=4, seed=0).factory()
+    brainstate.nn.init_all_states(model, batch_size=1)
+    algo = algo_factory(model)
+    algo.compile_graph(inputs[0])
+    algo.init_etrace_state()
+    if not fuse:
+        # Force the legacy two-scan path by dropping the stepper at the executor
+        # boundary (so the executor stacks the per-step Jacobians and
+        # ``_update_etrace_data`` rolls the trace in a second scan). We patch the
+        # executor rather than ``_make_etrace_stepper`` because the legacy
+        # ``_update_etrace_data`` itself builds its scan body via that hook.
+        exe = algo.graph_executor
+        _orig_j = exe.solve_h2w_h2h_jacobian
+        _orig_l = exe.solve_h2w_h2h_l2h_jacobian
+        exe.solve_h2w_h2h_jacobian = (
+            lambda *a, **k: _orig_j(*a, **{**k, 'etrace_stepper': None, 'init_etrace': None})
+        )
+        exe.solve_h2w_h2h_l2h_jacobian = (
+            lambda *a, **k: _orig_l(*a, **{**k, 'etrace_stepper': None, 'init_etrace': None})
+        )
+    return model, algo
+
+
+def _assert_tree_close(a, b, *, atol, msg):
+    leaves_a, leaves_b = jax.tree.leaves(a), jax.tree.leaves(b)
+    assert len(leaves_a) == len(leaves_b), f'{msg}: pytree structure differs'
+    for x, y in zip(leaves_a, leaves_b):
+        x, y = jnp.asarray(x), jnp.asarray(y)
+        maxdiff = float(jnp.max(jnp.abs(x - y))) if x.size else 0.0
+        assert bool(jnp.allclose(x, y, atol=atol)), f'{msg}: maxabsdiff={maxdiff:.3e}'
+
+
+@pytest.mark.parametrize('name', list(_ALGOS))
+def test_fused_multistep_matches_legacy(name):
+    algo_factory = _ALGOS[name]
+    inputs = _inputs(8, 3)
+
+    # --- forward: outputs + final eligibility trace (solve_h2w_h2h_jacobian) ---
+    _, algo_f = _build(algo_factory, inputs, fuse=True)
+    out_f = algo_f(braintrace.MultiStepData(inputs))
+    trace_f = algo_f._get_etrace_data()
+
+    _, algo_u = _build(algo_factory, inputs, fuse=False)
+    out_u = algo_u(braintrace.MultiStepData(inputs))
+    trace_u = algo_u._get_etrace_data()
+
+    _assert_tree_close(out_f, out_u, atol=1e-5, msg=f'{name} outputs')
+    _assert_tree_close(trace_f, trace_u, atol=1e-5, msg=f'{name} final trace')
+
+    # --- gradients (solve_h2w_h2h_l2h_jacobian custom-VJP path) ---
+    def grads(fuse):
+        model, algo = _build(algo_factory, inputs, fuse=fuse)
+        return brainstate.transform.grad(
+            lambda seq: (algo(braintrace.MultiStepData(seq)) ** 2).sum(),
+            model.states(brainstate.ParamState),
+        )(inputs)
+
+    assert_param_gradients_close(grads(True), grads(False), atol=1e-5)
+
+
+def test_fused_d_rtrl_multistep_matches_bptt():
+    """End-to-end: the fused multi-step D_RTRL path reproduces the exact BPTT gradient.
+
+    (``oracle_test.test_d_rtrl_multistep_matches_bptt`` covers the same path, since
+    multi-step now fuses; kept here to keep the fusion correctness self-contained.)
+    """
+    spec = tanh_rnn(n_in=3, n_rec=4, seed=0)
+    inputs = _inputs(8, 3)
+    g_bptt = bptt_param_gradients(spec.factory, inputs)
+
+    model = spec.factory()
+    brainstate.nn.init_all_states(model, batch_size=1)
+    algo = braintrace.ParamDimVjpAlgorithm(model, vjp_method='multi-step')
+    algo.compile_graph(inputs[0])
+    algo.init_etrace_state()
+    g_fused = brainstate.transform.grad(
+        lambda seq: (algo(braintrace.MultiStepData(seq)) ** 2).sum(),
+        model.states(brainstate.ParamState),
+    )(inputs)
+
+    assert_param_gradients_close(g_fused, g_bptt, atol=1e-4)

--- a/braintrace/_etrace_algorithms/vjp_base.py
+++ b/braintrace/_etrace_algorithms/vjp_base.py
@@ -14,7 +14,7 @@
 # ==============================================================================
 
 
-from typing import Dict, Tuple, Any, List, Optional, Sequence
+from typing import Callable, Dict, Tuple, Any, List, Optional, Sequence
 
 import brainstate
 import jax
@@ -323,28 +323,43 @@ class ETraceVjpAlgorithm(ETraceAlgorithm):
         assign_state_values_v2(self.hidden_states, hidden_vals, write=False)
         assign_state_values_v2(self.other_states, oth_state_vals, write=False)
 
+        # When the trace roll can be fused into the executor's over-time scan
+        # (multi-step input + a fusable subclass), hand the per-step stepper down
+        # so the executor updates the trace in-loop and returns the final trace,
+        # avoiding a second scan over stacked Jacobians.
+        etrace_stepper = self._make_etrace_stepper(weight_vals) if input_is_multi_step else None
+
         # necessary jacobian information of the weights
         (
             out,
             hidden_vals,
             oth_state_vals,
             hid2weight_jac_single_or_multi_steps,
-            hid2hid_jac_single_or_multi_steps
-        ) = self.graph_executor.solve_h2w_h2h_jacobian(*args)
-
-        # eligibility trace update
-        #
-        # "self._update_etrace_data()" is a protocol method that should be implemented in the subclass.
-        # It's logic may be different for different etrace algorithms.
-        #
-        etrace_vals = self._update_etrace_data(
-            running_index,
-            etrace_vals,
-            hid2weight_jac_single_or_multi_steps,
             hid2hid_jac_single_or_multi_steps,
-            weight_vals,
-            input_is_multi_step,
+            final_etrace,
+        ) = self.graph_executor.solve_h2w_h2h_jacobian(
+            *args,
+            etrace_stepper=etrace_stepper,
+            init_etrace=etrace_vals if etrace_stepper is not None else None,
         )
+
+        if final_etrace is not None:
+            # fused path: the executor already rolled the eligibility trace in-loop.
+            etrace_vals = final_etrace
+        else:
+            # eligibility trace update
+            #
+            # "self._update_etrace_data()" is a protocol method that should be implemented in the subclass.
+            # It's logic may be different for different etrace algorithms.
+            #
+            etrace_vals = self._update_etrace_data(
+                running_index,
+                etrace_vals,
+                hid2weight_jac_single_or_multi_steps,
+                hid2hid_jac_single_or_multi_steps,
+                weight_vals,
+                input_is_multi_step,
+            )
 
         # returns
         return out, hidden_vals, oth_state_vals, etrace_vals
@@ -393,6 +408,12 @@ class ETraceVjpAlgorithm(ETraceAlgorithm):
         assign_state_values_v2(self.hidden_states, hidden_vals, write=False)
         assign_state_values_v2(self.other_states, othstate_vals, write=False)
 
+        # As in ``_update_fn``: when fusable + multi-step, push the stepper down so
+        # the executor rolls the trace inside the same scan that builds the VJP
+        # residual. The trace carry is detached (stop_gradient), so it never enters
+        # the residual jaxpr.
+        etrace_stepper = self._make_etrace_stepper(weight_vals) if input_is_multi_step else None
+
         # necessary gradients of the weights
         (
             out,
@@ -400,22 +421,31 @@ class ETraceVjpAlgorithm(ETraceAlgorithm):
             oth_states,
             hid2weight_jac_single_or_multi_steps,
             hid2hid_jac_single_or_multi_steps,
-            residuals
-        ) = self.graph_executor.solve_h2w_h2h_l2h_jacobian(*args)
-
-        # eligibility trace update
-        #
-        # "self._update_etrace_data()" is a protocol method that should be implemented in the subclass.
-        # It's logic may be different for different etrace algorithms.
-        #
-        new_etrace_vals = self._update_etrace_data(
-            running_index,
-            etrace_vals,
-            hid2weight_jac_single_or_multi_steps,
-            hid2hid_jac_single_or_multi_steps,
-            weight_vals,
-            input_is_multi_step
+            residuals,
+            final_etrace,
+        ) = self.graph_executor.solve_h2w_h2h_l2h_jacobian(
+            *args,
+            etrace_stepper=etrace_stepper,
+            init_etrace=etrace_vals if etrace_stepper is not None else None,
         )
+
+        if final_etrace is not None:
+            # fused path: the executor already rolled the eligibility trace in-loop.
+            new_etrace_vals = final_etrace
+        else:
+            # eligibility trace update
+            #
+            # "self._update_etrace_data()" is a protocol method that should be implemented in the subclass.
+            # It's logic may be different for different etrace algorithms.
+            #
+            new_etrace_vals = self._update_etrace_data(
+                running_index,
+                etrace_vals,
+                hid2weight_jac_single_or_multi_steps,
+                hid2hid_jac_single_or_multi_steps,
+                weight_vals,
+                input_is_multi_step
+            )
 
         # returns
         old_etrace_vals = etrace_vals
@@ -661,6 +691,33 @@ class ETraceVjpAlgorithm(ETraceAlgorithm):
               at the time ``t``, i.e., :math:``\partial L^t / \partial W^t``.
         """
         raise NotImplementedError
+
+    def _make_etrace_stepper(self, weight_vals: WeightVals) -> Optional[Callable]:
+        """Return a per-step eligibility-trace update callback, or ``None``.
+
+        When a subclass can express its trace roll as a pure step function with
+        signature ``(etrace_carry, (x_dict, df_dict, diag_list)) -> (new_carry, None)``,
+        it should override this to return that callback (typically the same
+        ``partial`` it builds inside :meth:`_update_etrace_data`). For multi-step
+        input the graph executor then fuses the roll into its over-time scan,
+        eliminating the separate trace scan and the stacked per-step Jacobians.
+
+        Returning ``None`` (the default) keeps the legacy two-pass behavior: the
+        executor stacks the Jacobians and :meth:`_update_etrace_data` rolls the
+        trace in a second scan. Subclasses whose update cannot be written as such a
+        step function (or that do not support multi-step input) leave this ``None``.
+
+        Parameters
+        ----------
+        weight_vals : WeightVals
+            The current parameter values, captured by the returned callback.
+
+        Returns
+        -------
+        Callable or None
+            The per-step stepper, or ``None`` to disable scan fusion.
+        """
+        return None
 
     def _update_etrace_data(
         self,

--- a/braintrace/_etrace_algorithms/vjp_graph_executor.py
+++ b/braintrace/_etrace_algorithms/vjp_graph_executor.py
@@ -37,7 +37,7 @@
 
 # -*- coding: utf-8 -*-
 
-from typing import Dict, Tuple
+from typing import Any, Callable, Dict, Optional, Tuple
 
 import brainstate
 import jax.core
@@ -313,12 +313,15 @@ class ETraceVjpGraphExecutor(ETraceGraphExecutor):
     def solve_h2w_h2h_jacobian(
         self,
         *args,
+        etrace_stepper: Optional[Callable] = None,
+        init_etrace: Any = None,
     ) -> Tuple[
         Outputs,
         ETraceVals,
         StateVals,
         Hid2WeightJacobian,
         HiddenGroupJacobian,
+        Any,
     ]:
         r"""
         Solving the hidden-to-weight and hidden-to-hidden Jacobian according to the given inputs and parameters.
@@ -329,11 +332,24 @@ class ETraceVjpGraphExecutor(ETraceGraphExecutor):
         ----------
         *args
             The positional arguments for the model.
+        etrace_stepper : Callable, optional
+            A per-step eligibility-trace update callback with signature
+            ``(etrace_carry, (x_dict, df_dict, diag_list)) -> (new_carry, None)``.
+            When provided together with multi-step input, the trace roll is fused
+            into the model-forward scan (single loop, no stacked Jacobians) and the
+            final trace is returned in the last slot. When ``None`` (default), the
+            per-step Jacobians are stacked and returned as before.
+        init_etrace : Any, optional
+            The initial eligibility-trace carry, threaded through the scan when
+            ``etrace_stepper`` is given. Ignored otherwise.
 
         Returns
         -------
         tuple
-            The outputs, hidden states, other states, and the spatial gradients of the weights.
+            The outputs, hidden states, other states, the spatial gradients of the
+            weights, the hidden-to-hidden Jacobian, and the final eligibility trace.
+            When ``etrace_stepper`` is given the two Jacobian slots are ``None`` and
+            the last slot holds the fused trace; otherwise the last slot is ``None``.
             Return the single-step results if inputs do not contain multiple-step data,
             otherwise return the multi-step data.
 
@@ -375,7 +391,7 @@ class ETraceVjpGraphExecutor(ETraceGraphExecutor):
         def scan_fn(carray, single_step_of_multistep_arg):
             args_ = merge_data(tree_def, single_step_of_multistep_arg, args_single_step)
 
-            _etrace_state_vals, _oth_state_vals = carray
+            _etrace_state_vals, _oth_state_vals, _etrace_carry = carray
             # use "restore_value" to recover the hidden states
             # this keeps the reading/writing operations as
             # the same as the original model
@@ -401,7 +417,18 @@ class ETraceVjpGraphExecutor(ETraceGraphExecutor):
             # compute the hidden-to-hidden Jacobian
             hid2hid_jac = self._compute_hid2hid_jacobian(temps)
 
-            return (_etrace_state_vals, _oth_state_vals), (out, hid2weight_jac, hid2hid_jac)
+            if etrace_stepper is None:
+                # legacy path: stack the per-step Jacobians for a downstream scan.
+                return (_etrace_state_vals, _oth_state_vals, _etrace_carry), (out, hid2weight_jac, hid2hid_jac)
+
+            # fused path: roll the eligibility trace in-loop and drop the Jacobians
+            # from the scan outputs. ``stop_gradient`` keeps the trace detached from
+            # reverse-AD (the Jacobians are already stop_gradient'd; this also guards
+            # the weight values the stepper closes over on the conv/sparse/LoRA path).
+            _etrace_carry = jax.lax.stop_gradient(
+                etrace_stepper(_etrace_carry, (hid2weight_jac[0], hid2weight_jac[1], hid2hid_jac))[0]
+            )
+            return (_etrace_state_vals, _oth_state_vals, _etrace_carry), out
 
         # check the batch size
         if len(args_multi_steps):
@@ -409,31 +436,26 @@ class ETraceVjpGraphExecutor(ETraceGraphExecutor):
             if len(set(args_dim)) != 1:
                 raise ValueError(f'The sequence size should be the same for all inputs. But we got {args_dim}.')
 
+        init_carry = (etrace_state_vals, other_state_vals, init_etrace)
         if input_is_multi_step:
-            (
-                (
-                    etrace_state_vals,
-                    other_state_vals
-                ),
-                (
-                    outs_single_or_multi_steps,
-                    hid2weight_jac_single_or_multi_steps,
-                    hid2hid_jac_single_or_multi_steps
-                )
-            ) = jax.lax.scan(scan_fn, (etrace_state_vals, other_state_vals), args_multi_steps)
-
+            (etrace_state_vals, other_state_vals, etrace_carry), ys = jax.lax.scan(
+                scan_fn, init_carry, args_multi_steps
+            )
         else:
+            (etrace_state_vals, other_state_vals, etrace_carry), ys = scan_fn(init_carry, {})
+
+        if etrace_stepper is None:
             (
-                (
-                    etrace_state_vals,
-                    other_state_vals
-                ),
-                (
-                    outs_single_or_multi_steps,
-                    hid2weight_jac_single_or_multi_steps,
-                    hid2hid_jac_single_or_multi_steps
-                )
-            ) = scan_fn((etrace_state_vals, other_state_vals), {})
+                outs_single_or_multi_steps,
+                hid2weight_jac_single_or_multi_steps,
+                hid2hid_jac_single_or_multi_steps,
+            ) = ys
+            final_etrace = None
+        else:
+            outs_single_or_multi_steps = ys
+            hid2weight_jac_single_or_multi_steps = None
+            hid2hid_jac_single_or_multi_steps = None
+            final_etrace = etrace_carry
 
         # recovering the other non-etrace weights, although the weights are not changed
         assign_dict_state_values(non_etrace_params, non_etrace_param_vals, write=False)
@@ -445,12 +467,15 @@ class ETraceVjpGraphExecutor(ETraceGraphExecutor):
             etrace_state_vals,
             other_state_vals,
             hid2weight_jac_single_or_multi_steps,
-            hid2hid_jac_single_or_multi_steps
+            hid2hid_jac_single_or_multi_steps,
+            final_etrace,
         )
 
     def solve_h2w_h2h_l2h_jacobian(
         self,
         *args,
+        etrace_stepper: Optional[Callable] = None,
+        init_etrace: Any = None,
     ) -> Tuple[
         Outputs,
         ETraceVals,
@@ -458,6 +483,7 @@ class ETraceVjpGraphExecutor(ETraceGraphExecutor):
         Hid2WeightJacobian,
         HiddenGroupJacobian,
         VjpResiduals,
+        Any,
     ]:
         r"""
         Solving the hidden-to-weight and hidden-to-hidden Jacobian and the VJP transformed loss-to-hidden
@@ -470,11 +496,26 @@ class ETraceVjpGraphExecutor(ETraceGraphExecutor):
         ----------
         *args
             The positional arguments for the model.
+        etrace_stepper : Callable, optional
+            A per-step eligibility-trace update callback with signature
+            ``(etrace_carry, (x_dict, df_dict, diag_list)) -> (new_carry, None)``.
+            When provided together with multi-step input, the trace roll is fused
+            into the over-time scan (so the per-step Jacobians are never stacked)
+            and the final trace is returned in the last slot instead. The callback
+            and ``init_etrace`` are captured by closure, not passed to ``jax.vjp``,
+            so they never participate in reverse-mode differentiation.
+        init_etrace : Any, optional
+            The initial eligibility-trace carry, threaded through the scan when
+            ``etrace_stepper`` is given. Ignored otherwise.
 
         Returns
         -------
         tuple
-            The outputs, hidden states, other states, the spatial gradients of the weights, and the residuals.
+            The outputs, hidden states, other states, the spatial gradients of the
+            weights, the hidden-to-hidden Jacobian, the residuals, and the final
+            eligibility trace. When ``etrace_stepper`` is given the two Jacobian
+            slots are ``None`` and the last slot holds the fused trace; otherwise
+            the last slot is ``None``.
 
         Notes
         -----
@@ -611,7 +652,7 @@ class ETraceVjpGraphExecutor(ETraceGraphExecutor):
             def scan_fn(carray, x_ss: Dict):
                 args_ss = merge_data(tree_def, x_ss, args_single_step)
 
-                hidden_vals_iter, other_vals_iter = carray
+                hidden_vals_iter, other_vals_iter, etrace_carry_iter = carray
                 (
                     out,
                     hidden_vals_iter,
@@ -627,23 +668,32 @@ class ETraceVjpGraphExecutor(ETraceGraphExecutor):
                     hidden_perturbs_ss,
                 )
 
-                return (
-                    (hidden_vals_iter, other_vals_iter),
-                    (out, hid2weight_jac, hid2hid_jac)
+                if etrace_stepper is None:
+                    return (
+                        (hidden_vals_iter, other_vals_iter, etrace_carry_iter),
+                        (out, hid2weight_jac, hid2hid_jac)
+                    )
+
+                # fused path: roll the eligibility trace in-loop (detached) and drop
+                # the per-step Jacobians from the scan outputs.
+                etrace_carry_iter = jax.lax.stop_gradient(
+                    etrace_stepper(etrace_carry_iter, (hid2weight_jac[0], hid2weight_jac[1], hid2hid_jac))[0]
                 )
+                return (hidden_vals_iter, other_vals_iter, etrace_carry_iter), out
 
             # scan over multiple time steps
             (
-                (
-                    hidden_vals_ss,
-                    other_vals_ss
-                ),
-                (
-                    _outs_multi_steps,
-                    _hid2weight_jac_multi_steps,
-                    _hid2hid_jac_multi_steps
-                )
-            ) = jax.lax.scan(scan_fn, (hidden_vals_ss, other_vals_ss), args_multi_steps)
+                (hidden_vals_ss, other_vals_ss, etrace_carry_ss),
+                ys
+            ) = jax.lax.scan(scan_fn, (hidden_vals_ss, other_vals_ss, init_etrace), args_multi_steps)
+
+            aux: Tuple[Any, ...]
+            if etrace_stepper is None:
+                _outs_multi_steps, _hid2weight_jac_multi_steps, _hid2hid_jac_multi_steps = ys
+                aux = (_hid2weight_jac_multi_steps, _hid2hid_jac_multi_steps)
+            else:
+                _outs_multi_steps = ys
+                aux = (etrace_carry_ss,)
 
             return (
                 (
@@ -651,10 +701,7 @@ class ETraceVjpGraphExecutor(ETraceGraphExecutor):
                     hidden_vals_ss,
                     other_vals_ss
                 ),
-                (
-                    _hid2weight_jac_multi_steps,
-                    _hid2hid_jac_multi_steps
-                )
+                aux
             )
 
         # ---------------------- [Part 2.2] ----------------------
@@ -702,10 +749,7 @@ class ETraceVjpGraphExecutor(ETraceGraphExecutor):
                 other_state_vals
             ),
             f_vjp,
-            (
-                hid2weight_jac_single_or_multi_steps,
-                hid2hid_jac_single_or_multi_steps
-            )
+            aux,
         ) = jax.vjp(
             (scan_over_multiple_steps if input_is_multi_step else call_over_single_step),  # the function
             args,  # the inputs (multiple/single time)
@@ -716,6 +760,21 @@ class ETraceVjpGraphExecutor(ETraceGraphExecutor):
             hidden_perturbs,  # the inputs (single time)
             has_aux=True
         )
+
+        # The aux structure depends on whether the trace roll was fused into the
+        # over-time scan. Fused (multi-step + stepper): aux = (final_etrace,).
+        # Otherwise: aux = (stacked hid2weight_jac, stacked hid2hid_jac).
+        fused = etrace_stepper is not None and input_is_multi_step
+        hid2weight_jac_single_or_multi_steps: Any
+        hid2hid_jac_single_or_multi_steps: Any
+        if fused:
+            (final_etrace,) = aux
+            hid2weight_jac_single_or_multi_steps = None
+            hid2hid_jac_single_or_multi_steps = None
+        else:
+            hid2weight_jac_single_or_multi_steps, hid2hid_jac_single_or_multi_steps = aux
+            final_etrace = None
+
         out_flat, out_tree = jax.tree.flatten(((out_single_or_multi_steps, etrace_state_vals, other_state_vals),))
         rule, in_tree = jax.api_util.flatten_fun_nokwargs(lu.wrap_init(f_vjp), out_tree)
         out_avals = [get_aval(x).at_least_vspace() for x in out_flat]
@@ -737,4 +796,5 @@ class ETraceVjpGraphExecutor(ETraceGraphExecutor):
             hid2weight_jac_single_or_multi_steps,
             hid2hid_jac_single_or_multi_steps,
             residual,
+            final_etrace,
         )

--- a/braintrace/_etrace_algorithms/vjp_graph_executor_test.py
+++ b/braintrace/_etrace_algorithms/vjp_graph_executor_test.py
@@ -67,13 +67,17 @@ class TestETraceVjpGraphExecutor(unittest.TestCase):
         x = jnp.ones((self.in_size,))
         executor.compile_graph(x)
 
-        outputs, etrace_vals, state_vals, h2w_jacobian, h2h_jacobian = executor.solve_h2w_h2h_jacobian(x)
+        outputs, etrace_vals, state_vals, h2w_jacobian, h2h_jacobian, final_etrace = (
+            executor.solve_h2w_h2h_jacobian(x)
+        )
 
         self.assertIsInstance(outputs, jax.Array)
         self.assertIsInstance(etrace_vals, dict)
         self.assertIsInstance(state_vals, dict)
         self.assertIsInstance(h2w_jacobian, tuple)
         self.assertIsInstance(h2h_jacobian, list)
+        # No stepper passed -> legacy return, the fused-trace slot is None.
+        self.assertIsNone(final_etrace)
 
     def test_single_step_vs_multi_step(self):
         single_step_executor = braintrace.ETraceVjpGraphExecutor(self.model, vjp_method='single-step')


### PR DESCRIPTION
For MultiStepData rollout the exact ETP algorithms (D_RTRL, pp_prop) ran
two lax.scans: one in the graph executor (model forward + stacked per-step
Jacobians) and a second in _update_etrace_data (trace roll). XLA cannot
fuse across the scan boundary, forcing an O(T x Jacobian) HBM round-trip
and two While loops.

Thread the per-step trace update into the executor's existing scan via an
optional _make_etrace_stepper hook: the algorithm hands the executor a
stepper callback plus the initial trace, the executor rolls the trace
in-loop (stop_gradient'd, captured by closure so jax.vjp never
differentiates it) and returns the final trace, dropping the stacked
Jacobians. Fusion is opt-in and multi-step-only; single-step / OTPE /
OTTT / SNN paths are unchanged (no stepper -> identical legacy behavior).

Verified: fused == forced-legacy (outputs, final trace, gradients) and
fused D_RTRL == BPTT oracle; traced jaxpr scan count drops 3 -> 2.

## Summary by Sourcery

Fuse multi-step eligibility-trace updates into the graph executor’s existing over-time scan to avoid a second scan over stacked Jacobians while preserving correctness.

Enhancements:
- Extend VJP graph executor APIs to optionally accept a per-step eligibility-trace stepper and initial trace, returning a final fused trace instead of stacked Jacobians when enabled.
- Introduce a base-class hook for constructing an eligibility-trace stepper, with exact multi-step algorithms (parameter-dimension and IO-dimension VJP) overriding it to support scan fusion.
- Update VJP update routines to delegate multi-step trace rolling to the executor when fusion is available, falling back to the legacy two-scan path otherwise.

Tests:
- Add dedicated fusion equivalence tests that compare fused multi-step behavior against both the legacy two-scan path and a BPTT oracle, and adjust existing executor tests for the new return signature.