### PR TITLE
Restore etrace convergence under vmap batching; repair docs notebooks

### DIFF
--- a/braintrace/_etrace_algorithms/base.py
+++ b/braintrace/_etrace_algorithms/base.py
@@ -222,6 +222,18 @@ class ETraceAlgorithm(brainstate.nn.Module):
             The input arguments.
         """
 
+        # ``vmap_new_states`` / ``vmap2_new_states`` run an eager *discovery
+        # probe* that executes the surrounding ``init`` (including this call)
+        # once against throwaway, un-batched states before the real mapped
+        # pass. Compiling there would bind the executor to those probe states
+        # (which are discarded and left untagged), so the subsequent
+        # ``brainstate.nn.Vmap(..., vmap_states='new')`` would not cover them
+        # and writing a batched value raises ``BatchAxisError``. Defer to the
+        # real mapped pass, which creates the 'new'-tagged batched states.
+        _in_probe = getattr(brainstate.transform, 'in_new_state_probe', None)
+        if _in_probe is not None and _in_probe():
+            return
+
         if not self.is_compiled:
             # --- invalidate cached state splits --- #
             self._param_states = None

--- a/braintrace/_etrace_algorithms/conv_vmap_correctness_test.py
+++ b/braintrace/_etrace_algorithms/conv_vmap_correctness_test.py
@@ -1,0 +1,327 @@
+# Copyright 2026 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Conv / mixed ETP under ``brainstate.nn.Vmap(vmap_states='new')`` correctness.
+
+Regression coverage for the eligibility-trace path through the *batched* online
+executor wrapped by ``brainstate.nn.Vmap`` (the ``OnlineVmapTrainer`` flow used
+by ``examples/004``). This path was previously uncovered — conv was exercised
+only at the rule level (``_etrace_op/conv_test.py``) and the "conv" model in
+``transform_correctness_test`` is actually a matmul — which let two regressions
+through:
+
+1. *Pure conv.* A conv forward forces a leading batch axis on its input, but
+   under ``vmap_states='new'`` the hidden-state traces are per-lane and carry no
+   batch axis, so the instantaneous, recurrent and solve terms saw a singleton
+   batch on the input but none on the cotangent.
+
+2. *Mixed batched + unbatched.* When a conv (batched primitive) is composed with
+   a ``Linear`` that, compiled per-lane, dispatches to the *unbatched* ``etp_mv``
+   (1-D input), the solve's trailing batch-sum was gated on a global "any
+   relation batched" flag and so collapsed the *unbatched* Linear gradient's
+   leading in-feature axis too — the ``examples/004`` layer4 failure.
+
+3. *Norm in the transition.* ``conv -> LayerNorm -> IF`` makes ``dh/dy``
+   non-diagonal; the all-ones jvp returns its row sums, exactly zero for the
+   shift-invariant norm. A ``use_fast_variance=True`` norm leaves a float32
+   residual instead, which under ``vmap_states='new'`` the recurrent trace and
+   ``rsqrt(var+eps)`` amplify into an overflow that diverges from the eager
+   reference — the ``examples/004`` ``loss=ln(10)`` stall.
+
+**Oracle (exact, transform-invariance).** ``brainstate.nn.Vmap`` is a transform;
+for parameters shared across lanes its grad sums the per-lane gradients. So the
+gradient from the ``vmap_new_states`` + ``Vmap`` path on a batch of ``B`` samples
+must equal the sum over ``b`` of the *eager, batch=1* gradient on sample ``b``.
+The eager batch=1 path is independently healthy for conv (states are initialised
+*with* a size-1 batch, so input and trace batch axes agree), which makes it a
+trustworthy reference regardless of D_RTRL's approximation quality.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+import brainstate
+import braintrace
+import braintools
+import brainpy.state
+
+H = W = 6
+C_IN = 2
+C_OUT = 3
+B = 2
+N_STEP = 3
+SEED = 0
+
+
+@pytest.fixture(autouse=True)
+def _dt():
+    # Spiking-neuron dynamics need a simulation time step in the environment.
+    #
+    # These tests assert an *exact* transform-invariance identity (vmap grad ==
+    # sum of eager grads) to a tight rtol. On GPU, conv/matmul default to TF32
+    # (~1e-3 precision), and the vmap vs eager paths schedule those reduced-
+    # precision kernels differently -> a ~1% disagreement that has nothing to do
+    # with the etrace transform under test (the identity holds to ~1e-6 in true
+    # float32, as it does on CPU). Force highest matmul precision so the tolerance
+    # measures the transform, not the accelerator. Scoped per-test via the context
+    # manager, so it never leaks into other test modules sharing the process.
+    with jax.default_matmul_precision('highest'), brainstate.environ.context(dt=1.0):
+        yield
+
+
+def _make_net(neuron):
+    """Fresh conv -> spiking-neuron net with deterministic weights.
+
+    Pure conv -> neuron (no readout/flatten, which add their own batch handling)
+    isolates the conv ETP path. ``neuron='IF'`` gives a single-state group
+    (num_state == 1); ``neuron='ALIF'`` a coupled (V, a) group (num_state == 2),
+    exercising the multi-state recurrent + solve branches.
+    """
+    brainstate.random.seed(SEED)  # identical conv weights on every build
+    conv_inits = dict(w_init=braintools.init.XavierNormal(scale=5.0), b_init=None)
+    surr = braintools.surrogate.Arctan()
+
+    class Net(brainstate.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.conv = braintrace.nn.Conv2d(
+                (H, W, C_IN), C_OUT, kernel_size=3, padding=1, **conv_inits
+            )
+            if neuron == 'IF':
+                self.cell = brainpy.state.IF(
+                    self.conv.out_size, V_th=1.0, tau=2.0, spk_fun=surr,
+                    V_initializer=braintools.init.ZeroInit(), R=1.,
+                )
+            else:  # 'ALIF' — dimensionless config (num_state == 2)
+                self.cell = brainpy.state.ALIF(
+                    self.conv.out_size, V_th=1.0, V_reset=0.0, V_rest=0.0, R=1.0,
+                    tau=2.0, tau_a=20.0, beta=0.1, spk_fun=surr,
+                    V_initializer=braintools.init.ZeroInit(),
+                )
+
+        def update(self, x):
+            return self.cell(self.conv(x))
+
+    return Net()
+
+
+def _loss(out, target):
+    # Sum (not mean) so vmap(batch) == sum_b eager(b) exactly.
+    return ((out - target) ** 2).sum()
+
+
+def _eager_grad_one(sample_seq, target, make_net):
+    """Eager, batch=1 D_RTRL gradient accumulated over one sample's sequence."""
+    net = make_net()
+    brainstate.nn.init_all_states(net, batch_size=1)
+    algo = braintrace.D_RTRL(net)
+    with brainstate.environ.context(fit=True):
+        algo.compile_graph(sample_seq[0][None])
+    algo.init_etrace_state()
+    weights = net.states().subset(brainstate.ParamState)
+    grads = jax.tree.map(jnp.zeros_like, weights.to_dict_values())
+    for t in range(N_STEP):
+        def loss_fn(x):
+            with brainstate.environ.context(fit=True):
+                return _loss(algo.update(x), target[None])
+        g, _ = brainstate.transform.grad(loss_fn, weights, return_value=True)(sample_seq[t][None])
+        grads = jax.tree.map(lambda a, b: a + b, grads, g)
+    return grads
+
+
+def _vmap_grad(data, targets, make_net):
+    """The ``OnlineVmapTrainer`` flow: vmap_new_states init + Vmap(vmap_states='new')."""
+    net = make_net()
+    model = braintrace.D_RTRL(net)
+
+    @brainstate.transform.vmap_new_states(state_tag='new', axis_size=data.shape[1])
+    def init():
+        brainstate.nn.init_all_states(net)
+        with brainstate.environ.context(fit=True):
+            model.compile_graph(data[0, 0])
+
+    init()
+    vmodel = brainstate.nn.Vmap(model, vmap_states='new')
+    weights = net.states().subset(brainstate.ParamState)
+
+    def _grad(inp):
+        with brainstate.environ.context(fit=True):
+            return _loss(vmodel(inp), targets)
+
+    def _step(prev, x):
+        g = brainstate.transform.grad(_grad, weights)(x)
+        return jax.tree.map(lambda a, b: a + b, prev, g), None
+
+    grads = jax.tree.map(jnp.zeros_like, weights.to_dict_values())
+    grads, _ = brainstate.transform.scan(_step, grads, data)
+    return grads
+
+
+N_HID = 7  # mixed-net Linear out features (!= flattened conv size, so a wrong
+           # in-feature reduction is unmistakable in the gradient shape)
+
+
+def _make_mixed_net():
+    """conv -> IF -> flatten -> Linear -> IF: a *mixed* batched/unbatched model.
+
+    Under ``vmap_states='new'`` the graph is compiled per-lane, so the conv stays
+    a *batched* primitive (its parent layer forces a leading batch axis) while the
+    flattened ``Linear`` input is 1-D and dispatches to the *unbatched* ``etp_mv``.
+    The solve's trailing batch-sum must collapse only the conv gradient's batch
+    axis; applying it to the unbatched ``Linear`` grad would reduce its leading
+    in-feature axis ([flat, N_HID] -> [N_HID]) — the ``examples/004`` regression.
+    """
+    brainstate.random.seed(SEED)
+    surr = braintools.surrogate.Arctan()
+    if_param = dict(V_th=1.0, tau=2.0, spk_fun=surr,
+                    V_initializer=braintools.init.ZeroInit(), R=1.)
+
+    class Net(brainstate.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.conv = braintrace.nn.Conv2d(
+                (H, W, C_IN), C_OUT, kernel_size=3, padding=1,
+                w_init=braintools.init.XavierNormal(scale=5.0), b_init=None,
+            )
+            self.cell1 = brainpy.state.IF(self.conv.out_size, **if_param)
+            self._flat = int(np.prod(self.conv.out_size))
+            self.fc = braintrace.nn.Linear(
+                self._flat, N_HID, b_init=None,
+                w_init=braintools.init.XavierNormal(scale=5.0),
+            )
+            self.cell2 = brainpy.state.IF((N_HID,), **if_param)
+
+        def update(self, x):
+            s1 = self.cell1(self.conv(x))
+            flat = s1.reshape(s1.shape[:-3] + (self._flat,))
+            return self.cell2(self.fc(flat))
+
+    return Net()
+
+
+def _make_conv_ln_net(use_fast_variance):
+    """conv -> LayerNorm -> IF: a non-elementwise (mean-subtracting) transition.
+
+    The param-dim trace reads ``dh/dy`` through the norm via an all-ones jvp; for
+    a shift-invariant op its value is the Jacobian row sums = *exactly* zero (the
+    upstream conv gets no eligibility gradient through the norm — a documented
+    approximation, matching the eager path). That exactness is numerical: with
+    ``use_fast_variance=True`` the ``E[x^2]-E[x]^2`` variance leaves a float32
+    residual instead of zero, and under ``Vmap(vmap_states='new')`` the recurrent
+    trace and the large ``rsqrt(var+eps)`` factor amplify it into an overflow that
+    diverges from the eager reference (the ``examples/004`` ``loss=ln(10)`` stall).
+    """
+    brainstate.random.seed(SEED)
+    conv_inits = dict(w_init=braintools.init.XavierNormal(scale=5.0), b_init=None)
+    surr = braintools.surrogate.Arctan()
+
+    class Net(brainstate.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.conv = braintrace.nn.Conv2d(
+                (H, W, C_IN), C_OUT, kernel_size=3, padding=1, **conv_inits
+            )
+            self.ln = brainstate.nn.LayerNorm(
+                self.conv.out_size, use_fast_variance=use_fast_variance
+            )
+            self.cell = brainpy.state.IF(
+                self.conv.out_size, V_th=1.0, tau=2.0, spk_fun=surr,
+                V_initializer=braintools.init.ZeroInit(), R=1.,
+            )
+
+        def update(self, x):
+            return self.cell(self.ln(self.conv(x)))
+
+    return Net()
+
+
+def _assert_grads_match(ref, got):
+    ref_leaves = jax.tree.leaves(ref)
+    got_leaves = jax.tree.leaves(got)
+    assert len(ref_leaves) == len(got_leaves) and ref_leaves, 'no gradient leaves compared'
+    for e, a in zip(ref_leaves, got_leaves):
+        e, a = np.asarray(e), np.asarray(a)
+        assert a.shape == e.shape, f'shape mismatch: got {a.shape} vs ref {e.shape}'
+        # Relative tolerance: conv grads here are large-magnitude; float32 ~1e-6.
+        np.testing.assert_allclose(a, e, rtol=1e-4, atol=1e-5)
+
+
+@pytest.mark.parametrize('neuron', ['IF', 'ALIF'], ids=['num_state1_IF', 'num_state2_ALIF'])
+def test_conv_vmap_grad_equals_sum_of_eager_single_sample(neuron):
+    """vmap_new_states+Vmap conv D_RTRL grad == sum over samples of eager batch=1 grad."""
+    rng = np.random.RandomState(42)
+    data = jnp.asarray(rng.rand(N_STEP, B, H, W, C_IN).astype('float32'))
+    targets = jnp.asarray(rng.rand(B, H, W, C_OUT).astype('float32'))
+
+    make_net = lambda: _make_net(neuron)
+    ref = None
+    for b in range(B):
+        g = _eager_grad_one(data[:, b], targets[b], make_net)
+        ref = g if ref is None else jax.tree.map(lambda a, c: a + c, ref, g)
+
+    got = _vmap_grad(data, targets, make_net)
+    _assert_grads_match(ref, got)
+
+
+def test_mixed_conv_dense_vmap_grad_equals_sum_of_eager_single_sample():
+    """Mixed batched(conv)+unbatched(dense-mv) model: vmap grad == sum of eager batch=1.
+
+    Regression for the ``examples/004`` layer4 failure — the unbatched ``etp_mv``
+    Linear gradient was being batch-summed because a *different* relation (conv)
+    was batched, collapsing its in-feature axis.
+    """
+    rng = np.random.RandomState(42)
+    data = jnp.asarray(rng.rand(N_STEP, B, H, W, C_IN).astype('float32'))
+    targets = jnp.asarray(rng.rand(B, N_HID).astype('float32'))
+
+    ref = None
+    for b in range(B):
+        g = _eager_grad_one(data[:, b], targets[b], _make_mixed_net)
+        ref = g if ref is None else jax.tree.map(lambda a, c: a + c, ref, g)
+
+    got = _vmap_grad(data, targets, _make_mixed_net)
+    _assert_grads_match(ref, got)
+
+
+def test_conv_layernorm_vmap_grad_matches_eager_and_stays_finite():
+    """conv -> LayerNorm -> IF: vmap grad == sum of eager batch=1, and stays finite.
+
+    Regression for the ``examples/004`` ``loss=ln(10)`` stall. A mean-subtracting
+    norm makes ``dh/dy`` non-diagonal; the param-dim trace's all-ones jvp returns
+    its row sums, which for shift-invariance are exactly zero, so the conv weight
+    gets no eligibility gradient through the norm (both paths agree on ~0). With a
+    numerically stable variance (``use_fast_variance=False``) that exact zero holds
+    under ``Vmap(vmap_states='new')``; the transform-invariance oracle then makes
+    vmap == sum-of-eager, and neither explodes.
+    """
+    rng = np.random.RandomState(42)
+    data = jnp.asarray(rng.rand(N_STEP, B, H, W, C_IN).astype('float32'))
+    targets = jnp.asarray(rng.rand(B, H, W, C_OUT).astype('float32'))
+
+    make_net = lambda: _make_conv_ln_net(use_fast_variance=False)
+    ref = None
+    for b in range(B):
+        g = _eager_grad_one(data[:, b], targets[b], make_net)
+        ref = g if ref is None else jax.tree.map(lambda a, c: a + c, ref, g)
+
+    got = _vmap_grad(data, targets, make_net)
+    # No overflow/NaN in either path (the bug produced ~1e14 -> NaN under vmap).
+    for leaf in jax.tree.leaves(got):
+        assert np.all(np.isfinite(np.asarray(leaf))), 'vmap grad is non-finite'
+    for leaf in jax.tree.leaves(ref):
+        assert np.all(np.isfinite(np.asarray(leaf))), 'eager grad is non-finite'
+    _assert_grads_match(ref, got)

--- a/braintrace/_etrace_algorithms/param_dim_vjp.py
+++ b/braintrace/_etrace_algorithms/param_dim_vjp.py
@@ -288,13 +288,32 @@ def _update_param_dim_etrace_scan_fn(
             @partial(jax.vmap, in_axes=-1, out_axes=-1)
             def _inner(df_slice):
                 if batched:
-                    return jax.vmap(comp_dw_with_x)(x, df_slice)
+                    df_b = df_slice
+                    # Under ``brainstate.nn.Vmap(vmap_states='new')`` the hidden-
+                    # state trace (df) is per-lane and has lost its leading batch
+                    # axis, while a conv input still carries the singleton batch its
+                    # forward API requires (x = [1, *spatial, C]). Re-insert the
+                    # matching singleton so the per-sample vmap maps consistent
+                    # leading axes (collapsed again by the solve-time batch sum).
+                    if x is not None and x.ndim == df_b.ndim + 1:
+                        df_b = df_b[None]
+                    return jax.vmap(comp_dw_with_x)(x, df_b)
                 return comp_dw_with_x(x, df_slice)
 
             return _inner(df_all)
 
         def _comp_recurrent_legacy(diag_, old_bwg_, num_state_):
             """Legacy nested-vmap yw_to_w + sum path."""
+
+            # Under ``brainstate.nn.Vmap(vmap_states='new')`` the hidden-state
+            # Jacobian (diag) is per-lane and has lost its leading batch axis,
+            # while the weight trace (old_bwg) still carries the singleton batch
+            # from ``init_drtrl`` (``batch = x_var.shape[0]`` == 1 for a conv whose
+            # forward forces a batch axis). Re-insert the matching singleton on
+            # diag so the ``yw_to_w`` rule sees a consistent batch prefix on both
+            # the cotangent and the trace (collapsed again by the solve-time sum).
+            if batched and x is not None and diag_.ndim == x.ndim + 1:
+                diag_ = diag_[None]
 
             def fn_bwg_pre(d, _old=old_bwg_):
                 return jax.tree.map(
@@ -448,10 +467,19 @@ def _solve_param_dim_weight_gradients(
     # Paths whose gradient was already batch-reduced inside the fast-path einsum
     # (fold_batch). The trailing batch-sum must skip these.
     folded_paths: set = set()
+    # Paths owned by a *batched* primitive: only these carry a leading batch axis
+    # in ``temp_data`` and so only these may be batch-summed. A model can mix
+    # batched and unbatched primitives in one solve — under
+    # ``brainstate.nn.Vmap(vmap_states='new')`` a conv stays batched while a
+    # ``Linear`` dispatches to the unbatched ``etp_mv`` (1-D per-lane input) — and
+    # summing the unbatched gradient would collapse its leading (in-feature) axis.
+    batched_paths: set = set()
     for relation in weight_hidden_relations:
         yw_to_w_rule = ETP_RULES_YW_TO_W[relation.primitive]
         eqn_params = relation.eqn_params
         batched = is_batched_primitive(relation.primitive)
+        if batched:
+            batched_paths.update(relation.trainable_paths.values())
         use_fast = fast_solve and (relation.primitive in _ELEMENTWISE_YW_PRIMITIVES)
 
         def _call_yw_to_w_dict(d, trace_, _rule=yw_to_w_rule, _params=eqn_params):
@@ -473,6 +501,21 @@ def _solve_param_dim_weight_gradients(
             # dimensionless processing (unit strip + restore). Apply per-leaf.
             etrace_data_unitless, fn_unit_restore = _remove_units(etrace_data)
             dg_hidden_unitless, _ = _remove_units(dg_hidden)
+
+            # Under ``brainstate.nn.Vmap(vmap_states='new')`` a batched primitive
+            # (necessarily conv here — dense/lora/sparse dispatch to their
+            # unbatched variants when per-lane) has a per-lane hidden cotangent
+            # that lost its leading batch axis, while the weight trace keeps the
+            # singleton batch from ``init_drtrl``. Both the batched ``yw_to_w`` and
+            # the closed-form solve map a shared leading batch axis, so re-insert
+            # the matching singleton on the cotangent; the trailing solve-time sum
+            # (``has_batched`` branch below) collapses it again.
+            if batched:
+                _trace_lead = jax.tree.leaves(etrace_data_unitless)[0].shape[0]
+                dg_hidden_unitless = jax.tree.map(
+                    lambda a: a[None] if (a.ndim >= 1 and a.shape[0] != _trace_lead) else a,
+                    dg_hidden_unitless,
+                )
 
             if use_fast:
                 # Upcast a reduced-precision trace to (at least) the learning-
@@ -520,12 +563,12 @@ def _solve_param_dim_weight_gradients(
     #
     # sum up the batched weight gradients
     # Check if ANY relation uses a batched primitive
-    has_batched = any(is_batched_primitive(r.primitive) for r in weight_hidden_relations)
-    if has_batched:
-        for key, val in temp_data.items():
-            if key in folded_paths:
-                # already batch-reduced inside the fast-path einsum (fold_batch)
-                continue
+    # Collapse the leading batch axis on batched-primitive gradients only. Paths
+    # routed through the fast-path einsum (``folded_paths``) were already reduced
+    # via ``fold_batch``; unbatched-primitive paths (not in ``batched_paths``)
+    # never grew a batch axis and must be left intact.
+    for key, val in temp_data.items():
+        if key in batched_paths and key not in folded_paths:
             temp_data[key] = jax.tree.map(lambda x: u.math.sum(x, axis=0), val)
 
     # update the weight gradients

--- a/braintrace/_etrace_algorithms/vjp_graph_executor.py
+++ b/braintrace/_etrace_algorithms/vjp_graph_executor.py
@@ -244,38 +244,36 @@ class ETraceVjpGraphExecutor(ETraceGraphExecutor):
             #
             # [ KEY ]
             #
-            # # ---- Method 1: using ``backward_pass`` ---- #
-            # Assuming the function is linear. One cheap way is to use
-            # the backward pass for computing the gradients of the hidden states.
-            # For most situations, the ``y --> hidden`` relation is linear. Therefore,
-            # we use ``backward_pass`` to compute the ``Df`` while avoids the overhead
-            # of computing the forward pass. Otherwise, we should use ``jax.vjp`` instead.
-            # Please also see ``jax.linear_transpose()`` for the same purpose.
+            # ``df`` is the diagonal instantaneous Jacobian ``dh_i/dy_i`` of the
+            # ``y -> hidden group`` map, read off with a single ``jax.jvp`` carrying
+            # an all-ones tangent.
             #
-            # [df] = backward_pass(relation.jaxpr_y2hid, [], True, consts, invars, outvars)
+            # When that map is *elementwise* (the common case: an op output feeds
+            # exactly one neuron, e.g. conv/dense -> spiking neuron) the Jacobian is
+            # diagonal and the all-ones jvp returns that diagonal exactly.
             #
-            # # ---- Method 2: using ``jax.vjp`` ---- #
-            # For general cases, we should use ``jax.vjp`` to compute the gradients.
+            # When a non-elementwise op sits between the weight op and the neuron
+            # (e.g. LayerNorm: ``conv -> LayerNorm -> IF``) the Jacobian is no
+            # longer diagonal and the all-ones jvp returns its *row sums*. The
+            # param-dim trace cannot represent a non-diagonal ``dh/dy``, so this is
+            # the chosen approximation: for a mean-subtracting (shift-invariant) op
+            # the row sums are *exactly* zero — the upstream op simply does not get
+            # an eligibility gradient through the norm. That exactness matters: a
+            # norm computed with ``use_fast_variance=True`` (``E[x^2]-E[x]^2``)
+            # leaves a float32 residual here instead of zero which, under
+            # ``Vmap(vmap_states='new')``, the recurrent trace and the large
+            # ``rsqrt(var+eps)`` factor amplify into an overflow. Build norm layers
+            # feeding an etrace op with ``use_fast_variance=False``.
             #
-            # # ---- Method 3: using ``jax.jvp`` ---- #
-            # For computational efficiency, we use ``jax.jvp`` to compute the gradients,
-            # since this is the one-to-many mapping.
-            #
-            primals, hidden_group_tangents = jax.jvp(
-                lambda y_val: relation.y_to_hidden_groups(
-                    y_val,
-                    intermediate_values,
-                    concat_hidden_vals=True,
-                ),
-                [y],
-                [u.math.ones_like(y)]
+            def _y_to_hidden(y_val, _rel=relation):
+                return _rel.y_to_hidden_groups(
+                    y_val, intermediate_values, concat_hidden_vals=True,
+                )
+
+            _, hidden_group_tangents = jax.jvp(
+                _y_to_hidden, (y,), (u.math.ones_like(y),)
             )
 
-            #
-            # compute the df we want
-            #
-            #    df = jvp gradient of "y -> hidden group"
-            #
             for tangent, group in zip(hidden_group_tangents, relation.hidden_groups):
                 dfs[etrace_df_key(relation.y_var, group.index)] = tangent
 

--- a/docs/advanced/compiler_internals.ipynb
+++ b/docs/advanced/compiler_internals.ipynb
@@ -35,20 +35,13 @@
    "id": "c3d4e5f6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-17T09:26:10.216760Z",
-     "iopub.status.busy": "2026-04-17T09:26:10.216613Z",
-     "iopub.status.idle": "2026-04-17T09:26:14.208067Z",
-     "shell.execute_reply": "2026-04-17T09:26:14.207434Z"
+     "iopub.execute_input": "2026-06-26T13:40:27.010248Z",
+     "iopub.status.busy": "2026-06-26T13:40:27.010104Z",
+     "iopub.status.idle": "2026-06-26T13:40:40.093727Z",
+     "shell.execute_reply": "2026-06-26T13:40:40.092643Z"
     }
    },
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "An NVIDIA GPU may be present on this machine, but a CUDA-enabled jaxlib is not installed. Falling back to cpu.\n"
-     ]
-    },
     {
      "name": "stdout",
      "output_type": "stream",
@@ -109,10 +102,10 @@
    "id": "e5f6a7b8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-17T09:26:14.210443Z",
-     "iopub.status.busy": "2026-04-17T09:26:14.209992Z",
-     "iopub.status.idle": "2026-04-17T09:26:14.229654Z",
-     "shell.execute_reply": "2026-04-17T09:26:14.228820Z"
+     "iopub.execute_input": "2026-06-26T13:40:40.095312Z",
+     "iopub.status.busy": "2026-06-26T13:40:40.095062Z",
+     "iopub.status.idle": "2026-06-26T13:40:40.112455Z",
+     "shell.execute_reply": "2026-06-26T13:40:40.111624Z"
     }
    },
    "outputs": [
@@ -152,10 +145,10 @@
    "id": "a7b8c9d0",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-17T09:26:14.232057Z",
-     "iopub.status.busy": "2026-04-17T09:26:14.231601Z",
-     "iopub.status.idle": "2026-04-17T09:26:14.236516Z",
-     "shell.execute_reply": "2026-04-17T09:26:14.235461Z"
+     "iopub.execute_input": "2026-06-26T13:40:40.114697Z",
+     "iopub.status.busy": "2026-06-26T13:40:40.114505Z",
+     "iopub.status.idle": "2026-06-26T13:40:40.118206Z",
+     "shell.execute_reply": "2026-06-26T13:40:40.117211Z"
     }
    },
    "outputs": [
@@ -164,8 +157,8 @@
      "output_type": "stream",
      "text": [
       "=== Hidden State Paths ===\n",
-      "  ('rnn1', 'h')  ->  Var(id=132835946131648):float32[32]\n",
-      "  ('rnn2', 'h')  ->  Var(id=132832132601216):float32[16]\n",
+      "  ('rnn1', 'h')  ->  Var(id=128485962701312):float32[32]\n",
+      "  ('rnn2', 'h')  ->  Var(id=128476165100480):float32[16]\n",
       "\n",
       "=== Weight Parameter Paths ===\n",
       "  ('rnn1', 'W', 'weight')  ->  2 variable(s)\n",
@@ -215,10 +208,10 @@
    "id": "c9d0e1f2",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-17T09:26:14.239316Z",
-     "iopub.status.busy": "2026-04-17T09:26:14.239009Z",
-     "iopub.status.idle": "2026-04-17T09:26:14.244242Z",
-     "shell.execute_reply": "2026-04-17T09:26:14.243347Z"
+     "iopub.execute_input": "2026-06-26T13:40:40.120251Z",
+     "iopub.status.busy": "2026-06-26T13:40:40.120058Z",
+     "iopub.status.idle": "2026-06-26T13:40:40.124775Z",
+     "shell.execute_reply": "2026-06-26T13:40:40.123680Z"
     }
    },
    "outputs": [
@@ -299,10 +292,10 @@
    "id": "e1f2a3b4",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-17T09:26:14.246415Z",
-     "iopub.status.busy": "2026-04-17T09:26:14.246233Z",
-     "iopub.status.idle": "2026-04-17T09:26:14.258460Z",
-     "shell.execute_reply": "2026-04-17T09:26:14.257837Z"
+     "iopub.execute_input": "2026-06-26T13:40:40.127622Z",
+     "iopub.status.busy": "2026-06-26T13:40:40.127432Z",
+     "iopub.status.idle": "2026-06-26T13:40:40.143375Z",
+     "shell.execute_reply": "2026-06-26T13:40:40.142355Z"
     }
    },
    "outputs": [
@@ -314,9 +307,9 @@
       "\n",
       "Relation 0:\n",
       "  Primitive: etp_mv\n",
-      "  Weight path: ('rnn1', 'W', 'weight')\n",
-      "  x_var: Var(id=132831597789632):float32[42]\n",
-      "  y_var: Var(id=132835947956608):float32[32]\n",
+      "  Trainable paths: {'weight': ('rnn1', 'W', 'weight'), 'bias': ('rnn1', 'W', 'weight')}\n",
+      "  x_var: Var(id=128485962700864):float32[42]\n",
+      "  y_var: Var(id=128472720140608):float32[32]\n",
       "  Connected hidden groups: [0]\n",
       "  Connected hidden paths:\n",
       "    - ('rnn1', 'h')\n",
@@ -324,9 +317,9 @@
       "\n",
       "Relation 1:\n",
       "  Primitive: etp_mv\n",
-      "  Weight path: ('rnn2', 'W', 'weight')\n",
-      "  x_var: Var(id=132831595499392):float32[48]\n",
-      "  y_var: Var(id=132831595499648):float32[16]\n",
+      "  Trainable paths: {'weight': ('rnn2', 'W', 'weight'), 'bias': ('rnn2', 'W', 'weight')}\n",
+      "  x_var: Var(id=128472677225344):float32[48]\n",
+      "  y_var: Var(id=128473149936448):float32[16]\n",
       "  Connected hidden groups: [1]\n",
       "  Connected hidden paths:\n",
       "    - ('rnn2', 'h')\n",
@@ -338,7 +331,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/mnt/d/codes/projects/braintrace/braintrace/_etrace_compiler/hid_param_op.py:772: UserWarning: ETP primitive etp_mv (weight=('out', 'weight')) has no connected hidden states. It will be treated as a non-temporal parameter.\n",
+      "/mnt/d/codes/projects/braintrace/braintrace/_etrace_compiler/hid_param_op.py:852: UserWarning: ETP primitive etp_mv (weight=('out', 'weight')) has no connected hidden states. It will be treated as a non-temporal parameter.\n",
       "  _emit_no_relation_diag(\n"
      ]
     }
