### PR TITLE
docs: complete public-API docstrings + 0.2.0 changelog

### DIFF
--- a/braintrace/__init__.py
+++ b/braintrace/__init__.py
@@ -15,6 +15,56 @@
 
 # -*- coding: utf-8 -*-
 
+"""braintrace: online learning for recurrent networks via Eligibility Trace Propagation (ETP).
+
+``braintrace`` trains recurrent and spiking neural networks **online** — forward
+in time, without backpropagation through time (BPTT). Models mark their
+trainable operations with ETP user-API ops (for example :func:`matmul`,
+:func:`conv`, :func:`sparse_matmul`, :func:`lora_matmul`, :func:`element_wise`)
+instead of wrapping parameters in a special class. A compiler then walks the
+JAX ``jaxpr``, identifies those ETP primitives, and connects each parameter to
+the hidden states it influences so that eligibility traces can be propagated.
+
+The public API is organised in four layers, with dependencies pointing strictly
+downward:
+
+1. **ETP operators** — the user-facing ops (:func:`matmul`, :func:`conv`, ...),
+   the :class:`ETPPrimitive` class, and :func:`register_primitive` for adding
+   new ones.
+2. **Compiler** — :func:`compile_etrace_graph` and the analysis containers
+   (:class:`ETraceGraph`, :class:`ModuleInfo`, :class:`HiddenGroup`,
+   :class:`HiddenParamOpRelation`, :class:`HiddenPerturbation`) plus the
+   diagnostics types (:class:`CompilationRecord`, :class:`DiagnosticKind`,
+   :class:`DiagnosticLevel`).
+3. **Graph executor** — :class:`ETraceGraphExecutor` /
+   :class:`ETraceVjpGraphExecutor`, which run the forward pass and the
+   hidden->weight / hidden->hidden Jacobian computations.
+4. **Algorithms** — online-learning orchestrators: the exact algorithms
+   :class:`D_RTRL` / :func:`pp_prop` / :class:`ES_D_RTRL`, and the SNN family
+   :class:`EProp`, :class:`OSTLRecurrent`, :class:`OSTLFeedforward`,
+   :class:`OTPE`, :class:`OTTT`, :class:`OSTTP`.
+
+The :mod:`braintrace.nn` subpackage provides ready-made ETP-wired layers
+(linear maps, convolutions, recurrent cells, read-outs).
+
+Notes
+-----
+The convenience entry point :func:`compile` wraps a model together with an
+algorithm into a single trainable object and is the recommended starting point.
+The ``braintrace.MatMulOp`` / ``ETraceParam`` style names from the v0.1.x API
+are deprecated shims served lazily with a :class:`DeprecationWarning`; new code
+should mark parameters by routing them through ETP ops instead.
+
+Examples
+--------
+.. code-block:: python
+
+    >>> import braintrace
+    >>> # the public API surface is enumerated by __all__
+    >>> 'matmul' in braintrace.__all__
+    True
+"""
+
 
 from typing import TYPE_CHECKING
 

--- a/braintrace/_etrace_algorithms/_common.py
+++ b/braintrace/_etrace_algorithms/_common.py
@@ -46,6 +46,18 @@ class _ZeroResetState(brainstate.ShortTermState):
         self._init_dtype = init_value.dtype
 
     def reset_state(self, batch_size: Optional[int] = None, **kwargs):
+        """Re-zero the state at its original shape.
+
+        Parameters
+        ----------
+        batch_size : int or None, optional
+            If given, the state is re-zeroed with ``batch_size`` as the leading
+            dimension (prepended when the original state was scalar-shaped).
+            When ``None`` (default) the original unbatched shape is restored.
+        **kwargs
+            Ignored; accepted for compatibility with the brainstate state-reset
+            protocol.
+        """
         if batch_size is None:
             shape = self._init_shape
         elif len(self._init_shape) == 0:
@@ -156,6 +168,18 @@ class KappaFilter(_ZeroResetState):
         self.kappa = float(kappa)
 
     def update(self, x):
+        r"""Apply one low-pass step :math:`x_{\mathrm{filt}} \leftarrow (1-\kappa) x + \kappa\, x_{\mathrm{filt}}`.
+
+        Parameters
+        ----------
+        x : jax.Array
+            The new input mixed into the filtered state.
+
+        Returns
+        -------
+        jax.Array
+            The updated, filtered value.
+        """
         new = (1.0 - self.kappa) * x + self.kappa * self.value
         self.value = new
         return new

