### PR TITLE
docs: comprehensively cover and restructure docs/apis

### DIFF
--- a/docs/apis/algorithms.rst
+++ b/docs/apis/algorithms.rst
@@ -1,4 +1,4 @@
-Online Learning Algorithms
+Online-Learning Algorithms
 ==========================
 
 .. currentmodule:: braintrace
@@ -7,14 +7,39 @@ Online Learning Algorithms
    :local:
    :depth: 1
 
-``braintrace`` provides online learning algorithms based on
-eligibility trace propagation. All algorithms share the same interface:
-wrap a model, compile the graph, then call the algorithm as a drop-in
-replacement for the model's forward pass.
+``braintrace`` provides online-learning algorithms based on eligibility-trace
+propagation. They all share one interface: wrap a model, compile its graph,
+then call the learner as a drop-in replacement for the model's forward pass —
+gradients are accumulated forward in time instead of by BPTT.
+
+Two correctness classes appear below. **Exact** algorithms compute the same
+total gradient as BPTT (just forward); they match a BPTT oracle element-wise.
+**Approximate** algorithms deliberately drop or factor part of the computation
+and match BPTT only in the regime their math guarantees.
+
+
+One-Call Entry Point
+--------------------
+
+:func:`compile` is the recommended starting point. It constructs an algorithm
+for a model and eagerly builds its eligibility-trace graph, returning a
+ready-to-``update`` learner in a single call.
+
+.. autosummary::
+   :toctree: generated/
+   :nosignatures:
+   :template: classtemplate.rst
+
+   compile
 
 
 Base Classes
 ------------
+
+The abstract bases shared by every algorithm. :class:`ETraceAlgorithm` is the
+root; :class:`ETraceVjpAlgorithm` adds the VJP-based machinery that the
+concrete D-RTRL / ES-D-RTRL / SNN algorithms build on. :class:`EligibilityTrace`
+is the state these algorithms carry across time.
 
 .. autosummary::
    :toctree: generated/
@@ -22,15 +47,16 @@ Base Classes
    :template: classtemplate.rst
 
    ETraceAlgorithm
+   ETraceVjpAlgorithm
    EligibilityTrace
 
 
-D-RTRL (Parameter Dimension)
------------------------------
+D-RTRL — Parameter Dimension (exact)
+------------------------------------
 
-The Decoupled Real-Time Recurrent Learning algorithm with diagonal
-approximation. Memory complexity: :math:`O(B \cdot |\theta|)`, where
-:math:`B` is the batch size and :math:`|\theta|` is the number of parameters.
+Decoupled Real-Time Recurrent Learning with a diagonal approximation of the
+hidden-to-hidden Jacobian. Memory complexity :math:`O(B \cdot |\theta|)`, where
+:math:`B` is the batch size and :math:`|\theta|` the number of parameters.
 
 .. math::
 
