### PR TITLE
fix(mypy): treat brainunit/saiunit as untyped to restore type-check CI

### DIFF
--- a/braintrace/_etrace_compiler/hidden_group.py
+++ b/braintrace/_etrace_compiler/hidden_group.py
@@ -990,8 +990,10 @@ def find_hidden_groups_from_jaxpr(
         invar_to_hidden_path=invar_to_hidden_path,
         outvar_to_hidden_path=outvar_to_hidden_path,
         # the evaluator only indexes hidden-state paths, whose entries are HiddenStates,
-        # even though the passed mapping carries every model state.
-        path_to_state=cast(Dict[Path, brainstate.HiddenState], path_to_state),
+        # even though the passed mapping carries every model state. The cast is a real
+        # State -> HiddenState narrowing; mypy flags it as redundant only because
+        # brainstate is currently untyped (both collapse to Any).
+        path_to_state=cast(Dict[Path, brainstate.HiddenState], path_to_state),  # type: ignore[redundant-cast]
     )
     hidden_groups, hid_path_to_group = evaluator.compile()
     return hidden_groups, brainstate.util.PrettyDict(hid_path_to_group)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -116,7 +116,7 @@ no_implicit_reexport = false
 
 # Third-party scientific deps that ship without inline types or a py.typed
 # marker. Scoped per-module so missing stubs here never mask errors in our
-# own code. brainunit DOES ship types, so it is intentionally absent.
+# own code.
 [[tool.mypy.overrides]]
 module = [
     "brainstate.*",
@@ -125,4 +125,20 @@ module = [
     "brainevent.*",
     "numba.*",
 ]
+ignore_missing_imports = true
+
+# brainunit ships a py.typed marker, but its public API (brainunit.math.*,
+# Quantity, units, ...) is merely re-exported via `from saiunit... import *`,
+# and saiunit ships NO py.typed. mypy therefore cannot resolve any of the
+# re-exported names and emits spurious `attr-defined` errors at every call
+# site. Skip following both packages so they are treated as untyped (Any),
+# matching how saiunit itself was handled before it was renamed to brainunit.
+[[tool.mypy.overrides]]
+module = [
+    "brainunit",
+    "brainunit.*",
+    "saiunit",
+    "saiunit.*",
+]
+follow_imports = "skip"
 ignore_missing_imports = true


### PR DESCRIPTION
## Problem

The `typecheck_and_build` CI job (`python -m mypy braintrace`) fails with **42 errors**, all introduced by #106 (saiunit → brainunit).

## Root cause

- `brainunit` ships a `py.typed` marker, so mypy type-checks it.
- But its public API (`brainunit.math.exp/zeros/is_quantity/...`, `Quantity`, units) is merely re-exported via `from saiunit... import *`, and **`saiunit` ships no `py.typed`**.
- mypy cannot follow the star-import from an untyped package, so every `u.math.*`/unit call site reports `Module has no attribute ...` → **41 `[attr-defined]` errors**.
- The remaining **1 `[redundant-cast]`** in `hidden_group.py` is a `State -> HiddenState` narrowing that mypy sees as a no-op only because `brainstate` is untyped (`Any`).

The old config deliberately omitted brainunit from the ignore list ("brainunit DOES ship types") — an assumption that's hollow because the real implementations live in untyped saiunit.

## Fix

- **`pyproject.toml`**: add a mypy override for `brainunit`/`saiunit` with `follow_imports = "skip"` so they're treated as `Any` — exactly how saiunit was handled before the rename. (`ignore_missing_imports` alone doesn't work, since brainunit *is* resolvable via its `py.typed`.)
- **`hidden_group.py`**: keep the forward-looking narrowing cast (removing it would create a future error if brainstate ever ships types) with a targeted, explained `# type: ignore[redundant-cast]`.

## Verification

`python -m mypy braintrace` → `Success: no issues found in 51 source files` (exit 0).

## Summary by Sourcery

Adjust mypy configuration and a specific cast to restore passing type-checks after introducing brainunit/saiunit dependencies.

Enhancements:
- Document and suppress a mypy redundant-cast warning for a deliberate State-to-HiddenState narrowing cast in hidden_group.py.

Build:
- Update mypy overrides to treat brainunit and saiunit as untyped by skipping imports and ignoring missing imports.