### PR TITLE
Replace saiunit with brainunit for unit handling

### DIFF
--- a/braintrace/_etrace_algorithms/_common.py
+++ b/braintrace/_etrace_algorithms/_common.py
@@ -21,7 +21,7 @@ from typing import Any, Dict, Optional
 import brainstate
 import jax
 import jax.numpy as jnp
-import saiunit as u
+import brainunit as u
 
 from braintrace._typing import PyTree
 

--- a/braintrace/_etrace_algorithms/_common_test.py
+++ b/braintrace/_etrace_algorithms/_common_test.py
@@ -20,7 +20,7 @@ import jax
 import jax.numpy as jnp
 import numpy.testing as npt
 import pytest
-import saiunit as u
+import brainunit as u
 
 from braintrace._etrace_algorithms._common import (
     FixedRandomFeedback,

--- a/braintrace/_etrace_algorithms/d_rtrl_test.py
+++ b/braintrace/_etrace_algorithms/d_rtrl_test.py
@@ -18,7 +18,7 @@ import jax
 import jax.numpy as jnp
 import numpy.testing as npt
 import pytest
-import saiunit as u
+import brainunit as u
 
 import braintrace
 from braintrace._etrace_algorithms.d_rtrl import D_RTRL
@@ -227,7 +227,7 @@ class TestRemoveUnits:
         npt.assert_array_almost_equal(restored, x)
 
     def test_quantity_round_trip(self):
-        """A saiunit Quantity should be stripped and restored."""
+        """A brainunit Quantity should be stripped and restored."""
         x = jnp.array([1.0, 2.0]) * u.mV
         unitless, restore = _remove_units(x)
         # unitless should be the mantissa

--- a/braintrace/_etrace_algorithms/graph_executor_test.py
+++ b/braintrace/_etrace_algorithms/graph_executor_test.py
@@ -17,7 +17,7 @@ import unittest
 
 import brainstate
 import jax.numpy as jnp
-import saiunit as u
+import brainunit as u
 
 import braintrace
 from braintrace._etrace_model_test import (

--- a/braintrace/_etrace_algorithms/io_dim_vjp.py
+++ b/braintrace/_etrace_algorithms/io_dim_vjp.py
@@ -30,7 +30,7 @@ from typing import Callable, Dict, Tuple, Optional, Sequence, Any
 import brainstate
 import jax
 import jax.numpy as jnp
-import saiunit as u
+import brainunit as u
 
 from braintrace._etrace_compiler import HiddenGroup, HiddenParamOpRelation
 from braintrace._etrace_op import (

--- a/braintrace/_etrace_algorithms/param_dim_vjp.py
+++ b/braintrace/_etrace_algorithms/param_dim_vjp.py
@@ -19,7 +19,7 @@ from typing import Callable, Dict, Tuple, Optional, Sequence, Any
 import brainstate
 import jax
 import jax.numpy as jnp
-import saiunit as u
+import brainunit as u
 
 from braintrace._etrace_compiler import HiddenParamOpRelation, HiddenGroup
 from braintrace._etrace_op import (

--- a/braintrace/_etrace_algorithms/pp_prop_test.py
+++ b/braintrace/_etrace_algorithms/pp_prop_test.py
@@ -17,7 +17,7 @@ import brainstate
 import jax.numpy as jnp
 import numpy as np
 import pytest
-import saiunit as u
+import brainunit as u
 
 import braintrace
 from braintrace._etrace_algorithms.io_dim_vjp import (

--- a/braintrace/_etrace_algorithms/vjp_base.py
+++ b/braintrace/_etrace_algorithms/vjp_base.py
@@ -19,7 +19,7 @@ from typing import Callable, Dict, Tuple, Any, List, Optional, Sequence
 import brainstate
 import jax
 import jax.numpy as jnp
-import saiunit as u
+import brainunit as u
 
 from braintrace._input_data import has_multistep_data
 from braintrace._state_managment import assign_state_values_v2

--- a/braintrace/_etrace_algorithms/vjp_graph_executor.py
+++ b/braintrace/_etrace_algorithms/vjp_graph_executor.py
@@ -42,7 +42,7 @@ from typing import Any, Callable, Dict, Optional, Tuple
 import brainstate
 import jax.core
 import jax.numpy as jnp
-import saiunit as u
+import brainunit as u
 from brainstate._compatible_import import get_aval
 from jax.extend import linear_util as lu
 from jax.interpreters import partial_eval as pe

--- a/braintrace/_etrace_algorithms/vjp_graph_executor_test.py
+++ b/braintrace/_etrace_algorithms/vjp_graph_executor_test.py
@@ -19,7 +19,7 @@ import brainstate
 import jax
 import jax.numpy as jnp
 import numpy as np
-import saiunit as u
+import brainunit as u
 
 import braintrace
 

--- a/braintrace/_etrace_compiler/graph_test.py
+++ b/braintrace/_etrace_compiler/graph_test.py
@@ -18,7 +18,7 @@ import unittest
 from pprint import pprint
 
 import brainstate
-import saiunit as u
+import brainunit as u
 
 import braintrace
 from braintrace._etrace_model_test import (

--- a/braintrace/_etrace_compiler/hid_param_op_test.py
+++ b/braintrace/_etrace_compiler/hid_param_op_test.py
@@ -18,7 +18,7 @@ from pprint import pprint
 
 import brainstate
 import pytest
-import saiunit as u
+import brainunit as u
 
 import braintrace
 from braintrace import find_hidden_param_op_relations_from_module

--- a/braintrace/_etrace_compiler/hidden_group.py
+++ b/braintrace/_etrace_compiler/hidden_group.py
@@ -50,7 +50,7 @@ from typing import List, Dict, Sequence, Tuple, Set, Optional, Callable, NamedTu
 import brainstate
 import jax.core
 import numpy as np
-import saiunit as u
+import brainunit as u
 from brainstate import HiddenGroupState
 
 from braintrace._compatible_imports import Var, Literal, JaxprEqn, Jaxpr

--- a/braintrace/_etrace_compiler/hidden_group_test.py
+++ b/braintrace/_etrace_compiler/hidden_group_test.py
@@ -21,7 +21,7 @@ import brainstate
 import jax
 import numpy as np
 import pytest
-import saiunit as u
+import brainunit as u
 
 import braintrace
 from braintrace._etrace_compiler import model4test as group_etrace_model

--- a/braintrace/_etrace_compiler/hidden_pertubation.py
+++ b/braintrace/_etrace_compiler/hidden_pertubation.py
@@ -18,7 +18,7 @@ from typing import Dict, Set, Sequence, NamedTuple, Any
 
 import brainstate
 import jax.core
-import saiunit as u
+import brainunit as u
 
 from braintrace._compatible_imports import (
     Var,

--- a/braintrace/_etrace_compiler/hidden_pertubation_test.py
+++ b/braintrace/_etrace_compiler/hidden_pertubation_test.py
@@ -17,7 +17,7 @@ from pprint import pprint
 
 import brainstate
 import pytest
-import saiunit as u
+import brainunit as u
 
 import braintrace
 from braintrace._etrace_compiler.hidden_pertubation import add_hidden_perturbation_in_module

--- a/braintrace/_etrace_compiler/model4test.py
+++ b/braintrace/_etrace_compiler/model4test.py
@@ -21,7 +21,7 @@ import brainstate
 import braintools
 import jax
 import jax.numpy as jnp
-import saiunit as u
+import brainunit as u
 
 import braintrace
 

--- a/braintrace/_etrace_compiler/module_info.py
+++ b/braintrace/_etrace_compiler/module_info.py
@@ -18,7 +18,7 @@ from typing import Dict, Sequence, List, Tuple, Optional, NamedTuple, Any
 
 import brainstate
 import jax
-import saiunit as u
+import brainunit as u
 
 from braintrace._compatible_imports import (
     Var,

--- a/braintrace/_etrace_compiler/module_info_test.py
+++ b/braintrace/_etrace_compiler/module_info_test.py
@@ -17,7 +17,7 @@ from pprint import pprint
 
 import brainstate
 import pytest
-import saiunit as u
+import brainunit as u
 
 import braintrace
 from braintrace._etrace_model_test import (

--- a/braintrace/_etrace_model_test.py
+++ b/braintrace/_etrace_model_test.py
@@ -18,7 +18,7 @@ import brainpy
 import brainstate
 import braintools
 import jax.numpy as jnp
-import saiunit as u
+import brainunit as u
 
 import braintrace
 

--- a/braintrace/_etrace_op/conv.py
+++ b/braintrace/_etrace_op/conv.py
@@ -17,7 +17,7 @@ r"""Convolution ETP primitive (``etp_conv_p``).
 
 Always expects a batch dimension on the input. The full keyword surface
 of ``jax.lax.conv_general_dilated`` is preserved; the wrapper splits and
-recombines saiunit quantities for the input and kernel.
+recombines brainunit quantities for the input and kernel.
 
 **Forward operation**
 
@@ -73,7 +73,7 @@ from typing import Any, Optional, Sequence
 
 import jax
 import jax.numpy as jnp
-import saiunit as u
+import brainunit as u
 
 from ._primitive import register_primitive
 

--- a/braintrace/_etrace_op/conv_test.py
+++ b/braintrace/_etrace_op/conv_test.py
@@ -21,7 +21,7 @@ Coverage:
   under SAME and VALID padding, with and without bias.
 * The ``etp_conv_p`` primitive appears in the jaxpr and carries the
   expected static parameters.
-* saiunit support — quantities with units multiply correctly.
+* brainunit support — quantities with units multiply correctly.
 * JAX rules — jit / grad work.
 * Four ETP rules — the ``conv`` rules use a VJP-based ``xy_to_dw`` that
   must match a hand-written JAX VJP; the init fns return arrays of the
@@ -36,7 +36,7 @@ import brainstate
 import jax
 import jax.numpy as jnp
 import numpy as np
-import saiunit as u
+import brainunit as u
 
 import braintrace
 from braintrace._etrace_op import (
@@ -153,10 +153,10 @@ class TestPrimitiveAndParams:
 
 
 # ---------------------------------------------------------------------------
-# saiunit
+# brainunit
 # ---------------------------------------------------------------------------
 
-class TestSaiunit:
+class TestBrainunit:
 
     def test_unitless(self):
         x = jnp.ones((1, 3, 8))

--- a/braintrace/_etrace_op/dense.py
+++ b/braintrace/_etrace_op/dense.py
@@ -77,7 +77,7 @@ dict, so the legacy (no-bias) code path is unchanged in behaviour.
 
 import jax
 import jax.numpy as jnp
-import saiunit as u
+import brainunit as u
 
 from ._primitive import register_primitive
 

--- a/braintrace/_etrace_op/dense_test.py
+++ b/braintrace/_etrace_op/dense_test.py
@@ -21,7 +21,7 @@ Coverage:
   ``etp_mv_p``. Verified by jaxpr inspection.
 * Forward correctness — agrees with ``x @ w (+ b)``.
 * Bias presence — ``has_bias`` parameter is propagated through ``bind``.
-* saiunit support — quantities, mixed units, unitless inputs.
+* brainunit support — quantities, mixed units, unitless inputs.
 * JAX rules — jit, vmap, grad, jvp work with no extra plumbing.
 * Four ETP rules — ``yw_to_w``, ``xy_to_dw``, ``init_drtrl``, ``init_pp``
   return tensors of the documented shape and value.
@@ -34,7 +34,7 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 import numpy.testing as npt
-import saiunit as u
+import brainunit as u
 
 import braintrace
 from braintrace._etrace_op import (
@@ -123,10 +123,10 @@ class TestHasBiasParam:
 
 
 # ---------------------------------------------------------------------------
-# saiunit support
+# brainunit support
 # ---------------------------------------------------------------------------
 
-class TestSaiunit:
+class TestBrainunit:
 
     def test_unitless_input_returns_unitless(self):
         x = jnp.ones((2, 3))

--- a/braintrace/_etrace_op/elemwise.py
+++ b/braintrace/_etrace_op/elemwise.py
@@ -63,7 +63,7 @@ primitive when composing Jacobians).
 """
 
 import jax.numpy as jnp
-import saiunit as u
+import brainunit as u
 
 from ._primitive import register_primitive
 

--- a/braintrace/_etrace_op/elemwise_test.py
+++ b/braintrace/_etrace_op/elemwise_test.py
@@ -23,7 +23,7 @@ verifies:
 * ``element_wise(w)`` (default ``fn=identity``) round-trips ``w``.
 * ``element_wise(w, fn=lambda w: 2*w)`` applies ``fn`` *before* the bind
   (the primitive itself is the identity).
-* saiunit quantities pass through.
+* brainunit quantities pass through.
 * JAX rules — jit, vmap, grad, jvp.
 * Four ETP rules return the documented values / shapes.
 """
@@ -35,7 +35,7 @@ from collections import namedtuple
 import jax
 import jax.numpy as jnp
 import numpy as np
-import saiunit as u
+import brainunit as u
 
 import braintrace
 from braintrace._etrace_op import (
@@ -122,10 +122,10 @@ class TestPrimitiveInJaxpr:
 
 
 # ---------------------------------------------------------------------------
-# saiunit
+# brainunit
 # ---------------------------------------------------------------------------
 
-class TestSaiunit:
+class TestBrainunit:
 
     def test_unitless_passthrough(self):
         w = jnp.array([1.0, 2.0, 3.0])

--- a/braintrace/_etrace_op/lora.py
+++ b/braintrace/_etrace_op/lora.py
@@ -82,7 +82,7 @@ Keys ``'lora_b'`` / ``'lora_a'`` match the pytree leaf names in
 
 import jax
 import jax.numpy as jnp
-import saiunit as u
+import brainunit as u
 
 from ._primitive import register_primitive
 

--- a/braintrace/_etrace_op/lora_test.py
+++ b/braintrace/_etrace_op/lora_test.py
@@ -29,7 +29,7 @@ from collections import namedtuple
 import jax
 import jax.numpy as jnp
 import numpy as np
-import saiunit as u
+import brainunit as u
 
 import braintrace
 from braintrace._etrace_op import (
@@ -147,10 +147,10 @@ class TestPrimitiveParams:
 
 
 # ---------------------------------------------------------------------------
-# saiunit
+# brainunit
 # ---------------------------------------------------------------------------
 
-class TestSaiunit:
+class TestBrainunit:
 
     def test_unitless(self):
         x = jnp.ones((2, 3))

--- a/braintrace/_etrace_op/sparse.py
+++ b/braintrace/_etrace_op/sparse.py
@@ -79,7 +79,7 @@ dict, so the legacy (no-bias) code path is unchanged in behaviour.
 
 import jax
 import jax.numpy as jnp
-import saiunit as u
+import brainunit as u
 
 from ._primitive import register_primitive
 
@@ -330,7 +330,7 @@ def sparse_matmul(x, weight_data, *, sparse_mat, bias=None):
     weight_data : ArrayLike
         Sparse-matrix data, i.e. the non-zero values, shape ``(nnz,)``.
     sparse_mat : object
-        Sparse-matrix structure (e.g. a ``saiunit.sparse`` matrix object).
+        Sparse-matrix structure (e.g. a ``brainunit.sparse`` matrix object).
         Must expose ``with_data`` (substitute new data into the structure)
         and ``yw_to_w_transposed`` (apply the transposed sparse pattern to
         a trace).

--- a/braintrace/_etrace_op/sparse_test.py
+++ b/braintrace/_etrace_op/sparse_test.py
@@ -23,7 +23,7 @@ The sparse structure is supplied by the user as a static parameter
 * ``yw_to_w_transposed(hidden_dim, trace)`` — apply the transposed
   pattern when propagating the trace.
 
-For end-to-end forward correctness a real ``saiunit.sparse.CSR`` works.
+For end-to-end forward correctness a real ``brainunit.sparse.CSR`` works.
 For rule-level tests a tiny stub class fits the contract exactly so the
 test does not depend on the upstream sparse-matrix surface area.
 """
@@ -36,8 +36,8 @@ import brainstate
 import jax
 import jax.numpy as jnp
 import numpy as np
-import saiunit as u
-from saiunit import sparse as ss
+import brainunit as u
+from brainunit import sparse as ss
 
 import braintrace
 from braintrace._etrace_op import (
@@ -187,10 +187,10 @@ class TestAutoDispatch:
 
 
 # ---------------------------------------------------------------------------
-# saiunit
+# brainunit
 # ---------------------------------------------------------------------------
 
-class TestSaiunit:
+class TestBrainunit:
 
     def test_unitless(self):
         dense = jnp.eye(3) * 2.0
@@ -339,7 +339,7 @@ class TestSparseMMBiasGradient:
     """D-RTRL gradient correctness for etp_sp_mm_p with a bias vector.
 
     Uses a hashable stub sparse matrix (backed by a dense 3×4 identity-like
-    template) so the test does not depend on saiunit.CSR being hashable in JAX.
+    template) so the test does not depend on brainunit.CSR being hashable in JAX.
     The stub's ``with_data`` reconstructs the dense matrix from the flat data
     vector (one value per non-zero), and ``yw_to_w_transposed`` applies the
     transposed pattern.

--- a/braintrace/_grad_exponential.py
+++ b/braintrace/_grad_exponential.py
@@ -16,7 +16,7 @@
 
 import brainstate
 import jax.tree
-import saiunit as u
+import brainunit as u
 
 from braintrace._typing import PyTree
 
@@ -37,8 +37,8 @@ class GradExpon(brainstate.nn.Module):
         A pytree whose leaves give the shape and dtype of the gradients to
         accumulate. The accumulator is initialised to zeros matching each
         leaf.
-    tau_or_decay : saiunit.Quantity or float
-        Either a decay time constant (as a :class:`~saiunit.Quantity`), from
+    tau_or_decay : brainunit.Quantity or float
+        Either a decay time constant (as a :class:`~brainunit.Quantity`), from
         which the decay factor is computed as
         :math:`\exp(-1 / (\tau / \mathrm{dt}))`, or the decay factor itself
         (a ``float`` in the open interval :math:`(0, 1)`).

--- a/braintrace/_legacy/_legacy_test.py
+++ b/braintrace/_legacy/_legacy_test.py
@@ -113,7 +113,7 @@ class TestOpsForward:
         assert y.shape == (1, 4, 4, 2)
 
     def test_sparse_op(self):
-        from saiunit import sparse as ss
+        from brainunit import sparse as ss
         dense = jnp.eye(3) * 2.0
         csr = ss.CSR.fromdense(dense)
         op = SpMatMulOp(sparse_mat=csr)

--- a/braintrace/_legacy/_ops.py
+++ b/braintrace/_legacy/_ops.py
@@ -30,7 +30,7 @@ from typing import Any, Callable, Optional, Sequence
 
 import jax
 import numpy as np
-import saiunit as u
+import brainunit as u
 
 from .._etrace_op import (
     conv as _new_conv,
@@ -430,7 +430,7 @@ class SpMatMulOp(ETraceOp):
 
     Parameters
     ----------
-    sparse_mat : saiunit.sparse.SparseMatrix
+    sparse_mat : brainunit.sparse.SparseMatrix
         The sparse matrix whose structure is reused; its data is replaced
         by the weight values.
     weight_fn : Callable, optional
@@ -451,7 +451,7 @@ class SpMatMulOp(ETraceOp):
         super().__init__(is_diagonal=False)
         if not isinstance(sparse_mat, u.sparse.SparseMatrix):
             raise TypeError(
-                f'sparse_mat must be a saiunit SparseMatrix, got {type(sparse_mat)}'
+                f'sparse_mat must be a brainunit SparseMatrix, got {type(sparse_mat)}'
             )
         self.sparse_mat = sparse_mat
         assert callable(weight_fn)

--- a/braintrace/_misc.py
+++ b/braintrace/_misc.py
@@ -20,7 +20,7 @@ from typing import Sequence, Callable, Any
 
 import brainstate
 import jax.tree
-import saiunit as u
+import brainunit as u
 
 from ._compatible_imports import Var
 from ._typing import Path, ETraceDF_Key

--- a/braintrace/nn/_linear.py
+++ b/braintrace/nn/_linear.py
@@ -16,7 +16,7 @@
 # -*- coding: utf-8 -*-
 
 import brainstate
-import saiunit as u
+import brainunit as u
 
 from braintrace._etrace_op import matmul, sparse_matmul, lora_matmul
 from braintrace._typing import ArrayLike

--- a/braintrace/nn/_linear_test.py
+++ b/braintrace/nn/_linear_test.py
@@ -26,7 +26,7 @@ Tests cover:
 import brainstate
 import jax.numpy as jnp
 import pytest
-import saiunit as u
+import brainunit as u
 from braintools import init
 
 import braintrace

--- a/braintrace/nn/_readout.py
+++ b/braintrace/nn/_readout.py
@@ -19,7 +19,7 @@ from typing import Callable, Optional
 
 import brainstate
 import braintools
-import saiunit as u
+import brainunit as u
 
 from braintrace._etrace_op import matmul
 from braintrace._typing import Size, ArrayLike, as_size_tuple
@@ -80,7 +80,7 @@ class LeakyRateReadout(brainstate.nn.Module):
 
         >>> import braintrace
         >>> import brainstate
-        >>> import saiunit as u
+        >>> import brainunit as u
         >>>
         >>> brainstate.environ.set(dt=0.1 * u.ms)
         >>> # Create a leaky rate readout layer
@@ -103,7 +103,7 @@ class LeakyRateReadout(brainstate.nn.Module):
         self,
         in_size: Size,
         out_size: Size,
-        tau: ArrayLike = 5. * u.ms,  # type: ignore[assignment]  # saiunit types `float * Unit` as `Unit | Quantity`
+        tau: ArrayLike = 5. * u.ms,  # type: ignore[assignment]  # brainunit types `float * Unit` as `Unit | Quantity`
         w_init: Callable = braintools.init.KaimingNormal(),
         r_init: Callable = braintools.init.ZeroInit(),
         name: Optional[str] = None,

--- a/braintrace/nn/_readout_test.py
+++ b/braintrace/nn/_readout_test.py
@@ -22,7 +22,7 @@ Tests cover:
 
 import brainstate
 import jax.numpy as jnp
-import saiunit as u
+import brainunit as u
 from braintools import init
 
 import braintrace

--- a/braintrace/nn/_rnn.py
+++ b/braintrace/nn/_rnn.py
@@ -18,7 +18,7 @@ from typing import Any, Callable, Union
 
 import brainstate
 import braintools
-import saiunit as u
+import brainunit as u
 
 from braintrace._etrace_op import element_wise
 from braintrace._typing import ArrayLike, as_size_tuple as _as_size_tuple

--- a/braintrace/nn/_rnn_test.py
+++ b/braintrace/nn/_rnn_test.py
@@ -31,8 +31,8 @@ import pytest
 
 brainstate = pytest.importorskip("brainstate")
 braintools = pytest.importorskip("braintools")
-saiunit = pytest.importorskip("saiunit")
-u = saiunit
+brainunit = pytest.importorskip("brainunit")
+u = brainunit
 jnp = pytest.importorskip("jax.numpy")
 init = braintools.init
 braintrace = pytest.importorskip("braintrace")

--- a/docs/quickstart/snn_online_learning.ipynb
+++ b/docs/quickstart/snn_online_learning.ipynb
@@ -41,7 +41,7 @@
     "- `brainstate`: provides neuron models (LIF), state management, and JAX-based transformations\n",
     "- `braintrace`: provides online learning algorithms and ETP-aware neural network layers\n",
     "- `braintools`: provides initializers, optimizers, surrogate gradient functions, and metrics\n",
-    "- `saiunit`: provides physical units (ms, mV, etc.) for biologically meaningful parameters"
+    "- `brainunit`: provides physical units (ms, mV, etc.) for biologically meaningful parameters"
    ]
   },
   {
@@ -71,7 +71,7 @@
     "import brainstate\n",
     "import braintools\n",
     "import braintrace\n",
-    "import saiunit as u\n",
+    "import brainunit as u\n",
     "import brainpy.state\n",
     "import numpy as np"
    ]

--- a/docs/tutorials/drtrl.md
+++ b/docs/tutorials/drtrl.md
@@ -62,7 +62,7 @@ so both parameter sets end up in the trace.
 | Sparse matmul | `braintrace.sparse_matmul`, `braintrace.nn.SparseLinear` | — (skipped; see below) |
 | LoRA matmul | `braintrace.lora_matmul`, `braintrace.nn.LoRA` | 07 |
 
-> **Sparse-matmul note:** `saiunit.sparse` COO/CSR primitives do not yet
+> **Sparse-matmul note:** `brainunit.sparse` COO/CSR primitives do not yet
 > have JAX batching rules, which D_RTRL's internal Jacobian vmap requires.
 > `06-operator-sparse.py` is therefore not shipped. Adding batching rules
 > (or integrating `jax.experimental.sparse.BCOO`) is future framework work.

--- a/docs/tutorials/etp_primitives.ipynb
+++ b/docs/tutorials/etp_primitives.ipynb
@@ -345,8 +345,8 @@
     }
    ],
    "source": [
-    "import saiunit as u\n",
-    "from saiunit import sparse as ss\n",
+    "import brainunit as u\n",
+    "from brainunit import sparse as ss\n",
     "\n",
     "# Create a sparse connectivity matrix\n",
     "dense_w = jnp.where(\n",
@@ -425,9 +425,9 @@
    "id": "4edae675",
    "metadata": {},
    "source": [
-    "## Physical Units (`saiunit` / Quantity) Support\n",
+    "## Physical Units (`brainunit` / Quantity) Support\n",
     "\n",
-    "Every user-facing ETP function in `braintrace` — `matmul`, `conv`, `element_wise`, `sparse_matmul`, `lora_matmul` — accepts `saiunit.Quantity` inputs transparently. The wrapper\n",
+    "Every user-facing ETP function in `braintrace` — `matmul`, `conv`, `element_wise`, `sparse_matmul`, `lora_matmul` — accepts `brainunit.Quantity` inputs transparently. The wrapper\n",
     "\n",
     "1. splits each quantity into a plain-array *mantissa* and a *unit*,\n",
     "2. binds the primitive on the mantissas only,\n",
@@ -462,7 +462,7 @@
     }
    ],
    "source": [
-    "import saiunit as u\n",
+    "import brainunit as u\n",
     "\n",
     "# Quantity-valued inputs pass through unchanged.\n",
     "x_q = jnp.ones((4, 3)) * u.volt          # shape (4, 3), unit = V\n",
@@ -1060,7 +1060,7 @@
    "cell_type": "markdown",
    "id": "a1b2c3d5",
    "metadata": {},
-   "source": "## Summary\n\nETP primitives provide a clean, extensible foundation for online learning in recurrent networks:\n\n- **8 built-in primitives** cover the most common use cases: dense matmul (mm/mv), element-wise ops, convolution, sparse matmul (mm/mv), and LoRA matmul (mm/mv).\n\n- **Dict rule API** — every primitive declares its full set of trainable inputs via `trainable_invars_fn`, and the four ETP rules consume and return `Dict[str, Array]`. A single primitive can own several `ParamState` objects (e.g. weight + bias, or $B + A + b$ in LoRA) and the executor routes gradients to each in one pass.\n\n- **Custom primitives can be added in a few dozen lines**: implement the forward function, call `register_primitive` (declaring `trainable_invars_fn` so the compiler can discover it), then hand-write the four ETP rules.\n\n- **All JAX transformations (JIT, grad, vmap, JVP) work automatically** — only the four online-learning-specific rules need hand-writing.\n\n- **Parameter selection is primitive-based** — every `brainstate.ParamState` is eligible for ETP, and participation depends only on whether a `braintrace.*` ETP primitive consumed it. Use `gradient_enabled=True` exclusively for identity-like ops such as `etp_elemwise_p`.\n\n- **Saiunit quantities** are handled transparently by every user-facing wrapper.\n\nWhere to look for the math:\n\n| Rule | Algorithm term | Source with derivation |\n|---|---|---|\n| `xy_to_dw` | $\\operatorname{diag}(\\mathbf{D}_f^t) \\otimes \\mathbf{x}^t$ | docstrings in `braintrace/_etrace_op/{dense,conv,elemwise,sparse,lora}.py` |\n| `yw_to_w` | $\\mathbf{D}^t \\boldsymbol{\\epsilon}^{t-1}$ ($y \\to W$ link) | same files |\n| `init_drtrl` | param-dim trace shape | same files |\n| `init_pp` | output-dim df-trace shape | same files |\n\nFurther reading: `advanced/limitations.ipynb` explains the non-parametric-tail invariant and walks through `GRUCell` (3 Linears, only 2 ETP relations)."
+   "source": "## Summary\n\nETP primitives provide a clean, extensible foundation for online learning in recurrent networks:\n\n- **8 built-in primitives** cover the most common use cases: dense matmul (mm/mv), element-wise ops, convolution, sparse matmul (mm/mv), and LoRA matmul (mm/mv).\n\n- **Dict rule API** — every primitive declares its full set of trainable inputs via `trainable_invars_fn`, and the four ETP rules consume and return `Dict[str, Array]`. A single primitive can own several `ParamState` objects (e.g. weight + bias, or $B + A + b$ in LoRA) and the executor routes gradients to each in one pass.\n\n- **Custom primitives can be added in a few dozen lines**: implement the forward function, call `register_primitive` (declaring `trainable_invars_fn` so the compiler can discover it), then hand-write the four ETP rules.\n\n- **All JAX transformations (JIT, grad, vmap, JVP) work automatically** — only the four online-learning-specific rules need hand-writing.\n\n- **Parameter selection is primitive-based** — every `brainstate.ParamState` is eligible for ETP, and participation depends only on whether a `braintrace.*` ETP primitive consumed it. Use `gradient_enabled=True` exclusively for identity-like ops such as `etp_elemwise_p`.\n\n- **Brainunit quantities** are handled transparently by every user-facing wrapper.\n\nWhere to look for the math:\n\n| Rule | Algorithm term | Source with derivation |\n|---|---|---|\n| `xy_to_dw` | $\\operatorname{diag}(\\mathbf{D}_f^t) \\otimes \\mathbf{x}^t$ | docstrings in `braintrace/_etrace_op/{dense,conv,elemwise,sparse,lora}.py` |\n| `yw_to_w` | $\\mathbf{D}^t \\boldsymbol{\\epsilon}^{t-1}$ ($y \\to W$ link) | same files |\n| `init_drtrl` | param-dim trace shape | same files |\n| `init_pp` | output-dim df-trace shape | same files |\n\nFurther reading: `advanced/limitations.ipynb` explains the non-parametric-tail invariant and walks through `GRUCell` (3 Linears, only 2 ETP relations)."
   }
  ],
  "metadata": {

--- a/docs/tutorials/pp_prop.md
+++ b/docs/tutorials/pp_prop.md
@@ -112,7 +112,7 @@ but runs slower.
 ### 3.5 Operators (files 09-11)
 
 `09-operator-sparse.py` uses a fixed sparse connectivity mask on the
-recurrent matrix. Because `saiunit.sparse` COO/CSR primitives lack JAX
+recurrent matrix. Because `brainunit.sparse` COO/CSR primitives lack JAX
 batching rules today, the file uses a masked-dense fallback via
 `braintrace.nn.Linear(..., w_mask=...)` that still exercises pp_prop's
 per-primitive trace rule.

--- a/examples/000-lif-snn-for-nmnist.py
+++ b/examples/000-lif-snn-for-nmnist.py
@@ -22,7 +22,7 @@ import matplotlib
 matplotlib.use('Agg')  # headless backend: render to file, no display needed
 import matplotlib.pyplot as plt
 import numpy as np
-import saiunit as u
+import brainunit as u
 import tonic
 from tonic.datasets import NMNIST
 from torch.utils.data import DataLoader

--- a/examples/001-gif-snn-for-dms.py
+++ b/examples/001-gif-snn-for-dms.py
@@ -21,7 +21,7 @@ import matplotlib
 matplotlib.use('Agg')  # headless backend: render to file, no display needed
 import matplotlib.pyplot as plt
 import numpy as np
-import saiunit as u
+import brainunit as u
 
 from snn_models import DMSDataset, GifNet, OnlineTrainer
 

--- a/examples/002-coba-ei-rsnn.py
+++ b/examples/002-coba-ei-rsnn.py
@@ -25,7 +25,7 @@ import matplotlib
 matplotlib.use('Agg')  # headless backend: render to file, no display needed
 import matplotlib.pyplot as plt
 import numpy as np
-import saiunit as u
+import brainunit as u
 
 import braintrace
 
@@ -125,7 +125,7 @@ class EvidenceAccumulation:
                 X = jax.lax.dynamic_update_slice(X, update, (i_seq, i_start))
 
             # recall cue (functional update: in-place ``Quantity[...] =`` is
-            # rejected under jit/vmap on the latest saiunit; ``feat_fr * dt``
+            # rejected under jit/vmap on the latest brainunit; ``feat_fr * dt``
             # auto-simplifies Hz*ms to a plain dimensionless probability)
             X = X.at[-t_recall:, self.feat_neurons['recall']].set(self.feat_fr['recall'] * dt)
 

--- a/examples/003-snn-memory-and-speed-evaluation-all.py
+++ b/examples/003-snn-memory-and-speed-evaluation-all.py
@@ -25,7 +25,7 @@ import braintools
 import jax
 import jax.numpy as jnp
 import numpy as np
-import saiunit as u
+import brainunit as u
 
 import braintrace
 

--- a/examples/003-snn-memory-and-speed-evaluation-batched.py
+++ b/examples/003-snn-memory-and-speed-evaluation-batched.py
@@ -90,7 +90,7 @@ global_args = parser.parse_args()
 import braintrace
 import brainstate
 import braintools
-import saiunit as u
+import brainunit as u
 import jax
 import jax.numpy as jnp
 import tonic

--- a/examples/003-snn-memory-and-speed-evaluation-vmap.py
+++ b/examples/003-snn-memory-and-speed-evaluation-vmap.py
@@ -75,7 +75,7 @@ import brainpy
 import braintrace
 import brainstate
 import braintools
-import saiunit as u
+import brainunit as u
 import jax
 import jax.numpy as jnp
 import tonic

--- a/examples/004-feedforward-conv-snn.py
+++ b/examples/004-feedforward-conv-snn.py
@@ -22,7 +22,7 @@ sys.path.append('../')
 import brainstate
 import brainpy.state
 import braintools
-import saiunit as u
+import brainunit as u
 import jax
 import numpy as np
 import tonic
@@ -442,7 +442,7 @@ def get_nmnist_data(
 def data_processing(x_local):
     assert x_local.ndim == 5  # (sequence, batch, channel, height, width)
     x_local = x_local.permute(0, 1, 3, 4, 2)  # (sequence, batch, height, width, channel)
-    # x_local is a torch tensor here; convert via numpy first so saiunit stays on
+    # x_local is a torch tensor here; convert via numpy first so brainunit stays on
     # the numpy/jax backend (u.math.asarray would otherwise dispatch to the torch
     # backend and reject the JAX dtype).
     return u.math.asarray(np.asarray(x_local), dtype=brainstate.environ.dftype())

--- a/examples/README.md
+++ b/examples/README.md
@@ -22,7 +22,7 @@ The examples require the following packages:
 - numpy
 - matplotlib
 - braintrace
-- saiunit
+- brainunit
 - brainstate
 - tqdm
 - torch

--- a/examples/drtrl/README.md
+++ b/examples/drtrl/README.md
@@ -28,7 +28,7 @@ All examples run on CPU in roughly 1–2 minutes. Task 09 (MNIST) requires
 | BPTT baseline                              | 01, 09, 10, 12     |
 
 > **Note — skipped example:** `06-operator-sparse.py` is not currently
-> shipped. The ``saiunit.sparse`` COO/CSR primitives lack JAX batching
+> shipped. The ``brainunit.sparse`` COO/CSR primitives lack JAX batching
 > rules, which blocks D_RTRL's internal Jacobian vmap. Adding batching
 > rules (or an alternative sparse backend such as
 > ``jax.experimental.sparse.BCOO``) is tracked as future framework work.

--- a/examples/pp_prop/01-basics-lif-integrator.py
+++ b/examples/pp_prop/01-basics-lif-integrator.py
@@ -13,7 +13,7 @@ from typing import Dict
 import brainstate
 import braintools
 import jax.numpy as jnp
-import saiunit as u
+import brainunit as u
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 import _shared  # noqa: E402

--- a/examples/pp_prop/02-neurons-alif-dms.py
+++ b/examples/pp_prop/02-neurons-alif-dms.py
@@ -13,7 +13,7 @@ from typing import Dict
 import brainstate
 import braintools
 import jax.numpy as jnp
-import saiunit as u
+import brainunit as u
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 import _shared  # noqa: E402

--- a/examples/pp_prop/03-neurons-gif-working-memory.py
+++ b/examples/pp_prop/03-neurons-gif-working-memory.py
@@ -13,7 +13,7 @@ from typing import Dict
 import brainstate
 import braintools
 import jax.numpy as jnp
-import saiunit as u
+import brainunit as u
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 import _shared  # noqa: E402

--- a/examples/pp_prop/04-neurons-coba-ei-rsnn.py
+++ b/examples/pp_prop/04-neurons-coba-ei-rsnn.py
@@ -14,7 +14,7 @@ from typing import Dict
 import brainstate
 import braintools
 import jax.numpy as jnp
-import saiunit as u
+import brainunit as u
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 import _shared  # noqa: E402

--- a/examples/pp_prop/05-batching-vmap.py
+++ b/examples/pp_prop/05-batching-vmap.py
@@ -14,7 +14,7 @@ from typing import Dict
 import brainstate
 import braintools
 import jax.numpy as jnp
-import saiunit as u
+import brainunit as u
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 import _shared  # noqa: E402

--- a/examples/pp_prop/06-batching-batched.py
+++ b/examples/pp_prop/06-batching-batched.py
@@ -14,7 +14,7 @@ import brainstate
 import braintools
 import jax
 import jax.numpy as jnp
-import saiunit as u
+import brainunit as u
 
 import braintrace
 

--- a/examples/pp_prop/07-vjp-single-step.py
+++ b/examples/pp_prop/07-vjp-single-step.py
@@ -14,7 +14,7 @@ from typing import Dict
 import brainstate
 import braintools
 import jax.numpy as jnp
-import saiunit as u
+import brainunit as u
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 import _shared  # noqa: E402

--- a/examples/pp_prop/08-vjp-multi-step.py
+++ b/examples/pp_prop/08-vjp-multi-step.py
@@ -14,7 +14,7 @@ from typing import Dict
 import brainstate
 import braintools
 import jax.numpy as jnp
-import saiunit as u
+import brainunit as u
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 import _shared  # noqa: E402

--- a/examples/pp_prop/09-operator-sparse.py
+++ b/examples/pp_prop/09-operator-sparse.py
@@ -7,7 +7,7 @@ zero because Linear multiplies the weight by `w_mask` on every forward
 pass; pp_prop sees the combined op as a dense matmul and gradients for
 absent connections are zeroed by the same mask.
 
-Note: the sparse ETP primitive `etp_sp_mm_p` exists but `saiunit.sparse`
+Note: the sparse ETP primitive `etp_sp_mm_p` exists but `brainunit.sparse`
 COO/CSR formats lack JAX batching rules today (same constraint noted for
 `examples/drtrl/06-operator-sparse.py`). This masked-dense fallback still
 exercises `pp_prop` over a sparse connectivity pattern end-to-end.
@@ -22,7 +22,7 @@ import brainstate
 import braintools
 import jax.numpy as jnp
 import numpy as np
-import saiunit as u
+import brainunit as u
 
 import braintrace
 

--- a/examples/pp_prop/10-operator-lora.py
+++ b/examples/pp_prop/10-operator-lora.py
@@ -15,7 +15,7 @@ import brainpy.state
 import brainstate
 import braintools
 import jax.numpy as jnp
-import saiunit as u
+import brainunit as u
 
 import braintrace
 

--- a/examples/pp_prop/11-operator-conv.py
+++ b/examples/pp_prop/11-operator-conv.py
@@ -14,7 +14,7 @@ import brainpy.state
 import brainstate
 import braintools
 import jax.numpy as jnp
-import saiunit as u
+import brainunit as u
 
 import braintrace
 

--- a/examples/pp_prop/12-classification-neuromorphic.py
+++ b/examples/pp_prop/12-classification-neuromorphic.py
@@ -14,7 +14,7 @@ from typing import Dict
 import brainstate
 import braintools
 import jax.numpy as jnp
-import saiunit as u
+import brainunit as u
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 import _shared  # noqa: E402

--- a/examples/pp_prop/13-knob-decay-vs-rank.py
+++ b/examples/pp_prop/13-knob-decay-vs-rank.py
@@ -14,7 +14,7 @@ from typing import Dict, List
 import brainstate
 import braintools
 import jax.numpy as jnp
-import saiunit as u
+import brainunit as u
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 import _shared  # noqa: E402

--- a/examples/pp_prop/14-knob-vjp-method-contrast.py
+++ b/examples/pp_prop/14-knob-vjp-method-contrast.py
@@ -13,7 +13,7 @@ from typing import Dict
 import brainstate
 import braintools
 import jax.numpy as jnp
-import saiunit as u
+import brainunit as u
 
 sys.path.insert(0, str(pathlib.Path(__file__).resolve().parent))
 import _shared  # noqa: E402

--- a/examples/pp_prop/_shared.py
+++ b/examples/pp_prop/_shared.py
@@ -9,7 +9,7 @@ import braintools
 import jax
 import jax.numpy as jnp
 import numpy as np
-import saiunit as u
+import brainunit as u
 
 DEFAULT_DT = 1.0 * u.ms
 DEFAULT_SEED = 42
@@ -107,7 +107,7 @@ def make_poisson_mnist(
 # --- SNN cells -----------------------------------------------------------
 #
 # All cells use the AlignPostProj + Expon + CUBA pattern with consistent
-# saiunit units. Pattern:
+# brainunit units. Pattern:
 #
 #     linear (mA) -> Expon syn (mA) -> CUBA (scales to current) -> LIF/ALIF/GIF (mV)
 #

--- a/examples/pp_prop/tests/test_shared_cells.py
+++ b/examples/pp_prop/tests/test_shared_cells.py
@@ -5,7 +5,7 @@ import pathlib
 
 import brainstate
 import jax.numpy as jnp
-import saiunit as u
+import brainunit as u
 
 
 def _load_shared():

--- a/examples/snn_models.py
+++ b/examples/snn_models.py
@@ -26,7 +26,7 @@ matplotlib.use('Agg')  # headless backend: render to file, no display needed
 import matplotlib.pyplot as plt
 import numba
 import numpy as np
-import saiunit as u
+import brainunit as u
 from tqdm import tqdm
 
 import braintrace

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,7 +116,7 @@ no_implicit_reexport = false
 
 # Third-party scientific deps that ship without inline types or a py.typed
 # marker. Scoped per-module so missing stubs here never mask errors in our
-# own code. brainunit/saiunit DO ship types, so they are intentionally absent.
+# own code. brainunit DOES ship types, so it is intentionally absent.
 [[tool.mypy.overrides]]
 module = [
     "brainstate.*",


### PR DESCRIPTION
## Summary

Switches all imports, tests, examples, and current docs from `saiunit` to `brainunit`, which is **already the declared dependency** in `pyproject.toml` (so the code was inconsistent with the manifest). `brainunit` re-exports `saiunit` internally, making this a drop-in change.

## Changes

- **Source / tests / examples** — `import saiunit as u` → `import brainunit as u`, `from saiunit import sparse` → `from brainunit import sparse`, `pytest.importorskip("saiunit")` → `"brainunit"`, all docstrings/comments, and the `TestSaiunit` test classes renamed to `TestBrainunit`.
- **Current docs** — tutorials, quickstart notebooks, and example READMEs updated; notebooks re-validated as well-formed JSON.
- **pyproject.toml** — mypy-override comment simplified to `brainunit`.

## Intentionally left unchanged

`changelog.md` and `dev/LESSON.md` are historical records — a blind replace would produce nonsense (e.g. *"Replaced `brainunit` with `brainunit`"*) or rewrite past release/session history.

## Verification

- `braintrace` + `nn` modules import cleanly.
- Targeted tests pass (65 passed), including the renamed `TestBrainunit` class and the `from brainunit import sparse` path.

## Summary by Sourcery

Replace all remaining references to saiunit with brainunit across code, tests, examples, and documentation to align unit handling with the declared dependency.

Enhancements:
- Rename unit-related test classes and comments from saiunit to brainunit for clearer intent.
- Clarify unit-handling docstrings, markdown tutorials, and notebooks to describe brainunit usage instead of saiunit.
- Tighten type-related commentary in pyproject mypy overrides to reflect brainunit as the typed dependency.

Documentation:
- Update tutorials, quickstart notebooks, and example READMEs to use brainunit imports and terminology for physical units.

Tests:
- Switch tests to import and exercise brainunit (including sparse support) instead of saiunit and rename related test classes accordingly.

Chores:
- Adjust examples and internal comments to consistently reference brainunit as the unit library, including sparse-matrix notes and backend caveats.