### PR TITLE
fix: restore daily CI under pytest 9.1 + brainstate 0.5 typed API

### DIFF
--- a/braintrace/_compile.py
+++ b/braintrace/_compile.py
@@ -32,7 +32,7 @@ __all__ = ['compile']
 # Canonical lowercase name (+ aliases) -> algorithm class. No bare ``ostl``
 # alias: the ambiguous OSTL factory was removed in 0.2.0, so callers pick
 # ``ostl_recurrent`` vs ``ostl_feedforward`` explicitly.
-_ALGORITHM_REGISTRY = {
+_ALGORITHM_REGISTRY: dict[str, type[ETraceAlgorithm]] = {
     'd_rtrl': D_RTRL,
     'pp_prop': pp_prop,
     'es_d_rtrl': pp_prop,

--- a/braintrace/_etrace_algorithms/_common.py
+++ b/braintrace/_etrace_algorithms/_common.py
@@ -23,6 +23,8 @@ import jax
 import jax.numpy as jnp
 import saiunit as u
 
+from braintrace._typing import PyTree
+
 __all__ = [
     'PresynapticTrace',
     'KappaFilter',
@@ -388,7 +390,7 @@ def _unit_safe_add(a, b):
     return u.math.add(a, b)
 
 
-def _extract_leaf(pytree_val: brainstate.typing.PyTree, leaf_idx: int):
+def _extract_leaf(pytree_val: PyTree, leaf_idx: int):
     """Return the leaf at ``leaf_idx`` in ``jax.tree.leaves(pytree_val)``.
 
     Bare arrays (treedef with a single leaf) return the array unchanged.
@@ -405,7 +407,7 @@ def _extract_leaf(pytree_val: brainstate.typing.PyTree, leaf_idx: int):
 
 
 def _wrap_leaves_as_pytree(
-    reference_pytree: brainstate.typing.PyTree,
+    reference_pytree: PyTree,
     leaf_grads: Dict[int, jax.Array],
 ):
     """Build a pytree matching ``reference_pytree`` with ``leaf_grads``
@@ -441,8 +443,8 @@ def _wrap_leaves_as_pytree(
 def _route_grads_by_path(
     relation,
     per_key_grads: Dict[str, jax.Array],
-    weight_vals: Dict[Any, brainstate.typing.PyTree],
-    target_dict: Dict[Any, brainstate.typing.PyTree],
+    weight_vals: Dict[Any, PyTree],
+    target_dict: Dict[Any, PyTree],
 ) -> None:
     """Route per-key gradients from a dict-API rule into per-path pytrees.
 
@@ -474,7 +476,7 @@ def _route_grads_by_path(
 def _update_dict(
     the_dict: Dict,
     key: Any,
-    value: brainstate.typing.PyTree,
+    value: PyTree,
     error_when_no_key: Optional[bool] = False
 ):
     """Update the dictionary.

--- a/braintrace/_etrace_algorithms/base.py
+++ b/braintrace/_etrace_algorithms/base.py
@@ -90,7 +90,7 @@ class ETraceAlgorithm(brainstate.nn.Module):
         graph_executor: ETraceGraphExecutor,
         name: Optional[str] = None,
     ):
-        super().__init__(name=name)
+        super().__init__(name=name)  # type: ignore[call-arg]  # brainstate hides Module.__init__ from type checkers
 
         # the model
         if not isinstance(model, brainstate.nn.Module):
@@ -115,9 +115,9 @@ class ETraceAlgorithm(brainstate.nn.Module):
         self.running_index = brainstate.LongTermState(0)
 
         # other states
-        self._param_states = None
-        self._hidden_states = None
-        self._other_states = None
+        self._param_states: Optional[brainstate.util.FlattedDict] = None
+        self._hidden_states: Optional[brainstate.util.FlattedDict] = None
+        self._other_states: Optional[brainstate.util.FlattedDict] = None
 
     @property
     def graph(self) -> ETraceGraph:
@@ -144,7 +144,7 @@ class ETraceAlgorithm(brainstate.nn.Module):
         return self.graph_executor
 
     @property
-    def param_states(self) -> brainstate.util.FlattedDict[Path, brainstate.ParamState]:
+    def param_states(self) -> brainstate.util.FlattedDict:
         """
         Get the parameter weight states.
 
@@ -155,10 +155,11 @@ class ETraceAlgorithm(brainstate.nn.Module):
         """
         if self._param_states is None:
             self._split_state()
+        assert self._param_states is not None
         return self._param_states
 
     @property
-    def hidden_states(self) -> brainstate.util.FlattedDict[Path, brainstate.HiddenState]:
+    def hidden_states(self) -> brainstate.util.FlattedDict:
         """
         Get the hidden states.
 
@@ -169,10 +170,11 @@ class ETraceAlgorithm(brainstate.nn.Module):
         """
         if self._hidden_states is None:
             self._split_state()
+        assert self._hidden_states is not None
         return self._hidden_states
 
     @property
-    def other_states(self) -> brainstate.util.FlattedDict[Path, brainstate.State]:
+    def other_states(self) -> brainstate.util.FlattedDict:
         """
         Get the other states.
 
@@ -183,6 +185,7 @@ class ETraceAlgorithm(brainstate.nn.Module):
         """
         if self._other_states is None:
             self._split_state()
+        assert self._other_states is not None
         return self._other_states
 
     def _split_state(self):
@@ -235,7 +238,7 @@ class ETraceAlgorithm(brainstate.nn.Module):
             self.is_compiled = True
 
     @property
-    def path_to_states(self) -> brainstate.util.FlattedDict[Path, brainstate.State]:
+    def path_to_states(self) -> brainstate.util.FlattedDict:
         """
         Get the path to the states.
 

--- a/braintrace/_etrace_algorithms/graph_executor.py
+++ b/braintrace/_etrace_algorithms/graph_executor.py
@@ -110,7 +110,7 @@ class ETraceGraphExecutor:
         return self._compiled_graph
 
     @property
-    def states(self) -> brainstate.util.FlattedDict[Path, brainstate.State]:
+    def states(self) -> brainstate.util.FlattedDict:
         """
         The states for the model.
 
@@ -122,7 +122,7 @@ class ETraceGraphExecutor:
         return self.graph.module_info.retrieved_model_states
 
     @property
-    def path_to_states(self) -> brainstate.util.FlattedDict[Path, brainstate.State]:
+    def path_to_states(self) -> brainstate.util.FlattedDict:
         """
         The path to the states.
 
@@ -216,6 +216,8 @@ class ETraceGraphExecutor:
         # other hidden states
         other_states = []
         short_states = self.states.filter(brainstate.ShortTermState)
+        # a single-type filter returns one FlattedDict (brainstate types it as a union)
+        assert isinstance(short_states, brainstate.util.FlattedDict)
         for i, path in enumerate(short_states.keys()):
             if path not in hidden_paths:
                 other_states.append(path)
@@ -239,7 +241,9 @@ class ETraceGraphExecutor:
             msg += '\n\n'
 
         # non etrace weights
-        non_etratce_weight_paths = set(self.states.filter(brainstate.ParamState).keys())
+        param_states = self.states.filter(brainstate.ParamState)
+        assert isinstance(param_states, brainstate.util.FlattedDict)
+        non_etratce_weight_paths = set(param_states.keys())
         non_etratce_weight_paths = non_etratce_weight_paths.difference(etratce_weight_paths)
         if len(non_etratce_weight_paths):
             msg += 'The non-etrace weight parameters are:\n\n'

--- a/braintrace/_etrace_algorithms/oracle.py
+++ b/braintrace/_etrace_algorithms/oracle.py
@@ -59,8 +59,10 @@ def finite_difference_param_gradients(
     """
     template = model_factory()
     brainstate.nn.init_all_states(template, batch_size=1)
+    template_params = template.states(brainstate.ParamState)
+    assert isinstance(template_params, brainstate.util.FlattedDict)
     base_values = {
-        k: np.asarray(v.value) for k, v in template.states(brainstate.ParamState).items()
+        k: np.asarray(v.value) for k, v in template_params.items()
     }
 
     def loss_with(values):

--- a/braintrace/_etrace_algorithms/param_dim_vjp.py
+++ b/braintrace/_etrace_algorithms/param_dim_vjp.py
@@ -533,7 +533,7 @@ def _solve_param_dim_weight_gradients(
         _update_dict(dG_weights, key, val)
 
 
-def _remove_units(xs_maybe_quantity: brainstate.typing.PyTree):
+def _remove_units(xs_maybe_quantity: PyTree):
     """
     Removes units from a PyTree of quantities, returning a unitless PyTree and a function to restore the units.
 
@@ -542,10 +542,10 @@ def _remove_units(xs_maybe_quantity: brainstate.typing.PyTree):
     original units to the unitless PyTree.
 
     Args:
-        xs_maybe_quantity (brainstate.typing.PyTree): A PyTree structure containing quantities with units.
+        xs_maybe_quantity (PyTree): A PyTree structure containing quantities with units.
 
     Returns:
-        Tuple[brainstate.typing.PyTree, Callable]: A tuple containing:
+        Tuple[PyTree, Callable]: A tuple containing:
             - A PyTree with the same structure as the input, but with units removed from each quantity.
             - A function that takes a unitless PyTree and restores the original units to it.
     """
@@ -556,7 +556,7 @@ def _remove_units(xs_maybe_quantity: brainstate.typing.PyTree):
         new_leaves.append(leaf)
         units.append(unit)
 
-    def restore_units(xs_unitless: brainstate.typing.PyTree):
+    def restore_units(xs_unitless: PyTree):
         leaves, treedef2 = jax.tree.flatten(xs_unitless)
         # jax's PyTreeDef stubs omit __eq__; the comparison is valid at runtime.
         assert treedef == treedef2, 'The tree structure should be the same. '  # type: ignore[operator]

--- a/braintrace/_etrace_compiler/hid_param_op.py
+++ b/braintrace/_etrace_compiler/hid_param_op.py
@@ -800,6 +800,8 @@ def find_hidden_param_op_relations_from_jaxpr(
                 invar, t_path, producers, weight_path_to_invars,
             )
             t_state = path_to_state.get(t_path)
+            # ``t_path`` is a trainable weight path, so its state is always a present ParamState.
+            assert isinstance(t_state, brainstate.ParamState)
             trainable_vars[key] = invar
             trainable_paths[key] = t_path
             trainable_leaf_indices[key] = t_leaf

--- a/braintrace/_etrace_compiler/hid_param_op_test.py
+++ b/braintrace/_etrace_compiler/hid_param_op_test.py
@@ -59,7 +59,7 @@ class TestFindRelationsFromModule:
             assert relation.connected_hidden_paths[0] == ('h',)
 
     @pytest.mark.parametrize(
-        'cls,',
+        'cls',
         [
             IF_Delta_Dense_Layer,
             LIF_ExpCo_Dense_Layer,
@@ -87,7 +87,7 @@ class TestFindRelationsFromModule:
             print(relations)
 
     @pytest.mark.parametrize(
-        'cls,',
+        'cls',
         [
             IF_Delta_Dense_Layer,
             LIF_ExpCo_Dense_Layer,

--- a/braintrace/_etrace_compiler/hidden_group.py
+++ b/braintrace/_etrace_compiler/hidden_group.py
@@ -45,7 +45,7 @@
 # -*- coding: utf-8 -*-
 
 from itertools import combinations
-from typing import List, Dict, Sequence, Tuple, Set, Optional, Callable, NamedTuple, Any
+from typing import List, Dict, Sequence, Tuple, Set, Optional, Callable, NamedTuple, Any, cast
 
 import brainstate
 import jax.core
@@ -989,7 +989,9 @@ def find_hidden_groups_from_jaxpr(
         weight_invars=weight_invars,
         invar_to_hidden_path=invar_to_hidden_path,
         outvar_to_hidden_path=outvar_to_hidden_path,
-        path_to_state=path_to_state,
+        # the evaluator only indexes hidden-state paths, whose entries are HiddenStates,
+        # even though the passed mapping carries every model state.
+        path_to_state=cast(Dict[Path, brainstate.HiddenState], path_to_state),
     )
     hidden_groups, hid_path_to_group = evaluator.compile()
     return hidden_groups, brainstate.util.PrettyDict(hid_path_to_group)

--- a/braintrace/_etrace_compiler/hidden_group_test.py
+++ b/braintrace/_etrace_compiler/hidden_group_test.py
@@ -146,7 +146,7 @@ class Test_find_hidden_groups_from_module:
         print()
 
     @pytest.mark.parametrize(
-        'cls,',
+        'cls',
         [
             IF_Delta_Dense_Layer,
             LIF_ExpCo_Dense_Layer,
@@ -180,7 +180,7 @@ class Test_find_hidden_groups_from_module:
         print()
 
     @pytest.mark.parametrize(
-        'cls,',
+        'cls',
         [
             IF_Delta_Dense_Layer,
             LIF_ExpCo_Dense_Layer,
@@ -556,7 +556,7 @@ class TestHiddenGroup_state_transition:
             print(out_vals)
 
     @pytest.mark.parametrize(
-        'cls,',
+        'cls',
         [
             IF_Delta_Dense_Layer,
             LIF_ExpCo_Dense_Layer,
@@ -591,7 +591,7 @@ class TestHiddenGroup_state_transition:
             print(out_vals)
 
     @pytest.mark.parametrize(
-        'cls,',
+        'cls',
         [
             IF_Delta_Dense_Layer,
             LIF_ExpCo_Dense_Layer,
@@ -689,7 +689,7 @@ class TestHiddenGroup_diagonal_jacobian:
             assert (u.math.allclose(diag_jac, jax_jac, atol=1e-5))
 
     @pytest.mark.parametrize(
-        'cls,',
+        'cls',
         [
             IF_Delta_Dense_Layer,
             LIF_ExpCo_Dense_Layer,
@@ -724,7 +724,7 @@ class TestHiddenGroup_diagonal_jacobian:
             print(diag_jac)
 
     @pytest.mark.parametrize(
-        'cls,',
+        'cls',
         [
             IF_Delta_Dense_Layer,
             LIF_ExpCo_Dense_Layer,
@@ -767,7 +767,7 @@ class TestHiddenGroup_diagonal_jacobian:
             assert (u.math.allclose(diag_jac, jax_jac, atol=1e-5))
 
     @pytest.mark.parametrize(
-        'cls,',
+        'cls',
         [
             IF_Delta_Dense_Layer,
             LIF_ExpCo_Dense_Layer,
@@ -801,7 +801,7 @@ class TestHiddenGroup_diagonal_jacobian:
             print(diag_jac)
 
     @pytest.mark.parametrize(
-        'cls,',
+        'cls',
         [
             IF_Delta_Dense_Layer,
             LIF_ExpCo_Dense_Layer,

--- a/braintrace/_etrace_compiler/hidden_pertubation_test.py
+++ b/braintrace/_etrace_compiler/hidden_pertubation_test.py
@@ -62,7 +62,7 @@ class TestFindHiddenGroupsFromModule:
         assert len(states) == len(hidden_perturb.init_perturb_data())
 
     @pytest.mark.parametrize(
-        'cls,',
+        'cls',
         [
             IF_Delta_Dense_Layer,
             LIF_ExpCo_Dense_Layer,
@@ -94,7 +94,7 @@ class TestFindHiddenGroupsFromModule:
         assert len(states) == len(perturb)
 
     @pytest.mark.parametrize(
-        'cls,',
+        'cls',
         [
             IF_Delta_Dense_Layer,
             LIF_ExpCo_Dense_Layer,

--- a/braintrace/_etrace_compiler/module_info.py
+++ b/braintrace/_etrace_compiler/module_info.py
@@ -33,6 +33,7 @@ from braintrace._misc import (
 from braintrace._state_managment import sequence_split_state_values
 from braintrace._typing import (
     Path,
+    PyTree,
     StateID,
     Inputs,
     Outputs,
@@ -269,11 +270,11 @@ class ModuleInfo(NamedTuple):
     closed_jaxpr: ClosedJaxpr
 
     # states
-    retrieved_model_states: brainstate.util.FlattedDict[Path, brainstate.State]
+    retrieved_model_states: brainstate.util.FlattedDict
     compiled_model_states: Sequence[brainstate.State]
     state_id_to_path: Dict[StateID, Path]
-    state_tree_invars: brainstate.typing.PyTree[Var]
-    state_tree_outvars: brainstate.typing.PyTree[Var]
+    state_tree_invars: PyTree
+    state_tree_outvars: PyTree
 
     # hidden states
     hidden_path_to_invar: Dict[Path, Var]
@@ -434,7 +435,10 @@ class ModuleInfo(NamedTuple):
         cache_key = self.stateful_model.get_arg_cache_key(*args, compile_if_miss=True)
         i_start = self.num_var_out
         i_end = i_start + self.num_var_state
-        out, new_state_vals = self.stateful_model.get_out_treedef_by_cache(cache_key).unflatten(jaxpr_outs[:i_end])
+        # brainstate types the cached treedef as the broad ``PyTree``; at runtime it is a
+        # ``jax`` ``PyTreeDef`` that exposes ``unflatten``.
+        out, new_state_vals = self.stateful_model.get_out_treedef_by_cache(cache_key).unflatten(  # type: ignore[attr-defined]
+            jaxpr_outs[:i_end])
 
         #
         # check state value

--- a/braintrace/_etrace_compiler/module_info_test.py
+++ b/braintrace/_etrace_compiler/module_info_test.py
@@ -57,7 +57,7 @@ class Test_extract_model_info:
         pprint(minfo)
 
     @pytest.mark.parametrize(
-        'cls,',
+        'cls',
         [
             IF_Delta_Dense_Layer,
             LIF_ExpCo_Dense_Layer,
@@ -85,7 +85,7 @@ class Test_extract_model_info:
             pprint(minfo)
 
     @pytest.mark.parametrize(
-        'cls,',
+        'cls',
         [
             IF_Delta_Dense_Layer,
             LIF_ExpCo_Dense_Layer,

--- a/braintrace/_grad_exponential.py
+++ b/braintrace/_grad_exponential.py
@@ -18,6 +18,8 @@ import brainstate
 import jax.tree
 import saiunit as u
 
+from braintrace._typing import PyTree
+
 __all__ = [
     'GradExpon',
 ]
@@ -31,7 +33,7 @@ class GradExpon(brainstate.nn.Module):
 
     Parameters
     ----------
-    grad_shape : brainstate.typing.PyTree
+    grad_shape : PyTree
         A pytree whose leaves give the shape and dtype of the gradients to
         accumulate. The accumulator is initialised to zeros matching each
         leaf.
@@ -69,7 +71,7 @@ class GradExpon(brainstate.nn.Module):
 
     def __init__(
         self,
-        grad_shape: brainstate.typing.PyTree,
+        grad_shape: PyTree,
         tau_or_decay: u.Quantity | float,
     ):
         super().__init__()
@@ -90,7 +92,7 @@ class GradExpon(brainstate.nn.Module):
             raise TypeError(f"tau_or_decay must be a Quantity or a float, but got {tau_or_decay}")
         self.decay = decay
 
-    def update(self, grads: brainstate.typing.PyTree):
+    def update(self, grads: PyTree):
         r"""Update the accumulated gradients with the exponential decay rule.
 
         Applies :math:`g_{t+1} = \mathrm{decay} \cdot g_t + \mathrm{grads}`,
@@ -100,7 +102,7 @@ class GradExpon(brainstate.nn.Module):
 
         Parameters
         ----------
-        grads : brainstate.typing.PyTree
+        grads : PyTree
             The new gradients to incorporate into the accumulated gradients.
             Must match the pytree structure of the accumulator.
 

--- a/braintrace/_state_managment.py
+++ b/braintrace/_state_managment.py
@@ -18,12 +18,12 @@ from typing import Sequence, Tuple, List, Hashable, Dict, Mapping, Any
 import brainstate
 
 pass  # ParamState removed (primitive-based ETP)
-from ._typing import Path
+from ._typing import Path, PyTree
 
 
 def assign_dict_state_values(
-    states: Dict[Path, brainstate.State],
-    state_values: Dict[Path, brainstate.typing.PyTree],
+    states: Mapping[Path, brainstate.State],
+    state_values: Mapping[Path, PyTree],
     write: bool = True
 ):
     """
@@ -38,7 +38,7 @@ def assign_dict_state_values(
     states : Dict[Path, brainstate.State]
         A dictionary where keys are paths and values are state objects
         to which values will be assigned or restored.
-    state_values : Dict[Path, brainstate.typing.PyTree]
+    state_values : Dict[Path, PyTree]
         A dictionary where keys are paths and values are the values
         corresponding to each state in `states`.
     write : bool, optional
@@ -62,7 +62,7 @@ def assign_dict_state_values(
 
 def assign_state_values_v2(
     states: Mapping[Any, brainstate.State],
-    state_values: Mapping[Any, brainstate.typing.PyTree],
+    state_values: Mapping[Any, PyTree],
     write: bool = True
 ):
     """
@@ -77,7 +77,7 @@ def assign_state_values_v2(
     states : Dict[Hashable, brainstate.State]
         A dictionary where keys are hashable identifiers and values are state objects
         to which values will be assigned or restored.
-    state_values : Dict[Hashable, brainstate.typing.PyTree]
+    state_values : Dict[Hashable, PyTree]
         A dictionary where keys are hashable identifiers and values are the values
         corresponding to each state in `states`.
     write : bool, optional
@@ -106,18 +106,18 @@ def assign_state_values_v2(
 
 def sequence_split_state_values(
     states: Sequence[brainstate.State],
-    state_values: List[brainstate.typing.PyTree],
+    state_values: List[PyTree],
     include_weight: bool = True
 ) -> (
     Tuple[
-        Sequence[brainstate.typing.PyTree],
-        Sequence[brainstate.typing.PyTree],
-        Sequence[brainstate.typing.PyTree]
+        Sequence[PyTree],
+        Sequence[PyTree],
+        Sequence[PyTree]
     ]
     |
     Tuple[
-        Sequence[brainstate.typing.PyTree],
-        Sequence[brainstate.typing.PyTree]
+        Sequence[PyTree],
+        Sequence[PyTree]
     ]
 ):
     """

--- a/braintrace/_typing.py
+++ b/braintrace/_typing.py
@@ -19,6 +19,7 @@ from typing import Dict, Sequence, Union, FrozenSet, List, Tuple, Any, TypeAlias
 
 import brainstate
 import jax
+import numpy as np
 
 from ._compatible_imports import Var
 
@@ -32,6 +33,31 @@ StateID: TypeAlias = int
 WeightID: TypeAlias = int
 Size: TypeAlias = brainstate.typing.Size
 Axis: TypeAlias = int
+
+
+def as_size_tuple(size: Size) -> Tuple[int, ...]:
+    """Normalize an ``in_size``/``out_size`` spec to a tuple of ints.
+
+    ``brainstate``'s size setters accept a scalar ``int`` or a sequence, while
+    the matching getters are typed as the broad :data:`Size` union, which static
+    type checkers do not treat as indexable. Routing values through this helper
+    yields a concrete ``tuple[int, ...]`` so both property assignment and
+    trailing-dimension lookups (``size[-1]``) type-check cleanly, reproducing
+    ``brainstate``'s own normalization at runtime.
+
+    Parameters
+    ----------
+    size : Size
+        A scalar ``int`` / numpy integer, or a sequence of them.
+
+    Returns
+    -------
+    tuple of int
+        The size expressed as a tuple of Python ints.
+    """
+    if isinstance(size, (int, np.integer)):
+        return (int(size),)
+    return tuple(int(s) for s in size)
 Axes: TypeAlias = Union[int, Sequence[int]]
 Path: TypeAlias = Tuple[str, ...]
 

--- a/braintrace/nn/_conv.py
+++ b/braintrace/nn/_conv.py
@@ -60,17 +60,17 @@ def _etp_conv_op(self, x, params):
 
 class Conv1d(brainstate.nn.Conv1d):
     __module__ = 'braintrace.nn'
-    __doc__ = brainstate.nn.Conv1d.__doc__.replace('brainstate', 'braintrace')
+    __doc__ = (brainstate.nn.Conv1d.__doc__ or '').replace('brainstate', 'braintrace')
     _conv_op = _etp_conv_op
 
 
 class Conv2d(brainstate.nn.Conv2d):
     __module__ = 'braintrace.nn'
-    __doc__ = brainstate.nn.Conv2d.__doc__.replace('brainstate', 'braintrace')
+    __doc__ = (brainstate.nn.Conv2d.__doc__ or '').replace('brainstate', 'braintrace')
     _conv_op = _etp_conv_op
 
 
 class Conv3d(brainstate.nn.Conv3d):
     __module__ = 'braintrace.nn'
-    __doc__ = brainstate.nn.Conv3d.__doc__.replace('brainstate', 'braintrace')
+    __doc__ = (brainstate.nn.Conv3d.__doc__ or '').replace('brainstate', 'braintrace')
     _conv_op = _etp_conv_op

--- a/braintrace/nn/_conv_test.py
+++ b/braintrace/nn/_conv_test.py
@@ -494,12 +494,12 @@ class TestConv3d:
         assert y.shape[-1] == 64
 
     def test_conv3d_explicit_padding_tuple(self):
-        """Test Conv3d with explicit tuple padding."""
+        """Test Conv3d with explicit tuple padding (one value per spatial dim)."""
         conv = braintrace.nn.Conv3d(
             in_size=(16, 16, 16, 3),
             out_channels=64,
             kernel_size=3,
-            padding=(1, 1)
+            padding=(1, 1, 1)
         )
         x = brainstate.random.randn(2, 16, 16, 16, 3)
         y = conv(x)
@@ -662,17 +662,17 @@ class TestConvEdgeCases:
 
     def test_conv_invalid_groups_out_channels(self):
         """Test that out_channels must be divisible by groups."""
-        with pytest.raises(AssertionError):
+        with pytest.raises(ValueError):
             braintrace.nn.Conv2d(in_size=(28, 28, 4), out_channels=9, kernel_size=3, groups=2)
 
     def test_conv_invalid_groups_in_channels(self):
         """Test that in_channels must be divisible by groups."""
-        with pytest.raises(AssertionError):
+        with pytest.raises(ValueError):
             braintrace.nn.Conv2d(in_size=(28, 28, 3), out_channels=8, kernel_size=3, groups=2)
 
     def test_conv_invalid_padding_string(self):
         """Test that only SAME and VALID are accepted as string padding."""
-        with pytest.raises(AssertionError):
+        with pytest.raises(ValueError):
             braintrace.nn.Conv2d(
                 in_size=(28, 28, 3),
                 out_channels=32,
@@ -693,7 +693,7 @@ class TestConvEdgeCases:
 
     def test_conv_invalid_in_size_length(self):
         """Test that in_size must have correct length."""
-        with pytest.raises(AssertionError):
+        with pytest.raises(ValueError):
             braintrace.nn.Conv2d(
                 in_size=(28, 3),  # Should be 3D for Conv2d
                 out_channels=32,

--- a/braintrace/nn/_linear.py
+++ b/braintrace/nn/_linear.py
@@ -31,7 +31,7 @@ __all__ = [
 
 class Linear(brainstate.nn.Linear):
     __module__ = 'braintrace.nn'
-    __doc__ = brainstate.nn.Linear.__doc__.replace('brainstate', 'braintrace')
+    __doc__ = (brainstate.nn.Linear.__doc__ or '').replace('brainstate', 'braintrace')
 
     def update(self, x):
         """Apply the linear transform through the ETP ``matmul`` primitive.
@@ -59,7 +59,7 @@ class Linear(brainstate.nn.Linear):
 
 class SignedWLinear(brainstate.nn.SignedWLinear):
     __module__ = 'braintrace.nn'
-    __doc__ = brainstate.nn.SignedWLinear.__doc__.replace('brainstate', 'braintrace')
+    __doc__ = (brainstate.nn.SignedWLinear.__doc__ or '').replace('brainstate', 'braintrace')
 
     def update(self, x):
         """Apply the sign-constrained linear transform through ETP ``matmul``.
@@ -86,7 +86,7 @@ class SignedWLinear(brainstate.nn.SignedWLinear):
 
 class ScaledWSLinear(brainstate.nn.ScaledWSLinear):
     __module__ = 'braintrace.nn'
-    __doc__ = brainstate.nn.ScaledWSLinear.__doc__.replace('brainstate', 'braintrace')
+    __doc__ = (brainstate.nn.ScaledWSLinear.__doc__ or '').replace('brainstate', 'braintrace')
 
     def update(self, x):
         """Apply the weight-standardized linear transform through ETP ``matmul``.
@@ -115,7 +115,7 @@ class ScaledWSLinear(brainstate.nn.ScaledWSLinear):
 
 class SparseLinear(brainstate.nn.SparseLinear):
     __module__ = 'braintrace.nn'
-    __doc__ = brainstate.nn.SparseLinear.__doc__.replace('brainstate', 'braintrace')
+    __doc__ = (brainstate.nn.SparseLinear.__doc__ or '').replace('brainstate', 'braintrace')
 
     def update(self, x):
         """Apply the sparse linear transform through the ETP ``sparse_matmul``.

--- a/braintrace/nn/_readout.py
+++ b/braintrace/nn/_readout.py
@@ -15,7 +15,6 @@
 
 # -*- coding: utf-8 -*-
 
-import numbers
 from typing import Callable, Optional
 
 import brainstate
@@ -23,7 +22,7 @@ import braintools
 import saiunit as u
 
 from braintrace._etrace_op import matmul
-from braintrace._typing import Size, ArrayLike
+from braintrace._typing import Size, ArrayLike, as_size_tuple
 
 __all__ = [
     'LeakyRateReadout',
@@ -104,16 +103,16 @@ class LeakyRateReadout(brainstate.nn.Module):
         self,
         in_size: Size,
         out_size: Size,
-        tau: ArrayLike = 5. * u.ms,
+        tau: ArrayLike = 5. * u.ms,  # type: ignore[assignment]  # saiunit types `float * Unit` as `Unit | Quantity`
         w_init: Callable = braintools.init.KaimingNormal(),
         r_init: Callable = braintools.init.ZeroInit(),
         name: Optional[str] = None,
     ):
-        super().__init__(name=name)
+        super().__init__(name=name)  # type: ignore[call-arg]  # brainstate hides Module.__init__ from type checkers
 
         # parameters
-        self.in_size = (in_size,) if isinstance(in_size, numbers.Integral) else tuple(in_size)
-        self.out_size = (out_size,) if isinstance(out_size, numbers.Integral) else tuple(out_size)
+        self.in_size = as_size_tuple(in_size)
+        self.out_size = as_size_tuple(out_size)
         self.tau = braintools.init.param(tau, self.out_size)
         # Compute decay handling units properly
         tau_normalized = u.maybe_decimal(self.tau / brainstate.environ.get_dt())
@@ -122,7 +121,7 @@ class LeakyRateReadout(brainstate.nn.Module):
 
         # weights
         self.W = brainstate.ParamState(
-            braintools.init.param(w_init, (self.in_size[0], self.out_size[0]))
+            braintools.init.param(w_init, (as_size_tuple(self.in_size)[0], as_size_tuple(self.out_size)[0]))
         )
 
     def init_state(self, batch_size=None, **kwargs):

--- a/braintrace/nn/_rnn.py
+++ b/braintrace/nn/_rnn.py
@@ -14,14 +14,14 @@
 # ==============================================================================
 # -*- coding: utf-8 -*-
 
-from typing import Callable, Union
+from typing import Any, Callable, Union
 
 import brainstate
 import braintools
 import saiunit as u
 
 from braintrace._etrace_op import element_wise
-from braintrace._typing import ArrayLike
+from braintrace._typing import ArrayLike, as_size_tuple as _as_size_tuple
 from ._linear import Linear
 
 __all__ = [
@@ -89,12 +89,12 @@ class ValinaRNNCell(brainstate.nn.RNNCell):
         activation: str | Callable = 'relu',
         name: str = None,
     ):
-        super().__init__(name=name)
+        super().__init__(name=name)  # type: ignore[call-arg]
 
         # parameters
         self._state_initializer = state_init
-        self.out_size = out_size
-        self.in_size = in_size
+        self.out_size = _as_size_tuple(out_size)
+        self.in_size = _as_size_tuple(in_size)
 
         # activation function
         if isinstance(activation, str):
@@ -105,7 +105,7 @@ class ValinaRNNCell(brainstate.nn.RNNCell):
 
         # weights
         self.W = Linear(
-            self.in_size[-1] + self.out_size[-1], self.out_size[-1],
+            _as_size_tuple(self.in_size)[-1] + _as_size_tuple(self.out_size)[-1], _as_size_tuple(self.out_size)[-1],
             w_init=w_init,
             b_init=b_init,
         )
@@ -188,12 +188,12 @@ class GRUCell(brainstate.nn.RNNCell):
         activation: str | Callable = 'tanh',
         name: str = None,
     ):
-        super().__init__(name=name)
+        super().__init__(name=name)  # type: ignore[call-arg]
 
         # parameters
         self._state_initializer = state_init
-        self.out_size = out_size
-        self.in_size = in_size
+        self.out_size = _as_size_tuple(out_size)
+        self.in_size = _as_size_tuple(in_size)
 
         # activation function
         if isinstance(activation, str):
@@ -203,10 +203,10 @@ class GRUCell(brainstate.nn.RNNCell):
             self.activation = activation
 
         # weights
-        params = dict(w_init=w_init, b_init=b_init)
-        self.Wz = Linear(self.in_size[-1] + self.out_size[-1], self.out_size[-1], **params)
-        self.Wr = Linear(self.in_size[-1] + self.out_size[-1], self.out_size[-1], **params)
-        self.Wh = Linear(self.in_size[-1] + self.out_size[-1], self.out_size[-1], **params)
+        params: dict[str, Any] = dict(w_init=w_init, b_init=b_init)
+        self.Wz = Linear(_as_size_tuple(self.in_size)[-1] + _as_size_tuple(self.out_size)[-1], _as_size_tuple(self.out_size)[-1], **params)
+        self.Wr = Linear(_as_size_tuple(self.in_size)[-1] + _as_size_tuple(self.out_size)[-1], _as_size_tuple(self.out_size)[-1], **params)
+        self.Wh = Linear(_as_size_tuple(self.in_size)[-1] + _as_size_tuple(self.out_size)[-1], _as_size_tuple(self.out_size)[-1], **params)
 
     def init_state(self, batch_size: int = None, **kwargs):
         self.h = brainstate.HiddenState(braintools.init.param(self._state_initializer, self.out_size, batch_size))
@@ -290,12 +290,12 @@ class CFNCell(brainstate.nn.RNNCell):
         activation: str | Callable = 'tanh',
         name: str = None,
     ):
-        super().__init__(name=name)
+        super().__init__(name=name)  # type: ignore[call-arg]
 
         # parameters
         self._state_initializer = state_init
-        self.out_size = out_size
-        self.in_size = in_size
+        self.out_size = _as_size_tuple(out_size)
+        self.in_size = _as_size_tuple(in_size)
 
         # activation function
         if isinstance(activation, str):
@@ -305,10 +305,10 @@ class CFNCell(brainstate.nn.RNNCell):
             self.activation = activation
 
         # weights
-        params = dict(w_init=w_init, b_init=b_init)
-        self.Wf = Linear(self.in_size[-1] + self.out_size[-1], self.out_size[-1], **params)
-        self.Wi = Linear(self.in_size[-1] + self.out_size[-1], self.out_size[-1], **params)
-        self.Wh = Linear(self.out_size[-1], self.out_size[-1], **params)
+        params: dict[str, Any] = dict(w_init=w_init, b_init=b_init)
+        self.Wf = Linear(_as_size_tuple(self.in_size)[-1] + _as_size_tuple(self.out_size)[-1], _as_size_tuple(self.out_size)[-1], **params)
+        self.Wi = Linear(_as_size_tuple(self.in_size)[-1] + _as_size_tuple(self.out_size)[-1], _as_size_tuple(self.out_size)[-1], **params)
+        self.Wh = Linear(_as_size_tuple(self.out_size)[-1], _as_size_tuple(self.out_size)[-1], **params)
 
     def init_state(self, batch_size: int = None, **kwargs):
         self.h = brainstate.HiddenState(braintools.init.param(self._state_initializer, self.out_size, batch_size))
@@ -406,12 +406,12 @@ class MGUCell(brainstate.nn.RNNCell):
         activation: str | Callable = 'tanh',
         name: str = None,
     ):
-        super().__init__(name=name)
+        super().__init__(name=name)  # type: ignore[call-arg]
 
         # parameters
         self._state_initializer = state_init
-        self.out_size = out_size
-        self.in_size = in_size
+        self.out_size = _as_size_tuple(out_size)
+        self.in_size = _as_size_tuple(in_size)
 
         # activation function
         if isinstance(activation, str):
@@ -421,9 +421,9 @@ class MGUCell(brainstate.nn.RNNCell):
             self.activation = activation
 
         # weights
-        params = dict(w_init=w_init, b_init=b_init)
-        self.Wf = Linear(self.in_size[-1] + self.out_size[-1], self.out_size[-1], **params)
-        self.Wh = Linear(self.in_size[-1] + self.out_size[-1], self.out_size[-1], **params)
+        params: dict[str, Any] = dict(w_init=w_init, b_init=b_init)
+        self.Wf = Linear(_as_size_tuple(self.in_size)[-1] + _as_size_tuple(self.out_size)[-1], _as_size_tuple(self.out_size)[-1], **params)
+        self.Wh = Linear(_as_size_tuple(self.in_size)[-1] + _as_size_tuple(self.out_size)[-1], _as_size_tuple(self.out_size)[-1], **params)
 
     def init_state(self, batch_size: int = None, **kwargs):
         self.h = brainstate.HiddenState(braintools.init.param(self._state_initializer, self.out_size, batch_size))
@@ -536,11 +536,11 @@ class LSTMCell(brainstate.nn.RNNCell):
         activation: str | Callable = 'tanh',
         name: str = None,
     ):
-        super().__init__(name=name)
+        super().__init__(name=name)  # type: ignore[call-arg]
 
         # parameters
-        self.out_size = out_size
-        self.in_size = in_size
+        self.out_size = _as_size_tuple(out_size)
+        self.in_size = _as_size_tuple(in_size)
 
         # initializers
         self._state_initializer = state_init
@@ -553,11 +553,11 @@ class LSTMCell(brainstate.nn.RNNCell):
             self.activation = activation
 
         # weights
-        params = dict(w_init=w_init, b_init=b_init)
-        self.Wi = Linear(self.in_size[-1] + self.out_size[-1], self.out_size[-1], **params)
-        self.Wg = Linear(self.in_size[-1] + self.out_size[-1], self.out_size[-1], **params)
-        self.Wf = Linear(self.in_size[-1] + self.out_size[-1], self.out_size[-1], **params)
-        self.Wo = Linear(self.in_size[-1] + self.out_size[-1], self.out_size[-1], **params)
+        params: dict[str, Any] = dict(w_init=w_init, b_init=b_init)
+        self.Wi = Linear(_as_size_tuple(self.in_size)[-1] + _as_size_tuple(self.out_size)[-1], _as_size_tuple(self.out_size)[-1], **params)
+        self.Wg = Linear(_as_size_tuple(self.in_size)[-1] + _as_size_tuple(self.out_size)[-1], _as_size_tuple(self.out_size)[-1], **params)
+        self.Wf = Linear(_as_size_tuple(self.in_size)[-1] + _as_size_tuple(self.out_size)[-1], _as_size_tuple(self.out_size)[-1], **params)
+        self.Wo = Linear(_as_size_tuple(self.in_size)[-1] + _as_size_tuple(self.out_size)[-1], _as_size_tuple(self.out_size)[-1], **params)
 
     def init_state(self, batch_size: int = None, **kwargs):
         self.c = brainstate.HiddenState(braintools.init.param(self._state_initializer, self.out_size, batch_size))
@@ -644,11 +644,11 @@ class URLSTMCell(brainstate.nn.RNNCell):
         activation: str | Callable = 'tanh',
         name: str = None,
     ):
-        super().__init__(name=name)
+        super().__init__(name=name)  # type: ignore[call-arg]
 
         # parameters
-        self.out_size = out_size
-        self.in_size = in_size
+        self.out_size = _as_size_tuple(out_size)
+        self.in_size = _as_size_tuple(in_size)
 
         # initializers
         self._state_initializer = state_init
@@ -661,15 +661,15 @@ class URLSTMCell(brainstate.nn.RNNCell):
             self.activation = activation
 
         # weights
-        params = dict(w_init=w_init, b_init=None)
-        self.Wu = Linear(self.in_size[-1] + self.out_size[-1], self.out_size[-1], **params)
-        self.Wf = Linear(self.in_size[-1] + self.out_size[-1], self.out_size[-1], **params)
-        self.Wr = Linear(self.in_size[-1] + self.out_size[-1], self.out_size[-1], **params)
-        self.Wo = Linear(self.in_size[-1] + self.out_size[-1], self.out_size[-1], **params)
+        params: dict[str, Any] = dict(w_init=w_init, b_init=None)
+        self.Wu = Linear(_as_size_tuple(self.in_size)[-1] + _as_size_tuple(self.out_size)[-1], _as_size_tuple(self.out_size)[-1], **params)
+        self.Wf = Linear(_as_size_tuple(self.in_size)[-1] + _as_size_tuple(self.out_size)[-1], _as_size_tuple(self.out_size)[-1], **params)
+        self.Wr = Linear(_as_size_tuple(self.in_size)[-1] + _as_size_tuple(self.out_size)[-1], _as_size_tuple(self.out_size)[-1], **params)
+        self.Wo = Linear(_as_size_tuple(self.in_size)[-1] + _as_size_tuple(self.out_size)[-1], _as_size_tuple(self.out_size)[-1], **params)
         self.bias = brainstate.ParamState(self._forget_bias())
 
     def _forget_bias(self):
-        rand_val = brainstate.random.uniform(1 / self.out_size[-1], 1 - 1 / self.out_size[-1], (self.out_size[-1],))
+        rand_val = brainstate.random.uniform(1 / _as_size_tuple(self.out_size)[-1], 1 - 1 / _as_size_tuple(self.out_size)[-1], (_as_size_tuple(self.out_size)[-1],))
         return -u.math.log(1 / rand_val - 1)
 
     def init_state(self, batch_size: int = None, **kwargs):
@@ -780,22 +780,22 @@ class MinimalRNNCell(brainstate.nn.RNNCell):
         phi: Callable = None,
         name: str = None,
     ):
-        super().__init__(name=name)
+        super().__init__(name=name)  # type: ignore[call-arg]
 
         # parameters
         self._state_initializer = state_init
-        self.out_size = out_size
-        self.in_size = in_size
+        self.out_size = _as_size_tuple(out_size)
+        self.in_size = _as_size_tuple(in_size)
 
         # functions
-        params = dict(w_init=w_init, b_init=b_init)
+        params: dict[str, Any] = dict(w_init=w_init, b_init=b_init)
         if phi is None:
-            phi = Linear(self.in_size[-1], self.out_size[-1], **params)
+            phi = Linear(_as_size_tuple(self.in_size)[-1], _as_size_tuple(self.out_size)[-1], **params)
         assert callable(phi), f"The phi function should be a callable function. But got {phi}"
         self.phi = phi
 
         # weights
-        self.W_u = Linear(self.out_size[-1] * 2, self.out_size[-1], **params)
+        self.W_u = Linear(_as_size_tuple(self.out_size)[-1] * 2, _as_size_tuple(self.out_size)[-1], **params)
 
     def init_state(self, batch_size: int = None, **kwargs):
         self.h = brainstate.HiddenState(braintools.init.param(self._state_initializer, self.out_size, batch_size))
@@ -881,19 +881,19 @@ class MiniGRU(brainstate.nn.RNNCell):
         state_init: Union[ArrayLike, Callable] = braintools.init.ZeroInit(),
         name: str = None,
     ):
-        super().__init__(name=name)
+        super().__init__(name=name)  # type: ignore[call-arg]
 
         # parameters
         self._state_initializer = state_init
-        self.out_size = out_size
-        self.in_size = in_size
+        self.out_size = _as_size_tuple(out_size)
+        self.in_size = _as_size_tuple(in_size)
 
         # functions
-        params = dict(w_init=w_init, b_init=b_init)
-        self.W_x = Linear(self.in_size[-1], self.out_size[-1], **params)
+        params: dict[str, Any] = dict(w_init=w_init, b_init=b_init)
+        self.W_x = Linear(_as_size_tuple(self.in_size)[-1], _as_size_tuple(self.out_size)[-1], **params)
 
         # weights
-        self.W_z = Linear(self.in_size[-1] + self.out_size[-1], self.out_size[-1], **params)
+        self.W_z = Linear(_as_size_tuple(self.in_size)[-1] + _as_size_tuple(self.out_size)[-1], _as_size_tuple(self.out_size)[-1], **params)
 
     def init_state(self, batch_size: int = None, **kwargs):
         self.h = brainstate.HiddenState(braintools.init.param(self._state_initializer, self.out_size, batch_size))
@@ -978,20 +978,20 @@ class MiniLSTM(brainstate.nn.RNNCell):
         state_init: Union[ArrayLike, Callable] = braintools.init.ZeroInit(),
         name: str = None,
     ):
-        super().__init__(name=name)
+        super().__init__(name=name)  # type: ignore[call-arg]
 
         # parameters
         self._state_initializer = state_init
-        self.out_size = out_size
-        self.in_size = in_size
+        self.out_size = _as_size_tuple(out_size)
+        self.in_size = _as_size_tuple(in_size)
 
         # functions
-        params = dict(w_init=w_init, b_init=b_init)
-        self.W_x = Linear(self.in_size[-1], self.out_size[-1], **params)
+        params: dict[str, Any] = dict(w_init=w_init, b_init=b_init)
+        self.W_x = Linear(_as_size_tuple(self.in_size)[-1], _as_size_tuple(self.out_size)[-1], **params)
 
         # weights
-        self.W_f = Linear(self.in_size[-1] + self.out_size[-1], self.out_size[-1], **params)
-        self.W_i = Linear(self.in_size[-1] + self.out_size[-1], self.out_size[-1], **params)
+        self.W_f = Linear(_as_size_tuple(self.in_size)[-1] + _as_size_tuple(self.out_size)[-1], _as_size_tuple(self.out_size)[-1], **params)
+        self.W_i = Linear(_as_size_tuple(self.in_size)[-1] + _as_size_tuple(self.out_size)[-1], _as_size_tuple(self.out_size)[-1], **params)
 
     def init_state(self, batch_size: int = None, **kwargs):
         self.h = brainstate.HiddenState(braintools.init.param(self._state_initializer, self.out_size, batch_size))


### PR DESCRIPTION
## Summary

The scheduled **daily CI** began failing on the frozen commit `d0627d4` purely from upstream dependency drift (CI was green 2026-06-01, red from 2026-06-02 on the same commit). Diagnosis found **four independent root causes**; this PR fixes the three braintrace-side ones. The fourth was an upstream `saiunit` bug, now fixed in `saiunit`/`brainunit` **0.5.1** — no braintrace change required.

| # | Failure | Root cause | Fix |
|---|---------|-----------|-----|
| 1 | Collection error (`GraphNodeMeta has no len()`) | pytest 9.1.0 parses `'cls,'` trailing comma as 2 values | drop trailing commas in 4 compiler test files |
| 2 | 154 mypy errors | brainstate 0.4+ ships `py.typed` | adopt the typed API in source |
| 3 | 5 conv tests | brainstate 0.5.0 hardened validation (`assert`→`ValueError`) + padding-tuple semantics | update `_conv_test` expectations |
| 4 | 40 SNN VJP tests | `saiunit` 0.4.0 `str`-mantissa guard crashed JAX 0.10.1's `custom_vjp` error-rendering for any unit-carrying output | **fixed upstream in saiunit 0.5.1** |

### Details

- **#1** — pytest 9.1.0's `ParameterSet._for_parametrize` length check treats a single-arg id with a trailing comma (`'cls,'`) as two parameters. Removed the trailing commas (`module_info_test`, `hidden_group_test`, `hid_param_op_test`, `hidden_pertubation_test`).
- **#2** — Routed `PyTree` through braintrace's existing alias, centralized an `as_size_tuple()` helper in `_typing`, dropped `FlattedDict` subscripts, and added boundary asserts/casts. `# type: ignore` only where brainstate's typing makes it unavoidable (hidden `Module.__init__`, saiunit `Unit|Quantity`, treedef-as-PyTree).
- **#3** — brainstate 0.5.0 raises `ValueError` (not bare `assert`) for invalid groups/padding-string/in_size, and interprets an int padding tuple as one value per spatial dim. Updated the affected expectations only.
- **#4** — No braintrace bug: JAX 0.10.1 eagerly builds a display tree via `tree_unflatten(out_tree, [aval.str_short() …])` (string leaves) before the structure-match check; saiunit 0.4.0's new `str`-mantissa guard crashed on those strings for every `custom_vjp` carrying a `Quantity`. Fixed in saiunit by letting `tree_unflatten` round-trip placeholder leaves.

## Verification (local, mirrors CI)

- `pytest braintrace/` → **1367 passed, 3 skipped, 2 xfailed, 0 failed**
- `mypy braintrace` → **Success: no issues found in 51 source files**
- `python -m build` → wheel + sdist build; **py.typed shipped** in both (PEP 561)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Restore compatibility with newer pytest and the typed brainstate/brainunit stack by tightening typing, normalizing size handling, and aligning tests with updated runtime validation and PyTree semantics.

Bug Fixes:
- Fix RNN, readout, and tracing components to use normalized size tuples and robust PyTree/unit handling so they work with brainstate 0.5's typed API.
- Adjust convolution tests and padding/group validation expectations to match brainstate's updated error types and padding semantics.
- Update parametrized compiler tests to avoid pytest 9.1 collection errors caused by single-argument parameter IDs with trailing commas.

Enhancements:
- Introduce a shared as_size_tuple helper and centralize PyTree aliases to satisfy static type checking with brainstate's exported typing, including safer use of FlattedDict and cached PyTreeDefs.
- Harden algorithm and executor internals with explicit type annotations, runtime asserts, and nullability checks for state splits and filtered state views.
- Guard docstring propagation and registry definitions to be type-checker friendly under the new dependency versions.