@@ -43,24 +69,25 @@ approximation. Memory complexity: :math:`O(B \cdot |\theta|)`, where
    = \sum_{t' \in \mathcal{T}} \frac{\partial \mathcal{L}^{t'}}{\partial \mathbf{h}^{t'}}
    \circ \boldsymbol{\epsilon}^{t'}
 
-
 .. autosummary::
    :toctree: generated/
    :nosignatures:
    :template: classtemplate.rst
 
    ParamDimVjpAlgorithm
+   D_RTRL
 
-``D_RTRL`` is an alias for :class:`ParamDimVjpAlgorithm`.
+:class:`D_RTRL` is the concrete, ready-to-use subclass of
+:class:`ParamDimVjpAlgorithm`.
 
 
-ES-D-RTRL (Input-Output Dimension)
-------------------------------------
+ES-D-RTRL — Input/Output Dimension (exact)
+------------------------------------------
 
-The Event-Synchronized D-RTRL algorithm. Factorizes the eligibility trace
-into input and output components with exponential smoothing. Memory
-complexity: :math:`O(B(I + O))`, where :math:`I` and :math:`O` are the
-input and output dimensions.
+The Event-Synchronized D-RTRL algorithm factorizes the eligibility trace into
+input and output components with exponential smoothing, reducing memory to
+:math:`O(B(I + O))`, where :math:`I` and :math:`O` are the input and output
+dimensions.
 
 .. math::
 
@@ -78,33 +105,24 @@ input and output dimensions.
    = \alpha \operatorname{diag}(\mathbf{D}^t) \circ \boldsymbol{\epsilon}_{\mathbf{f}}^{t-1}
    + (1 - \alpha) \operatorname{diag}(\mathbf{D}_f^t)
 
-
 .. autosummary::
    :toctree: generated/
    :nosignatures:
    :template: classtemplate.rst
 
+   IODimVjpAlgorithm
    pp_prop
 
-``ES_D_RTRL`` and ``IODimVjpAlgorithm`` are aliases for :class:`pp_prop`.
-
-
-VJP Algorithm Base
-------------------
-
-.. autosummary::
-   :toctree: generated/
-   :nosignatures:
-   :template: classtemplate.rst
-
-   ETraceVjpAlgorithm
+:class:`pp_prop` is the concrete subclass of :class:`IODimVjpAlgorithm`;
+``ES_D_RTRL`` is an alias for :class:`pp_prop`.
 
 
 SNN Online-Learning Algorithms
 ------------------------------
 
-Paper-faithful algorithms tailored to spiking neural networks. All are
-``ETraceVjpAlgorithm`` subclasses (or factories over the VJP algorithms).
+Paper-faithful algorithms tailored to spiking neural networks, all
+``ETraceVjpAlgorithm`` subclasses. These are **approximate** (except where a
+regime makes them exact); know the regime before relying on their gradients.
 
 .. autosummary::
    :toctree: generated/
@@ -118,7 +136,9 @@ Paper-faithful algorithms tailored to spiking neural networks. All are
    OTTT
    OSTTP
 
-SNN helpers reusable across the above algorithms:
+Trace helpers reused across the SNN algorithms — a frozen random-feedback
+projection, an output-side low-pass filter, and a leaky presynaptic
+accumulator:
 
 .. autosummary::
    :toctree: generated/

--- a/docs/apis/compiler.rst
+++ b/docs/apis/compiler.rst
@@ -1,5 +1,5 @@
-Compiler
-========
+Compiler, Executor & Diagnostics
+================================
 
 .. currentmodule:: braintrace
 
@@ -7,16 +7,22 @@ Compiler
    :local:
    :depth: 1
 
-The compiler analyzes the model's JAX intermediate representation (Jaxpr)
-to discover relationships between ETP primitives, weight parameters,
-and hidden states. This page documents the compiler pipeline and its
-data structures.
+The compiler analyzes a model's JAX intermediate representation (``jaxpr``) to
+discover the relationships between ETP primitives, weight parameters, and
+hidden states. It recognizes ETP primitives by **primitive-type identity**
+(never by string-matching names), and the result is an :class:`ETraceGraph`
+that the executor and the online-learning algorithms consume.
+
+Most users never call this layer directly — :func:`compile` and the algorithm
+classes drive it for you. It is documented here for building custom algorithms,
+inspecting what the compiler discovered, and acting on diagnostics.
 
 
 Graph Compilation
 -----------------
 
-The main entry point for compiling a model into an eligibility trace graph.
+The entry point that compiles a model into an eligibility-trace graph, and the
+graph object it returns.
 
 .. autosummary::
    :toctree: generated/
@@ -30,7 +36,8 @@ The main entry point for compiling a model into an eligibility trace graph.
 Module Info
 -----------
 
-Extracts the Jaxpr and state information from a ``brainstate.nn.Module``.
+Extracts the ``jaxpr`` and state information from a ``brainstate.nn.Module``.
+``ModuleInfo`` is the compiler's structured view of a model.
 
 .. autosummary::
    :toctree: generated/
@@ -44,7 +51,9 @@ Extracts the Jaxpr and state information from a ``brainstate.nn.Module``.
 Hidden Groups
 -------------
 
-Groups of hidden states that are updated together in the recurrent computation.
+Sets of hidden states that are updated together in the recurrent computation.
+The finder functions discover them either from an extracted ``ModuleInfo`` or
+directly from a module.
 
 .. autosummary::
    :toctree: generated/
@@ -56,12 +65,14 @@ Groups of hidden states that are updated together in the recurrent computation.
    find_hidden_groups_from_module
 
 
-Hidden-Parameter-Operation Relations
+Hidden–Parameter–Operation Relations
 -------------------------------------
 
-Connections between ETP primitives, weight parameters, and hidden states.
-Each relation describes: *"weight W is used through ETP primitive P,
-and the output feeds into hidden group H."*
+The core data structure connecting ETP primitives, weight parameters, and
+hidden states. Each relation encodes *"weight W is used through ETP primitive
+P, and P's output feeds hidden group H."* Per the non-parametric-tail
+invariant, a weight that reaches a hidden state only through another trainable
+ETP primitive is deliberately excluded.
 
 .. autosummary::
    :toctree: generated/
@@ -76,8 +87,8 @@ and the output feeds into hidden group H."*
 Hidden Perturbation
 -------------------
 
-Perturbation structures for computing hidden-to-hidden Jacobians
-(the diagonal approximation of :math:`\partial h^t / \partial h^{t-1}`).
+Perturbation structures used to compute hidden-to-hidden Jacobians
+(the diagonal approximation of :math:`\partial \mathbf{h}^t / \partial \mathbf{h}^{t-1}`).
 
 .. autosummary::
    :toctree: generated/
@@ -92,8 +103,10 @@ Perturbation structures for computing hidden-to-hidden Jacobians
 Graph Executor
 --------------
 
-Executes the compiled graph: runs the forward pass and computes
-the hidden-to-weight and hidden-to-hidden Jacobians.
+Executes the compiled graph: runs the forward pass and computes the
+hidden-to-weight and hidden-to-hidden Jacobians the algorithms consume.
+:class:`ETraceVjpGraphExecutor` is the VJP-based executor used by the
+``ETraceVjpAlgorithm`` family.
 
 .. autosummary::
    :toctree: generated/
@@ -102,3 +115,23 @@ the hidden-to-weight and hidden-to-hidden Jacobians.
 
    ETraceGraphExecutor
    ETraceVjpGraphExecutor
+
+
+Diagnostics
+-----------
+
+Structured, leveled records emitted while the compiler analyzes a model. They
+surface issues that would otherwise be silent — for example a trainable input
+that does not trace back to a ``ParamState``, or an ETP weight excluded because
+it only reaches a hidden state through another trainable primitive.
+:class:`DiagnosticLevel` orders records by severity (``INFO`` < ``WARNING`` <
+``ERROR``) and :class:`DiagnosticKind` names the specific condition.
+
+.. autosummary::
+   :toctree: generated/
+   :nosignatures:
+   :template: classtemplate.rst
+
+   CompilationRecord
+   DiagnosticKind
+   DiagnosticLevel

--- a/docs/apis/concepts.rst
+++ b/docs/apis/concepts.rst
@@ -1,5 +1,5 @@
-Core Concepts
-=============
+ETP Operators & Core Types
+==========================
 
 .. currentmodule:: braintrace
 
@@ -7,14 +7,28 @@ Core Concepts
    :local:
    :depth: 1
 
+This page documents the **user-facing ETP operators** — the ops you call inside
+a model's ``update`` to make a weight participate in online learning — together
+with the small set of core types every algorithm consumes: input wrappers, the
+eligibility-trace state, gradient utilities, and the error hierarchy.
 
-ETP Primitives (User API)
--------------------------
+To add your *own* ETP primitive (with custom trace-propagation rules), see
+:doc:`primitives`.
 
-These functions mark weight operations for inclusion in online learning.
-Use ``braintrace.matmul(x, w)`` instead of ``x @ w`` to include a weight
-in eligibility trace computation. Parameters used with regular JAX ops
-are automatically excluded — no special parameter classes needed.
+
+ETP Primitive Operators
+-----------------------
+
+These functions mark weight operations for inclusion in online learning. Use
+``braintrace.matmul(x, w)`` instead of ``x @ w`` to include a weight in
+eligibility-trace computation; a parameter used through a regular JAX op is
+automatically excluded. There is **no special parameter class** — every
+``brainstate.ParamState`` is eligible, and participation is decided purely by
+whether an ETP operator consumed it.
+
+All operators accept physical-unit quantities (mantissa/unit are split,
+computed, and recombined) and come in batched and unbatched forms selected by
+input rank.
 
 .. autosummary::
    :toctree: generated/
@@ -33,6 +47,7 @@ Controlling Parameter Participation
 
 .. code-block:: python
 
+   import jax
    import braintrace
    import brainstate
 
@@ -56,21 +71,21 @@ Controlling Parameter Participation
 
    * - Goal
      - How
-   * - Include parameter in online learning
-     - Use a ``braintrace.*`` ETP primitive (e.g. ``braintrace.matmul(x, w)``)
-   * - Exclude parameter from online learning
-     - Use a regular JAX op (e.g. ``x @ w``)
+   * - Include a parameter in online learning
+     - Use a ``braintrace.*`` ETP operator (e.g. ``braintrace.matmul(x, w)``).
+   * - Exclude a parameter from online learning
+     - Use a regular JAX op (e.g. ``x @ w``).
    * - Selection mechanism
-     - Operation primitive type — *not* parameter class type. Every
-       ``brainstate.ParamState`` is eligible; participation depends solely
-       on whether an ETP primitive consumed it.
+     - The *operation's* primitive type — not the parameter's class. Every
+       ``brainstate.ParamState`` is eligible; participation depends solely on
+       whether an ETP primitive consumed it.
 
 
 Input Data
 ----------
 
-Wrappers that tell the online learning algorithm whether the input
-is a single time step or a sequence of time steps.
+Wrappers that tell an online-learning algorithm whether a step receives a
+single time step or a whole sequence of time steps.
 
 .. autosummary::
    :toctree: generated/
@@ -84,6 +99,9 @@ is a single time step or a sequence of time steps.
 Eligibility Trace State
 -----------------------
 
+The state object that stores the eligibility trace carried forward across time
+steps during online learning.
+
 .. autosummary::
    :toctree: generated/
    :nosignatures:
@@ -95,6 +113,9 @@ Eligibility Trace State
 Gradient Utilities
 ------------------
 
+Helpers used when combining per-step gradients into the running online
+gradient.
+
 .. autosummary::
    :toctree: generated/
    :nosignatures:
@@ -105,6 +126,8 @@ Gradient Utilities
 
 Errors
 ------
+
+Exceptions raised by the compilation and execution machinery.
 
 .. autosummary::
    :toctree: generated/

--- a/docs/apis/index.rst
+++ b/docs/apis/index.rst
@@ -1,0 +1,52 @@
+API Reference
+=============
+
+``braintrace`` trains recurrent and spiking neural networks **online** —
+forward in time, without backpropagation through time (BPTT). You mark the
+trainable operations of a model with **ETP primitives** (for example
+:func:`braintrace.matmul` instead of ``x @ w``); a compiler then discovers how
+each parameter influences the network's hidden states and wires up the
+eligibility traces that carry gradient information forward.
+
+This reference is organized around the four layers of the package, with
+dependencies pointing strictly downward, plus the ready-made neural-network
+layers built on top.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 48 30
+
+   * - Layer
+     - What it does
+     - Reference
+   * - **Operators**
+     - User-facing ETP ops that mark weights for online learning, and the
+       machinery to register your own primitives.
+     - :doc:`concepts`, :doc:`primitives`
+   * - **Compiler**
+     - Walks the JAX ``jaxpr``, identifies ETP primitives by type, and connects
+       each parameter to the hidden states it influences.
+     - :doc:`compiler`
+   * - **Executor**
+     - Runs the forward pass and computes the hidden→weight / hidden→hidden
+       Jacobians the algorithms consume.
+     - :doc:`compiler`
+   * - **Algorithms**
+     - Online-learning orchestrators: the exact D-RTRL / ES-D-RTRL family and
+       the SNN algorithms (EProp, OSTL, OTPE, OTTT, OSTTP).
+     - :doc:`algorithms`
+   * - **Layers**
+     - Drop-in ``brainstate.nn``-style layers pre-wired through ETP primitives.
+     - :doc:`nn`
+
+The fastest way in is the one-call :func:`braintrace.compile` entry point,
+documented in :doc:`algorithms`.
+
+.. toctree::
+   :maxdepth: 2
+
+   concepts
+   primitives
+   compiler
+   algorithms
+   nn

--- a/docs/apis/nn.rst
+++ b/docs/apis/nn.rst
@@ -1,17 +1,24 @@
-Neural Network Modules
-======================
+Neural-Network Layers
+=====================
 
 .. currentmodule:: braintrace.nn
-.. automodule:: braintrace.nn
 
-``braintrace.nn`` provides neural network layers that use ETP primitives
-internally. These layers are drop-in replacements for standard layers
-but automatically participate in online learning.
+``braintrace.nn`` mirrors a subset of ``brainstate.nn``, but routes each
+layer's trainable forward pass through ETP primitives. As a result, the layers
+are drop-in replacements whose parameters **automatically participate in online
+learning** — no manual wiring required.
 
-For example, ``braintrace.nn.Linear`` uses ``braintrace.matmul`` internally,
-so its weight is automatically included in eligibility trace computation.
-Similarly, ``braintrace.nn.GRUCell`` uses ``braintrace.matmul`` for its
-recurrent weight and ``braintrace.element_wise`` for gate operations.
+For example, :class:`Linear` uses :func:`braintrace.matmul` internally, so its
+weight is included in eligibility-trace computation; :class:`GRUCell` uses
+:func:`braintrace.matmul` for its recurrent maps and :func:`braintrace.element_wise`
+for gate operations.
+
+.. note::
+
+   Activation, normalization, and pooling layers are intentionally **not**
+   re-implemented here. Accessing them through ``braintrace.nn`` (e.g.
+   ``braintrace.nn.LayerNorm``) emits a :class:`DeprecationWarning` and forwards
+   to ``brainstate.nn`` / ``brainstate.state``; use those packages directly.
 
 
 Linear Layers
@@ -44,6 +51,9 @@ Convolutional Layers
 Recurrent Layers
 ----------------
 
+Single-step recurrent cells. Each updates its hidden state in place and returns
+the new hidden state (or, for :class:`LRUCell`, the projected output).
+
 .. autosummary::
    :toctree: generated/
    :nosignatures:
@@ -58,23 +68,6 @@ Recurrent Layers
    MiniGRU
    MiniLSTM
    LRUCell
-
-
-Normalization Layers
---------------------
-
-.. autosummary::
-   :toctree: generated/
-   :nosignatures:
-   :template: classtemplate.rst
-
-   BatchNorm0d
-   BatchNorm1d
-   BatchNorm2d
-   BatchNorm3d
-   LayerNorm
-   RMSNorm
-   GroupNorm
 
 
 Readout Layers

--- a/docs/apis/primitives.rst
+++ b/docs/apis/primitives.rst
@@ -1,5 +1,5 @@
-Custom Primitives
-=================
+Custom ETP Primitives
+=====================
 
 .. currentmodule:: braintrace
 
@@ -7,40 +7,42 @@ Custom Primitives
    :local:
    :depth: 2
 
-This page documents how to register a new ETP primitive and the four
-ETP-specific rules every primitive must provide. The built-in primitives
-(``etp_mm``, ``etp_mv``, ``etp_conv``, ``etp_elemwise``, ``etp_sp_mm``,
-``etp_sp_mv``, ``etp_lora_mm``, ``etp_lora_mv``) are themselves registered
-through this same machinery — adding a custom op uses the same surface.
+An ETP primitive is a thin marker around a standard JAX op. All standard JAX
+rules (abstract eval, lowering, JVP, transpose, batching) are **auto-derived**
+from the op's implementation — you only hand-write the small set of
+*ETP-specific* rules that describe trace propagation. This page shows how to
+register your own primitive; the built-ins (``etp_mm``, ``etp_mv``,
+``etp_conv``, ``etp_elemwise``, ``etp_sp_mm``, ``etp_sp_mv``, ``etp_lora_mm``,
+``etp_lora_mv``) are registered through the very same machinery.
 
 
 Registration
 -----------
 
-Register a primitive by calling :func:`register_primitive` to obtain an
-:class:`ETPPrimitive`, then attach the four ETP rules via its
-``register_*`` methods (or in one call via ``register_etp_rules``).
+Call :func:`register_primitive` to obtain an :class:`ETPPrimitive`, then attach
+the four ETP rules via its ``register_*`` methods (or all at once with
+``register_etp_rules``).
 
-Beyond the implementation function, :func:`register_primitive` accepts a
-few keyword arguments that record the primitive's invar / outvar layout
-for the compiler:
+Beyond the implementation function, :func:`register_primitive` accepts a few
+keyword arguments that record the primitive's invar / outvar layout for the
+compiler:
 
-* ``trainable_invars_fn`` — ``eqn.params -> {key: invar_index}``,
-  declaring every trainable input (e.g. ``{'weight': 1}`` for a plain
-  matmul, ``{'weight': 1, 'bias': 2}`` when a bias is present). Defaults
-  to the single-weight ``{'weight': 1}`` layout when omitted.
+* ``trainable_invars_fn`` — ``eqn.params -> {key: invar_index}``, declaring
+  every trainable input (e.g. ``{'weight': 1}`` for a plain matmul, or
+  ``{'weight': 1, 'bias': 2}`` when a bias is present). Defaults to the
+  single-weight ``{'weight': 1}`` layout when omitted.
 * ``x_invar_index`` — position of the input ``x`` in ``eqn.invars``
   (``None`` for input-free primitives such as ``etp_elemwise_p``).
 * ``y_outvar_index`` — position of the output ``y`` in ``eqn.outvars``.
 
-The call populates the same four global rule registries
+The call populates the four global rule registries
 (:data:`ETP_RULES_YW_TO_W`, :data:`ETP_RULES_XY_TO_DW`,
-:data:`ETP_RULES_INIT_DRTRL`, :data:`ETP_RULES_INIT_PP`) and results in a
-fully-functional ``ETPPrimitive``.
+:data:`ETP_RULES_INIT_DRTRL`, :data:`ETP_RULES_INIT_PP`) and returns a
+fully-functional :class:`ETPPrimitive`.
 
 
 Registration entry points
--------------------------
+^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 .. autosummary::
    :toctree: generated/
@@ -50,7 +52,7 @@ Registration entry points
 
 
 Primitive class
----------------
+^^^^^^^^^^^^^^^
 
 .. autosummary::
    :toctree: generated/
@@ -63,10 +65,9 @@ Primitive class
 The four ETP rules
 ------------------
 
-Every ETP primitive must supply four rules. They are stored in four
-global ``dict`` registries keyed by primitive — the compiler and the
-online-learning algorithms look up the rule for a primitive at compile
-time.
+Every ETP primitive must supply four rules. They are stored in four global
+``dict`` registries keyed by primitive; the compiler and the online-learning
+algorithms look up the rule for a primitive at compile time.
 
 .. list-table::
    :header-rows: 1
@@ -77,23 +78,23 @@ time.
      - Purpose
    * - ``ETP_RULES_YW_TO_W``
      - ``(hidden_dim, trace, **params) -> trace``
-     - D-RTRL trace propagation: combine an upstream hidden-state
-       Jacobian factor with the trace through the current weight.
+     - D-RTRL trace propagation: combine an upstream hidden-state Jacobian
+       factor with the trace through the current weight.
    * - ``ETP_RULES_XY_TO_DW``
      - ``(x, hidden_dim, weight, **params) -> dW``
-     - Weight-gradient rule: produce ``dL/dW`` given ``x``, the
-       hidden-state Jacobian factor, and the current weight value.
+     - Weight-gradient rule: produce ``dL/dW`` given ``x``, the hidden-state
+       Jacobian factor, and the current weight value.
    * - ``ETP_RULES_INIT_DRTRL``
      - ``(x_var, y_var, weight, num_hidden_state) -> zeros``
-     - D-RTRL trace initialiser. Returns a zero array (or pytree of
-       arrays) shaped to hold the parameter-dim trace.
+     - D-RTRL trace initialiser. Returns a zero array (or pytree of arrays)
+       shaped to hold the parameter-dim trace.
    * - ``ETP_RULES_INIT_PP``
      - ``(x_var, y_var, weight, num_hidden_state) -> zeros``
-     - pp_prop / ES-D-RTRL trace initialiser. Returns a zero array
-       shaped to hold the IO-dim trace.
+     - pp_prop / ES-D-RTRL trace initialiser. Returns a zero array shaped to
+       hold the IO-dim trace.
 
-The four registries live in :mod:`braintrace._etrace_op` and are
-populated by :func:`register_primitive`.
+The four registries live in :mod:`braintrace._etrace_op` and are populated by
+:func:`register_primitive`.
 
 
 Registration example
@@ -147,8 +148,8 @@ After registration the primitive is ready to use:
 Auto-derived JAX rules
 ----------------------
 
-You **only** need to write the four ETP rules above. All standard JAX
-machinery is derived automatically from your ``impl``:
+You **only** write the four ETP rules above. All standard JAX machinery is
+derived automatically from your ``impl``:
 
 * ``abstract_eval`` — via ``jax.eval_shape(impl)``
 * MLIR lowering — via ``mlir.lower_fun(impl)``
@@ -156,22 +157,22 @@ machinery is derived automatically from your ``impl``:
 * transpose — derived by JAX from the JVP
 * batching — via ``jax.vmap(impl)``
 
-This means a custom primitive immediately works under
-``jit``/``grad``/``vmap``/``jvp`` without any extra code.
+So a custom primitive immediately works under ``jit`` / ``grad`` / ``vmap`` /
+``jvp`` without any extra code.
 
 
 The ``gradient_enabled`` flag
 -----------------------------
 
-Pass ``gradient_enabled=True`` only for **identity-like** primitives
-that may sit on the tail of the ``y -> h`` walk (the only built-in is
+Pass ``gradient_enabled=True`` only for **identity-like** primitives that may
+sit on the tail of the ``y -> h`` walk (the only built-in is
 ``etp_elemwise_p``).
 
-For *trainable* ops, leave the default ``gradient_enabled=False``. The
-compiler treats such a primitive as a tail boundary: a preceding ETP
-weight whose only path to ``h`` passes through it is correctly excluded
-from ETP, because per-primitive ETP rules cannot express the
-"weight-then-weight-then-hidden" composition.
+For *trainable* ops, leave the default ``gradient_enabled=False``. The compiler
+treats such a primitive as a tail boundary: a preceding ETP weight whose only
+path to ``h`` passes through it is correctly excluded from ETP, because
+per-primitive ETP rules cannot express the "weight-then-weight-then-hidden"
+composition.
 
-See :doc:`/tutorial/etp_primitives` for a full walk-through and
+See :doc:`/tutorials/etp_primitives` for a full walk-through and
 :doc:`/advanced/compiler_internals` for the underlying invariant.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -119,9 +119,5 @@ See also the ecosystem
    :maxdepth: 2
    :caption: API Reference
 
+   apis/index.rst
    changelog.md
-   apis/concepts.rst
-   apis/primitives.rst
-   apis/compiler.rst
-   apis/algorithms.rst
-   apis/nn.rst


### PR DESCRIPTION
Ensure every public API appears in the documentation site and rewrite
the API reference for consistency:

- Add an apis/index.rst landing page mapping the four architecture
  layers to their reference pages, and wire it into the main toctree.
- Document previously-missing public APIs: the compile() entry point,
  D_RTRL / IODimVjpAlgorithm, and the compiler diagnostics
  (CompilationRecord, DiagnosticKind, DiagnosticLevel).
- Correct inaccurate "alias" notes (D_RTRL subclasses ParamDimVjpAlgorithm;
  pp_prop subclasses IODimVjpAlgorithm; ES_D_RTRL aliases pp_prop).
- Drop the deprecated normalization-layer entries from nn (they forward
  to brainstate.nn and are not braintrace public API); note the forwards.
- Fix a broken cross-reference (/tutorial -> /tutorials).

## Summary by Sourcery

Restructure and complete the public API documentation to provide a consistent, layer-based reference for all supported interfaces.

Documentation:
- Add an API documentation landing page that maps architectural layers to their reference pages and integrates it into the main documentation navigation.
- Document previously undocumented public APIs, including the compile entry point, algorithm types, and compiler diagnostic objects.
- Clarify and correct API relationships and alias notes for algorithm classes in the documentation.
- Remove deprecated normalization-layer entries from the nn API docs and document that they are forwarded to brainstate.nn.
- Fix a broken tutorial cross-reference path in the documentation.