### PR TITLE
test: add Codecov coverage reporting and raise source coverage to 93%

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -59,7 +59,18 @@ jobs:
           python -m pip install . || exit 1
       - name: Test with pytest
         run: |
-          pytest braintrace/
+          pytest braintrace/ --cov=braintrace --cov-report=xml --cov-report=term-missing
+      - name: Upload coverage to Codecov
+        # Upload from a single matrix entry (latest JAX) to avoid duplicate
+        # reports. Never fail CI on an upload hiccup / missing token.
+        if: matrix.jax-version == ''
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ./coverage.xml
+          flags: unittests
+          name: braintrace-coverage
+          fail_ci_if_error: false
 
 
   typecheck_and_build:

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
   	<a href="https://brainx.chaobrain.com/braintrace/"><img alt="Documentation" src="https://readthedocs.org/projects/braintrace/badge/?version=latest"></a>
   	<a href="https://badge.fury.io/py/braintrace"><img alt="PyPI version" src="https://badge.fury.io/py/braintrace.svg"></a>
     <a href="https://github.com/chaobrain/braintrace/actions/workflows/CI.yml"><img alt="Continuous Integration" src="https://github.com/chaobrain/braintrace/actions/workflows/CI.yml/badge.svg"></a>
+    <a href="https://codecov.io/gh/chaobrain/braintrace"><img alt="Code Coverage" src="https://codecov.io/gh/chaobrain/braintrace/branch/main/graph/badge.svg"></a>
 </p>
 
 [``braintrace``](https://github.com/chaobrain/braintrace) provides online learning algorithms for biological neural networks.

--- a/braintrace/_grad_exponential_test.py
+++ b/braintrace/_grad_exponential_test.py
@@ -1,0 +1,82 @@
+# Copyright 2026 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+import brainstate
+import brainunit as u
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from braintrace._grad_exponential import GradExpon
+
+
+class TestGradExponInit:
+    """Construction of :class:`GradExpon` and decay-factor resolution."""
+
+    def test_float_decay_is_used_directly(self):
+        acc = GradExpon(jnp.zeros((3,)), 0.9)
+        assert acc.decay == 0.9
+
+    def test_gradients_initialised_to_zeros(self):
+        acc = GradExpon(jnp.ones((2, 4)), 0.5)
+        assert acc.gradients.value.shape == (2, 4)
+        assert jnp.allclose(acc.gradients.value, 0.0)
+
+    def test_quantity_tau_resolves_to_exponential_decay(self):
+        # decay = exp(-1 / (tau / dt)) = exp(-1 / 100) for tau=10ms, dt=0.1ms.
+        with brainstate.environ.context(dt=0.1 * u.ms):
+            acc = GradExpon(jnp.zeros((3,)), 10.0 * u.ms)
+        assert 0.0 < float(acc.decay) < 1.0
+        assert np.isclose(float(acc.decay), np.exp(-0.01))
+
+    @pytest.mark.parametrize("bad_decay", [0.0, 1.0, 1.5, -0.2])
+    def test_out_of_range_float_decay_raises(self, bad_decay):
+        with pytest.raises(AssertionError):
+            GradExpon(jnp.zeros((3,)), bad_decay)
+
+    @pytest.mark.parametrize("bad_tau", [1, "0.9", None])
+    def test_non_float_non_quantity_raises_type_error(self, bad_tau):
+        with pytest.raises(TypeError):
+            GradExpon(jnp.zeros((3,)), bad_tau)
+
+
+class TestGradExponUpdate:
+    """The exponential (leaky) accumulation rule g <- decay * g + grads."""
+
+    def test_single_update_equals_input(self):
+        acc = GradExpon(jnp.zeros((3,)), 0.9)
+        acc.update(jnp.ones((3,)))
+        assert jnp.allclose(acc.gradients.value, 1.0)
+
+    def test_two_updates_match_docstring_example(self):
+        acc = GradExpon(jnp.zeros((3,)), 0.9)
+        acc.update(jnp.ones((3,)))
+        acc.update(jnp.ones((3,)))
+        # 0.9 * 1.0 + 1.0 = 1.9
+        assert jnp.allclose(acc.gradients.value, 1.9)
+
+    def test_decay_attenuates_old_gradient(self):
+        acc = GradExpon(jnp.zeros((1,)), 0.5)
+        acc.update(jnp.array([2.0]))      # -> 2.0
+        acc.update(jnp.array([0.0]))      # -> 0.5 * 2.0 + 0.0 = 1.0
+        assert jnp.allclose(acc.gradients.value, 1.0)
+
+    def test_pytree_gradients_are_accumulated_leafwise(self):
+        shape = {"a": jnp.zeros((2,)), "b": jnp.zeros((3,))}
+        acc = GradExpon(shape, 0.5)
+        acc.update({"a": jnp.ones((2,)), "b": jnp.full((3,), 4.0)})
+        acc.update({"a": jnp.ones((2,)), "b": jnp.zeros((3,))})
+        assert jnp.allclose(acc.gradients.value["a"], 1.5)   # 0.5*1 + 1
+        assert jnp.allclose(acc.gradients.value["b"], 2.0)   # 0.5*4 + 0

--- a/braintrace/_misc_test.py
+++ b/braintrace/_misc_test.py
@@ -1,0 +1,163 @@
+# Copyright 2026 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+import warnings
+
+import brainstate
+import brainunit as u
+import jax.numpy as jnp
+from jax import make_jaxpr
+import pytest
+
+from braintrace._misc import (
+    BaseEnum,
+    CompilationError,
+    NotSupportedError,
+    check_dict_keys,
+    deprecation_getattr,
+    etrace_df_key,
+    etrace_x_key,
+    hid_group_key,
+    remove_units,
+    set_module_as,
+    state_traceback,
+    unknown_state_path,
+)
+
+
+def _a_jax_var():
+    """Return a real jax ``Var`` extracted from a trivial jaxpr."""
+    jaxpr = make_jaxpr(lambda a: a + 1.0)(jnp.zeros(3))
+    return jaxpr.jaxpr.invars[0]
+
+
+class TestCheckDictKeys:
+    def test_matching_keys_pass_silently(self):
+        check_dict_keys({"a": 1, "b": 2}, {"a": 9, "b": 8})
+
+    def test_mismatched_keys_raise(self):
+        with pytest.raises(ValueError):
+            check_dict_keys({"a": 1}, {"b": 2})
+
+
+class TestKeyHelpers:
+    def test_hid_group_key_formats_id(self):
+        assert hid_group_key(3) == "hidden_group_3"
+
+    def test_hid_group_key_rejects_non_int(self):
+        with pytest.raises(AssertionError):
+            hid_group_key("x")
+
+    def test_etrace_x_key_is_object_id(self):
+        obj = object()
+        assert etrace_x_key(obj) == id(obj)
+
+    def test_etrace_df_key_pairs_var_id_with_group(self):
+        var = _a_jax_var()
+        assert etrace_df_key(var, 2) == (id(var), "hidden_group_2")
+
+    def test_etrace_df_key_rejects_non_var(self):
+        with pytest.raises(AssertionError):
+            etrace_df_key(123, 0)
+
+    def test_unknown_state_path(self):
+        assert unknown_state_path(5) == ("_unknown_path_5",)
+
+
+class TestRemoveUnits:
+    def test_strips_units_from_quantity_leaves(self):
+        tree = {"q": u.Quantity([1.0, 2.0, 3.0], unit=u.mV), "plain": jnp.ones(2)}
+        out = remove_units(tree)
+        assert not isinstance(out["q"], u.Quantity)
+        assert jnp.allclose(out["q"], jnp.array([1.0, 2.0, 3.0]))
+        # Non-quantity leaves are passed through unchanged.
+        assert jnp.allclose(out["plain"], jnp.ones(2))
+
+
+class TestDeprecationGetattr:
+    def test_deprecated_attribute_warns_and_returns_replacement(self):
+        sentinel = object()
+        getter = deprecation_getattr(
+            "mymod", {"old": ("old is deprecated, use new", sentinel)}
+        )
+        with pytest.warns(DeprecationWarning):
+            assert getter("old") is sentinel
+
+    def test_accelerated_deprecation_raises_attribute_error(self):
+        getter = deprecation_getattr("mymod", {"gone": ("gone was removed", None)})
+        with pytest.raises(AttributeError):
+            getter("gone")
+
+    def test_unknown_attribute_raises_attribute_error(self):
+        getter = deprecation_getattr("mymod", {})
+        with pytest.raises(AttributeError):
+            getter("does_not_exist")
+
+
+class TestSetModuleAs:
+    def test_sets_explicit_module(self):
+        @set_module_as("braintrace.sub")
+        def fn():
+            return 1
+
+        assert fn.__module__ == "braintrace.sub"
+
+    def test_defaults_to_braintrace(self):
+        @set_module_as()
+        def fn():
+            return 1
+
+        assert fn.__module__ == "braintrace"
+
+
+class TestExceptions:
+    @pytest.mark.parametrize("exc", [NotSupportedError, CompilationError])
+    def test_exception_module_and_inheritance(self, exc):
+        assert exc.__module__ == "braintrace"
+        assert issubclass(exc, Exception)
+        with pytest.raises(exc):
+            raise exc("boom")
+
+
+class TestStateTraceback:
+    def test_traceback_string_contains_state_index(self):
+        st = brainstate.ParamState(jnp.zeros(2))
+        text = state_traceback([st])
+        assert isinstance(text, str)
+        assert "State 0" in text
+
+
+class _Color(BaseEnum):
+    RED = 1
+    GREEN = 2
+
+
+class TestBaseEnum:
+    def test_get_by_name_returns_member(self):
+        assert _Color.get_by_name("RED") is _Color.RED
+
+    def test_get_by_name_unknown_raises(self):
+        with pytest.raises(ValueError):
+            _Color.get_by_name("BLUE")
+
+    def test_get_passthrough_instance(self):
+        assert _Color.get(_Color.GREEN) is _Color.GREEN
+
+    def test_get_resolves_string(self):
+        assert _Color.get("GREEN") is _Color.GREEN
+
+    def test_get_rejects_other_types(self):
+        with pytest.raises(ValueError):
+            _Color.get(123)

--- a/braintrace/_state_managment_test.py
+++ b/braintrace/_state_managment_test.py
@@ -1,0 +1,108 @@
+# Copyright 2026 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+import brainstate
+import jax.numpy as jnp
+import pytest
+
+from braintrace._state_managment import (
+    assign_dict_state_values,
+    assign_state_values_v2,
+    sequence_split_state_values,
+    split_dict_states_v2,
+)
+
+
+class TestAssignDictStateValues:
+    def test_write_assigns_values(self):
+        states = {("w",): brainstate.ParamState(jnp.zeros(3))}
+        assign_dict_state_values(states, {("w",): jnp.ones(3)}, write=True)
+        assert jnp.allclose(states[("w",)].value, 1.0)
+
+    def test_restore_recovers_values(self):
+        st = brainstate.ParamState(jnp.zeros(3))
+        assign_dict_state_values({("w",): st}, {("w",): jnp.full((3,), 2.0)}, write=False)
+        assert jnp.allclose(st.value, 2.0)
+
+    def test_key_mismatch_raises(self):
+        with pytest.raises(ValueError):
+            assign_dict_state_values(
+                {("a",): brainstate.ParamState(jnp.zeros(1))},
+                {("b",): jnp.ones(1)},
+            )
+
+
+class TestAssignStateValuesV2:
+    def test_write_assigns_values_with_hashable_keys(self):
+        states = {0: brainstate.ParamState(jnp.zeros(2))}
+        assign_state_values_v2(states, {0: jnp.full((2,), 3.0)}, write=True)
+        assert jnp.allclose(states[0].value, 3.0)
+
+    def test_restore_recovers_values(self):
+        st = brainstate.ParamState(jnp.zeros(2))
+        assign_state_values_v2({0: st}, {0: jnp.ones(2)}, write=False)
+        assert jnp.allclose(st.value, 1.0)
+
+    def test_key_mismatch_raises(self):
+        with pytest.raises(ValueError):
+            assign_state_values_v2(
+                {0: brainstate.ParamState(jnp.zeros(1))},
+                {1: jnp.ones(1)},
+            )
+
+
+def _mixed_states():
+    return [
+        brainstate.ParamState(jnp.ones(2)),
+        brainstate.HiddenState(jnp.zeros(3)),
+        brainstate.LongTermState(jnp.zeros(1)),
+    ]
+
+
+def _mixed_values():
+    return [jnp.ones(2), jnp.zeros(3), jnp.zeros(1)]
+
+
+class TestSequenceSplitStateValues:
+    def test_split_with_weight(self):
+        weights, hidden, other = sequence_split_state_values(
+            _mixed_states(), _mixed_values(), include_weight=True
+        )
+        assert len(weights) == 1
+        assert len(hidden) == 1
+        assert len(other) == 1
+
+    def test_split_without_weight(self):
+        hidden, other = sequence_split_state_values(
+            _mixed_states(), _mixed_values(), include_weight=False
+        )
+        assert len(hidden) == 1
+        assert len(other) == 1
+
+
+class TestSplitDictStatesV2:
+    def test_categorises_states_by_type(self):
+        w = brainstate.ParamState(jnp.ones(2))
+        h = brainstate.HiddenState(jnp.zeros(3))
+        o = brainstate.LongTermState(jnp.zeros(1))
+        states = {("w",): w, ("h",): h, ("o",): o}
+
+        etrace_params, hidden, params, other = split_dict_states_v2(states)
+
+        assert etrace_params == {("w",): w}
+        assert hidden == {("h",): h}
+        assert other == {("o",): o}
+        # ParamState selection is decided by the compiler, so this stays empty.
+        assert params == {}

--- a/braintrace/nn/_linear_test.py
+++ b/braintrace/nn/_linear_test.py
@@ -492,6 +492,27 @@ class TestLoRA:
         y = lora(x)
         assert y.shape == (4, 2048)
 
+
+class TestScaledWSLinear:
+    """Weight-standardized linear layer (routed through ETP ``matmul``)."""
+
+    def test_forward_shape(self):
+        from braintrace.nn._linear import ScaledWSLinear
+
+        layer = ScaledWSLinear(in_size=5, out_size=3)
+        x = brainstate.random.randn(8, 5)
+        y = layer(x)
+        assert y.shape == (8, 3)
+
+    def test_forward_with_weight_mask(self):
+        # Exercises the ``w_mask`` multiplication branch in update().
+        from braintrace.nn._linear import ScaledWSLinear
+
+        layer = ScaledWSLinear(in_size=4, out_size=2, w_mask=jnp.ones((4, 2)))
+        x = brainstate.random.randn(6, 4)
+        y = layer(x)
+        assert y.shape == (6, 2)
+
     def test_lora_with_callable_base_module(self):
         """Test LoRA with a callable base module."""
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,32 @@
+# Codecov configuration for braintrace.
+# Docs: https://docs.codecov.com/docs/codecov-yaml
+coverage:
+  # Round/precision of the reported percentage.
+  precision: 2
+  round: down
+  range: "70...100"
+  status:
+    # Overall project coverage must stay at or above the target.
+    project:
+      default:
+        target: 90%
+        threshold: 1%
+    # Coverage of the lines changed by a pull request.
+    patch:
+      default:
+        target: 90%
+        threshold: 1%
+
+comment:
+  layout: "reach, diff, flags, files"
+  behavior: default
+  require_changes: false
+
+# Files excluded from the Codecov report. Mirrors the coverage `omit` list in
+# pyproject.toml (co-located tests + test-only helper modules) so the Codecov
+# percentage matches the locally measured source coverage.
+ignore:
+  - "**/*_test.py"
+  - "**/model4test.py"
+  - "**/scenario_catalog.py"
+  - "**/oracle_models.py"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,8 +74,8 @@ cpu = ["jax[cpu]"]
 cuda12 = ["jax[cuda12]"]
 cuda13 = ["jax[cuda13]"]
 tpu = ["jax[tpu]"]
-testing = ["pytest", "jax[cpu]", "hypothesis"]
-dev = ["pytest", "jax[cpu]", "hypothesis", "mypy>=1.8", "build"]
+testing = ["pytest", "pytest-cov", "jax[cpu]", "hypothesis"]
+dev = ["pytest", "pytest-cov", "jax[cpu]", "hypothesis", "mypy>=1.8", "build"]
 
 
 [tool.setuptools.package-data]
@@ -142,3 +142,30 @@ module = [
 ]
 follow_imports = "skip"
 ignore_missing_imports = true
+
+
+# Coverage configuration (coverage.py / pytest-cov). The measured surface is the
+# shipped `braintrace` package only: co-located `*_test.py` files and the
+# test-only helper modules (mirroring the mypy `exclude` list) are omitted so the
+# reported percentage reflects real source coverage rather than the tests
+# exercising themselves.
+[tool.coverage.run]
+source = ["braintrace"]
+omit = [
+    "*_test.py",
+    "*/model4test.py",
+    "*/scenario_catalog.py",
+    "*/oracle_models.py",
+]
+
+[tool.coverage.report]
+show_missing = true
+exclude_lines = [
+    "pragma: no cover",
+    "raise NotImplementedError",
+    "raise AssertionError",
+    "if __name__ == .__main__.:",
+    "if TYPE_CHECKING:",
+    "@(abc\\.)?abstractmethod",
+    "\\.\\.\\.",
+]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,6 +4,7 @@ matplotlib
 
 
 pytest
+pytest-cov  # coverage measurement + Codecov XML report
 hypothesis  # property-based tests (compiler_property_test, diagnostic_exploration_test)
 numba  # for brainevent cpu operator
 mypy>=1.8  # static type checking


### PR DESCRIPTION
Enable a code-coverage badge via codecov.io and tighten test coverage of
previously-untested modules.

Tooling:
- pyproject.toml: add [tool.coverage.run]/[report] (source-only omit of
  *_test.py and test-only helpers; line exclusions).
- requirements-dev.txt + testing/dev extras: add pytest-cov.
- CI.yml: run pytest with --cov and upload coverage.xml via
  codecov/codecov-action@v5 (single matrix entry, non-failing on upload error).
- codecov.yml: project/patch target 90%, ignore tests/helpers.
- README.md: add Codecov badge.

Tests (source-only coverage 92% -> 93%):
- _grad_exponential.py 42% -> 100%
- _misc.py 57% -> 100%
- _state_managment.py 55% -> 100%
- nn/_linear.py: add ScaledWSLinear forward coverage.

## Summary by Sourcery

Integrate coverage reporting with Codecov and strengthen test coverage across core utility and state management modules.

New Features:
- Add Codecov coverage reporting to the CI pipeline and surface a coverage badge in the README.

Enhancements:
- Configure coverage.py and pytest-cov to measure source-only coverage for the braintrace package, excluding tests and test helpers.
- Increase source test coverage by adding comprehensive tests for GradExpon, miscellaneous helpers, state management utilities, and ScaledWSLinear forward behavior.

CI:
- Update the CI workflow to run pytest with coverage enabled and upload coverage reports via the Codecov GitHub Action.