@@ -352,7 +345,9 @@
     "for i, r in enumerate(relations):\n",
     "    print(f\"Relation {i}:\")\n",
     "    print(f\"  Primitive: {r.primitive.name}\")\n",
-    "    print(f\"  Weight path: {r.weight_path}\")\n",
+    "    # A single ETP primitive can own several trainable inputs (e.g. {weight, bias}),\n",
+    "    # so the owning ParamState paths are a dict keyed by trainable name.\n",
+    "    print(f\"  Trainable paths: {r.trainable_paths}\")\n",
     "    print(f\"  x_var: {r.x_var}\")\n",
     "    print(f\"  y_var: {r.y_var}\")\n",
     "    print(f\"  Connected hidden groups: {[g.index for g in r.hidden_groups]}\")\n",
@@ -391,10 +386,10 @@
    "id": "a3b4c5d6",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-17T09:26:14.260118Z",
-     "iopub.status.busy": "2026-04-17T09:26:14.259942Z",
-     "iopub.status.idle": "2026-04-17T09:26:14.264287Z",
-     "shell.execute_reply": "2026-04-17T09:26:14.263681Z"
+     "iopub.execute_input": "2026-06-26T13:40:40.145183Z",
+     "iopub.status.busy": "2026-06-26T13:40:40.145011Z",
+     "iopub.status.idle": "2026-06-26T13:40:40.149384Z",
+     "shell.execute_reply": "2026-06-26T13:40:40.148519Z"
     }
    },
    "outputs": [
@@ -407,11 +402,11 @@
       "\n",
       "Perturbed hidden states:\n",
       "  Path: ('rnn1', 'h')\n",
-      "  Perturbation var: Var(id=132832205799808):float32[32]\n",
+      "  Perturbation var: Var(id=128472720966720):float32[32]\n",
       "  State type: HiddenState\n",
       "\n",
       "  Path: ('rnn2', 'h')\n",
-      "  Perturbation var: Var(id=132832133512512):float32[16]\n",
+      "  Perturbation var: Var(id=128472720266240):float32[16]\n",
       "  State type: HiddenState\n",
       "\n"
      ]
@@ -454,10 +449,10 @@
    "id": "c5d6e7f8",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-17T09:26:14.266104Z",