--- a/braintrace/_etrace_compiler/graph.py
+++ b/braintrace/_etrace_compiler/graph.py
@@ -170,6 +170,31 @@ class ETraceGraph(NamedTuple):
         perturb_data: Sequence[jax.Array],
         old_state_vals: Optional[Sequence[jax.Array]] = None,
     ):
+        r"""Run the forward pass with additive perturbations injected at the hidden states.
+
+        Evaluates the perturbed-forward jaxpr built during compilation, which is
+        the forward computation augmented so that each tracked hidden state has a
+        perturbation term added to it. This is the primitive used to probe
+        hidden->hidden and hidden->output sensitivities.
+
+        Parameters
+        ----------
+        args : Inputs
+            The model inputs for this step, matching the signature captured at
+            compile time.
+        perturb_data : Sequence[jax.Array]
+            One perturbation array per tracked hidden state, added at the
+            corresponding perturbation site.
+        old_state_vals : Sequence[jax.Array] or None, optional
+            The state values to run from. When ``None`` (default) the current
+            values of the compiled model states are used.
+
+        Returns
+        -------
+        object
+            The processed model outputs, in the same structure produced by a
+            normal forward call.
+        """
         # state checking
         if old_state_vals is None:
             old_state_vals = [st.value for st in self.module_info.compiled_model_states]
@@ -184,6 +209,14 @@ class ETraceGraph(NamedTuple):
         return self.module_info._process(*args, jaxpr_outs=jaxpr_outs)
 
     def dict(self) -> Dict:
+        """Return the graph's fields as a plain dictionary.
+
+        Returns
+        -------
+        dict
+            A mapping from field name to value for every attribute of this
+            :class:`ETraceGraph`.
+        """
         return self._asdict()
 
     def __repr__(self) -> str:

--- a/braintrace/_etrace_compiler/hid_param_op.py
+++ b/braintrace/_etrace_compiler/hid_param_op.py
@@ -226,6 +226,14 @@ class HiddenParamOpRelation(NamedTuple):
         return vals_of_hidden_groups
 
     def dict(self) -> Dict[str, Any]:
+        """Return this relation's named fields as a plain dictionary.
+
+        Returns
+        -------
+        dict
+            An ordered mapping from field name to value, as produced by the
+            underlying :class:`typing.NamedTuple`.
+        """
         return self._asdict()
 
     def __repr__(self) -> str:

--- a/braintrace/_etrace_compiler/hidden_group.py
+++ b/braintrace/_etrace_compiler/hidden_group.py
@@ -286,6 +286,14 @@ class HiddenGroup(NamedTuple):
         return splitted_hid_vals
 
     def dict(self) -> Dict[str, Any]:
+        """Return this group's named fields as a plain dictionary.
+
+        Returns
+        -------
+        dict
+            An ordered mapping from field name to value, as produced by the
+            underlying :class:`typing.NamedTuple`.
+        """
         return self._asdict()
 
     def __repr__(self) -> str:
@@ -349,6 +357,14 @@ class HiddenToHiddenGroupTracer(NamedTuple):
     trace: List[JaxprEqn]
 
     def dict(self) -> Dict[str, Any]:
+        """Return this tracer's named fields as a plain dictionary.
+
+        Returns
+        -------
+        dict
+            An ordered mapping from field name to value, as produced by the
+            underlying :class:`typing.NamedTuple`.
+        """
         return self._asdict()
 
     def __repr__(self) -> str:
@@ -413,6 +429,14 @@ class Hidden2GroupTransition(NamedTuple):
         return new_hidden_vals
 
     def dict(self) -> Dict[str, Any]:
+        """Return this transition's named fields as a plain dictionary.
+
+        Returns
+        -------
+        dict
+            An ordered mapping from field name to value, as produced by the
+            underlying :class:`typing.NamedTuple`.
+        """
         return self._asdict()
 
     def __repr__(self) -> str:

--- a/braintrace/_etrace_compiler/hidden_pertubation.py
+++ b/braintrace/_etrace_compiler/hidden_pertubation.py
@@ -193,6 +193,14 @@ class HiddenPerturbation(NamedTuple):
         ]
 
     def dict(self) -> Dict[str, Any]:
+        """Return this perturbation's named fields as a plain dictionary.
+
+        Returns
+        -------
+        dict
+            An ordered mapping from field name to value, as produced by the
+            underlying :class:`typing.NamedTuple`.
+        """
         return self._asdict()
 
     def __repr__(self) -> str:

--- a/braintrace/_etrace_compiler/module_info.py
+++ b/braintrace/_etrace_compiler/module_info.py
@@ -457,6 +457,14 @@ class ModuleInfo(NamedTuple):
         return out, etrace_vals, oth_state_vals, temps
 
     def dict(self) -> Dict[str, Any]:
