### PR TITLE
release: 0.2.1

### DIFF
--- a/braintrace/_version.py
+++ b/braintrace/_version.py
@@ -13,5 +13,5 @@
 # limitations under the License.
 # ==============================================================================
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"
 __version_info__ = tuple(map(int, __version__.split('.')))

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,39 @@
 # Release Notes
 
 
+## Version 0.2.1
+
+This is a maintenance release that restores compatibility with the latest
+brain-ecosystem dependencies and toolchain. It contains no functional or
+public-API changes — code written against 0.2.0 continues to work unchanged —
+and exists to keep BrainTrace green against `brainstate` 0.5, `saiunit`/
+`brainunit` 0.5.1, and `pytest` 9.1.
+
+### Fixes
+
+#### Dependency Compatibility
+
+- **`brainstate` 0.5 typed API**: adopted `brainstate`'s PEP 561 `py.typed`
+  surface throughout the source — routed `PyTree` through BrainTrace's existing
+  type alias, centralized an `as_size_tuple()` helper in `_typing`, dropped
+  `FlattedDict` subscripts, and added boundary asserts/casts. This clears the
+  154 mypy errors newly exposed by the upstream typing, with minimal
+  `# type: ignore` only where `brainstate`'s typing makes it unavoidable.
+- **`brainstate` 0.5.0 convolution validation**: updated convolution test
+  expectations for the hardened validation (bare `assert` → `ValueError`) and
+  the new one-value-per-spatial-dimension padding-tuple semantics.
+- **`pytest` 9.1.0 collection**: removed trailing commas in single-argument
+  `parametrize` ids that `pytest` 9.1.0 mis-parses as two values, fixing a
+  collection-time `GraphNodeMeta has no len()` error.
+
+### Notes
+
+- All changes are BrainTrace-side. A related upstream `saiunit` issue is
+  resolved in `saiunit`/`brainunit` 0.5.1 and requires no change here.
+- Verified locally: full suite 1367 passed (2 xfailed), mypy clean across 51
+  files, and wheel + sdist build with `py.typed` shipped (PEP 561).
+
+
 ## Version 0.2.0
 
 This release is a major step for BrainTrace. It adds a family of spiking neural


### PR DESCRIPTION
## Summary

Prepare the **0.2.1** maintenance release.

- Bump `braintrace/_version.py` from `0.2.0` → `0.2.1`.
- Add a `## Version 0.2.1` section to `changelog.md`.

0.2.1 is a maintenance release that restores compatibility with the latest
brain-ecosystem dependencies and toolchain (`brainstate` 0.5, `saiunit`/
`brainunit` 0.5.1, `pytest` 9.1), shipped in #102. There are **no functional
or public-API changes** — code written against 0.2.0 works unchanged.

The Publish workflow verifies the release tag matches `braintrace/_version.py`,
so this bump is required before tagging `v0.2.1`.

## Verification

From #102, verified locally: full suite 1367 passed (2 xfailed), mypy clean
across 51 files, and wheel + sdist build with `py.typed` shipped (PEP 561).

## Summary by Sourcery

Prepare the 0.2.1 maintenance release to restore compatibility with updated brain-ecosystem dependencies and testing/tooling stack.

Bug Fixes:
- Restore compatibility with brainstate 0.5, saiunit/brainunit 0.5.1, and pytest 9.1 without changing public APIs or behavior.

Enhancements:
- Document the 0.2.1 maintenance release details, including dependency compatibility updates and verification status, in the changelog.

Build:
- Bump the internal package version from 0.2.0 to 0.2.1 for the new release.