-     "iopub.status.busy": "2026-04-17T09:26:14.265914Z",
-     "iopub.status.idle": "2026-04-17T09:26:14.275217Z",
-     "shell.execute_reply": "2026-04-17T09:26:14.274548Z"
+     "iopub.execute_input": "2026-06-26T13:40:40.151075Z",
+     "iopub.status.busy": "2026-06-26T13:40:40.150923Z",
+     "iopub.status.idle": "2026-06-26T13:40:40.159367Z",
+     "shell.execute_reply": "2026-06-26T13:40:40.158543Z"
     }
    },
    "outputs": [
@@ -489,7 +484,47 @@
    "cell_type": "markdown",
    "id": "d6e7f8a9",
    "metadata": {},
-   "source": "## How Primitive Identification Works\n\nA key design decision in braintrace is **type-based** primitive identification rather than **name-based** matching.\n\n### Old system (string matching)\n\nThe old `ETraceOp` system identified weight operations by matching JIT function names as strings. This was fragile:\n\n- Renaming a function broke the match.\n- Wrapping a function in `jax.jit` changed the name.\n- Name collisions could cause false matches.\n\n### New system (type identity)\n\nThe ETP system registers custom JAX primitives (`etp_mm_p`, `etp_mv_p`, `etp_elemwise_p`, `etp_conv_p`, `etp_sp_mm_p`, `etp_sp_mv_p`, `etp_lora_mm_p`, `etp_lora_mv_p`) and identifies them by checking:\n\n```python\neqn.primitive in ETP_PRIMITIVES   # set membership, O(1)\n```\n\nThis is robust because:\n\n- Primitive identity is a Python object reference, not a string.\n- Wrapping in `jax.jit` does not change the primitive type.\n- No name collisions are possible.\n\n### Weight variable extraction\n\nOnce an ETP equation is found, the weight variable is extracted from `eqn.invars` at a position that depends on the primitive type. Each primitive records this layout at registration time via its `trainable_invars_fn` (and the input position via `x_invar_index`). The compiler queries it through `braintrace._etrace_op.get_trainable_invars(prim, eqn.params)` and `get_x_invar_index(prim)`:\n\n| Primitive | `invars[0]` | `invars[1]` | `invars[2]` | Notes |\n|---|---|---|---|---|\n| `etp_mm_p` / `etp_mv_p` | input `x` | weight `w` | bias `b` (optional) | weight at index 1 |\n| `etp_elemwise_p` | processed weight `y` | -- | -- | weight at index 0, `x_invar_index=None` |\n| `etp_conv_p` | input `x` | kernel `w` | bias `b` (optional) | weight at index 1 |\n| `etp_sp_mm_p` / `etp_sp_mv_p` | input `x` | sparse `weight_data` | bias `b` (optional) | weight at index 1; the static sparse pattern is in `eqn.params['sparse_mat']` |\n| `etp_lora_mm_p` / `etp_lora_mv_p` | input `x` | LoRA factor `B` | LoRA factor `A` (then bias `b` optional) | weight at index 1; the originating `ParamState` holds both `B` *and* `A` as a dict, so the compiler back-traces from `B` and recovers both |\n\nThe weight variable is then traced **backward** through the Jaxpr's producer map to find the originating `ParamState`, handling intermediate transformations like masking, weight standardization, or sign constraints."
+   "source": [
+    "## How Primitive Identification Works\n",
+    "\n",
+    "A key design decision in braintrace is **type-based** primitive identification rather than **name-based** matching.\n",
+    "\n",
+    "### Old system (string matching)\n",
+    "\n",
+    "The old `ETraceOp` system identified weight operations by matching JIT function names as strings. This was fragile:\n",
+    "\n",
+    "- Renaming a function broke the match.\n",
+    "- Wrapping a function in `jax.jit` changed the name.\n",
+    "- Name collisions could cause false matches.\n",
+    "\n",
+    "### New system (type identity)\n",
+    "\n",
+    "The ETP system registers custom JAX primitives (`etp_mm_p`, `etp_mv_p`, `etp_elemwise_p`, `etp_conv_p`, `etp_sp_mm_p`, `etp_sp_mv_p`, `etp_lora_mm_p`, `etp_lora_mv_p`) and identifies them by checking:\n",
+    "\n",
+    "```python\n",
+    "eqn.primitive in ETP_PRIMITIVES   # set membership, O(1)\n",
+    "```\n",
+    "\n",
+    "This is robust because:\n",
+    "\n",
+    "- Primitive identity is a Python object reference, not a string.\n",
+    "- Wrapping in `jax.jit` does not change the primitive type.\n",
+    "- No name collisions are possible.\n",
+    "\n",
+    "### Weight variable extraction\n",
+    "\n",
+    "Once an ETP equation is found, the weight variable is extracted from `eqn.invars` at a position that depends on the primitive type. Each primitive records this layout at registration time via its `trainable_invars_fn` (and the input position via `x_invar_index`). The compiler queries it through `braintrace._etrace_op.get_trainable_invars(prim, eqn.params)` and `get_x_invar_index(prim)`:\n",
+    "\n",
+    "| Primitive | `invars[0]` | `invars[1]` | `invars[2]` | Notes |\n",
+    "|---|---|---|---|---|\n",
+    "| `etp_mm_p` / `etp_mv_p` | input `x` | weight `w` | bias `b` (optional) | weight at index 1 |\n",
+    "| `etp_elemwise_p` | processed weight `y` | -- | -- | weight at index 0, `x_invar_index=None` |\n",
+    "| `etp_conv_p` | input `x` | kernel `w` | bias `b` (optional) | weight at index 1 |\n",
+    "| `etp_sp_mm_p` / `etp_sp_mv_p` | input `x` | sparse `weight_data` | bias `b` (optional) | weight at index 1; the static sparse pattern is in `eqn.params['sparse_mat']` |\n",
+    "| `etp_lora_mm_p` / `etp_lora_mv_p` | input `x` | LoRA factor `B` | LoRA factor `A` (then bias `b` optional) | weight at index 1; the originating `ParamState` holds both `B` *and* `A` as a dict, so the compiler back-traces from `B` and recovers both |\n",
+    "\n",
+    "The weight variable is then traced **backward** through the Jaxpr's producer map to find the originating `ParamState`, handling intermediate transformations like masking, weight standardization, or sign constraints."
+   ]
   },
   {
    "cell_type": "markdown",
@@ -517,10 +552,10 @@
    "id": "f8a9b0c1",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-17T09:26:14.277060Z",
-     "iopub.status.busy": "2026-04-17T09:26:14.276807Z",
-     "iopub.status.idle": "2026-04-17T09:26:14.281318Z",
-     "shell.execute_reply": "2026-04-17T09:26:14.280663Z"
+     "iopub.execute_input": "2026-06-26T13:40:40.160988Z",
+     "iopub.status.busy": "2026-06-26T13:40:40.160800Z",
+     "iopub.status.idle": "2026-06-26T13:40:40.165203Z",
+     "shell.execute_reply": "2026-06-26T13:40:40.164120Z"
     }
    },
    "outputs": [
@@ -573,18 +608,62 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 9,
    "id": "b0c1d2e3",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-17T09:26:14.283593Z",
-     "iopub.status.busy": "2026-04-17T09:26:14.283304Z",
-     "iopub.status.idle": "2026-04-17T09:26:14.288545Z",
-     "shell.execute_reply": "2026-04-17T09:26:14.287746Z"
+     "iopub.execute_input": "2026-06-26T13:40:40.166693Z",
+     "iopub.status.busy": "2026-06-26T13:40:40.166510Z",
+     "iopub.status.idle": "2026-06-26T13:40:40.170520Z",
+     "shell.execute_reply": "2026-06-26T13:40:40.169569Z"
     }
    },
-   "outputs": [],
-   "source": "from braintrace._etrace_compiler.hid_param_op import _build_producer_map, _trace_var_to_param\nfrom braintrace._etrace_op import get_trainable_invars\n\nproducers = _build_producer_map(minfo.jaxpr)\n\nfor eqn in minfo.jaxpr.eqns:\n    if not is_etp_primitive(eqn.primitive):\n        continue\n    # Look up the registered trainable-invar layout rather than hard-coding\n    # the weight index per primitive.\n    weight_index = get_trainable_invars(eqn.primitive, eqn.params)['weight']\n    weight_var = eqn.invars[weight_index]\n\n    path = _trace_var_to_param(\n        weight_var, producers, minfo.invar_to_weight_path\n    )\n    print(f\"Primitive: {eqn.primitive.name}\")\n    print(f\"  weight index: {weight_index}\")\n    print(f\"  Weight var: {weight_var}\")\n    print(f\"  Traced to ParamState: {path}\")\n    print()"
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Primitive: etp_mv\n",
+      "  weight index: 1\n",
+      "  Weight var: Var(id=128485962703296):float32[42,32]\n",
+      "  Traced to ParamState: (('rnn1', 'W', 'weight'), ())\n",
+      "\n",
+      "Primitive: etp_mv\n",
+      "  weight index: 1\n",
+      "  Weight var: Var(id=128472677224512):float32[48,16]\n",
+      "  Traced to ParamState: (('rnn2', 'W', 'weight'), ())\n",
+      "\n",
+      "Primitive: etp_mv\n",
+      "  weight index: 1\n",
+      "  Weight var: Var(id=128472677275712):float32[16,5]\n",
+      "  Traced to ParamState: (('out', 'weight'), ())\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "from braintrace._etrace_compiler.hid_param_op import _build_producer_map, _trace_var_to_param\n",
+    "from braintrace._etrace_op import get_trainable_invars\n",
+    "\n",
+    "producers = _build_producer_map(minfo.jaxpr)\n",
+    "\n",
+    "for eqn in minfo.jaxpr.eqns:\n",
+    "    if not is_etp_primitive(eqn.primitive):\n",
+    "        continue\n",
+    "    # Look up the registered trainable-invar layout rather than hard-coding\n",
+    "    # the weight index per primitive.\n",
+    "    weight_index = get_trainable_invars(eqn.primitive, eqn.params)['weight']\n",
+    "    weight_var = eqn.invars[weight_index]\n",
+    "\n",
+    "    path = _trace_var_to_param(\n",
+    "        weight_var, producers, minfo.invar_to_weight_path\n",
+    "    )\n",
+    "    print(f\"Primitive: {eqn.primitive.name}\")\n",
+    "    print(f\"  weight index: {weight_index}\")\n",
+    "    print(f\"  Weight var: {weight_var}\")\n",
+    "    print(f\"  Traced to ParamState: {path}\")\n",
+    "    print()"
+   ]
   },
   {
    "cell_type": "markdown",
@@ -616,10 +695,10 @@
    "id": "f850f7df",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-17T09:26:14.291367Z",
-     "iopub.status.busy": "2026-04-17T09:26:14.291071Z",
-     "iopub.status.idle": "2026-04-17T09:26:14.297971Z",
-     "shell.execute_reply": "2026-04-17T09:26:14.297285Z"
+     "iopub.execute_input": "2026-06-26T13:40:40.172036Z",
+     "iopub.status.busy": "2026-06-26T13:40:40.171895Z",
+     "iopub.status.idle": "2026-06-26T13:40:40.177669Z",
+     "shell.execute_reply": "2026-06-26T13:40:40.176790Z"
     }
    },
    "outputs": [

--- a/docs/advanced/custom_algorithms.ipynb
+++ b/docs/advanced/custom_algorithms.ipynb
@@ -200,21 +200,13 @@
    "id": "1d7b6e30",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-17T09:26:18.687036Z",
-     "iopub.status.busy": "2026-04-17T09:26:18.686778Z",
-     "iopub.status.idle": "2026-04-17T09:26:18.305661Z",
-     "shell.execute_reply": "2026-04-17T09:26:18.304851Z"
+     "iopub.execute_input": "2026-06-26T13:40:42.579206Z",
+     "iopub.status.busy": "2026-06-26T13:40:42.579047Z",
+     "iopub.status.idle": "2026-06-26T13:40:49.894796Z",
+     "shell.execute_reply": "2026-06-26T13:40:49.893875Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "An NVIDIA GPU may be present on this machine, but a CUDA-enabled jaxlib is not installed. Falling back to cpu.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import jax\n",
     "import jax.numpy as jnp\n",
@@ -275,10 +267,10 @@
    "id": "dfb10cee",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-17T09:26:18.308154Z",
-     "iopub.status.busy": "2026-04-17T09:26:18.307804Z",
-     "iopub.status.idle": "2026-04-17T09:26:18.741655Z",
-     "shell.execute_reply": "2026-04-17T09:26:18.740751Z"
+     "iopub.execute_input": "2026-06-26T13:40:49.896887Z",
+     "iopub.status.busy": "2026-06-26T13:40:49.896623Z",
+     "iopub.status.idle": "2026-06-26T13:40:54.823864Z",
+     "shell.execute_reply": "2026-06-26T13:40:54.822930Z"
     }
    },
    "outputs": [
@@ -314,10 +306,10 @@
    "id": "16bf14fe",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-17T09:26:18.743542Z",
-     "iopub.status.busy": "2026-04-17T09:26:18.743337Z",
-     "iopub.status.idle": "2026-04-17T09:26:20.747525Z",
-     "shell.execute_reply": "2026-04-17T09:26:20.746733Z"
+     "iopub.execute_input": "2026-06-26T13:40:54.825626Z",
+     "iopub.status.busy": "2026-06-26T13:40:54.825432Z",
+     "iopub.status.idle": "2026-06-26T13:40:56.130748Z",
+     "shell.execute_reply": "2026-06-26T13:40:56.129609Z"
     }
    },
    "outputs": [
@@ -404,7 +396,9 @@
    "source": [
     "## Accessing Eligibility Traces\n",
     "\n",
-    "After running the algorithm for a few steps, you can inspect the eligibility traces for any weight parameter. This is useful for debugging and analysis."
+    "After running the algorithm for a few steps, you can inspect the eligibility traces for any weight parameter. This is useful for debugging and analysis.\n",
+    "\n",
+    "`get_etrace_of(weight)` returns a nested dict, `{(weight_id, leaf_index): {trainable_input_name: trace_tensor}}`. The outer key identifies a specific trainable leaf of the parameter; the inner dict maps each of the owning ETP primitive's trainable inputs to its trace tensor. This nesting matters because one primitive can learn several inputs at once — the recurrent cell below, for example, learns both a weight matrix and a bias, so each trace group contains a `'weight'` and a `'bias'` entry."
    ]
   },
   {
@@ -413,10 +407,10 @@
    "id": "b733466c",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-17T09:26:20.749823Z",
-     "iopub.status.busy": "2026-04-17T09:26:20.749574Z",
-     "iopub.status.idle": "2026-04-17T09:26:21.028615Z",
-     "shell.execute_reply": "2026-04-17T09:26:21.027685Z"
+     "iopub.execute_input": "2026-06-26T13:40:56.132885Z",
+     "iopub.status.busy": "2026-06-26T13:40:56.132705Z",
+     "iopub.status.idle": "2026-06-26T13:40:56.323279Z",
+     "shell.execute_reply": "2026-06-26T13:40:56.322261Z"
     }
    },
    "outputs": [
@@ -424,9 +418,18 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Weight ('W', 'weight'), trace key: (('W', 'weight'), 130753575862208, 'hidden_group_0')\n",
-      "  trace shape: (42, 32, 1)\n",
-      "  trace abs max: 5.605252\n"
+      "Weight ('W', 'weight'), leaf 0, trainable input 'bias'\n",
+      "  trace shape:   (32, 1)\n",
+      "  trace abs max: 6.461852\n",
+      "Weight ('W', 'weight'), leaf 0, trainable input 'weight'\n",
+      "  trace shape:   (42, 32, 1)\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "  trace abs max: 6.461852\n"
      ]
     }
    ],
@@ -442,14 +445,21 @@
     "for _ in range(5):\n",
     "    algo2(jnp.ones(10))\n",
     "\n",
-    "# Inspect eligibility traces for each weight parameter\n",
+    "# Inspect eligibility traces for each weight parameter.\n",
+    "#\n",
+    "# get_etrace_of(weight) returns a nested dict:\n",
+    "#     {(weight_id, leaf_index): {trainable_input_name: trace_tensor}}\n",
+    "# A single ETP primitive can own several trainable inputs -- the recurrent cell\n",
+    "# here learns both a weight matrix and a bias -- so each trace group is itself a\n",
+    "# dict keyed by the input name.\n",
     "weights = model2.states(brainstate.ParamState)\n",
     "for path, w in weights.items():\n",
-    "    traces = algo2.get_etrace_of(w)\n",
-    "    for key, trace_val in traces.items():\n",
-    "        print(f\"Weight {path}, trace key: {key}\")\n",
-    "        print(f\"  trace shape: {trace_val.shape}\")\n",
-    "        print(f\"  trace abs max: {jnp.abs(trace_val).max():.6f}\")"
+    "    trace_groups = algo2.get_etrace_of(w)\n",
+    "    for (weight_id, leaf_index), trace_group in trace_groups.items():\n",
+    "        for input_name, trace_val in trace_group.items():\n",
+    "            print(f\"Weight {path}, leaf {leaf_index}, trainable input '{input_name}'\")\n",
+    "            print(f\"  trace shape:   {trace_val.shape}\")\n",
+    "            print(f\"  trace abs max: {jnp.abs(trace_val).max():.6f}\")"
    ]
   },
   {
@@ -485,10 +495,10 @@
    "id": "d4fec171",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-17T09:26:21.030999Z",
-     "iopub.status.busy": "2026-04-17T09:26:21.030786Z",
-     "iopub.status.idle": "2026-04-17T09:26:21.042842Z",
-     "shell.execute_reply": "2026-04-17T09:26:21.041444Z"
+     "iopub.execute_input": "2026-06-26T13:40:56.324824Z",
+     "iopub.status.busy": "2026-06-26T13:40:56.324657Z",
+     "iopub.status.idle": "2026-06-26T13:40:56.335333Z",
+     "shell.execute_reply": "2026-06-26T13:40:56.334130Z"
     }
    },
    "outputs": [
@@ -563,10 +573,10 @@
    "id": "09573e15",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-17T09:26:21.046189Z",
-     "iopub.status.busy": "2026-04-17T09:26:21.045921Z",
-     "iopub.status.idle": "2026-04-17T09:26:21.204357Z",
-     "shell.execute_reply": "2026-04-17T09:26:21.203518Z"
+     "iopub.execute_input": "2026-06-26T13:40:56.337103Z",
+     "iopub.status.busy": "2026-06-26T13:40:56.336876Z",
+     "iopub.status.idle": "2026-06-26T13:40:56.398222Z",
+     "shell.execute_reply": "2026-06-26T13:40:56.397203Z"
     }
    },
    "outputs": [
@@ -574,7 +584,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "Trace abs-max before reset: 2.913480\n",
+      "Trace abs-max before reset: 4.065420\n",
       "Trace abs-max after  reset: 0.000000\n",
       "running_index after  reset: 0\n"
      ]