+        """Return this module info's named fields as a plain dictionary.
+
+        Returns
+        -------
+        dict
+            An ordered mapping from field name to value, as produced by the
+            underlying :class:`typing.NamedTuple`.
+        """
         return self._asdict()
 
     def __repr__(self) -> str:

--- a/braintrace/nn/__init__.py
+++ b/braintrace/nn/__init__.py
@@ -13,6 +13,33 @@
 # limitations under the License.
 # ==============================================================================
 
+"""Neural-network layers wired for Eligibility Trace Propagation (ETP).
+
+This subpackage mirrors a subset of :mod:`brainstate.nn` but routes the
+trainable forward passes through ETP primitives (``braintrace.matmul``,
+``braintrace.conv``, ``braintrace.sparse_matmul``, ``braintrace.lora_matmul``,
+``braintrace.element_wise``). As a result, the parameters of these layers are
+automatically recognised by the ETP compiler and become eligible for online
+learning, while the public construction and call signatures stay compatible
+with their :mod:`brainstate.nn` counterparts.
+
+The exported building blocks fall into four groups:
+
+- **Linear maps** — :class:`Linear`, :class:`SignedWLinear`,
+  :class:`SparseLinear`, :class:`LoRA`.
+- **Convolutions** — :class:`Conv1d`, :class:`Conv2d`, :class:`Conv3d`.
+- **Read-outs** — :class:`LeakyRateReadout`.
+- **Recurrent cells** — :class:`ValinaRNNCell`, :class:`GRUCell`,
+  :class:`MGUCell`, :class:`LSTMCell`, :class:`URLSTMCell`,
+  :class:`MinimalRNNCell`, :class:`MiniGRU`, :class:`MiniLSTM`,
+  :class:`LRUCell`.
+
+Activation, normalisation and pooling layers are intentionally not
+re-implemented here; accessing them through ``braintrace.nn`` emits a
+:class:`DeprecationWarning` and forwards to :mod:`brainstate.nn` /
+:mod:`brainstate.state`.
+"""
+
 from ._conv import Conv1d, Conv2d, Conv3d
 from ._linear import Linear, SignedWLinear, SparseLinear, LoRA
 from ._readout import LeakyRateReadout

--- a/braintrace/nn/_conv.py
+++ b/braintrace/nn/_conv.py
@@ -23,6 +23,26 @@ __all__ = ['Conv1d', 'Conv2d', 'Conv3d']
 
 
 def _etp_conv_op(self, x, params):
+    """Route a convolution through the ETP ``conv`` primitive.
+
+    Shared ``_conv_op`` override installed on :class:`Conv1d`, :class:`Conv2d`
+    and :class:`Conv3d`. Using :func:`braintrace.conv` instead of a plain JAX
+    convolution is what makes the kernel eligible for online-learning trace
+    computation; all convolution hyper-parameters are taken from ``self``.
+
+    Parameters
+    ----------
+    x : ArrayLike
+        Input feature map.
+    params : dict
+        Parameter dict holding the convolution ``'weight'`` and an optional
+        ``'bias'``.
+
+    Returns
+    -------
+    ArrayLike
+        The convolution output.
+    """
     w = params['weight']
     if self.w_mask is not None:
         w = w * self.w_mask

--- a/braintrace/nn/_linear.py
+++ b/braintrace/nn/_linear.py
@@ -34,6 +34,22 @@ class Linear(brainstate.nn.Linear):
     __doc__ = brainstate.nn.Linear.__doc__.replace('brainstate', 'braintrace')
 
     def update(self, x):
+        """Apply the linear transform through the ETP ``matmul`` primitive.
+
+        Routing the matrix multiplication through :func:`braintrace.matmul`
+        (instead of a plain JAX dot) is what makes ``weight`` eligible for
+        online-learning trace computation.
+
+        Parameters
+        ----------
+        x : ArrayLike
+            Input array, of shape ``(..., in_size)``.
+
+        Returns
+        -------
+        ArrayLike
+            The transformed output, of shape ``(..., out_size)``.
+        """
         w = self.weight.value['weight']
         if self.w_mask is not None:
             w = w * self.w_mask
@@ -46,6 +62,22 @@ class SignedWLinear(brainstate.nn.SignedWLinear):
     __doc__ = brainstate.nn.SignedWLinear.__doc__.replace('brainstate', 'braintrace')
 
     def update(self, x):