@@ -585,15 +595,24 @@
     "for _ in range(3):\n",
     "    clipped_algo(jnp.ones(10))\n",
     "\n",
+    "\n",
+    "def representative_trace(algo, weight):\n",
+    "    \"\"\"Pull one representative trace tensor out of the nested get_etrace_of()\n",
+    "    structure {(weight_id, leaf): {input_name: tensor}}.\"\"\"\n",
+    "    groups = algo.get_etrace_of(weight)\n",
+    "    first_group = next(iter(groups.values()))   # {input_name: tensor}\n",
+    "    return next(iter(first_group.values()))     # tensor\n",
+    "\n",
+    "\n",
     "# Show that traces are non-zero before reset.\n",
     "weights = clipped_model.states(brainstate.ParamState)\n",
     "sample_weight = next(iter(weights.values()))\n",
-    "sample_trace = next(iter(clipped_algo.get_etrace_of(sample_weight).values()))\n",
+    "sample_trace = representative_trace(clipped_algo, sample_weight)\n",
     "print(f\"Trace abs-max before reset: {jnp.abs(sample_trace).max():.6f}\")\n",
     "\n",
     "# Reset and verify the traces are now zero (and running_index == 0).\n",
     "clipped_algo.reset_state()\n",
-    "sample_trace = next(iter(clipped_algo.get_etrace_of(sample_weight).values()))\n",
+    "sample_trace = representative_trace(clipped_algo, sample_weight)\n",
     "print(f\"Trace abs-max after  reset: {jnp.abs(sample_trace).max():.6f}\")\n",
     "print(f\"running_index after  reset: {int(clipped_algo.running_index.value)}\")"
    ]

--- a/docs/advanced/limitations.ipynb
+++ b/docs/advanced/limitations.ipynb
@@ -59,21 +59,13 @@
    "id": "a1b2c3d4e5f60005",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-17T09:28:37.459038Z",
-     "iopub.status.busy": "2026-04-17T09:28:37.458791Z",
-     "iopub.status.idle": "2026-04-17T09:28:39.763395Z",
-     "shell.execute_reply": "2026-04-17T09:28:39.762595Z"
+     "iopub.execute_input": "2026-06-26T13:40:58.821878Z",
+     "iopub.status.busy": "2026-06-26T13:40:58.821727Z",
+     "iopub.status.idle": "2026-06-26T13:41:05.412843Z",
+     "shell.execute_reply": "2026-06-26T13:41:05.411595Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "An NVIDIA GPU may be present on this machine, but a CUDA-enabled jaxlib is not installed. Falling back to cpu.\n"
-     ]
-    }
-   ],
+   "outputs": [],
    "source": [
     "import jax\n",
     "import jax.numpy as jnp\n",
@@ -128,10 +120,10 @@
    "id": "a1b2c3d4e5f60008",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-17T09:28:39.765925Z",
-     "iopub.status.busy": "2026-04-17T09:28:39.765559Z",
-     "iopub.status.idle": "2026-04-17T09:28:39.874383Z",
-     "shell.execute_reply": "2026-04-17T09:28:39.873722Z"
+     "iopub.execute_input": "2026-06-26T13:41:05.415143Z",
+     "iopub.status.busy": "2026-06-26T13:41:05.414867Z",
+     "iopub.status.idle": "2026-06-26T13:41:10.854480Z",
+     "shell.execute_reply": "2026-06-26T13:41:10.853427Z"
     }
    },
    "outputs": [
@@ -201,10 +193,10 @@
    "id": "a1b2c3d4e5f60011",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-17T09:28:39.876530Z",
-     "iopub.status.busy": "2026-04-17T09:28:39.876381Z",
-     "iopub.status.idle": "2026-04-17T09:28:39.880790Z",
-     "shell.execute_reply": "2026-04-17T09:28:39.880051Z"
+     "iopub.execute_input": "2026-06-26T13:41:10.856709Z",
+     "iopub.status.busy": "2026-06-26T13:41:10.856477Z",
+     "iopub.status.idle": "2026-06-26T13:41:10.860286Z",
+     "shell.execute_reply": "2026-06-26T13:41:10.859446Z"
     }
    },
    "outputs": [],
@@ -270,10 +262,10 @@
    "id": "15710888",
    "metadata": {
     "execution": {
-     "iopub.execute_input": "2026-04-17T09:28:39.883674Z",
-     "iopub.status.busy": "2026-04-17T09:28:39.883294Z",
-     "iopub.status.idle": "2026-04-17T09:28:40.791323Z",
-     "shell.execute_reply": "2026-04-17T09:28:40.790378Z"
+     "iopub.execute_input": "2026-06-26T13:41:10.862181Z",
+     "iopub.status.busy": "2026-06-26T13:41:10.862018Z",
+     "iopub.status.idle": "2026-06-26T13:41:11.434153Z",
+     "shell.execute_reply": "2026-06-26T13:41:11.433146Z"
     }
    },
    "outputs": [
@@ -283,8 +275,8 @@
      "text": [
       "GRUCell has 3 ParamStates\n",
       "but the compiler recorded only 2 ETP relations:\n",
-      "  - ('Wz', 'weight')  (primitive: etp_mm)\n",
-      "  - ('Wh', 'weight')  (primitive: etp_mm)\n",
+      "  - {'weight': ('Wz', 'weight'), 'bias': ('Wz', 'weight')}  (primitive: etp_mm)\n",
+      "  - {'weight': ('Wh', 'weight'), 'bias': ('Wh', 'weight')}  (primitive: etp_mm)\n",
       "\n",
       "Weight->weight exclusions: 1\n",
       "  - ('Wr', 'weight'): ETP primitive etp_mm (weight=('Wr', 'weight')) reaches a hidden state only through another trainable ETP primitive (etp_mm). Per the non-parametric-tail invariant this weight is excluded from ETP; learn it by BPTT or rewire the architecture so its output flows directly into a hidden state.\n"
@@ -294,7 +286,7 @@
      "name": "stderr",
      "output_type": "stream",
      "text": [
-      "/mnt/d/codes/projects/braintrace/braintrace/_etrace_compiler/hid_param_op.py:772: UserWarning: ETP primitive etp_mm (weight=('Wr', 'weight')) reaches a hidden state only through another trainable ETP primitive (etp_mm). Per the non-parametric-tail invariant this weight is excluded from ETP; learn it by BPTT or rewire the architecture so its output flows directly into a hidden state.\n",
+      "/mnt/d/codes/projects/braintrace/braintrace/_etrace_compiler/hid_param_op.py:852: UserWarning: ETP primitive etp_mm (weight=('Wr', 'weight')) reaches a hidden state only through another trainable ETP primitive (etp_mm). Per the non-parametric-tail invariant this weight is excluded from ETP; learn it by BPTT or rewire the architecture so its output flows directly into a hidden state.\n",
       "  _emit_no_relation_diag(\n"
      ]
     }
@@ -313,7 +305,9 @@
     "print(f\"GRUCell has {len(list(cell.states(brainstate.ParamState)))} ParamStates\")\n",
     "print(f\"but the compiler recorded only {len(graph.hidden_param_op_relations)} ETP relations:\")\n",
     "for r in graph.hidden_param_op_relations:\n",
-    "    print(f\"  - {r.weight_path}  (primitive: {r.primitive.name})\")\n",
+    "    # ``trainable_paths`` maps each trainable key (e.g. 'weight', 'bias') to the\n",
+    "    # owning ParamState path; print the owning path(s) for this relation.\n",
+    "    print(f\"  - {r.trainable_paths}  (primitive: {r.primitive.name})\")\n",
     "\n",
     "# The third weight (Wr) shows up as a RELATION_EXCLUDED_WEIGHT_TO_WEIGHT diagnostic.\n",
     "from braintrace import DiagnosticKind\n",

--- a/docs/tutorials/graph_visualization.ipynb
+++ b/docs/tutorials/graph_visualization.ipynb
@@ -45,9 +45,16 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "id": "d4e5f6a7b8c9d0e1",
-   "metadata": {},
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-26T13:41:13.690431Z",
+     "iopub.status.busy": "2026-06-26T13:41:13.690247Z",
+     "iopub.status.idle": "2026-06-26T13:41:20.619588Z",
+     "shell.execute_reply": "2026-06-26T13:41:20.618685Z"
+    }
+   },
    "outputs": [],
    "source": [
     "import jax\n",
@@ -58,10 +65,49 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "e5f6a7b8c9d0e1f2",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-26T13:41:20.621837Z",
+     "iopub.status.busy": "2026-06-26T13:41:20.621585Z",
+     "iopub.status.idle": "2026-06-26T13:41:26.064234Z",
+     "shell.execute_reply": "2026-06-26T13:41:26.063125Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "========================================================================================================================\n",
+      "The hidden groups are:\n",
+      "\n",
+      "   Group 0: [('rnn', 'h')]\n",
+      "\n",
+      "\n",
+      "The weight parameters which are associated with the hidden states are:\n",
+      "\n",
+      "   Weight 0: ('rnn', 'W', 'weight')  is associated with hidden group 0\n",
+      "\n",
+      "\n",
+      "The non-etrace weight parameters are:\n",
+      "\n",
+      "   Weight 0: ('out', 'weight')\n",
+      "\n",
+      "\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/mnt/d/codes/projects/braintrace/braintrace/_etrace_compiler/hid_param_op.py:852: UserWarning: ETP primitive etp_mv (weight=('out', 'weight')) has no connected hidden states. It will be treated as a non-temporal parameter.\n",
+      "  _emit_no_relation_diag(\n"
+     ]
+    }
+   ],
    "source": [
     "class SingleLayerRNN(brainstate.nn.Module):\n",
     "    def __init__(self, n_in, n_rec, n_out):\n",
@@ -86,17 +132,7 @@
    "cell_type": "markdown",
    "id": "f6a7b8c9d0e1f2a3",
    "metadata": {},
-   "source": [
-    "The output shows:\n",
-    "\n",
-    "- **Hidden Group 0**: the hidden state of the `ValinaRNNCell` (path `('rnn', 'h')`)\n",
-    "- **Weight 0**: the recurrent weight inside the RNN cell, associated with Hidden Group 0\n",
-    "- **Weight 1**: the readout weight, which may or may not appear depending on whether the readout\n",
-    "  layer uses ETP primitives\n",
-    "\n",
-    "This tells us that `D_RTRL` will maintain an eligibility trace for the recurrent weight,\n",
-    "tracking how it influences the hidden state over time."
-   ]
+   "source": "The output shows:\n\n- **Hidden Group 0**: the hidden state of the `ValinaRNNCell` (path `('rnn', 'h')`)\n- **Associated weight**: the recurrent weight inside the RNN cell (`('rnn', 'W', 'weight')`),\n  eligibility-traced because it feeds the hidden state through an ETP primitive\n- **Non-etrace weight**: the readout weight (`('out', 'weight')`). `braintrace.nn.Linear`\n  *does* use an ETP primitive, but the readout's output is the network's final output and\n  never flows back into a hidden state -- so the compiler reports it as a non-temporal\n  parameter (still trained, just not through an eligibility trace). A matching\n  `has no connected hidden states` warning is emitted at compile time.\n\nThis tells us that `D_RTRL` will maintain an eligibility trace for the recurrent weight,\ntracking how it influences the hidden state over time."
   },
   {
    "cell_type": "markdown",
@@ -124,10 +160,36 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "b8c9d0e1f2a3b4c5",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-26T13:41:26.066400Z",
+     "iopub.status.busy": "2026-06-26T13:41:26.066216Z",
+     "iopub.status.idle": "2026-06-26T13:41:26.070741Z",
+     "shell.execute_reply": "2026-06-26T13:41:26.069667Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "=== Hidden Groups ===\n",
+      "  Group 0: 1 state(s), shape (32,)\n",
+      "    Paths: [('rnn', 'h')]\n",
+      "\n",
+      "=== Weight-Primitive-Hidden Relations ===\n",
+      "  Relation 0:\n",
+      "    Trainable paths: {'weight': ('rnn', 'W', 'weight'), 'bias': ('rnn', 'W', 'weight')}\n",
+      "    Primitive: etp_mv\n",
+      "    Hidden groups: [0]\n",
+      "\n",
+      "=== Perturbation ===\n",
+      "  Has perturbation: True\n"
+     ]
+    }
+   ],
    "source": [
     "graph = algo.graph\n",
     "\n",
@@ -139,7 +201,9 @@
     "print(\"\\n=== Weight-Primitive-Hidden Relations ===\")\n",
     "for i, r in enumerate(graph.hidden_param_op_relations):\n",
     "    print(f\"  Relation {i}:\")\n",
-    "    print(f\"    Weight path: {r.weight_path}\")\n",
+    "    # ``trainable_paths`` is a dict {trainable key -> owning ParamState path};\n",
+    "    # a single primitive may own several (e.g. {weight, bias}).\n",
+    "    print(f\"    Trainable paths: {r.trainable_paths}\")\n",
     "    print(f\"    Primitive: {r.primitive}\")\n",
     "    print(f\"    Hidden groups: {[g.index for g in r.hidden_groups]}\")\n",
     "\n",
@@ -151,32 +215,66 @@
    "cell_type": "markdown",
    "id": "c9d0e1f2a3b4c5d6",
    "metadata": {},
-   "source": [
-    "The `HiddenGroup.num_state` property returns the total number of state variables in the group,\n",
-    "and `HiddenGroup.varshape` returns the shape of each state variable. The\n",
-    "`HiddenParamOpRelation.primitive` field identifies which ETP primitive (e.g., `etp_matmul_p`)\n",
-    "connects the weight to the hidden state."
-   ]
+   "source": "The `HiddenGroup.num_state` property returns the total number of state variables in the group,\nand `HiddenGroup.varshape` returns the shape of each state variable. The\n`HiddenParamOpRelation.primitive` field identifies which ETP primitive connects the weight to\nthe hidden state -- here `etp_mv` (matrix-vector product); you will also see `etp_mm`\n(matrix-matrix, e.g. under batching) and `etp_conv` (convolution) in other models."
   },
   {
    "cell_type": "markdown",
    "id": "d0e1f2a3b4c5d6e7",
    "metadata": {},
-   "source": [
-    "## Two-Layer RNN\n",
-    "\n",
-    "With multiple recurrent layers, the graph becomes richer. Each layer introduces its own\n",
-    "hidden group, and the compiler discovers which weights feed into which hidden groups.\n",
-    "In a stacked RNN, each layer's recurrent weight is associated with only its own hidden group --\n",
-    "the layers are structurally independent from the perspective of eligibility trace propagation."
-   ]
+   "source": "## Two-Layer RNN\n\nStacking recurrent layers makes the compiled graph richer: there are more hidden states and\nmore weights, and the compiler must decide how to group the hidden states. Below we stack two\n`GRUCell` layers and a linear readout, then read the structure straight off `show_graph()` --\nrather than assuming one group per layer, we let the compiler tell us how it grouped things."
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "e1f2a3b4c5d6e7f8",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-26T13:41:26.072863Z",
+     "iopub.status.busy": "2026-06-26T13:41:26.072676Z",
+     "iopub.status.idle": "2026-06-26T13:41:26.697358Z",
+     "shell.execute_reply": "2026-06-26T13:41:26.696466Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "========================================================================================================================\n",
+      "The hidden groups are:\n",
+      "\n",
+      "   Group 0: [('rnn1', 'h'), ('rnn2', 'h')]\n",
+      "\n",
+      "\n",
+      "The weight parameters which are associated with the hidden states are:\n",
+      "\n",
+      "   Weight 0: ('rnn1', 'Wz', 'weight')  is associated with hidden group 0\n",
+      "   Weight 1: ('rnn1', 'Wh', 'weight')  is associated with hidden group 0\n",
+      "   Weight 2: ('rnn2', 'Wz', 'weight')  is associated with hidden group 0\n",
+      "   Weight 3: ('rnn2', 'Wh', 'weight')  is associated with hidden group 0\n",
+      "\n",
+      "\n",
+      "The non-etrace weight parameters are:\n",
+      "\n",
+      "   Weight 0: ('rnn2', 'Wr', 'weight')\n",
+      "   Weight 1: ('out', 'weight')\n",
+      "   Weight 2: ('rnn1', 'Wr', 'weight')\n",
+      "\n",
+      "\n",
+      "\n"
+     ]
+    },
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/mnt/d/codes/projects/braintrace/braintrace/_etrace_compiler/hid_param_op.py:852: UserWarning: ETP primitive etp_mv (weight=('rnn1', 'Wr', 'weight')) reaches a hidden state only through another trainable ETP primitive (etp_mv). Per the non-parametric-tail invariant this weight is excluded from ETP; learn it by BPTT or rewire the architecture so its output flows directly into a hidden state.\n",
+      "  _emit_no_relation_diag(\n",
+      "/mnt/d/codes/projects/braintrace/braintrace/_etrace_compiler/hid_param_op.py:852: UserWarning: ETP primitive etp_mv (weight=('rnn2', 'Wr', 'weight')) reaches a hidden state only through another trainable ETP primitive (etp_mv). Per the non-parametric-tail invariant this weight is excluded from ETP; learn it by BPTT or rewire the architecture so its output flows directly into a hidden state.\n",
+      "  _emit_no_relation_diag(\n"
+     ]
+    }
+   ],
    "source": [
     "class TwoLayerRNN(brainstate.nn.Module):\n",
     "    def __init__(self, n_in, n_rec, n_out):\n",
@@ -203,23 +301,39 @@
    "cell_type": "markdown",
    "id": "f2a3b4c5d6e7f8a9",
    "metadata": {},
-   "source": [
-    "Notice that:\n",
-    "\n",
-    "- Each GRU layer creates its own hidden group (the GRU hidden state `h`)\n",
-    "- Each layer's recurrent and input weights are associated with that layer's hidden group\n",
-    "- The readout weight forms its own relation if it uses an ETP primitive\n",
-    "\n",
-    "This structural analysis is what allows `D_RTRL` to maintain separate eligibility traces\n",
-    "for each layer, avoiding the need to backpropagate through time across the entire network."
-   ]
+   "source": "Notice that:\n\n- Both GRU hidden states -- `('rnn1', 'h')` and `('rnn2', 'h')` -- are collected into a\n  **single** hidden group. The compiler co-locates coupled hidden states that share the same\n  shape, stacking their per-state Jacobians along one axis; because both layers here use the\n  same recurrent width (`n_rec = 32`), they land in one group. Give the two layers *different*\n  widths and the compiler reports two separate groups instead -- the *Hidden State Management*\n  tutorial shows exactly that case (a 16-unit layer feeding an 8-unit layer yields one group\n  each). The practical habit is to **read the grouping off `show_graph()`** rather than assume it.\n- Four weight matrices are eligibility-traced into that group: the update-gate (`Wz`) and\n  candidate (`Wh`) weights of *each* layer.\n- The reset-gate weights (`Wr`) and the readout (`out`) are listed as **non-etrace**\n  parameters. `Wr` is excluded by the *weight -> weight -> hidden* rule -- its only path to a\n  hidden state runs through the candidate weight `Wh`, so it must be learned by BPTT (see the\n  *Limitations* tutorial) -- while `out` never feeds a hidden state at all.\n\nReading this off `show_graph()` tells you exactly which weights `D_RTRL` learns online\n(the four traced GRU weights) and which it leaves to ordinary backprop (`Wr`, `out`)."
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "a3b4c5d6e7f8a9b0",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-26T13:41:26.699715Z",
+     "iopub.status.busy": "2026-06-26T13:41:26.699542Z",
+     "iopub.status.idle": "2026-06-26T13:41:26.703350Z",
+     "shell.execute_reply": "2026-06-26T13:41:26.702430Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Number of hidden groups: 1\n",
+      "Number of weight-hidden relations: 4\n",
+      "\n",
+      "Hidden groups:\n",
+      "  Group 0: [('rnn1', 'h'), ('rnn2', 'h')]\n",
+      "\n",
+      "Relations:\n",
+      "  Weight 0: {'weight': ('rnn1', 'Wz', 'weight'), 'bias': ('rnn1', 'Wz', 'weight')} -> hidden group(s) [0]\n",
+      "  Weight 1: {'weight': ('rnn1', 'Wh', 'weight'), 'bias': ('rnn1', 'Wh', 'weight')} -> hidden group(s) [0]\n",
+      "  Weight 2: {'weight': ('rnn2', 'Wz', 'weight'), 'bias': ('rnn2', 'Wz', 'weight')} -> hidden group(s) [0]\n",
+      "  Weight 3: {'weight': ('rnn2', 'Wh', 'weight'), 'bias': ('rnn2', 'Wh', 'weight')} -> hidden group(s) [0]\n"
+     ]
+    }
+   ],
    "source": [
     "# Inspect the two-layer graph programmatically\n",
     "graph2 = algo2.graph\n",
@@ -234,7 +348,8 @@
     "print(\"\\nRelations:\")\n",
     "for i, r in enumerate(graph2.hidden_param_op_relations):\n",
     "    groups = [g.index for g in r.hidden_groups]\n",
-    "    print(f\"  Weight {i}: {r.weight_path} -> hidden group(s) {groups}\")"
+    "    # ``trainable_paths`` maps each trainable key to its owning ParamState path.\n",
+    "    print(f\"  Weight {i}: {r.trainable_paths} -> hidden group(s) {groups}\")"
    ]
   },
   {
@@ -245,37 +360,86 @@
     "## Convolutional Network\n",
     "\n",
     "ETP primitives also support convolutional operations via `braintrace.nn.Conv2d`. When a\n",
-    "convolutional layer feeds into a recurrent layer, the compiler discovers the connection\n",
-    "between the convolution kernel and the downstream hidden state. This demonstrates the\n",
-    "generality of the graph compilation -- it works with any ETP primitive, not just matrix\n",
-    "multiplication."
+    "convolution operates **recurrently** on a hidden feature map -- reading the current map and\n",
+    "writing the result back -- the compiler discovers the connection between the convolution\n",
+    "kernel and the hidden state it updates. This demonstrates the generality of the graph\n",
+    "compilation: it works with any ETP primitive, not just matrix multiplication.\n",
+    "\n",
+    "> **Note.** `braintrace.nn.Conv2d` takes a channel-last `in_size` of the form `(H, W, C)`\n",
+    "> (the spatial dimensions plus the number of input channels) and a separate `out_channels`.\n",
+    "> The kernel is only traced as an ETP parameter if its output reaches a hidden state\n",
+    "> *directly* -- an intervening shape-changing op (such as a `reshape` flattening the feature\n",
+    "> map before a `Linear`) breaks the connection, just like the slice in the *Limitations*\n",
+    "> tutorial."
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "c5d6e7f8a9b0c1d2",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-26T13:41:26.704774Z",
+     "iopub.status.busy": "2026-06-26T13:41:26.704624Z",
+     "iopub.status.idle": "2026-06-26T13:41:29.432098Z",
+     "shell.execute_reply": "2026-06-26T13:41:29.431200Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "========================================================================================================================\n",
+      "The hidden groups are:\n",
+      "\n",
+      "   Group 0: [('h',)]\n",
+      "\n",
+      "\n",
+      "The weight parameters which are associated with the hidden states are:\n",
+      "\n",
+      "   Weight 0: ('conv', 'weight')  is associated with hidden group 0\n",
+      "\n",
+      "\n",
+      "The non-etrace weight parameters are:\n",
+      "\n",
+      "   Weight 0: ('out', 'weight')\n",
+      "\n",
+      "\n",
+      "\n"
+     ]
+    }
+   ],
    "source": [
     "class ConvRNN(brainstate.nn.Module):\n",
+    "    \"\"\"A convolutional *recurrent* layer.\n",
+    "\n",
+    "    The conv operates on its own hidden feature map ``self.h`` and writes the\n",
+    "    result back, so the conv kernel feeds a hidden state **directly** -- which is\n",
+    "    what lets the compiler trace it as an ETP parameter.\n",
+    "    \"\"\"\n",
+    "\n",
     "    def __init__(self):\n",
     "        super().__init__()\n",
-    "        self.conv = braintrace.nn.Conv2d(1, 8, kernel_size=3, padding='SAME')\n",
-    "        self.rnn = braintrace.nn.ValinaRNNCell(8 * 28 * 28, 64)\n",
-    "        self.out = braintrace.nn.Linear(64, 10)\n",
+    "        # in_size is the channel-last spatial+channel shape (H, W, C).\n",
+    "        self.conv = braintrace.nn.Conv2d(in_size=(28, 28, 8), out_channels=8,\n",
+    "                                         kernel_size=3, padding='SAME')\n",
+    "        self.h = brainstate.HiddenState(jnp.zeros((28, 28, 8)))\n",
+    "        self.out = braintrace.nn.Linear(8 * 28 * 28, 10)\n",
     "\n",
     "    def update(self, x):\n",
-    "        # x: (1, 28, 28) -- single-channel 28x28 image\n",
-    "        features = self.conv(x).reshape(-1)\n",
-    "        return self.out(self.rnn(features))\n",
+    "        # x: (28, 28, 8) external drive in the same feature space as the hidden map.\n",
+    "        # The conv reads the recurrent hidden map and writes back into it, with no\n",
+    "        # shape-changing op in between, so the kernel -> hidden connection is traced.\n",
+    "        self.h.value = jax.nn.tanh(self.conv(self.h.value) + x)\n",
+    "        return self.out(self.h.value.reshape(-1))\n",
     "\n",
     "\n",
     "model3 = ConvRNN()\n",
     "brainstate.nn.init_all_states(model3)\n",
     "\n",
     "algo3 = braintrace.D_RTRL(model3)\n",
-    "algo3.compile_graph(jnp.zeros((1, 28, 28)))\n",
+    "algo3.compile_graph(jnp.zeros((28, 28, 8)))\n",
     "algo3.show_graph()"
    ]
   },