+        """Apply the sign-constrained linear transform through ETP ``matmul``.
+
+        The stored weight magnitudes are made non-negative and then given a
+        fixed sign before being routed through :func:`braintrace.matmul`, so
+        the weight participates in online-learning trace computation.
+
+        Parameters
+        ----------
+        x : ArrayLike
+            Input array, of shape ``(..., in_size)``.
+
+        Returns
+        -------
+        ArrayLike
+            The transformed output, of shape ``(..., out_size)``.
+        """
         w = u.math.abs(self.weight.value)
         if self.w_sign is not None:
             w = w * self.w_sign
@@ -57,6 +89,22 @@ class ScaledWSLinear(brainstate.nn.ScaledWSLinear):
     __doc__ = brainstate.nn.ScaledWSLinear.__doc__.replace('brainstate', 'braintrace')
 
     def update(self, x):
+        """Apply the weight-standardized linear transform through ETP ``matmul``.
+
+        The weight is standardized (zero-mean, unit-variance per output unit)
+        before being routed through :func:`braintrace.matmul`, so it
+        participates in online-learning trace computation.
+
+        Parameters
+        ----------
+        x : ArrayLike
+            Input array, of shape ``(..., in_size)``.
+
+        Returns
+        -------
+        ArrayLike
+            The transformed output, of shape ``(..., out_size)``.
+        """
         params = self.weight.value
         w = brainstate.nn.weight_standardization(params['weight'], self.eps, params.get('gain', None))
         if self.w_mask is not None:
@@ -70,6 +118,22 @@ class SparseLinear(brainstate.nn.SparseLinear):
     __doc__ = brainstate.nn.SparseLinear.__doc__.replace('brainstate', 'braintrace')
 
     def update(self, x):
+        """Apply the sparse linear transform through the ETP ``sparse_matmul``.
+
+        The dense data of the sparse weight is routed through
+        :func:`braintrace.sparse_matmul`, so it participates in
+        online-learning trace computation.
+
+        Parameters
+        ----------
+        x : ArrayLike
+            Input array, of shape ``(..., in_size)``.
+
+        Returns
+        -------
+        ArrayLike
+            The transformed output, of shape ``(..., out_size)``.
+        """
         weight = self.weight.value['weight']
         bias = self.weight.value.get('bias', None)
         return sparse_matmul(x, weight, sparse_mat=self.spar_mat, bias=bias)
@@ -156,6 +220,22 @@ class LoRA(brainstate.nn.LoRA):
     __module__ = 'braintrace.nn'
 
     def update(self, x: ArrayLike):
+        r"""Apply the low-rank adaptation through the ETP ``lora_matmul``.
+
+        Computes :math:`\frac{1}{r} B A\, x` via :func:`braintrace.lora_matmul`
+        (so the LoRA factors participate in online-learning trace
+        computation) and adds the optional base-module output.
+
+        Parameters
+        ----------
+        x : ArrayLike
+            Input array, of shape ``(..., in_features)``.
+
+        Returns
+        -------
+        ArrayLike
+            The adapted output, of shape ``(..., out_features)``.
+        """
         param = self.weight.value
         lora_rank = param['lora_b'].shape[0]
         out = lora_matmul(x, param['lora_b'], param['lora_a'], alpha=1.0 / lora_rank)

--- a/braintrace/nn/_readout.py
+++ b/braintrace/nn/_readout.py
@@ -132,6 +132,21 @@ class LeakyRateReadout(brainstate.nn.Module):
         self.r.value = braintools.init.param(self.r_init, self.out_size, batch_size)
 
     def update(self, x):
+        r"""Advance the readout by one time step of leaky integration.
+
+        Applies :math:`r_t = \mathrm{decay} \cdot r_{t-1} + W^\top x_t` and
+        stores the result in the readout state.
+
+        Parameters
+        ----------
+        x : ArrayLike
+            Input for the current step, of shape ``(..., in_size)``.
+
+        Returns
+        -------
+        ArrayLike
+            The updated readout state, of shape ``(..., out_size)``.
+        """
         r = self.decay * self.r.value + matmul(x, self.W.value)
         self.r.value = r
         return r

--- a/braintrace/nn/_rnn.py
+++ b/braintrace/nn/_rnn.py
@@ -118,6 +118,18 @@ class ValinaRNNCell(brainstate.nn.RNNCell):
         self.h.value = braintools.init.param(self._state_initializer, self.out_size, batch_size)
 
     def update(self, x):
+        r"""Advance the cell by one time step.
+
+        Parameters
+        ----------
+        x : ArrayLike
+            Input for the current step, of shape ``(..., in_size)``.
+
+        Returns
+        -------
+        ArrayLike
+            The updated hidden state, of shape ``(..., out_size)``.
+        """
         xh = u.math.concatenate([x, self.h.value], axis=-1)
         self.h.value = self.activation(self.W(xh))
         return self.h.value
@@ -203,6 +215,18 @@ class GRUCell(brainstate.nn.RNNCell):
         self.h.value = braintools.init.param(self._state_initializer, self.out_size, batch_size)
 
     def update(self, x):
+        r"""Advance the cell by one time step.
+
+        Parameters
+        ----------
+        x : ArrayLike
+            Input for the current step, of shape ``(..., in_size)``.
+
+        Returns
+        -------
+        ArrayLike
+            The updated hidden state, of shape ``(..., out_size)``.
+        """
         old_h = self.h.value
         xh = u.math.concatenate([x, old_h], axis=-1)
         z = brainstate.nn.sigmoid(self.Wz(xh))
@@ -293,6 +317,18 @@ class CFNCell(brainstate.nn.RNNCell):
         self.h.value = braintools.init.param(self._state_initializer, self.out_size, batch_size)
 
     def update(self, x):
+        r"""Advance the cell by one time step.
+
+        Parameters
+        ----------
+        x : ArrayLike
+            Input for the current step, of shape ``(..., in_size)``.
+
+        Returns
+        -------
+        ArrayLike
+            The updated hidden state, of shape ``(..., out_size)``.
+        """
         old_h = self.h.value
         xh = u.math.concatenate([x, old_h], axis=-1)
         f = brainstate.nn.sigmoid(self.Wf(xh))
@@ -396,6 +432,18 @@ class MGUCell(brainstate.nn.RNNCell):
         self.h.value = braintools.init.param(self._state_initializer, self.out_size, batch_size)
 
     def update(self, x):
+        r"""Advance the cell by one time step.
+
+        Parameters
+        ----------
+        x : ArrayLike
+            Input for the current step, of shape ``(..., in_size)``.
+
+        Returns
+        -------
+        ArrayLike
+            The updated hidden state, of shape ``(..., out_size)``.
+        """
         old_h = self.h.value
         xh = u.math.concatenate([x, old_h], axis=-1)
         f = brainstate.nn.sigmoid(self.Wf(xh))
@@ -520,6 +568,20 @@ class LSTMCell(brainstate.nn.RNNCell):
         self.h.value = braintools.init.param(self._state_initializer, self.out_size, batch_size)
 
     def update(self, x):
+        r"""Advance the cell by one time step.
+
+        Updates both the cell state ``c`` and the hidden state ``h`` in place.
+
+        Parameters
+        ----------
+        x : ArrayLike
+            Input for the current step, of shape ``(..., in_size)``.
+
+        Returns
+        -------
+        ArrayLike
+            The updated hidden state ``h``, of shape ``(..., out_size)``.
+        """
         h, c = self.h.value, self.c.value
         xh = u.math.concatenate([x, h], axis=-1)
         i = self.Wi(xh)
@@ -621,6 +683,20 @@ class URLSTMCell(brainstate.nn.RNNCell):
         self.h.value = braintools.init.param(self._state_initializer, self.out_size, batch_size)
 
     def update(self, x: ArrayLike) -> ArrayLike:
+        r"""Advance the cell by one time step.
+
+        Updates both the cell state ``c`` and the hidden state ``h`` in place.
+
+        Parameters
+        ----------
+        x : ArrayLike
+            Input for the current step, of shape ``(..., in_size)``.
+
+        Returns
+        -------
+        ArrayLike
+            The updated hidden state ``h``, of shape ``(..., out_size)``.
+        """
         h, c = self.h.value, self.c.value
         xh = u.math.concatenate([x, h], axis=-1)
         f = self.Wf(xh)
@@ -728,6 +804,18 @@ class MinimalRNNCell(brainstate.nn.RNNCell):
         self.h.value = braintools.init.param(self._state_initializer, self.out_size, batch_size)
 
     def update(self, x):
+        r"""Advance the cell by one time step.
+
+        Parameters
+        ----------
+        x : ArrayLike
+            Input for the current step, of shape ``(..., in_size)``.
+
+        Returns
+        -------
+        ArrayLike
+            The updated hidden state, of shape ``(..., out_size)``.
+        """
         z = self.phi(x)
         f = brainstate.nn.sigmoid(self.W_u(u.math.concatenate([z, self.h.value], axis=-1)))
         self.h.value = f * self.h.value + (1 - f) * z
@@ -814,6 +902,18 @@ class MiniGRU(brainstate.nn.RNNCell):
         self.h.value = braintools.init.param(self._state_initializer, self.out_size, batch_size)
 
     def update(self, x):