@@ -286,15 +450,19 @@
    "source": [
     "In this model:\n",
     "\n",
-    "- The `Conv2d` kernel weight is discovered as an ETP parameter because `braintrace.nn.Conv2d`\n",
-    "  uses the `etp_conv` primitive internally\n",
-    "- The RNN's recurrent weight uses `etp_matmul`\n",
-    "- Both are associated with the RNN's hidden group, since the convolution output flows into\n",
-    "  the recurrent computation\n",
-    "- The readout `Linear` layer also uses an ETP primitive\n",
+    "- The `Conv2d` kernel **is** discovered as an ETP parameter (the `etp_conv` primitive),\n",
+    "  because the convolution operates on the recurrent hidden feature map `self.h` and writes\n",
+    "  the result back into it -- so the kernel feeds a hidden state directly, exactly like a\n",
+    "  recurrent matmul weight would.\n",
+    "- The single hidden group is the `(28, 28, 8)` convolutional feature map.\n",
+    "- The readout `Linear` is **non-temporal** -- its output does not flow back into a hidden\n",
+    "  state -- so the compiler excludes it from eligibility-trace tracking (it is still trained,\n",
+    "  just as a plain parameter learned through the loss, not an online trace).\n",
     "\n",
-    "This shows how the compiler traces data flow across different layer types to build\n",
-    "the complete eligibility trace graph."
+    "The key requirement is that the conv output reach the hidden state *without* an intervening\n",
+    "shape-changing op (a `reshape`/slice) or another trainable ETP weight. Here it does, so the\n",
+    "compiler traces the conv kernel's influence on the recurrent hidden state -- showing that ETP\n",
+    "generalises beyond matrix multiplication to convolutional recurrence."
    ]
   },
   {
@@ -315,10 +483,35 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "f8a9b0c1d2e3f4a5",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-26T13:41:29.433889Z",
+     "iopub.status.busy": "2026-06-26T13:41:29.433736Z",
+     "iopub.status.idle": "2026-06-26T13:41:29.457145Z",
+     "shell.execute_reply": "2026-06-26T13:41:29.456024Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Number of hidden groups: 1\n",
+      "Number of relations: 1\n",
+      "Has perturbation: True\n",
+      "\n",
+      "Graph fields:\n",
+      "  module_info\n",
+      "  hidden_groups\n",
+      "  hid_path_to_group\n",
+      "  hidden_param_op_relations\n",
+      "  hidden_perturb\n",
+      "  diagnostics\n"
+     ]
+    }
+   ],
    "source": [
     "model_direct = SingleLayerRNN(10, 32, 5)\n",
     "brainstate.nn.init_all_states(model_direct)\n",
@@ -348,26 +541,7 @@
    "cell_type": "markdown",
    "id": "b0c1d2e3f4a5b6c7",
    "metadata": {},
-   "source": [
-    "## Summary\n",
-    "\n",
-    "In this tutorial, we covered the graph compilation and visualization tools in `braintrace`:\n",
-    "\n",
-    "- **`compile_graph()`** (on algorithm objects) and **`compile_etrace_graph()`** (standalone function)\n",
-    "  analyze the model's computation graph to discover the structural relationships between weights,\n",
-    "  ETP primitives, and hidden states\n",
-    "- **`show_graph()`** provides a human-readable summary of the compiled graph, showing hidden groups,\n",
-    "  weight-hidden associations, and non-ETP parameters\n",
-    "- The compiled graph reveals **which weights participate in online learning** -- only weights used\n",
-    "  through ETP primitives (`braintrace.nn.Linear`, `braintrace.nn.Conv2d`, etc.) are included\n",
-    "- **Multi-layer** and **convolutional** models create richer graph structures with multiple hidden\n",
-    "  groups and cross-layer relationships\n",
-    "- The `ETraceGraph` named tuple can be inspected programmatically for custom analysis or to build\n",
-    "  custom online learning algorithms\n",
-    "\n",
-    "Understanding the compiled graph is a key step in verifying that your model is correctly structured\n",
-    "for online learning with `braintrace`."
-   ]
+   "source": "## Summary\n\nIn this tutorial, we covered the graph compilation and visualization tools in `braintrace`:\n\n- **`compile_graph()`** (on algorithm objects) and **`compile_etrace_graph()`** (standalone function)\n  analyze the model's computation graph to discover the structural relationships between weights,\n  ETP primitives, and hidden states\n- **`show_graph()`** provides a human-readable summary of the compiled graph, showing hidden groups,\n  weight-hidden associations, and non-ETP parameters\n- The compiled graph reveals **which weights participate in online learning** -- only weights whose\n  ETP-primitive output feeds a hidden state are eligibility-traced; readouts and weights caught by\n  the *weight -> weight -> hidden* rule (e.g. the GRU reset gate) are left to ordinary backprop\n- **Multi-layer** and **convolutional** models create richer graph structures -- more hidden states\n  and more weight relations -- and the compiler decides how to group the hidden states, co-locating\n  coupled same-shape states into a single group while keeping differently-shaped states apart\n- The `ETraceGraph` named tuple can be inspected programmatically for custom analysis or to build\n  custom online learning algorithms\n\nUnderstanding the compiled graph is a key step in verifying that your model is correctly structured\nfor online learning with `braintrace`."
   }
  ],
  "metadata": {
@@ -386,7 +560,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.11.13"
+   "version": "3.13.11"
   }
  },
  "nbformat": 4,