+        r"""Advance the cell by one time step.
+
+        Parameters
+        ----------
+        x : ArrayLike
+            Input for the current step, of shape ``(..., in_size)``.
+
+        Returns
+        -------
+        ArrayLike
+            The updated hidden state, of shape ``(..., out_size)``.
+        """
         z = brainstate.nn.sigmoid(self.W_z(u.math.concatenate([x, self.h.value], axis=-1)))
         self.h.value = (1 - z) * self.h.value + z * self.W_x(x)
         return self.h.value
@@ -900,6 +1000,18 @@ class MiniLSTM(brainstate.nn.RNNCell):
         self.h.value = braintools.init.param(self._state_initializer, self.out_size, batch_size)
 
     def update(self, x):
+        r"""Advance the cell by one time step.
+
+        Parameters
+        ----------
+        x : ArrayLike
+            Input for the current step, of shape ``(..., in_size)``.
+
+        Returns
+        -------
+        ArrayLike
+            The updated hidden state, of shape ``(..., out_size)``.
+        """
         xh = u.math.concatenate([x, self.h.value], axis=-1)
         f = brainstate.nn.sigmoid(self.W_f(xh))
         i = brainstate.nn.sigmoid(self.W_i(xh))
@@ -1015,6 +1127,21 @@ class LRUCell(brainstate.nn.Module):
         self.h_im.value = braintools.init.param(braintools.init.ZeroInit(), self.d_hidden, batch_size)
 
     def update(self, inputs):
+        r"""Advance the unit by one time step.
+
+        Updates the real and imaginary parts of the complex hidden state
+        (``h_re`` and ``h_im``) in place and returns the projected output.
+
+        Parameters
+        ----------
+        inputs : ArrayLike
+            Input for the current step, of shape ``(..., d_model)``.
+
+        Returns
+        -------
+        ArrayLike
+            The real-valued output ``y``, of shape ``(..., d_model)``.
+        """
         a = u.math.exp(-u.math.exp(element_wise(self.nu_log.value)))
         b = u.math.exp(element_wise(self.theta_log.value))
         c = u.math.exp(element_wise(self.gamma_log.value))

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,219 @@
 # Release Notes
 
 
+## Version 0.2.0
+
+This release is a major step for BrainTrace. It adds a family of spiking neural
+network (SNN) online-learning algorithms, rewrites the eligibility-trace
+compiler around primitive-type dispatch, generalizes every ETP primitive to
+support multiple trainable inputs (fixing a silent bias-gradient drop),
+delivers substantial performance gains for D-RTRL and multi-step rollouts, and
+hardens the package with PEP 561 typing and a BPTT-oracle-backed test suite.
+
+### Major Changes
+
+#### New: SNN Online-Learning Algorithms
+
+- **Added five SNN online-learning algorithms** as flat `ETraceVjpAlgorithm`
+  subclasses: `EProp`, `OSTL` (`OSTLRecurrent` / `OSTLFeedforward`), `OTPE`,
+  `OTTT`, and `OSTTP`. All are exported at the top level.
+- **Added a `_compute_learning_signal` hook** to `ETraceVjpAlgorithm` to support
+  target-projection algorithms (`OSTTP`) without disrupting the existing D-RTRL
+  and pp-prop paths.
+- **Added supporting trace helpers**: `PresynapticTrace`, `KappaFilter`,
+  `FixedRandomFeedback`, and target-signal extraction utilities.
+- Algorithms are cross-checked for regime equivalence and verified to decrease
+  loss in integration smoke tests.
+
+#### ETP Compiler Rewrite
+
+- **Rewrote the eligibility-trace compiler to dispatch on primitive-type
+  identity** rather than string-matching op or trace names, with structured,
+  leveled diagnostics (`DiagnosticKind`, `DiagnosticLevel`,
+  `CompilationRecord`) replacing ad-hoc warnings.
+- **Added compile-time diagnostics** that surface previously silent issues —
+  e.g. `TRAINABLE_INVAR_NOT_PARAMSTATE` flags a trainable input (such as a
+  constant bias) that does not trace to a `ParamState`, so users can wrap it
+  intentionally instead of silently losing its gradient.
+
+#### Multi-Trainable-Input ETP Primitives (Bias Gradients)
+
+- **Generalized every ETP primitive from a single-"weight" assumption to an
+  arbitrary named dict of trainable inputs.** This fixes a silent bias-gradient
+  drop and a LoRA executor signature mismatch in one coherent refactor.
+- Migrated all built-in primitives (`elemwise`, dense `mm`/`mv`, `conv`,
+  `sparse` `mm`/`mv`, and `lora`) to the dict-based rule API with first-class
+  **bias gradient support**, each verified element-wise against a BPTT oracle.
+- **Fixed layout-aware axis handling in conv** primitives (1D/2D, NHWC/NCHW,
+  OIHW/HWIO kernel layouts) that previously corrupted gradients on non-default
+  layouts, and **fixed non-square dense weight broadcasting** in `_mm_yw_to_w`.
+- Eligibility traces are now stored as per-key dicts; the transitional
+  legacy-array adapter has been fully removed.
+
+#### Performance
+
+- **D-RTRL einsum fast path** (`fast_solve=True`, default on): replaces nested
+  `vmap`-of-`vjp` and per-step `lax.cond` overhead with direct einsum kernels
+  for `mm`/`mv`/`elemwise`; conv/sparse/LoRA fall back to the legacy path.
+- **Reduced-precision trace storage** (`trace_dtype`, e.g. bf16/fp16) halves the
+  dominant `B*N^2` trace bandwidth on GPU/TPU while keeping Jacobians, learning
+  signals, and final gradients in fp32. Default `None` preserves exact behavior.
+- **Multi-step trace fusion**: the per-step eligibility-trace roll for exact
+  algorithms (D-RTRL, pp-prop) is now threaded into the graph executor's forward
+  scan, eliminating an `O(T × Jacobian)` HBM round-trip (traced scan count drops
+  3 → 2). Opt-in and multi-step-only; single-step/SNN paths are unchanged.
+- Branch-free spectrum/vector normalization to restore XLA fusion across steps.
+
+#### Primitive Registration Simplification
+
+- **Removed `ETPPrimitiveSpec`** and the spec-based registration layer; invar/
+  outvar layout metadata (`trainable_invars_fn`, `x_invar_index`,
+  `y_outvar_index`) now lives in internal registries populated directly through
+  `register_primitive` keyword arguments.
+
+#### Package Restructuring
+
+- **Consolidated the eligibility-trace code into a single flat
+  `_etrace_algorithms` package**, merging the former `_etrace_vjp/`,
+  `_etrace_algorithms.py`, `_etrace_graph_executor.py`, and `_snn_algorithms/`
+  modules. The top-level public API is unchanged.
+- **Split the algorithm base hierarchy into dedicated modules**:
+  `ParamDimVjpAlgorithm` (D-RTRL) and `IODimVjpAlgorithm` (pp-prop) now live in
+  their own files, with `D_RTRL`/`pp_prop` as thin subclasses.
+- Removed the experimental hybrid online-learning method.
+
+#### Typing & Packaging
+
+- **The package is now PEP 561 compliant**: ships a `py.typed` marker so
+  downstream users receive inline type hints.
+- Added a pragmatic `mypy` configuration and wired type checking plus packaging
+  verification (`python -m build`, `py.typed` presence) into CI.
+
+#### Testing
+
+- **Added a BPTT gradient oracle and a layered correctness test suite** (P2–P8):
+  per-operator rule oracles, public-API contract tests, exact-class
+  element-wise equivalence with BPTT, approximate-class direction-alignment
+  checks, transform/integration invariance, and per-cell compiler relation
+  guardrails tied to the cell registry.
+
+#### Documentation
+
+- **Converted all public-API docstrings to NumPy-doc style** with math,
+  references, and runnable examples.
+- Documentation is now self-hosted at `brainx.chaobrain.com/braintrace/`, with
+  refreshed RTD links and a WebP logo.
+
+#### Dependencies & Tooling
+
+- **Replaced `brainunit` with `saiunit`** throughout for unit handling.
+- Numerous CI/CD upgrades (checkout, setup-python, artifact actions, sphinx and
+  theme requirements); docs deploy on release publication.
+
+### Deprecations
+
+The entire v0.1.x **class-based** operator/parameter API is deprecated in favor
+of the new **primitive-based** ETP user-API. The legacy classes still work —
+they are thin back-compatibility shims that route through the new primitives —
+but each emits a `DeprecationWarning` (once per class, per process) on first
+use, and they will be removed in a future release. Migrate at your convenience.
+
+**Deprecated operator classes** → new primitive functions:
+
+| Deprecated (v0.1.x) | Use instead (v0.2.0) |
+| --- | --- |
+| `MatMulOp` | `braintrace.matmul` |
+| `ElemWiseOp` | `braintrace.element_wise` |
+| `ConvOp` | `braintrace.conv` |
+| `SpMatMulOp` | `braintrace.sparse_matmul` |
+| `LoraOp` | `braintrace.lora_matmul` |
+| `ETraceOp` (base) | the ETP primitive functions above |
+
+**Deprecated parameter classes** → `brainstate.ParamState` + a primitive:
+
+| Deprecated (v0.1.x) | Use instead (v0.2.0) |
+| --- | --- |
+| `ETraceParam` | `brainstate.ParamState` + an ETP primitive function (e.g. `braintrace.matmul`) |
+| `ElemWiseParam` | `brainstate.ParamState` + `braintrace.element_wise` |
+| `NonTempParam` | `brainstate.ParamState` + plain JAX ops (`x @ w`) — keeps the weight out of the ETP graph |
+| `FakeETraceParam`, `FakeElemWiseParam` | plain objects with plain JAX ops |
+
+The `stop_param_gradients` context manager and the `general_y2w` helper are kept
+as no-op compatibility shims and have no effect on the new primitive path.
+
+### Breaking Changes
+
+1. **OSTL factory removed** — use `OSTLRecurrent` or `OSTLFeedforward` directly
+   instead of the former `OSTL` factory function.
+
+2. **`OTTT` and `OTPE` require an explicit `leak`** — the membrane leak is no
+   longer inferred from `model.states()` (it silently picked a wrong value on
+   heterogeneous/multi-population models). Both now also reject hidden groups
+   with `num_state > 1` at compile time, as collapsing the `num_state` axis has
+   no theoretical basis for these LIF-derived rules. `OTPE` additionally
+   documents a narrower feed-forward / single-layer / global-scalar-leak regime.
+
+3. **Unit dependency change** — code relying on `brainunit` internals should
+   migrate to `saiunit`.
+
+4. **`ETPPrimitiveSpec` removed** — custom primitives must register layout
+   metadata via `register_primitive` keyword arguments
+   (`trainable_invars_fn`, `x_invar_index`, `y_outvar_index`).
+
+### Migration Guide
+
+#### OSTL
+```python
+# Old
+algo = OSTL(model, ...)         # factory
+
+# New — choose the regime explicitly
+algo = OSTLRecurrent(model, ...)
+# or
+algo = OSTLFeedforward(model, ...)
+```
+
+#### OTTT / OTPE
+```python
+# Old
+algo = OTTT(model, ...)               # leak inferred from model.states()
+
+# New — pass the postsynaptic membrane leak explicitly
+algo = OTTT(model, leak=0.9, ...)
+```
+
+#### Custom ETP primitives
+```python
+# Old: register_primitive_spec(ETPPrimitiveSpec(...))
+# New: pass layout metadata directly
+register_primitive(
+    prim,
+    trainable_invars_fn=...,
+    x_invar_index=...,
+    y_outvar_index=...,
+)
+```
+
+#### Deprecated class-based API → primitive-based API
+```python
+# Old (v0.1.x): wrap the weight in an ETraceParam bound to an op
+self.w = braintrace.ETraceParam({'weight': w}, braintrace.MatMulOp())
+y = self.w.execute(x)
+
+# New (v0.2.0): a plain ParamState + the ETP primitive function
+self.w = brainstate.ParamState({'weight': w})
+y = braintrace.matmul(x, self.w.value)
+```
+
+The element-wise case is analogous (`ElemWiseParam`/`ElemWiseOp` →
+`brainstate.ParamState` + `braintrace.element_wise`); to keep a weight out of
+the eligibility-trace graph, use a plain `brainstate.ParamState` with ordinary
+JAX ops instead of `NonTempParam` / `FakeETraceParam`.
+
+### Version
+- Bumped version from `0.1.3` to `0.2.0`
+
+
 ## Version 0.1.2
 
 ### Major Changes


### PR DESCRIPTION
## Summary
- Complete NumPy-doc docstrings across the entire public API surface: package-level module docstrings for `braintrace` and `braintrace.nn`, plus docstrings for every previously-undocumented public method (`update()` on all `nn` cells/layers, the SNN trace helpers' `reset_state`/`update`, `ETraceGraph.call_hidden_perturb`, and the compiler containers' `dict()` helpers).
- The `nn` layer `update()` docstrings note which forward passes route through ETP primitives (so their parameters are eligible for online learning).
- Add the 0.2.0 release notes to `changelog.md` (SNN algorithms, compiler rewrite, multi-trainable-input ETP primitives, performance fast paths, package restructuring, PEP 561 typing, BPTT-oracle test suite, `saiunit` migration, deprecations, breaking changes, migration guide).

No code behavior changes — docstrings and release notes only.

## Test plan
- [x] All public symbols and their braintrace-defined public methods have docstrings (introspection check: 0 undocumented).
- [x] `doctest` over the package docstrings: 127 examples attempted, 0 failed.
- [x] Package imports cleanly.