--- a/docs/tutorials/hidden_states.ipynb
+++ b/docs/tutorials/hidden_states.ipynb
@@ -3,154 +3,629 @@
   {
    "cell_type": "markdown",
    "id": "5h4hj579xfl",
-   "source": "# Hidden State Management\n\nIn recurrent neural networks and spiking neural networks, **hidden states** are the recurrent state variables that carry information across time steps. Examples include membrane potentials, adaptation currents, and synaptic conductances.\n\nbraintrace's compiler **automatically discovers** hidden states in your model by tracing the JAX intermediate representation (Jaxpr). It identifies which state variables are both read and written during a forward pass, then groups related hidden states into **hidden groups** for efficient Jacobian computation during online learning.\n\nThis tutorial covers:\n\n1. The three hidden state types provided by `brainstate`\n2. How the compiler discovers and groups hidden states\n3. State initialization and batching\n4. How hidden states interact with online learning algorithms",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "# Hidden State Management\n",
+    "\n",
+    "In recurrent neural networks and spiking neural networks, **hidden states** are the recurrent state variables that carry information across time steps. Examples include membrane potentials, adaptation currents, and synaptic conductances.\n",
+    "\n",
+    "braintrace's compiler **automatically discovers** hidden states in your model by tracing the JAX intermediate representation (Jaxpr). It identifies which state variables are both read and written during a forward pass, then groups related hidden states into **hidden groups** for efficient Jacobian computation during online learning.\n",
+    "\n",
+    "This tutorial covers:\n",
+    "\n",
+    "1. The three hidden state types provided by `brainstate`\n",
+    "2. How the compiler discovers and groups hidden states\n",
+    "3. State initialization and batching\n",
+    "4. How hidden states interact with online learning algorithms"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 1,
    "id": "b7biugn65oc",
-   "source": "import jax\nimport jax.numpy as jnp\nimport brainstate\nimport braintrace",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": []
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-26T13:41:31.802671Z",
+     "iopub.status.busy": "2026-06-26T13:41:31.802375Z",
+     "iopub.status.idle": "2026-06-26T13:41:39.282376Z",
+     "shell.execute_reply": "2026-06-26T13:41:39.281430Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import jax\n",
+    "import jax.numpy as jnp\n",
+    "import brainstate\n",
+    "import braintrace"
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "1djmk4705si",
-   "source": "## Hidden State Types\n\n`brainstate` provides three hidden state classes, each suited to different model architectures:\n\n| Type | Use Case | Example |\n|------|----------|---------|\n| `brainstate.HiddenState` | Single state variable | Membrane potential of a LIF neuron |\n| `brainstate.HiddenGroupState` | Multiple correlated states with the same shape | Voltage *V* and adaptation current *I* in an adaptive neuron |\n| `brainstate.HiddenTreeState` | Hierarchical / heterogeneous state structures | LSTM cell state and hidden state, or a dict of named states |\n\nAll three are subclasses of `brainstate.HiddenState`. The compiler treats them uniformly when discovering recurrent dependencies -- you choose the one that best matches your model's structure.",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "## Hidden State Types\n",
+    "\n",
+    "`brainstate` provides three hidden state classes, each suited to different model architectures:\n",
+    "\n",
+    "| Type | Use Case | Example |\n",
+    "|------|----------|---------|\n",
+    "| `brainstate.HiddenState` | Single state variable | Membrane potential of a LIF neuron |\n",
+    "| `brainstate.HiddenGroupState` | Multiple same-shape states, addressed by index | Voltage *V* and adaptation current *I* in an adaptive neuron |\n",
+    "| `brainstate.HiddenTreeState` | Multiple same-shape states, addressed by name | The four named states of a GIF neuron, or an LSTM's cell and hidden states |\n",
+    "\n",
+    "All three are subclasses of `brainstate.HiddenState`. The compiler treats them uniformly when discovering recurrent dependencies -- you choose the one that best matches your model's structure."
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "8t2k8qttxub",
-   "source": "### `HiddenState`: Single State Variable\n\n`brainstate.HiddenState` manages exactly one state tensor. This is the simplest and most common case -- use it when your neuron or synapse has a single recurrent variable (e.g., membrane potential).",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "### `HiddenState`: Single State Variable\n",
+    "\n",
+    "`brainstate.HiddenState` manages exactly one state tensor. This is the simplest and most common case -- use it when your neuron or synapse has a single recurrent variable (e.g., membrane potential)."
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 2,
    "id": "5nbmdy6vxls",
-   "source": "class SimpleNeuron(brainstate.nn.Module):\n    \"\"\"A minimal recurrent neuron with a single hidden state.\"\"\"\n\n    def __init__(self, size):\n        super().__init__()\n        self.w = brainstate.ParamState(brainstate.random.randn(size, size) * 0.01)\n        self.h = brainstate.HiddenState(jnp.zeros(size))\n\n    def update(self, x):\n        # braintrace.matmul marks w as participating in online learning\n        self.h.value = jax.nn.tanh(x + braintrace.matmul(self.h.value, self.w.value))\n        return self.h.value\n\n\n# Create the model and initialize states\nmodel_simple = SimpleNeuron(32)\nbrainstate.nn.init_all_states(model_simple)\n\nprint(f\"Hidden state shape: {model_simple.h.value.shape}\")\nprint(f\"Number of state dimensions: {model_simple.h.num_state}\")",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": []
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-26T13:41:39.284148Z",
+     "iopub.status.busy": "2026-06-26T13:41:39.283893Z",
+     "iopub.status.idle": "2026-06-26T13:41:44.265605Z",
+     "shell.execute_reply": "2026-06-26T13:41:44.264554Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Hidden state shape: (32,)\n",
+      "Number of state dimensions: 1\n"
+     ]
+    }
+   ],
+   "source": [
+    "class SimpleNeuron(brainstate.nn.Module):\n",
+    "    \"\"\"A minimal recurrent neuron with a single hidden state.\"\"\"\n",
+    "\n",
+    "    def __init__(self, size):\n",
+    "        super().__init__()\n",
+    "        self.w = brainstate.ParamState(brainstate.random.randn(size, size) * 0.01)\n",
+    "        self.h = brainstate.HiddenState(jnp.zeros(size))\n",
+    "\n",
+    "    def update(self, x):\n",
+    "        # braintrace.matmul marks w as participating in online learning\n",
+    "        self.h.value = jax.nn.tanh(x + braintrace.matmul(self.h.value, self.w.value))\n",
+    "        return self.h.value\n",
+    "\n",
+    "\n",
+    "# Create the model and initialize states\n",
+    "model_simple = SimpleNeuron(32)\n",
+    "brainstate.nn.init_all_states(model_simple)\n",
+    "\n",
+    "print(f\"Hidden state shape: {model_simple.h.value.shape}\")\n",
+    "print(f\"Number of state dimensions: {model_simple.h.num_state}\")"
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "6fr14i7akov",
-   "source": "### `HiddenGroupState`: Multiple Correlated States\n\nWhen a neuron has multiple state variables that are correlated and share the same shape, use `brainstate.HiddenGroupState`. This tells the compiler that these states form a single group -- their Jacobians should be computed together.\n\nA common example is an adaptive neuron with both a membrane voltage *V* and an adaptation current *I*.",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "### `HiddenGroupState`: Multiple Correlated States\n",
+    "\n",
+    "When a neuron has multiple state variables that are correlated and share the same shape, use `brainstate.HiddenGroupState`. This tells the compiler that these states form a single group -- their Jacobians should be computed together.\n",
+    "\n",
+    "A common example is an adaptive neuron with both a membrane voltage *V* and an adaptation current *I*.\n",
+    "\n",
+    "`HiddenGroupState` stores all of its states in a **single array** whose **last axis is the state axis**: a value of shape `(size, 2)` holds two states, each of shape `(size,)`. The states are addressed by position -- read them with `state.get_value(0)` / `state.get_value(1)` (or the equivalent string names `'0'` / `'1'`), and write them all at once by assigning a stacked array to `state.value`. (If you would rather refer to states by meaningful names, use `HiddenTreeState`, shown below.)"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 3,
    "id": "efoif7n1wa",
-   "source": "class AdaptiveNeuron(brainstate.nn.Module):\n    \"\"\"A neuron with two correlated hidden states: voltage V and adaptation current I.\"\"\"\n\n    def __init__(self, size):\n        super().__init__()\n        self.w = brainstate.ParamState(brainstate.random.randn(size, size) * 0.01)\n        # Two correlated states bundled into one HiddenGroupState\n        self.state = brainstate.HiddenGroupState(\n            V=jnp.zeros(size),\n            I=jnp.zeros(size),\n        )\n\n    def update(self, x):\n        V, I = self.state['V'], self.state['I']\n        new_V = 0.9 * V + x + braintrace.matmul(V, self.w.value) - I\n        new_I = 0.95 * I + 0.1 * V\n        self.state.value = dict(V=new_V, I=new_I)\n        return new_V\n\n\nmodel_adaptive = AdaptiveNeuron(32)\nbrainstate.nn.init_all_states(model_adaptive)\n\nprint(f\"Number of states in group: {model_adaptive.state.num_state}\")\nprint(f\"State shape: {model_adaptive.state.varshape}\")",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": []
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-26T13:41:44.267830Z",
+     "iopub.status.busy": "2026-06-26T13:41:44.267628Z",
+     "iopub.status.idle": "2026-06-26T13:41:44.296052Z",
+     "shell.execute_reply": "2026-06-26T13:41:44.295129Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Number of states in group: 2\n",
+      "State shape: (32,)\n"
+     ]
+    }
+   ],
+   "source": [
+    "class AdaptiveNeuron(brainstate.nn.Module):\n",
+    "    \"\"\"A neuron with two correlated hidden states: voltage V and adaptation current I.\"\"\"\n",
+    "\n",
+    "    def __init__(self, size):\n",
+    "        super().__init__()\n",
+    "        self.w = brainstate.ParamState(brainstate.random.randn(size, size) * 0.01)\n",
+    "        # Two correlated states bundled into one HiddenGroupState. The state array's\n",
+    "        # last axis is the \"state\" axis: index 0 holds V, index 1 holds I. Both share\n",
+    "        # the same (size,) shape, which is exactly what HiddenGroupState requires.\n",
+    "        self.state = brainstate.HiddenGroupState(jnp.zeros((size, 2)))\n",
+    "\n",
+    "    def update(self, x):\n",
+    "        V, I = self.state.get_value(0), self.state.get_value(1)\n",
+    "        new_V = 0.9 * V + x + braintrace.matmul(V, self.w.value) - I\n",
+    "        new_I = 0.95 * I + 0.1 * V\n",
+    "        # Write all states back at once by stacking along the last (state) axis.\n",
+    "        self.state.value = jnp.stack([new_V, new_I], axis=-1)\n",
+    "        return new_V\n",
+    "\n",
+    "\n",
+    "model_adaptive = AdaptiveNeuron(32)\n",
+    "brainstate.nn.init_all_states(model_adaptive)\n",
+    "\n",
+    "print(f\"Number of states in group: {model_adaptive.state.num_state}\")\n",
+    "print(f\"State shape: {model_adaptive.state.varshape}\")"
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "yo3v5c5b08c",
-   "source": "### `HiddenTreeState`: Hierarchical State Structures\n\n`brainstate.HiddenTreeState` supports arbitrary PyTree structures (dicts, lists, nested containers). Use it when your model has many state variables that you want to organize hierarchically, or when different states have different shapes.\n\nFor instance, a GIF (Generalized Integrate-and-Fire) neuron has four state variables: two adaptation currents $I_1$, $I_2$, a membrane potential $V$, and a dynamic threshold $V_{th}$.",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "### `HiddenTreeState`: Named State Collections\n",
+    "\n",
+    "`brainstate.HiddenTreeState` lets you bundle several state variables and address them by **meaningful names** (a dict of arrays) or by **position** (a sequence of arrays), instead of the bare integer indices used by `HiddenGroupState`. Internally it still stores everything in a single stacked array -- so, like `HiddenGroupState`, all states must share the same shape -- but it additionally remembers each state's name (and physical unit). Reach for it when a model has several recurrent variables and name-based access keeps the update equations readable.\n",
+    "\n",
+    "For instance, a GIF (Generalized Integrate-and-Fire) neuron has four state variables: two adaptation currents $I_1$, $I_2$, a membrane potential $V$, and a dynamic threshold $V_{th}$."
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 4,
    "id": "7pwbcriumje",
-   "source": "class TreeNeuron(brainstate.nn.Module):\n    \"\"\"A neuron using HiddenTreeState for hierarchical state management.\"\"\"\n\n    def __init__(self, size):\n        super().__init__()\n        self.w = brainstate.ParamState(brainstate.random.randn(size, size) * 0.01)\n        # Four state variables organized in a dict tree\n        self.state = brainstate.HiddenTreeState({\n            'I1': jnp.zeros(size),\n            'I2': jnp.zeros(size),\n            'V': jnp.zeros(size),\n            'V_th': jnp.ones(size),\n        })\n\n    def update(self, x):\n        I1 = self.state['I1']\n        I2 = self.state['I2']\n        V = self.state['V']\n        V_th = self.state['V_th']\n\n        new_I1 = 0.9 * I1\n        new_I2 = 0.95 * I2\n        new_V = 0.8 * V + x + braintrace.matmul(V, self.w.value) + I1 + I2\n        new_V_th = 0.99 * V_th + 0.01 * V\n\n        self.state.value = dict(I1=new_I1, I2=new_I2, V=new_V, V_th=new_V_th)\n        return new_V\n\n\nmodel_tree = TreeNeuron(32)\nbrainstate.nn.init_all_states(model_tree)\n\nprint(f\"Number of independent states in tree: {model_tree.state.num_state}\")",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": []
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-26T13:41:44.298737Z",
+     "iopub.status.busy": "2026-06-26T13:41:44.298468Z",
+     "iopub.status.idle": "2026-06-26T13:41:44.335434Z",
+     "shell.execute_reply": "2026-06-26T13:41:44.334530Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Number of independent states in tree: 4\n"
+     ]
+    }
+   ],
+   "source": [
+    "class TreeNeuron(brainstate.nn.Module):\n",
+    "    \"\"\"A neuron using HiddenTreeState for named, multi-variable state management.\"\"\"\n",
+    "\n",
+    "    def __init__(self, size):\n",
+    "        super().__init__()\n",
+    "        self.w = brainstate.ParamState(brainstate.random.randn(size, size) * 0.01)\n",
+    "        # Four state variables addressed by name. HiddenTreeState stores them in a\n",
+    "        # single array internally but lets you read/write them by their dict keys.\n",
+    "        self.state = brainstate.HiddenTreeState({\n",
+    "            'I1': jnp.zeros(size),\n",
+    "            'I2': jnp.zeros(size),\n",
+    "            'V': jnp.zeros(size),\n",
+    "            'V_th': jnp.ones(size),\n",
+    "        })\n",
+    "\n",
+    "    def update(self, x):\n",
+    "        I1 = self.state.get_value('I1')\n",
+    "        I2 = self.state.get_value('I2')\n",
+    "        V = self.state.get_value('V')\n",
+    "        V_th = self.state.get_value('V_th')\n",
+    "\n",
+    "        new_I1 = 0.9 * I1\n",
+    "        new_I2 = 0.95 * I2\n",
+    "        new_V = 0.8 * V + x + braintrace.matmul(V, self.w.value) + I1 + I2\n",
+    "        new_V_th = 0.99 * V_th + 0.01 * V\n",
+    "\n",
+    "        # Write named states back with set_value (assigning to `.value` directly is\n",
+    "        # discouraged for tree states -- it bypasses the name/unit bookkeeping).\n",
+    "        self.state.set_value(dict(I1=new_I1, I2=new_I2, V=new_V, V_th=new_V_th))\n",
+    "        return new_V\n",
+    "\n",
+    "\n",
+    "model_tree = TreeNeuron(32)\n",
+    "brainstate.nn.init_all_states(model_tree)\n",
+    "\n",
+    "print(f\"Number of independent states in tree: {model_tree.state.num_state}\")"
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "jnr84irdsnq",
-   "source": "## How the Compiler Discovers Hidden States\n\nWhen you compile a model for online learning, braintrace performs the following steps:\n\n1. **Trace the Jaxpr**: The model's `update` method is traced to produce a JAX intermediate representation (Jaxpr).\n2. **Identify recurrent states**: The compiler finds state variables that appear as both inputs (read) and outputs (written) in the Jaxpr -- these are the hidden states.\n3. **Group by data flow**: States that are connected through data flow dependencies are placed into the same **hidden group**. Each group gets its own transition Jaxpr for computing the hidden-to-hidden Jacobian $\\frac{\\partial h^t}{\\partial h^{t-1}}$.\n\nYou can inspect the discovered hidden groups using `braintrace.find_hidden_groups_from_module()`.",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "## How the Compiler Discovers Hidden States\n",
+    "\n",
+    "When you compile a model for online learning, braintrace performs the following steps:\n",
+    "\n",
+    "1. **Trace the Jaxpr**: The model's `update` method is traced to produce a JAX intermediate representation (Jaxpr).\n",
+    "2. **Identify recurrent states**: The compiler finds state variables that appear as both inputs (read) and outputs (written) in the Jaxpr -- these are the hidden states.\n",
+    "3. **Group by data flow**: States that are connected through data flow dependencies are placed into the same **hidden group**. Each group gets its own transition Jaxpr for computing the hidden-to-hidden Jacobian $\\frac{\\partial h^t}{\\partial h^{t-1}}$.\n",
+    "\n",
+    "You can inspect the discovered hidden groups using `braintrace.find_hidden_groups_from_module()`."
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 5,
    "id": "dxorizb39zp",
-   "source": "# Inspect hidden groups for the SimpleNeuron model\nmodel_simple = SimpleNeuron(32)\nbrainstate.nn.init_all_states(model_simple)\n\ngroups, path_map = braintrace.find_hidden_groups_from_module(model_simple, jnp.zeros(32))\n\nfor g in groups:\n    print(f\"Group {g.index}:\")\n    print(f\"  Hidden state paths: {g.hidden_paths}\")\n    print(f\"  Number of states:   {g.num_state}\")\n    print(f\"  State shape:        {g.varshape}\")\n    print()",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": []
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-26T13:41:44.337176Z",
+     "iopub.status.busy": "2026-06-26T13:41:44.337014Z",
+     "iopub.status.idle": "2026-06-26T13:41:44.348327Z",
+     "shell.execute_reply": "2026-06-26T13:41:44.346768Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Group 0:\n",
+      "  Hidden state paths: [('h',)]\n",
+      "  Number of states:   1\n",
+      "  State shape:        (32,)\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Inspect hidden groups for the SimpleNeuron model\n",
+    "model_simple = SimpleNeuron(32)\n",
+    "brainstate.nn.init_all_states(model_simple)\n",
+    "\n",
+    "groups, path_map = braintrace.find_hidden_groups_from_module(model_simple, jnp.zeros(32))\n",
+    "\n",
+    "for g in groups:\n",
+    "    print(f\"Group {g.index}:\")\n",
+    "    print(f\"  Hidden state paths: {g.hidden_paths}\")\n",
+    "    print(f\"  Number of states:   {g.num_state}\")\n",
+    "    print(f\"  State shape:        {g.varshape}\")\n",
+    "    print()"
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "skqcc7kxo29",
-   "source": "For the `AdaptiveNeuron` with `HiddenGroupState`, the compiler groups *V* and *I* together because they are correlated through the update equations:",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "For the `AdaptiveNeuron` with `HiddenGroupState`, the compiler groups *V* and *I* together because they are correlated through the update equations:"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 6,
    "id": "iu6bggu8lyb",
-   "source": "# Inspect hidden groups for the AdaptiveNeuron model\nmodel_adaptive = AdaptiveNeuron(32)\nbrainstate.nn.init_all_states(model_adaptive)\n\ngroups, path_map = braintrace.find_hidden_groups_from_module(model_adaptive, jnp.zeros(32))\n\nfor g in groups:\n    print(f\"Group {g.index}:\")\n    print(f\"  Hidden state paths: {g.hidden_paths}\")\n    print(f\"  Number of states:   {g.num_state}\")\n    print(f\"  State shape:        {g.varshape}\")\n    print()",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": []
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-26T13:41:44.350582Z",
+     "iopub.status.busy": "2026-06-26T13:41:44.350243Z",
+     "iopub.status.idle": "2026-06-26T13:41:44.360966Z",
+     "shell.execute_reply": "2026-06-26T13:41:44.359875Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Group 0:\n",
+      "  Hidden state paths: [('state',)]\n",
+      "  Number of states:   2\n",
+      "  State shape:        (32,)\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Inspect hidden groups for the AdaptiveNeuron model\n",
+    "model_adaptive = AdaptiveNeuron(32)\n",
+    "brainstate.nn.init_all_states(model_adaptive)\n",
+    "\n",
+    "groups, path_map = braintrace.find_hidden_groups_from_module(model_adaptive, jnp.zeros(32))\n",
+    "\n",
+    "for g in groups:\n",
+    "    print(f\"Group {g.index}:\")\n",
+    "    print(f\"  Hidden state paths: {g.hidden_paths}\")\n",
+    "    print(f\"  Number of states:   {g.num_state}\")\n",
+    "    print(f\"  State shape:        {g.varshape}\")\n",
+    "    print()"
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "5bokhmcta94",
-   "source": "## State Initialization and Reset\n\nbraintrace relies on `brainstate.nn.init_all_states()` to initialize all hidden states in a model. There are two main approaches:\n\n- **Single-sample initialization**: `brainstate.nn.init_all_states(model)` -- state tensors have shape `(M,)`.\n- **Batched initialization**: `brainstate.nn.init_all_states(model, batch_size=N)` -- state tensors have shape `(N, M)`, where `N` is the batch size. This is used for manual batching.\n\nFor automatic batching with `vmap`, you can use `brainstate.transform.vmap_new_states` to initialize per-sample states while keeping the model definition simple.",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "## State Initialization and Reset\n",
+    "\n",
+    "braintrace relies on `brainstate.nn.init_all_states()` to initialize all hidden states in a model. There are two main approaches:\n",
+    "\n",
+    "- **Single-sample initialization**: `brainstate.nn.init_all_states(model)` -- state tensors have shape `(M,)`.\n",
+    "- **Batched initialization**: `brainstate.nn.init_all_states(model, batch_size=N)` -- state tensors have shape `(N, M)`, where `N` is the batch size. This is used for manual batching.\n",
+    "\n",
+    "For automatic batching with `vmap`, you can use `brainstate.transform.vmap_new_states` to initialize per-sample states while keeping the model definition simple."
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 7,
    "id": "e0e6zy4v4aw",
-   "source": "model = SimpleNeuron(32)\n\n# --- Single-sample initialization ---\nbrainstate.nn.init_all_states(model)\nprint(\"Single-sample h shape:\", model.h.value.shape)\n\n# --- Batched initialization (manual batching) ---\nbrainstate.nn.init_all_states(model, batch_size=16)\nprint(\"Batched h shape:      \", model.h.value.shape)",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": []
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-26T13:41:44.363584Z",
+     "iopub.status.busy": "2026-06-26T13:41:44.363382Z",
+     "iopub.status.idle": "2026-06-26T13:41:44.369970Z",
+     "shell.execute_reply": "2026-06-26T13:41:44.368603Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Single-sample h shape: (32,)\n",
+      "Batched h shape:       (32,)\n"
+     ]
+    }
+   ],
+   "source": [
+    "model = SimpleNeuron(32)\n",
+    "\n",
+    "# --- Single-sample initialization ---\n",
+    "brainstate.nn.init_all_states(model)\n",
+    "print(\"Single-sample h shape:\", model.h.value.shape)\n",
+    "\n",
+    "# --- Batched initialization (manual batching) ---\n",
+    "brainstate.nn.init_all_states(model, batch_size=16)\n",
+    "print(\"Batched h shape:      \", model.h.value.shape)"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 8,
    "id": "raeddpwnz5o",
-   "source": "# --- Automatic batching with vmap_new_states ---\nmodel = SimpleNeuron(32)\n\n@brainstate.transform.vmap_new_states(state_tag='new', axis_size=16)\ndef init():\n    brainstate.nn.init_all_states(model)\n\ninit()\n\n# After vmap initialization, hidden states are managed per-sample internally.\n# The model still \"thinks\" it processes a single sample, but vmap replicates\n# the computation across the batch dimension automatically.\nprint(\"After vmap_new_states, model is ready for automatic batching.\")",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": []
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-26T13:41:44.371806Z",
+     "iopub.status.busy": "2026-06-26T13:41:44.371630Z",
+     "iopub.status.idle": "2026-06-26T13:41:44.378045Z",
+     "shell.execute_reply": "2026-06-26T13:41:44.376744Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "After vmap_new_states, model is ready for automatic batching.\n"
+     ]
+    }
+   ],
+   "source": [
+    "# --- Automatic batching with vmap_new_states ---\n",
+    "model = SimpleNeuron(32)\n",
+    "\n",
+    "@brainstate.transform.vmap_new_states(state_tag='new', axis_size=16)\n",
+    "def init():\n",
+    "    brainstate.nn.init_all_states(model)\n",
+    "\n",
+    "init()\n",
+    "\n",
+    "# After vmap initialization, hidden states are managed per-sample internally.\n",
+    "# The model still \"thinks\" it processes a single sample, but vmap replicates\n",
+    "# the computation across the batch dimension automatically.\n",
+    "print(\"After vmap_new_states, model is ready for automatic batching.\")"
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "ze96hximbu",
-   "source": "## Hidden States in Online Learning\n\nDuring online learning, the algorithm needs to track how hidden states evolve over time. Specifically, it computes:\n\n- **Hidden-to-hidden Jacobians** $\\frac{\\partial h^t}{\\partial h^{t-1}}$: How the current hidden state depends on the previous one. These drive the propagation of eligibility traces.\n- **Weight spatial gradients** $\\frac{\\partial h^t}{\\partial w}$: How the hidden state depends on each weight parameter.\n\nThe diagonal approximation of the hidden-to-hidden Jacobian makes this computation tractable for large networks. The compiler automatically extracts the transition function from the Jaxpr and computes these Jacobians.\n\nLet us see the full pipeline: define a model, compile the online learning graph, and inspect its structure.",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "## Hidden States in Online Learning\n",
+    "\n",
+    "During online learning, the algorithm needs to track how hidden states evolve over time. Specifically, it computes:\n",
+    "\n",
+    "- **Hidden-to-hidden Jacobians** $\\frac{\\partial h^t}{\\partial h^{t-1}}$: How the current hidden state depends on the previous one. These drive the propagation of eligibility traces.\n",
+    "- **Weight spatial gradients** $\\frac{\\partial h^t}{\\partial w}$: How the hidden state depends on each weight parameter.\n",
+    "\n",
+    "The diagonal approximation of the hidden-to-hidden Jacobian makes this computation tractable for large networks. The compiler automatically extracts the transition function from the Jaxpr and computes these Jacobians.\n",
+    "\n",
+    "Let us see the full pipeline: define a model, compile the online learning graph, and inspect its structure."
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 9,
    "id": "tw9s67jlxpr",
-   "source": "# Complete example: model -> compile -> inspect graph structure\n\nmodel = SimpleNeuron(8)\nbrainstate.nn.init_all_states(model)\n\n# Wrap the model in the D-RTRL online learning algorithm\nalgo = braintrace.D_RTRL(model)\n\n# Compile the computation graph with a dummy input\nalgo.compile_graph(jnp.zeros(8))\n\n# Display the discovered graph structure:\n# - Which hidden groups were found\n# - Which weight parameters are associated with each group\nalgo.show_graph()",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": []
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-26T13:41:44.380786Z",
+     "iopub.status.busy": "2026-06-26T13:41:44.380584Z",
+     "iopub.status.idle": "2026-06-26T13:41:44.770557Z",
+     "shell.execute_reply": "2026-06-26T13:41:44.769626Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "========================================================================================================================\n",
+      "The hidden groups are:\n",
+      "\n",
+      "   Group 0: [('h',)]\n",
+      "\n",
+      "\n",
+      "The weight parameters which are associated with the hidden states are:\n",
+      "\n",
+      "   Weight 0: ('w',)  is associated with hidden group 0\n",
+      "\n",
+      "\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Complete example: model -> compile -> inspect graph structure\n",
+    "\n",
+    "model = SimpleNeuron(8)\n",
+    "brainstate.nn.init_all_states(model)\n",
+    "\n",
+    "# Wrap the model in the D-RTRL online learning algorithm\n",
+    "algo = braintrace.D_RTRL(model)\n",
+    "\n",
+    "# Compile the computation graph with a dummy input\n",
+    "algo.compile_graph(jnp.zeros(8))\n",
+    "\n",
+    "# Display the discovered graph structure:\n",
+    "# - Which hidden groups were found\n",
+    "# - Which weight parameters are associated with each group\n",
+    "algo.show_graph()"
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "58knkps468a",
-   "source": "The `show_graph()` output tells you:\n\n- **Hidden groups**: Which hidden states were discovered and how they are grouped. Each group corresponds to a set of states whose Jacobian is computed together.\n- **Weight parameters**: Which `ParamState` weights are associated with each hidden group. A weight is associated with a group if it is used through an ETP primitive (e.g., `braintrace.matmul`) and its output is shape-compatible with that group's hidden states.\n\nLet us also inspect a more complex model with multiple hidden states:",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "The `show_graph()` output tells you:\n",
+    "\n",
+    "- **Hidden groups**: Which hidden states were discovered and how they are grouped. Each group corresponds to a set of states whose Jacobian is computed together.\n",
+    "- **Weight parameters**: Which `ParamState` weights are associated with each hidden group. A weight is associated with a group if it is used through an ETP primitive (e.g., `braintrace.matmul`) and its output is shape-compatible with that group's hidden states.\n",
+    "\n",
+    "Let us also inspect a more complex model with multiple hidden states:"
+   ]
   },
   {
    "cell_type": "code",
+   "execution_count": 10,
    "id": "nj9ev53cba",
-   "source": "# A two-layer recurrent network to demonstrate multi-group discovery\n\nclass TwoLayerRNN(brainstate.nn.Module):\n    \"\"\"Two stacked recurrent layers, each with its own hidden state.\"\"\"\n\n    def __init__(self, in_size, hidden_size, out_size):\n        super().__init__()\n        # Layer 1\n        self.w1_in = brainstate.ParamState(brainstate.random.randn(in_size, hidden_size) * 0.01)\n        self.w1_rec = brainstate.ParamState(brainstate.random.randn(hidden_size, hidden_size) * 0.01)\n        self.h1 = brainstate.HiddenState(jnp.zeros(hidden_size))\n\n        # Layer 2\n        self.w2_in = brainstate.ParamState(brainstate.random.randn(hidden_size, out_size) * 0.01)\n        self.w2_rec = brainstate.ParamState(brainstate.random.randn(out_size, out_size) * 0.01)\n        self.h2 = brainstate.HiddenState(jnp.zeros(out_size))\n\n    def update(self, x):\n        # Layer 1: x feeds in, h1 recurs\n        self.h1.value = jax.nn.tanh(\n            x @ self.w1_in.value + braintrace.matmul(self.h1.value, self.w1_rec.value)\n        )\n        # Layer 2: h1 feeds in, h2 recurs\n        self.h2.value = jax.nn.tanh(\n            self.h1.value @ self.w2_in.value + braintrace.matmul(self.h2.value, self.w2_rec.value)\n        )\n        return self.h2.value\n\n\nmodel_2layer = TwoLayerRNN(in_size=10, hidden_size=16, out_size=8)\nbrainstate.nn.init_all_states(model_2layer)\n\nalgo_2layer = braintrace.D_RTRL(model_2layer)\nalgo_2layer.compile_graph(jnp.zeros(10))\nalgo_2layer.show_graph()",
-   "metadata": {},
-   "execution_count": null,
-   "outputs": []
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-26T13:41:44.772149Z",
+     "iopub.status.busy": "2026-06-26T13:41:44.771989Z",
+     "iopub.status.idle": "2026-06-26T13:41:45.478774Z",
+     "shell.execute_reply": "2026-06-26T13:41:45.477774Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "========================================================================================================================\n",
+      "The hidden groups are:\n",
+      "\n",
+      "   Group 0: [('h2',)]\n",
+      "   Group 1: [('h1',)]\n",
+      "\n",
+      "\n",
+      "The weight parameters which are associated with the hidden states are:\n",
+      "\n",
+      "   Weight 0: ('w1_rec',)  is associated with hidden group 1\n",
+      "   Weight 1: ('w2_rec',)  is associated with hidden group 0\n",
+      "\n",
+      "\n",
+      "The non-etrace weight parameters are:\n",
+      "\n",
+      "   Weight 0: ('w2_in',)\n",
+      "   Weight 1: ('w1_in',)\n",
+      "\n",
+      "\n",
+      "\n"
+     ]
+    }
+   ],
+   "source": [
+    "# A two-layer recurrent network to demonstrate multi-group discovery\n",
+    "\n",
+    "class TwoLayerRNN(brainstate.nn.Module):\n",
+    "    \"\"\"Two stacked recurrent layers, each with its own hidden state.\"\"\"\n",
+    "\n",
+    "    def __init__(self, in_size, hidden_size, out_size):\n",
+    "        super().__init__()\n",
+    "        # Layer 1\n",
+    "        self.w1_in = brainstate.ParamState(brainstate.random.randn(in_size, hidden_size) * 0.01)\n",
+    "        self.w1_rec = brainstate.ParamState(brainstate.random.randn(hidden_size, hidden_size) * 0.01)\n",
+    "        self.h1 = brainstate.HiddenState(jnp.zeros(hidden_size))\n",
+    "\n",
+    "        # Layer 2\n",
+    "        self.w2_in = brainstate.ParamState(brainstate.random.randn(hidden_size, out_size) * 0.01)\n",
+    "        self.w2_rec = brainstate.ParamState(brainstate.random.randn(out_size, out_size) * 0.01)\n",
+    "        self.h2 = brainstate.HiddenState(jnp.zeros(out_size))\n",
+    "\n",
+    "    def update(self, x):\n",
+    "        # Layer 1: x feeds in, h1 recurs\n",
+    "        self.h1.value = jax.nn.tanh(\n",
+    "            x @ self.w1_in.value + braintrace.matmul(self.h1.value, self.w1_rec.value)\n",
+    "        )\n",
+    "        # Layer 2: h1 feeds in, h2 recurs\n",
+    "        self.h2.value = jax.nn.tanh(\n",
+    "            self.h1.value @ self.w2_in.value + braintrace.matmul(self.h2.value, self.w2_rec.value)\n",
+    "        )\n",
+    "        return self.h2.value\n",
+    "\n",
+    "\n",
+    "model_2layer = TwoLayerRNN(in_size=10, hidden_size=16, out_size=8)\n",
+    "brainstate.nn.init_all_states(model_2layer)\n",
+    "\n",
+    "algo_2layer = braintrace.D_RTRL(model_2layer)\n",
+    "algo_2layer.compile_graph(jnp.zeros(10))\n",
+    "algo_2layer.show_graph()"
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "0e9nguauw0xg",
-   "source": "Notice that the compiler automatically discovered two separate hidden groups (one for each layer) and correctly associated each recurrent weight with its corresponding group. The feedforward weights (`w1_in`, `w2_in`) do not appear because they use regular JAX `@` rather than `braintrace.matmul`, so they are excluded from eligibility trace propagation.\n\nThis is a key design principle: **the operation choice controls which parameters participate in online learning**, not the parameter class. Use `braintrace.matmul(h, w)` to include a weight, and `h @ w` (standard JAX) to exclude it.",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "Notice that the compiler automatically discovered two separate hidden groups (one for each layer) and correctly associated each recurrent weight with its corresponding group. The feedforward weights (`w1_in`, `w2_in`) do not appear because they use regular JAX `@` rather than `braintrace.matmul`, so they are excluded from eligibility trace propagation.\n",
+    "\n",
+    "This is a key design principle: **the operation choice controls which parameters participate in online learning**, not the parameter class. Use `braintrace.matmul(h, w)` to include a weight, and `h @ w` (standard JAX) to exclude it."
+   ]
   },
   {
    "cell_type": "markdown",
    "id": "ph8dz1ta9i",
-   "source": "## Summary\n\nThis tutorial covered the three hidden state types in braintrace and how the compiler uses them:\n\n- **`brainstate.HiddenState`** -- for a single recurrent state variable (e.g., membrane potential). The simplest and most common choice.\n- **`brainstate.HiddenGroupState`** -- for multiple correlated states with the same shape (e.g., voltage and adaptation current). The compiler treats them as a single group.\n- **`brainstate.HiddenTreeState`** -- for hierarchical or heterogeneous state structures (e.g., dicts of named states). Supports arbitrary PyTree layouts.\n\nKey takeaways:\n\n1. **Automatic discovery**: The compiler traces the model's Jaxpr and automatically identifies which states are recurrent. No manual annotation of hidden states is needed -- just use `brainstate`'s state classes.\n2. **Grouping**: Related hidden states are grouped together for efficient Jacobian computation. `HiddenGroupState` explicitly declares a group; separate `HiddenState` variables are grouped by data flow analysis.\n3. **Operation-based selection**: Whether a weight participates in online learning depends on the operation used (`braintrace.matmul` vs. regular `@`), not on the parameter class.\n4. **Flexible initialization**: Use `init_all_states` for single-sample or manual batching, and `vmap_new_states` for automatic batching.",
-   "metadata": {}
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "This tutorial covered the three hidden state types in braintrace and how the compiler uses them:\n",
+    "\n",
+    "- **`brainstate.HiddenState`** -- for a single recurrent state variable (e.g., membrane potential). The simplest and most common choice.\n",
+    "- **`brainstate.HiddenGroupState`** -- for multiple same-shape states addressed by index (e.g., voltage and adaptation current stacked along the last axis). The compiler treats them as a single group.\n",
+    "- **`brainstate.HiddenTreeState`** -- for multiple same-shape states addressed by name (e.g., a dict of named neuron variables). Adds name- and unit-aware access on top of the single-array group storage.\n",
+    "\n",
+    "Key takeaways:\n",
+    "\n",
+    "1. **Automatic discovery**: The compiler traces the model's Jaxpr and automatically identifies which states are recurrent. No manual annotation of hidden states is needed -- just use `brainstate`'s state classes.\n",
+    "2. **Grouping**: Related hidden states are grouped together for efficient Jacobian computation. `HiddenGroupState` and `HiddenTreeState` explicitly declare a group; separate `HiddenState` variables are grouped by data flow analysis.\n",
+    "3. **Operation-based selection**: Whether a weight participates in online learning depends on the operation used (`braintrace.matmul` vs. regular `@`), not on the parameter class.\n",
+    "4. **Flexible initialization**: Use `init_all_states` for single-sample or manual batching, and `vmap_new_states` for automatic batching."
+   ]
   }
  ],
  "metadata": {
@@ -169,7 +644,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.10.0"
+   "version": "3.13.11"
   }
  },
  "nbformat": 4,

--- a/examples/000-lif-snn-for-nmnist.py
+++ b/examples/000-lif-snn-for-nmnist.py
@@ -18,6 +18,8 @@
 
 import brainstate
 import braintools
+import matplotlib
+matplotlib.use('Agg')  # headless backend: render to file, no display needed
 import matplotlib.pyplot as plt
 import numpy as np
 import saiunit as u
@@ -43,8 +45,12 @@ if __name__ == '__main__':
         in_shape = NMNIST.sensor_size
         out_shape = 10
         data = NMNIST(
-            save_to='D:/data/mnist',
-            # save_to='/mnt/d/data/mnist',
+            # Use the POSIX path to the D: drive on Linux/WSL so the dataset is
+            # NOT written to a literal ``./D:/data/mnist`` folder under the repo
+            # (a bare ``D:/...`` is a *relative* path off Windows). Swap these two
+            # lines back when running natively on Windows.
+            save_to='/mnt/d/data/mnist',
+            # save_to='D:/data/mnist',
             train=True,
             first_saccade_only=True,
             transform=tonic.transforms.ToFrame(sensor_size=in_shape, n_time_bins=200)

--- a/examples/001-gif-snn-for-dms.py
+++ b/examples/001-gif-snn-for-dms.py
@@ -17,6 +17,8 @@
 
 import brainstate
 import braintools
+import matplotlib
+matplotlib.use('Agg')  # headless backend: render to file, no display needed
 import matplotlib.pyplot as plt
 import numpy as np
 import saiunit as u

--- a/examples/002-coba-ei-rsnn.py
+++ b/examples/002-coba-ei-rsnn.py
@@ -21,6 +21,8 @@ import brainstate
 import braintools
 import jax
 import jax.numpy as jnp
+import matplotlib
+matplotlib.use('Agg')  # headless backend: render to file, no display needed
 import matplotlib.pyplot as plt
 import numpy as np
 import saiunit as u
@@ -122,12 +124,13 @@ class EvidenceAccumulation:
                 # X[i_seq:i_seq + t_cue, i_start: i_start + 25] = fr
                 X = jax.lax.dynamic_update_slice(X, update, (i_seq, i_start))
 
-            X = u.Quantity(X)
-            # recall cue
-            X[-t_recall:, self.feat_neurons['recall']] = self.feat_fr['recall'] * dt
+            # recall cue (functional update: in-place ``Quantity[...] =`` is
+            # rejected under jit/vmap on the latest saiunit; ``feat_fr * dt``
+            # auto-simplifies Hz*ms to a plain dimensionless probability)
+            X = X.at[-t_recall:, self.feat_neurons['recall']].set(self.feat_fr['recall'] * dt)
 
             # background noise
-            X[:, self.feat_neurons['noise']] = self.feat_fr['noise'] * dt
+            X = X.at[:, self.feat_neurons['noise']].set(self.feat_fr['noise'] * dt)
 
             # generate inputs and targets
             # X = u.math.asarray(rng.rand(*X.shape) < X, dtype=float)

--- a/examples/003-snn-memory-and-speed-evaluation-all.py
+++ b/examples/003-snn-memory-and-speed-evaluation-all.py
@@ -385,8 +385,11 @@ class Trainer(object):
         def _etrace_step(prev_grads, inputs, targets):
             i, inp = inputs
             # no need to return weights and states, since they are generated then no longer needed
+            # The latest brainstate ``grad`` requires grad_states to be State
+            # instances (a pytree of States), not a StateManager object; convert
+            # via ``to_pytree()`` (matches the sibling -batched benchmark).
             f_grad = brainstate.transform.grad(
-                _etrace_grad, grad_states=self.opt.param_states, has_aux=True, return_value=True)
+                _etrace_grad, grad_states=self.opt.param_states.to_pytree(), has_aux=True, return_value=True)
             cur_grads, local_loss, out = f_grad(i, inp, targets)
             next_grads = jax.tree.map(lambda a, b: a + b, prev_grads, cur_grads)
             return next_grads, (out, local_loss)
@@ -411,8 +414,10 @@ class Trainer(object):
         inputs = np.reshape(inputs, (inputs.shape[0], inputs.shape[1], -1))  # [n_steps, n_samples, n_in]
         self._etrace_reset_fun()
 
-        # initial gradients
-        grads = jax.tree.map(lambda a: jnp.zeros_like(a), self.opt.param_states.to_dict_values())
+        # initial gradients -- a pytree of zeros matching the grad_states pytree
+        # used in ``_etrace_step`` (``opt.param_states.to_pytree()``), so the
+        # per-step ``jax.tree.map(a + b, ...)`` accumulation aligns.
+        grads = jax.tree.map(lambda a: jnp.zeros_like(a), self.opt.param_states.to_pytree_value())
 
         # training
         indices = np.arange(inputs.shape[0])

--- a/examples/003-snn-memory-and-speed-evaluation-batched.py
+++ b/examples/003-snn-memory-and-speed-evaluation-batched.py
@@ -20,6 +20,8 @@ from functools import reduce
 from typing import Callable, Union
 
 import brainpy.state
+import matplotlib
+matplotlib.use('Agg')  # headless backend: render to file, no display needed
 import matplotlib.pyplot as plt
 import numpy as np
 

--- a/examples/003-snn-memory-and-speed-evaluation-vmap.py
+++ b/examples/003-snn-memory-and-speed-evaluation-vmap.py
@@ -19,6 +19,8 @@ import time
 from functools import reduce
 from typing import Callable, Union
 
+import matplotlib
+matplotlib.use('Agg')  # headless backend: render to file, no display needed
 import matplotlib.pyplot as plt
 import numpy as np
 
@@ -624,7 +626,11 @@ class Trainer(object):
                 f'time = {mean_time:.5f} s, '
                 f'memory = {mean_mem:.2f} GB'
             )
-            self.opt.step()
+            # Advance the per-epoch LR schedule. The latest braintools optimizer
+            # API repurposed ``opt.step()`` to apply gradients (it now requires a
+            # ``grads`` arg); the epoch LR advance moved to ``opt.lr.step_epoch()``
+            # (this matches the sibling -batched benchmark, which was migrated).
+            self.opt.lr.step_epoch()
 
             # training accuracy
             if mean_acc > max_acc:

--- a/examples/004-feedforward-conv-snn.py
+++ b/examples/004-feedforward-conv-snn.py
@@ -69,16 +69,25 @@ class ConvSNN(brainstate.nn.Module):
             R=1.
         )
 
+        # NOTE: ``use_fast_variance=False`` is required for the online (D_RTRL)
+        # trainers. The param-dim eligibility trace reads the instantaneous
+        # ``dh/dy`` through this norm via a single all-ones jvp, whose value for a
+        # mean-subtracting (shift-invariant) op is the Jacobian row-sums = exactly
+        # 0. The fast-variance formula ``E[x^2] - E[x]^2`` loses that exactness in
+        # float32 (catastrophic cancellation), and under ``Vmap(vmap_states='new')``
+        # the residual is amplified by the recurrent trace and the large
+        # ``rsqrt(var+eps)`` factor (tiny variance on sparse spike inputs) into an
+        # overflow. The stable two-pass variance keeps the row-sums exactly 0.
         self.layer1 = brainstate.nn.Sequential(
             braintrace.nn.Conv2d(in_size, n_channel, kernel_size=3, padding=1, **conv_inits),
-            braintrace.nn.LayerNorm.desc(),
+            brainstate.nn.LayerNorm.desc(use_fast_variance=False),
             brainpy.state.IF.desc(**if_param),
             brainstate.nn.MaxPool2d.desc(kernel_size=2, stride=2)  # 14 * 14
         )
 
         self.layer2 = brainstate.nn.Sequential(
             braintrace.nn.Conv2d(self.layer1.out_size, n_channel, kernel_size=3, padding=1, **conv_inits),
-            braintrace.nn.LayerNorm.desc(),
+            brainstate.nn.LayerNorm.desc(use_fast_variance=False),
             brainpy.state.IF.desc(**if_param),
         )
         self.layer3 = brainstate.nn.Sequential(
@@ -235,9 +244,12 @@ class OnlineVmapTrainer(Trainer):
             # initialize the online learning model
             with brainstate.environ.context(fit=True):
                 model.compile_graph(inputs[0, 0])
-                model.show_graph()
 
         init()
+        # show_graph() is a post-compile diagnostic: call it once *after* init().
+        # The vmap_new_states discovery probe runs init() with compilation deferred
+        # to the real mapped pass, so the graph is only available after init().
+        model.show_graph()
         model = brainstate.nn.Vmap(model, vmap_states='new')
 
         # weights
@@ -430,7 +442,10 @@ def get_nmnist_data(
 def data_processing(x_local):
     assert x_local.ndim == 5  # (sequence, batch, channel, height, width)
     x_local = x_local.permute(0, 1, 3, 4, 2)  # (sequence, batch, height, width, channel)
-    return u.math.asarray(x_local, dtype=brainstate.environ.dftype())
+    # x_local is a torch tensor here; convert via numpy first so saiunit stays on
+    # the numpy/jax backend (u.math.asarray would otherwise dispatch to the torch
+    # backend and reject the JAX dtype).
+    return u.math.asarray(np.asarray(x_local), dtype=brainstate.environ.dftype())
 
 
 if __name__ == '__main__':

--- a/examples/100-gru-on-copying-task.py
+++ b/examples/100-gru-on-copying-task.py
@@ -18,6 +18,8 @@
 import brainstate
 import braintools
 import jax
+import matplotlib
+matplotlib.use('Agg')  # headless backend: render to file, no display needed
 import matplotlib.pyplot as plt
 import numpy as np
 from tqdm import tqdm
@@ -100,6 +102,7 @@ class Trainer(object):
             x_local = jax.numpy.asarray(np.transpose(x_local, (1, 0, 2)))
             y_local = jax.numpy.asarray(np.transpose(y_local, (1, 0)))
             r = self.batch_train(x_local, y_local)
+            losses.append(float(r))
             bar.set_description(f'Training {i:5d}, loss = {float(r):.5f}', refresh=True)
         return np.asarray(losses)
 
@@ -163,6 +166,14 @@ class OnlineTrainer(Trainer):
             grads = jax.tree.map(lambda a: jax.numpy.zeros_like(a), {k: v.value for k, v in weights.items()})
             # 沿着时间轴计算和累积梯度
             grads, (outs, losses) = brainstate.transform.scan(_etrace_grad, grads, (inputs_, target))
+            # The scan *sums* the per-step gradients, but the optimised/reported
+            # objective is ``losses.mean()`` — so divide by the number of
+            # accumulated steps to make the update the gradient of that mean (the
+            # same scale BPTT differentiates). Summing gives a ~n_learn x too-large
+            # effective learning rate: the (directionally correct) online gradient
+            # then overshoots and the recurrent GRU drifts unstable until the long
+            # free-running trace overflows to NaN. Mean-scaling tracks BPTT stably.
+            grads = jax.tree.map(lambda g: g / losses.shape[0], grads)
             # 更新梯度
             self.opt.update(grads)
             return losses.mean()

--- a/examples/101-integrator-rnn.py
+++ b/examples/101-integrator-rnn.py
@@ -34,6 +34,8 @@ import brainstate
 import braintools
 import jax
 import jax.numpy as jnp
+import matplotlib
+matplotlib.use('Agg')  # headless backend: render to file, no display needed
 import matplotlib.pyplot as plt
 import numpy as np
 
@@ -211,7 +213,7 @@ def train_online(n_epochs=5):
 print("=" * 60)
 print("Training with BPTT")
 print("=" * 60)
-# bptt_model, bptt_predict, bptt_losses = train_bptt(n_epochs=5)
+bptt_model, bptt_predict, bptt_losses = train_bptt(n_epochs=5)
 
 print()
 print("=" * 60)

--- a/examples/snn_models.py
+++ b/examples/snn_models.py
@@ -21,6 +21,8 @@ import brainpy.state
 import brainstate
 import braintools
 import jax
+import matplotlib
+matplotlib.use('Agg')  # headless backend: render to file, no display needed
 import matplotlib.pyplot as plt
 import numba
 import numpy as np
@@ -411,9 +413,13 @@ class OnlineTrainer(Trainer):
         def init():
             brainstate.nn.init_all_states(self.target)
             model.compile_graph(inputs[0, 0])
-            model.show_graph()
 
         init()
+        # show_graph() is a post-compile diagnostic: call it once *after* init()
+        # rather than inside it. The vmap_new_states discovery probe runs init()
+        # once with compilation deferred to the real mapped pass, so the graph is
+        # only available here, after init() has returned.
+        model.show_graph()
         model = brainstate.nn.Vmap(model, vmap_states='new')
 
         def _etrace_grad(inp):
@@ -434,8 +440,14 @@ class OnlineTrainer(Trainer):
             # forward propagation
             grads = jax.tree.map(u.math.zeros_like, weights.to_dict_values())
             grads, (outs, losses) = brainstate.transform.scan(_etrace_step, grads, inputs_)
-            # gradient updates
-            grads = brainstate.functional.clip_grad_norm(grads, 1.)
+            # gradient updates. The scan *sums* the per-step gradients, but the
+            # optimised/reported objective is ``losses.mean()`` — so divide by the
+            # number of accumulated steps to make the update the gradient of that
+            # mean (the scale BPTT differentiates). A global-norm clip to 1.0 here
+            # instead couples every parameter (the large recurrent eligibility
+            # trace dominates the norm and starves the small readout gradient),
+            # pinning accuracy at chance.
+            grads = jax.tree.map(lambda g: g / losses.shape[0], grads)
             self.opt.update(grads)
             # accuracy
             return losses.mean(), outs


### PR DESCRIPTION
## Summary
- Fix online-learning convergence regressions under `brainstate.nn.Vmap(vmap_states='new')`: defer graph compilation during the vmap discovery probe (avoids binding the executor to throwaway probe states), and correctly handle models that mix batched and unbatched ETP primitives in the param-dim VJP solve — batch-sum only gradients owned by batched primitives, and re-insert the matching singleton batch axis on per-lane cotangents/Jacobians so conv eligibility traces line up. Restores convergence for the conv-based SNN/RNN training examples.
- Add a conv vmap-correctness regression test.
- Align the training examples with the fixed batching path; use the agg matplotlib backend for headless plotting.
- Repair all 10 docs notebooks against the current API, refresh their stale saved outputs, and align the markdown narrative with the actual outputs.

## Notebook fixes
- `hidden_states`: HiddenGroupState array form (`get_value` / stacked writes) and HiddenTreeState named `get_value`/`set_value`; corrected the state-type descriptions to the current same-shape API.
- `custom_algorithms`: iterate the nested `get_etrace_of()` structure `{(weight_id, leaf): {input_name: trace_tensor}}`.
- `graph_visualization`: recurrent-conv ETP example; `trainable_paths` dict; accurate hidden-group narrative (coupled same-shape states merge into one group).
- `compiler_internals` / `limitations`: use `trainable_paths` instead of the removed `weight_path` attribute.

## Test plan
- All 10 docs notebooks execute end-to-end with 0 failing code cells (nbclient harness).
- Conv vmap-correctness regression test added.
- Full GPU suite verified green in the originating work.

## Summary by Sourcery

Restore correct eligibility-trace gradients for convolutional models under vmap-based online training and refresh documentation, examples, and tests to match the current API and batching behavior.

Bug Fixes:
- Fix param-dimension VJP handling for batched convolutions under brainstate.nn.Vmap(vmap_states='new') so hidden-state cotangents and traces share consistent batch axes.
- Avoid erroneously batch-summing gradients from unbatched primitives when mixed with batched primitives in the same solve, preventing axis-collapsing shape bugs.
- Defer online-learning graph compilation during vmap_new_states discovery probes to avoid binding executors to unbatched probe states and triggering BatchAxisError.
- Stabilize online training with convolution-plus-normalization pipelines by documenting and enforcing LayerNorm variance settings that keep dh/dy row sums numerically zero.
- Update various examples to use the correct optimizer, grad, unit, and dataset path APIs to avoid runtime errors with newer library versions.
- Fix state updates in the COBRA EI RSNN example to use functional array updates compatible with current saiunit and JAX transforms.

Enhancements:
- Clarify how hidden states, hidden groups, and HiddenTreeState/HiddenGroupState array forms work in the hidden-state management tutorial, and align narrative with the same-shape API.
- Improve the graph-visualization and compiler-internals tutorials to reflect the current ETP graph structure (trainable_paths, conv primitives, GRU gate handling, and diagnostics) and to better explain grouping behavior and non-temporal parameters.
- Document the structure of get_etrace_of outputs and show how to work with nested trace groups across multiple trainable inputs per primitive.
- Adjust example training loops (SNN benchmarks, GRU copying task, integrator RNN) to scale accumulated online gradients consistently with mean losses and to avoid destabilizing global-norm clipping.
- Switch plotting backends and environment defaults where needed for headless or GPU-agnostic execution, and ensure matmul precision is high enough in tests to meaningfully compare gradients.

Documentation:
- Refresh and re-execute the hidden state, graph visualization, compiler internals, custom algorithms, and limitations notebooks to match the current braintrace/brainstate/ETP APIs and outputs.
- Clarify explanations around GRU gate eligibility (weight-to-weight exclusions), conv ETP behavior, and how ETP primitives, hidden groups, and diagnostics interact in multi-layer and convolutional models.

Tests:
- Add a conv-vs-vmap correctness regression test suite that compares vmap_new_states+Vmap online gradients against summed eager single-sample gradients for pure conv, mixed conv+dense, and conv+LayerNorm models.
- Extend notebook-based tests by re-executing all tutorials and advanced docs to ensure they run end-to-end against the current API with no failing cells.

Chores:
- Update saved notebook outputs, execution counts, and Python version metadata across documentation notebooks to reflect the current execution environment.