### PR TITLE
docs: route all examples through braintrace.compile and verify with tests

### DIFF
--- a/braintrace/_algorithm/e_prop.py
+++ b/braintrace/_algorithm/e_prop.py
@@ -134,10 +134,9 @@ class EProp(ParamDimVjpAlgorithm):
         ...         return x >> self.cell >> self.out
         >>>
         >>> model = RSNN()
-        >>> _ = brainstate.nn.init_all_states(model)
-        >>> learner = braintrace.EProp(model, kappa_filter_decay=0.9)
         >>> x0 = brainstate.random.randn(1)
-        >>> learner.compile_graph(x0)   # trace the graph once
+        >>> # one call: initialise states, build the trace graph, return a learner
+        >>> learner = braintrace.compile(model, braintrace.EProp, x0, kappa_filter_decay=0.9)
         >>> y = learner(x0)             # forward pass + eligibility-trace update
 
     References

--- a/braintrace/_algorithm/e_prop_test.py
+++ b/braintrace/_algorithm/e_prop_test.py
@@ -190,3 +190,29 @@ class TestSmokeLossDecreases(unittest.TestCase):
     def test_eprop(self):
         losses = _run(EProp(_toy_net()))
         assert losses[-1] < losses[0]
+
+
+def _docstring_rsnn():
+    """The exact ``RSNN`` model used in the ``EProp`` docstring example."""
+
+    class RSNN(brainstate.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.cell = braintrace.nn.ValinaRNNCell(1, 20, activation='tanh')
+            self.out = braintrace.nn.Linear(20, 1)
+
+        def update(self, x):
+            return x >> self.cell >> self.out
+
+    return RSNN()
+
+
+def test_docstring_compile_example_runs():
+    """Verify the runnable ``braintrace.compile`` example in ``EProp``'s docstring."""
+    model = _docstring_rsnn()
+    x0 = brainstate.random.randn(1)
+    learner = braintrace.compile(model, braintrace.EProp, x0, kappa_filter_decay=0.9)
+    y = learner(x0)
+    assert y.shape == (1,)
+    assert bool(jnp.all(jnp.isfinite(y)))
+    assert len(learner.graph.hidden_param_op_relations) >= 1

--- a/braintrace/_algorithm/io_dim_vjp.py
+++ b/braintrace/_algorithm/io_dim_vjp.py
@@ -592,10 +592,9 @@ class IODimVjpAlgorithm(ETraceVjpAlgorithm):
         ...         return x >> self.cell >> self.out
         >>>
         >>> model = RNN()
-        >>> _ = brainstate.nn.init_all_states(model)
-        >>> learner = braintrace.pp_prop(model, decay_or_rank=0.9)  # or rank: decay_or_rank=19
         >>> x0 = brainstate.random.randn(1)
-        >>> learner.compile_graph(x0)   # trace the graph once
+        >>> # one call: initialise states, build the trace graph, return a learner
+        >>> learner = braintrace.compile(model, braintrace.pp_prop, x0, decay_or_rank=0.9)  # or rank: decay_or_rank=19
         >>> y = learner(x0)             # forward pass + eligibility-trace update
 
     References

--- a/braintrace/_algorithm/io_dim_vjp_test.py
+++ b/braintrace/_algorithm/io_dim_vjp_test.py
@@ -391,3 +391,33 @@ class TestElemwiseBatchingMode:
         _assert_batching_matches_per_example(
             lambda m, **kw: braintrace.IODimVjpAlgorithm(m, 0.9, **kw)
         )
+
+
+def _docstring_rnn():
+    """The exact ``RNN`` model used in the ``IODimVjpAlgorithm`` docstring example."""
+
+    class RNN(brainstate.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.cell = braintrace.nn.ValinaRNNCell(1, 20, activation='tanh')
+            self.out = braintrace.nn.Linear(20, 1)
+
+        def update(self, x):
+            return x >> self.cell >> self.out
+
+    return RNN()
+
+
+def test_docstring_compile_example_runs():
+    """Verify the ``braintrace.compile`` example in ``IODimVjpAlgorithm``'s docstring.
+
+    Exercises the integer-rank variant (``decay_or_rank=19``) flagged in the
+    docstring comment, which is distinct from ``pp_prop_test``'s decay variant.
+    """
+    model = _docstring_rnn()
+    x0 = brainstate.random.randn(1)
+    learner = braintrace.compile(model, braintrace.pp_prop, x0, decay_or_rank=19)
+    y = learner(x0)
+    assert y.shape == (1,)
+    assert bool(jnp.all(jnp.isfinite(y)))
+    assert len(learner.graph.hidden_param_op_relations) >= 1

--- a/braintrace/_algorithm/ostl.py
+++ b/braintrace/_algorithm/ostl.py
@@ -90,10 +90,9 @@ class OSTLRecurrent(ParamDimVjpAlgorithm):
         ...         return x >> self.cell >> self.out
         >>>
         >>> model = Net()
-        >>> _ = brainstate.nn.init_all_states(model)
-        >>> learner = braintrace.OSTLRecurrent(model)
         >>> x0 = brainstate.random.randn(1)
-        >>> learner.compile_graph(x0)
+        >>> # one call: initialise states, build the trace graph, return a learner
+        >>> learner = braintrace.compile(model, braintrace.OSTLRecurrent, x0)
         >>> y = learner(x0)
 
     References
@@ -163,10 +162,9 @@ class OSTLFeedforward(pp_prop):
         ...         return x >> self.cell >> self.out
         >>>
         >>> model = Net()
-        >>> _ = brainstate.nn.init_all_states(model)
-        >>> learner = braintrace.OSTLFeedforward(model)
         >>> x0 = brainstate.random.randn(1)
-        >>> learner.compile_graph(x0)
+        >>> # one call: initialise states, build the trace graph, return a learner
+        >>> learner = braintrace.compile(model, braintrace.OSTLFeedforward, x0)
         >>> y = learner(x0)
 
     References

--- a/braintrace/_algorithm/ostl_test.py
+++ b/braintrace/_algorithm/ostl_test.py
@@ -245,3 +245,40 @@ class TestSmokeLossDecreases(unittest.TestCase):
     def test_ostl(self):
         losses = _run(OSTLRecurrent(_toy_net()))
         assert losses[-1] < losses[0]
+
+
+def _docstring_net():
+    """The exact ``Net`` model used in the ``OSTL*`` docstring examples."""
+
+    class Net(brainstate.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.cell = braintrace.nn.ValinaRNNCell(1, 20, activation='tanh')
+            self.out = braintrace.nn.Linear(20, 1)
+
+        def update(self, x):
+            return x >> self.cell >> self.out
+
+    return Net()
+
+
+def test_docstring_ostl_recurrent_compile_example_runs():
+    """Verify the ``braintrace.compile`` example in ``OSTLRecurrent``'s docstring."""
+    model = _docstring_net()
+    x0 = brainstate.random.randn(1)
+    learner = braintrace.compile(model, braintrace.OSTLRecurrent, x0)
+    y = learner(x0)
+    assert y.shape == (1,)
+    assert bool(jnp.all(jnp.isfinite(y)))
+    assert len(learner.graph.hidden_param_op_relations) >= 1
+
+
+def test_docstring_ostl_feedforward_compile_example_runs():
+    """Verify the ``braintrace.compile`` example in ``OSTLFeedforward``'s docstring."""
+    model = _docstring_net()
+    x0 = brainstate.random.randn(1)
+    learner = braintrace.compile(model, braintrace.OSTLFeedforward, x0)
+    y = learner(x0)
+    assert y.shape == (1,)
+    assert bool(jnp.all(jnp.isfinite(y)))
+    assert len(learner.graph.hidden_param_op_relations) >= 1

--- a/braintrace/_algorithm/osttp.py
+++ b/braintrace/_algorithm/osttp.py
@@ -108,12 +108,11 @@ class OSTTP(ParamDimVjpAlgorithm):
         ...         return x >> self.cell >> self.out
         >>>
         >>> model = Net()
-        >>> _ = brainstate.nn.init_all_states(model)
+        >>> x0 = brainstate.random.randn(1)
         >>> # one (n_target, n_l) feedback matrix per HiddenGroup (here n_l = 20)
         >>> B = jax.random.normal(jax.random.PRNGKey(0), (1, 20))
-        >>> learner = braintrace.OSTTP(model, B_list=[B])
-        >>> x0 = brainstate.random.randn(1)
-        >>> learner.compile_graph(x0)
+        >>> # ``compile`` initialises states + builds the trace graph in one call
+        >>> learner = braintrace.compile(model, braintrace.OSTTP, x0, B_list=[B])
         >>> y = learner.update(x0, y_target=brainstate.random.randn(1))
 
     References

--- a/braintrace/_algorithm/osttp_test.py
+++ b/braintrace/_algorithm/osttp_test.py
@@ -170,3 +170,31 @@ class TestSmokeLossDecreases(unittest.TestCase):
         y = jnp.ones((1, 3))
         losses = _run(algo, y_target=y, pass_y=True)
         assert losses[-1] < losses[0]
+
+
+def _docstring_net():
+    """The exact ``Net`` model used in the ``OSTTP`` docstring example."""
+
+    class Net(brainstate.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.cell = braintrace.nn.ValinaRNNCell(1, 20, activation='tanh')
+            self.out = braintrace.nn.Linear(20, 1)
+
+        def update(self, x):
+            return x >> self.cell >> self.out
+
+    return Net()
+
+
+def test_docstring_compile_example_runs():
+    """Verify the runnable ``braintrace.compile`` example in ``OSTTP``'s docstring."""
+    model = _docstring_net()
+    x0 = brainstate.random.randn(1)
+    # one (n_target, n_l) feedback matrix per HiddenGroup (here n_l = 20)
+    B = jax.random.normal(jax.random.PRNGKey(0), (1, 20))
+    learner = braintrace.compile(model, braintrace.OSTTP, x0, B_list=[B])
+    y = learner.update(x0, y_target=brainstate.random.randn(1))
+    assert y.shape == (1,)
+    assert bool(jnp.all(jnp.isfinite(y)))
+    assert len(learner.graph.hidden_param_op_relations) >= 1

--- a/braintrace/_algorithm/otpe.py
+++ b/braintrace/_algorithm/otpe.py
@@ -173,12 +173,11 @@ class OTPE(ETraceVjpAlgorithm):
         ...         return x >> self.cell >> self.out
         >>>
         >>> model = Net()
-        >>> _ = brainstate.nn.init_all_states(model)
-        >>> # ``leak`` is the postsynaptic membrane leak and must be passed
-        >>> # explicitly; it is never inferred from the model.
-        >>> learner = braintrace.OTPE(model, mode='full', leak=0.9)
         >>> x0 = brainstate.random.randn(1)
-        >>> learner.compile_graph(x0)
+        >>> # ``leak`` is the postsynaptic membrane leak and must be passed
+        >>> # explicitly; it is never inferred from the model. ``compile`` does the
+        >>> # state init + graph build in one call.
+        >>> learner = braintrace.compile(model, braintrace.OTPE, x0, mode='full', leak=0.9)
         >>> y = learner(x0)
 
     References

--- a/braintrace/_algorithm/otpe_test.py
+++ b/braintrace/_algorithm/otpe_test.py
@@ -187,3 +187,29 @@ class TestSmokeLossDecreases(unittest.TestCase):
     def test_otpe(self):
         losses = _run(OTPE(_toy_net(), leak=0.9))
         assert losses[-1] < losses[0]
+
+
+def _docstring_net():
+    """The exact ``Net`` model used in the ``OTPE`` docstring example."""
+
+    class Net(brainstate.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.cell = braintrace.nn.ValinaRNNCell(1, 20, activation='tanh')
+            self.out = braintrace.nn.Linear(20, 1)
+
+        def update(self, x):
+            return x >> self.cell >> self.out
+
+    return Net()
+
+
+def test_docstring_compile_example_runs():
+    """Verify the runnable ``braintrace.compile`` example in ``OTPE``'s docstring."""
+    model = _docstring_net()
+    x0 = brainstate.random.randn(1)
+    learner = braintrace.compile(model, braintrace.OTPE, x0, mode='full', leak=0.9)
+    y = learner(x0)
+    assert y.shape == (1,)
+    assert bool(jnp.all(jnp.isfinite(y)))
+    assert len(learner.graph.hidden_param_op_relations) >= 1

--- a/braintrace/_algorithm/ottt.py
+++ b/braintrace/_algorithm/ottt.py
@@ -138,12 +138,11 @@ class OTTT(ETraceVjpAlgorithm):
         ...         return x >> self.cell >> self.out
         >>>
         >>> model = Net()
-        >>> _ = brainstate.nn.init_all_states(model)
-        >>> # ``leak`` is the postsynaptic membrane leak and must be passed
-        >>> # explicitly; it is never inferred from the model.
-        >>> learner = braintrace.OTTT(model, mode='A', leak=0.9)
         >>> x0 = brainstate.random.randn(1)
-        >>> learner.compile_graph(x0)
+        >>> # ``leak`` is the postsynaptic membrane leak and must be passed
+        >>> # explicitly; it is never inferred from the model. ``compile`` does the
+        >>> # state init + graph build in one call.
+        >>> learner = braintrace.compile(model, braintrace.OTTT, x0, mode='A', leak=0.9)
         >>> y = learner(x0)
 
     References

--- a/braintrace/_algorithm/ottt_test.py
+++ b/braintrace/_algorithm/ottt_test.py
@@ -181,3 +181,29 @@ class TestSmokeLossDecreases(unittest.TestCase):
     def test_ottt(self):
         losses = _run(OTTT(_toy_net(), leak=0.9))
         assert losses[-1] < losses[0]
+
+
+def _docstring_net():
+    """The exact ``Net`` model used in the ``OTTT`` docstring example."""
+
+    class Net(brainstate.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.cell = braintrace.nn.ValinaRNNCell(1, 20, activation='tanh')
+            self.out = braintrace.nn.Linear(20, 1)
+
+        def update(self, x):
+            return x >> self.cell >> self.out
+
+    return Net()
+
+
+def test_docstring_compile_example_runs():
+    """Verify the runnable ``braintrace.compile`` example in ``OTTT``'s docstring."""
+    model = _docstring_net()
+    x0 = brainstate.random.randn(1)
+    learner = braintrace.compile(model, braintrace.OTTT, x0, mode='A', leak=0.9)
+    y = learner(x0)
+    assert y.shape == (1,)
+    assert bool(jnp.all(jnp.isfinite(y)))
+    assert len(learner.graph.hidden_param_op_relations) >= 1

--- a/braintrace/_algorithm/param_dim_vjp.py
+++ b/braintrace/_algorithm/param_dim_vjp.py
@@ -685,10 +685,10 @@ class ParamDimVjpAlgorithm(ETraceVjpAlgorithm):
         ...         return x >> self.cell >> self.out
         >>>
         >>> model = RNN()
-        >>> _ = brainstate.nn.init_all_states(model)
-        >>> learner = braintrace.D_RTRL(model)  # alias of ParamDimVjpAlgorithm
         >>> x0 = brainstate.random.randn(1)
-        >>> learner.compile_graph(x0)   # trace the graph once
+        >>> # ``braintrace.D_RTRL`` is an alias of ``ParamDimVjpAlgorithm``; one call
+        >>> # initialises states, builds the trace graph, and returns a learner.
+        >>> learner = braintrace.compile(model, braintrace.D_RTRL, x0)
         >>> y = learner(x0)             # forward pass + eligibility-trace update
 
     References

--- a/braintrace/_algorithm/param_dim_vjp_test.py
+++ b/braintrace/_algorithm/param_dim_vjp_test.py
@@ -431,3 +431,29 @@ class TestElemwiseBatchingMode:
 
     def test_d_rtrl_batching_matches_per_example(self):
         _assert_batching_matches_per_example(lambda m, **kw: braintrace.D_RTRL(m, **kw))
+
+
+def _docstring_rnn():
+    """The exact ``RNN`` model used in the ``ParamDimVjpAlgorithm`` docstring example."""
+
+    class RNN(brainstate.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.cell = braintrace.nn.ValinaRNNCell(1, 20, activation='tanh')
+            self.out = braintrace.nn.Linear(20, 1)
+
+        def update(self, x):
+            return x >> self.cell >> self.out
+
+    return RNN()
+
+
+def test_docstring_compile_example_runs():
+    """Verify the ``braintrace.compile`` example in ``ParamDimVjpAlgorithm``'s docstring."""
+    model = _docstring_rnn()
+    x0 = brainstate.random.randn(1)
+    learner = braintrace.compile(model, braintrace.D_RTRL, x0)
+    y = learner(x0)
+    assert y.shape == (1,)
+    assert bool(jnp.all(jnp.isfinite(y)))
+    assert len(learner.graph.hidden_param_op_relations) >= 1

--- a/braintrace/_algorithm/pp_prop.py
+++ b/braintrace/_algorithm/pp_prop.py
@@ -68,10 +68,9 @@ class pp_prop(IODimVjpAlgorithm):
         ...         return x >> self.cell >> self.out
         >>>
         >>> model = RNN()
-        >>> _ = brainstate.nn.init_all_states(model)
-        >>> learner = braintrace.pp_prop(model, decay_or_rank=0.9)  # or rank: decay_or_rank=19
         >>> x0 = brainstate.random.randn(1)
-        >>> learner.compile_graph(x0)   # trace the graph once
+        >>> # one call: initialise states, build the trace graph, return a learner
+        >>> learner = braintrace.compile(model, braintrace.pp_prop, x0, decay_or_rank=0.9)  # or rank: decay_or_rank=19
         >>> y = learner(x0)             # forward pass + eligibility-trace update
 
     References

--- a/braintrace/_algorithm/pp_prop_test.py
+++ b/braintrace/_algorithm/pp_prop_test.py
@@ -979,3 +979,29 @@ class TestPPPropDictGradientRouting:
         # All gradient leaves should be finite.
         for leaf in flat:
             assert jnp.all(jnp.isfinite(leaf)), f"Non-finite gradient leaf with shape {leaf.shape}"
+
+
+def _docstring_rnn():
+    """The exact ``RNN`` model used in the ``pp_prop`` docstring example."""
+
+    class RNN(brainstate.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.cell = braintrace.nn.ValinaRNNCell(1, 20, activation='tanh')
+            self.out = braintrace.nn.Linear(20, 1)
+
+        def update(self, x):
+            return x >> self.cell >> self.out
+
+    return RNN()
+
+
+def test_docstring_compile_example_runs():
+    """Verify the runnable ``braintrace.compile`` example in ``pp_prop``'s docstring."""
+    model = _docstring_rnn()
+    x0 = brainstate.random.randn(1)
+    learner = braintrace.compile(model, braintrace.pp_prop, x0, decay_or_rank=0.9)
+    y = learner(x0)
+    assert y.shape == (1,)
+    assert bool(jnp.all(jnp.isfinite(y)))
+    assert len(learner.graph.hidden_param_op_relations) >= 1

--- a/braintrace/_compile.py
+++ b/braintrace/_compile.py
@@ -218,11 +218,22 @@ def compile(
     --------
     .. code-block:: python
 
-        >>> import braintrace, jax.numpy as jnp
-        >>> model = MyRNN()
-        >>> x0 = jnp.ones((1, 3))
-        >>> learner = braintrace.compile(model, 'D_RTRL', x0, batch_size=1, verbose=1)
-        >>> y = learner.update(x0)
+        >>> import brainstate
+        >>> import braintrace
+        >>>
+        >>> class RNN(brainstate.nn.Module):
+        ...     def __init__(self):
+        ...         super().__init__()
+        ...         self.cell = braintrace.nn.ValinaRNNCell(3, 4, activation='tanh')
+        ...         self.out = braintrace.nn.Linear(4, 1)
+        ...     def update(self, x):
+        ...         return x >> self.cell >> self.out
+        >>>
+        >>> model = RNN()
+        >>> x0 = brainstate.random.randn(1, 3)   # (batch, features)
+        >>> # one call: initialise states, build the trace graph, return a learner
+        >>> learner = braintrace.compile(model, 'D_RTRL', x0, batch_size=1)
+        >>> y = learner.update(x0)               # forward pass + eligibility-trace update
     """
     cls = _resolve_algorithm(algorithm)
     if len(example_inputs) == 0:

--- a/braintrace/_compile_test.py
+++ b/braintrace/_compile_test.py
@@ -407,3 +407,29 @@ def test_compile_both_modes_finite_nonzero_grad(name, builder, algo, kw, feat, v
         f'{name} vmap={vmap}: non-finite grad'
     assert sum(float(jnp.sum(jnp.asarray(g) ** 2)) for g in leaves) > 0.0, \
         f'{name} vmap={vmap}: zero grad'
+
+
+# --- docstring example: braintrace.compile -----------------------------------
+
+def test_compile_docstring_example_runs():
+    """Verify the runnable, self-contained example in ``compile``'s docstring.
+
+    Mirrors the public-API example exactly (``braintrace.nn`` building blocks +
+    ``braintrace.compile``), so the docstring is guaranteed to execute.
+    """
+    class RNN(brainstate.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.cell = braintrace.nn.ValinaRNNCell(3, 4, activation='tanh')
+            self.out = braintrace.nn.Linear(4, 1)
+
+        def update(self, x):
+            return x >> self.cell >> self.out
+
+    model = RNN()
+    x0 = brainstate.random.randn(1, 3)
+    learner = braintrace.compile(model, 'D_RTRL', x0, batch_size=1)
+    y = learner.update(x0)
+    assert y.shape == (1, 1)
+    assert bool(jnp.all(jnp.isfinite(y)))
+    assert len(learner.graph.hidden_param_op_relations) >= 1

--- a/braintrace/_docs_examples_test.py
+++ b/braintrace/_docs_examples_test.py
@@ -1,0 +1,247 @@
+# Copyright 2026 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Executable regression tests for the ``braintrace.compile`` examples in ``docs/``.
+
+The documentation notebooks are *not* executed during the Sphinx build
+(``jupyter_execute_notebooks = "off"``), so their code is otherwise never run.
+This module reconstructs the *distinct* model architectures documented across the
+tutorials and runs each through ``braintrace.compile`` with the same invocation
+shown in the docs, asserting the documented behaviour. It guards against silent
+API drift in the docs and is co-located in ``braintrace/`` so CI (``pytest
+braintrace/``) executes it.
+
+Each test names the doc page it mirrors. Architectures already covered by other
+test modules (plain D-RTRL compile, vmap mechanics, ES-D-RTRL decay/rank) are not
+duplicated here; only the documented *architectures* missing elsewhere are added:
+``lax.select`` control-flow, recurrent ``Conv2d``, mixed ETP/plain selection,
+GRU via ``braintrace.compile`` (batched + unbatched + vmap), and manual
+multi-group RNNs.
+"""
+
+import jax
+import jax.numpy as jnp
+import brainstate
+
+import braintrace
+
+
+def test_docs_limitations_good_model_lax_select():
+    """docs/advanced/limitations.ipynb — ``jax.lax.select`` control-flow workaround."""
+
+    class GoodModel(brainstate.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.w = brainstate.ParamState(jnp.ones((10, 10)))
+            self.h = brainstate.HiddenState(jnp.zeros(10))
+
+        def update(self, x):
+            new_h = jax.nn.tanh(braintrace.matmul(self.h.value, self.w.value) + x)
+            # jax.lax.select compiles to a single select_n primitive the compiler
+            # can trace through (unlike jnp.where, which now jits a sub-jaxpr).
+            self.h.value = jax.lax.select(jnp.sum(x) > 0, new_h, self.h.value)
+            return self.h.value
+
+    model = GoodModel()
+    algo = braintrace.compile(model, braintrace.D_RTRL, jnp.zeros(10), batch_size=1)
+    y = algo(jnp.ones(10))
+    assert y.shape == (10,)
+    assert bool(jnp.all(jnp.isfinite(y)))
+    assert len(algo.graph.hidden_param_op_relations) == 1
+
+
+def test_docs_graphviz_conv_rnn():
+    """docs/tutorials/graph_visualization.ipynb — recurrent Conv2d (etp_conv)."""
+
+    class ConvRNN(brainstate.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.conv = braintrace.nn.Conv2d(in_size=(28, 28, 8), out_channels=8,
+                                             kernel_size=3, padding='SAME')
+            self.h = brainstate.HiddenState(jnp.zeros((28, 28, 8)))
+            self.out = braintrace.nn.Linear(8 * 28 * 28, 10)
+
+        def update(self, x):
+            self.h.value = jax.nn.tanh(self.conv(self.h.value) + x)
+            return self.out(self.h.value.reshape(-1))
+
+    model = ConvRNN()
+    algo = braintrace.compile(model, braintrace.D_RTRL, jnp.zeros((28, 28, 8)), batch_size=1)
+    y = algo(jnp.zeros((28, 28, 8)))
+    assert y.shape == (10,)
+    assert bool(jnp.all(jnp.isfinite(y)))
+    # The conv kernel feeds the hidden map directly -> exactly one ETP relation,
+    # carried by the convolution primitive (etp_conv).
+    rels = algo.graph.hidden_param_op_relations
+    assert len(rels) == 1
+    assert 'conv' in str(rels[0].primitive)
+
+
+def test_docs_etp_primitives_tiny_rnn_mixed_selection():
+    """docs/tutorials/etp_primitives.ipynb — mixed ETP / plain primitive selection."""
+
+    class TinyRNN(brainstate.nn.Module):
+        def __init__(self, in_dim=4, hid_dim=6):
+            super().__init__()
+            self.in_dim = in_dim
+            self.hid_dim = hid_dim
+            # ETP-enabled (online learning via D-RTRL).
+            self.W_rec = brainstate.ParamState(brainstate.random.randn(hid_dim, hid_dim) * 0.1)
+            # Plain matmul -> learned via BPTT, excluded from online learning.
+            self.W_in = brainstate.ParamState(brainstate.random.randn(in_dim, hid_dim) * 0.1)
+
+        def init_state(self, batch_size=None, **kwargs):
+            self.h = brainstate.HiddenState(jnp.zeros((batch_size or 1, self.hid_dim)))
+
+        def update(self, x):
+            input_drive = x @ self.W_in.value            # NOT marked -> excluded
+            rec_drive = braintrace.matmul(self.h.value, self.W_rec.value)  # marked
+            self.h.value = jax.nn.tanh(input_drive + rec_drive)
+            return self.h.value
+
+    model = TinyRNN(in_dim=4, hid_dim=6)
+    algo = braintrace.compile(model, braintrace.D_RTRL, jnp.zeros((2, model.in_dim)), batch_size=2)
+    y = algo(jnp.ones((2, model.in_dim)))
+    assert y.shape == (2, 6)
+    assert bool(jnp.all(jnp.isfinite(y)))
+    # Only W_rec is routed through an ETP op -> exactly one relation; W_in excluded.
+    rels = algo.graph.hidden_param_op_relations
+    assert len(rels) == 1
+    assert any('W_rec' in str(p) for p in rels[0].trainable_paths.values())
+
+
+def test_docs_concepts_gru_net_batched():
+    """docs/quickstart/concepts.ipynb — GRUNet via braintrace.compile (batched, bs=1)."""
+
+    class GRUNet(brainstate.nn.Module):
+        def __init__(self, n_in, n_rec, n_out):
+            super().__init__()
+            self.rnn = braintrace.nn.GRUCell(n_in, n_rec)
+            self.readout = braintrace.nn.Linear(n_rec, n_out)
+
+        def update(self, x):
+            return self.readout(self.rnn(x))
+
+    model = GRUNet(10, 64, 10)
+    # The example input carries the batch axis to match batch_size=1.
+    trainer = braintrace.compile(model, braintrace.D_RTRL, jnp.zeros((1, 10)), batch_size=1)
+
+    weights = model.states(brainstate.ParamState)
+
+    def loss_fn(x):
+        return jnp.mean(trainer(x) ** 2)
+
+    grads = brainstate.transform.grad(loss_fn, weights)(jnp.ones((1, 10)))
+    leaves = jax.tree.leaves(grads)
+    assert leaves and all(bool(jnp.all(jnp.isfinite(g))) for g in leaves)
+    assert len(trainer.graph.hidden_param_op_relations) >= 1
+
+
+def test_docs_batching_gru_single_sample_unbatched():
+    """docs/tutorials/batching.ipynb — single-sample mode (omit batch_size)."""
+
+    class SimpleGRU(brainstate.nn.Module):
+        def __init__(self, n_in, n_rec, n_out):
+            super().__init__()
+            self.rnn = braintrace.nn.GRUCell(n_in, n_rec)
+            self.out = braintrace.nn.Linear(n_rec, n_out)
+
+        def update(self, x):
+            return self.out(self.rnn(x))
+
+    model = SimpleGRU(10, 64, 5)
+    algo = braintrace.compile(model, braintrace.D_RTRL, jnp.zeros(10))
+    out = algo(jnp.ones(10))
+    assert out.shape == (5,)
+    assert bool(jnp.all(jnp.isfinite(out)))
+
+
+def test_docs_batching_gru_vmap_batched():
+    """docs/tutorials/batching.ipynb — vmap mode with a batched example input."""
+
+    class SimpleGRU(brainstate.nn.Module):
+        def __init__(self, n_in, n_rec, n_out):
+            super().__init__()
+            self.rnn = braintrace.nn.GRUCell(n_in, n_rec)
+            self.out = braintrace.nn.Linear(n_rec, n_out)
+
+        def update(self, x):
+            return self.out(self.rnn(x))
+
+    model = SimpleGRU(10, 64, 5)
+    batch_size = 16
+    # In vmap mode the example carries the batch axis (axis 0), stripped internally.
+    algo_vmapped = braintrace.compile(
+        model, braintrace.D_RTRL, jnp.zeros((batch_size, 10)),
+        batch_size=batch_size, vmap=True,
+    )
+    out = algo_vmapped(jnp.ones((batch_size, 10)))
+    assert out.shape == (batch_size, 5)
+    assert bool(jnp.all(jnp.isfinite(out)))
+
+
+def test_docs_graphviz_single_layer_rnn_unbatched_structure():
+    """docs/tutorials/graph_visualization.ipynb — unbatched structure (etp_mv, (32,))."""
+
+    class SingleLayerRNN(brainstate.nn.Module):
+        def __init__(self, n_in, n_rec, n_out):
+            super().__init__()
+            self.rnn = braintrace.nn.ValinaRNNCell(n_in, n_rec)
+            self.out = braintrace.nn.Linear(n_rec, n_out)
+
+        def update(self, x):
+            return self.out(self.rnn(x))
+
+    model = SingleLayerRNN(10, 32, 5)
+    learner = braintrace.compile(model, braintrace.D_RTRL, jnp.zeros(10))
+    graph = learner.graph
+    # Documented structure: one hidden group of shape (32,), one matrix-vector relation.
+    assert len(graph.hidden_groups) == 1
+    assert tuple(graph.hidden_groups[0].varshape) == (32,)
+    assert len(graph.hidden_param_op_relations) == 1
+    assert 'etp_mv' in str(graph.hidden_param_op_relations[0].primitive)
+
+
+def test_docs_hidden_states_two_layer_manual_multigroup():
+    """docs/tutorials/hidden_states.ipynb — manual two-layer RNN, two hidden groups."""
+
+    class TwoLayerRNN(brainstate.nn.Module):
+        def __init__(self, in_size, hidden_size, out_size):
+            super().__init__()
+            self.w1_in = brainstate.ParamState(brainstate.random.randn(in_size, hidden_size) * 0.01)
+            self.w1_rec = brainstate.ParamState(brainstate.random.randn(hidden_size, hidden_size) * 0.01)
+            self.h1 = brainstate.HiddenState(jnp.zeros(hidden_size))
+            self.w2_in = brainstate.ParamState(brainstate.random.randn(hidden_size, out_size) * 0.01)
+            self.w2_rec = brainstate.ParamState(brainstate.random.randn(out_size, out_size) * 0.01)
+            self.h2 = brainstate.HiddenState(jnp.zeros(out_size))
+
+        def update(self, x):
+            self.h1.value = jax.nn.tanh(
+                x @ self.w1_in.value + braintrace.matmul(self.h1.value, self.w1_rec.value)
+            )
+            self.h2.value = jax.nn.tanh(
+                self.h1.value @ self.w2_in.value + braintrace.matmul(self.h2.value, self.w2_rec.value)
+            )
+            return self.h2.value
+
+    model = TwoLayerRNN(in_size=10, hidden_size=16, out_size=8)
+    algo = braintrace.compile(model, braintrace.D_RTRL, jnp.zeros(10), batch_size=1)
+    y = algo(jnp.ones(10))
+    assert y.shape == (8,)
+    assert bool(jnp.all(jnp.isfinite(y)))
+    # Differently-shaped hidden states (16 vs 8) -> two distinct groups, two relations
+    # (each recurrent weight traced; the two input weights are plain matmuls).
+    assert len(algo.graph.hidden_groups) == 2
+    assert len(algo.graph.hidden_param_op_relations) == 2

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -26,9 +26,12 @@ Basic Usage
            return self.out(self.rnn(x))
 
    model = MyRNN()
+   example_input = brainstate.random.randn(1, 10)   # (batch_size, n_in)
 
-   # One call initialises states, compiles the graph, and returns a ready learner
+   # One call initialises states, compiles the graph, and returns a ready learner.
+   # The example input carries the batch axis to match ``batch_size=1``.
    learner = braintrace.compile(model, braintrace.D_RTRL, example_input, batch_size=1)
+   y = learner(example_input)
 
    # Now use brainstate.transform.grad as usual — gradients are
    # computed online via eligibility traces, not BPTT.

--- a/docs/quickstart/concepts.ipynb
+++ b/docs/quickstart/concepts.ipynb
@@ -254,7 +254,7 @@
     }
    },
    "outputs": [],
-   "source": "# Step 1: Define model\nmodel = GRUNet(10, 64, 10)\n\n# Step 2: Compile — initialises states, builds the trace graph, returns a ready learner\ntrainer = braintrace.compile(model, braintrace.D_RTRL, jnp.zeros(10), batch_size=1)"
+   "source": "# Step 1: Define model\nmodel = GRUNet(10, 64, 10)\n\n# Step 2: Compile — initialises states, builds the trace graph, returns a ready learner.\n# The example input carries the batch axis: shape (batch_size, n_in) = (1, 10).\ntrainer = braintrace.compile(model, braintrace.D_RTRL, jnp.zeros((1, 10)), batch_size=1)"
   },
   {
    "cell_type": "code",
@@ -269,11 +269,11 @@
     }
    },
    "outputs": [],
-   "source": "# Step 3: Use standard JAX gradient computation\n# The eligibility traces are updated inside trainer(x)\nweights = model.states(brainstate.ParamState)\n\ndef loss_fn(x):\n    out = trainer(x)\n    return jnp.mean(out ** 2)\n\ngrad_fn = brainstate.transform.grad(loss_fn, weights)\ngrads = grad_fn(jnp.ones(10))"
+   "source": "# Step 3: Use standard JAX gradient computation\n# The eligibility traces are updated inside trainer(x)\nweights = model.states(brainstate.ParamState)\n\ndef loss_fn(x):\n    out = trainer(x)\n    return jnp.mean(out ** 2)\n\ngrad_fn = brainstate.transform.grad(loss_fn, weights)\ngrads = grad_fn(jnp.ones((1, 10)))   # input carries the batch axis (1, 10)"
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": null,
    "id": "c5d6e7f8a9b0c1d2",
    "metadata": {
     "execution": {
@@ -284,18 +284,7 @@
     }
    },
    "outputs": [],
-   "source": [
-    "# Step 3: Use standard JAX gradient computation\n",
-    "# The eligibility traces are updated inside trainer(x)\n",
-    "weights = model.states(brainstate.ParamState)\n",
-    "\n",
-    "def loss_fn(x):\n",
-    "    out = trainer(x)\n",
-    "    return jnp.mean(out ** 2)\n",
-    "\n",
-    "grad_fn = brainstate.transform.grad(loss_fn, weights)\n",
-    "grads = grad_fn(jnp.ones(10))"
-   ]
+   "source": "# Step 3: Use standard JAX gradient computation\n# The eligibility traces are updated inside trainer(x)\nweights = model.states(brainstate.ParamState)\n\ndef loss_fn(x):\n    out = trainer(x)\n    return jnp.mean(out ** 2)\n\ngrad_fn = brainstate.transform.grad(loss_fn, weights)\ngrads = grad_fn(jnp.ones((1, 10)))   # input carries the batch axis (1, 10)"
   },
   {
    "cell_type": "markdown",

--- a/docs/tutorials/batching.ipynb
+++ b/docs/tutorials/batching.ipynb
@@ -21,7 +21,7 @@
    "cell_type": "markdown",
    "id": "a1b2c3d4e5f60002",
    "metadata": {},
-   "source": "## Vmap-Based Batching (Recommended)\n\nThe recommended approach is to compile the online learning graph for a **single sample**, then leverage JAX's `vmap` to parallelize across the batch. `braintrace.compile(..., batch_size=B, vmap=True)` does this in one call:\n\n1. It initialises per-sample states for `batch_size` samples.\n2. It compiles the ETP graph using a single-sample example input.\n3. It wraps the algorithm with `brainstate.nn.Vmap` for parallel execution.\n4. It returns the vmapped learner, ready to call on batched inputs.\n\nThis pattern keeps the model definition simple (single-sample logic) while gaining efficient batch parallelism automatically."
+   "source": "## Vmap-Based Batching (Recommended)\n\nThe recommended approach is to compile the online learning graph for a **single sample**, then leverage JAX's `vmap` to parallelize across the batch. `braintrace.compile(..., batch_size=B, vmap=True)` does this in one call:\n\n1. It initialises per-sample states for `batch_size` samples.\n2. It compiles the ETP graph from a single **batched** time step (shape `(batch_size, n_in)`); the batch axis (axis 0) is stripped internally to recover the per-sample example.\n3. It wraps the algorithm with `brainstate.nn.Vmap` for parallel execution.\n4. It returns the vmapped learner, ready to call on batched inputs.\n\nThis pattern keeps the model definition simple (single-sample logic) while gaining efficient batch parallelism automatically."
   },
   {
    "cell_type": "code",
@@ -60,7 +60,7 @@
    "id": "a1b2c3d4e5f60005",
    "metadata": {},
    "outputs": [],
-   "source": "model = SimpleGRU(10, 64, 5)\nbatch_size = 16\n\n# braintrace.compile with vmap=True:\n#   - initialises per-sample hidden states (batch_size independent copies)\n#   - compiles the ETP graph on a single-sample input shape\n#   - wraps the result in brainstate.nn.Vmap for parallel execution\nalgo_vmapped = braintrace.compile(\n    model, braintrace.D_RTRL, jnp.zeros(10),\n    batch_size=batch_size, vmap=True,\n)\n\n# Run on batched input — the returned learner handles the batch axis transparently\nx_batch = jnp.ones((batch_size, 10))\nout = algo_vmapped(x_batch)\nprint(\"Output shape:\", out.shape)  # (16, 5)"
+   "source": "model = SimpleGRU(10, 64, 5)\nbatch_size = 16\n\n# braintrace.compile with vmap=True:\n#   - initialises per-sample hidden states (batch_size independent copies)\n#   - compiles the ETP graph from a single batched time step: axis 0 is the batch\n#     axis, which compile strips internally to recover the per-sample example\n#   - wraps the result in brainstate.nn.Vmap for parallel execution\nalgo_vmapped = braintrace.compile(\n    model, braintrace.D_RTRL, jnp.zeros((batch_size, 10)),\n    batch_size=batch_size, vmap=True,\n)\n\n# Run on batched input — the returned learner handles the batch axis transparently\nx_batch = jnp.ones((batch_size, 10))\nout = algo_vmapped(x_batch)\nprint(\"Output shape:\", out.shape)  # (16, 5)"
   },
   {
    "cell_type": "markdown",
@@ -84,7 +84,7 @@
    "id": "a1b2c3d4e5f60008",
    "metadata": {},
    "outputs": [],
-   "source": "model2 = SimpleGRU(10, 64, 5)\n\n# Single-sample: no vmap, batch_size=1 (or omit batch_size for unbatched states)\nalgo2 = braintrace.compile(model2, braintrace.D_RTRL, jnp.zeros(10), batch_size=1)\n\n# Process one sample at a time\nx_single = jnp.ones(10)\nout = algo2(x_single)\nprint(\"Single sample output shape:\", out.shape)  # (5,)"
+   "source": "model2 = SimpleGRU(10, 64, 5)\n\n# Single-sample mode: omit batch_size so states are created unbatched.\nalgo2 = braintrace.compile(model2, braintrace.D_RTRL, jnp.zeros(10))\n\n# Process one sample at a time\nx_single = jnp.ones(10)\nout = algo2(x_single)\nprint(\"Single sample output shape:\", out.shape)  # (5,)"
   },
   {
    "cell_type": "markdown",

--- a/docs/tutorials/graph_visualization.ipynb
+++ b/docs/tutorials/graph_visualization.ipynb
@@ -76,7 +76,7 @@
     }
    },
    "outputs": [],
-   "source": "class SingleLayerRNN(brainstate.nn.Module):\n    def __init__(self, n_in, n_rec, n_out):\n        super().__init__()\n        self.rnn = braintrace.nn.ValinaRNNCell(n_in, n_rec)\n        self.out = braintrace.nn.Linear(n_rec, n_out)\n\n    def update(self, x):\n        return self.out(self.rnn(x))\n\n\nmodel = SingleLayerRNN(10, 32, 5)\n\n# braintrace.compile initialises states, compiles the ETP graph, and returns a ready learner.\n# verbose=2 prints full compiler diagnostics during compilation.\nlearner = braintrace.compile(model, braintrace.D_RTRL, jnp.zeros(10), batch_size=1, verbose=2)\nlearner.show_graph()"
+   "source": "class SingleLayerRNN(brainstate.nn.Module):\n    def __init__(self, n_in, n_rec, n_out):\n        super().__init__()\n        self.rnn = braintrace.nn.ValinaRNNCell(n_in, n_rec)\n        self.out = braintrace.nn.Linear(n_rec, n_out)\n\n    def update(self, x):\n        return self.out(self.rnn(x))\n\n\nmodel = SingleLayerRNN(10, 32, 5)\n\n# braintrace.compile initialises states, compiles the ETP graph, and returns a ready learner.\n# We compile for a single unbatched sample (no batch_size), so the hidden state is (32,) and\n# the recurrent op is the matrix-vector primitive etp_mv. verbose=2 prints full diagnostics.\nlearner = braintrace.compile(model, braintrace.D_RTRL, jnp.zeros(10), verbose=2)\nlearner.show_graph()"
   },
   {
    "cell_type": "markdown",
@@ -124,7 +124,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 3,
+   "execution_count": null,
    "id": "b8c9d0e1f2a3b4c5",
    "metadata": {
     "execution": {
@@ -134,46 +134,8 @@
      "shell.execute_reply": "2026-06-26T13:41:26.069667Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "=== Hidden Groups ===\n",
-      "  Group 0: 1 state(s), shape (32,)\n",
-      "    Paths: [('rnn', 'h')]\n",
-      "\n",
-      "=== Weight-Primitive-Hidden Relations ===\n",
-      "  Relation 0:\n",
-      "    Trainable paths: {'weight': ('rnn', 'W', 'weight'), 'bias': ('rnn', 'W', 'weight')}\n",
-      "    Primitive: etp_mv\n",
-      "    Hidden groups: [0]\n",
-      "\n",
-      "=== Perturbation ===\n",
-      "  Has perturbation: True\n"
-     ]
-    }
-   ],
-   "source": [
-    "graph = algo.graph\n",
-    "\n",
-    "print(\"=== Hidden Groups ===\")\n",
-    "for g in graph.hidden_groups:\n",
-    "    print(f\"  Group {g.index}: {g.num_state} state(s), shape {g.varshape}\")\n",
-    "    print(f\"    Paths: {g.hidden_paths}\")\n",
-    "\n",
-    "print(\"\\n=== Weight-Primitive-Hidden Relations ===\")\n",
-    "for i, r in enumerate(graph.hidden_param_op_relations):\n",
-    "    print(f\"  Relation {i}:\")\n",
-    "    # ``trainable_paths`` is a dict {trainable key -> owning ParamState path};\n",
-    "    # a single primitive may own several (e.g. {weight, bias}).\n",
-    "    print(f\"    Trainable paths: {r.trainable_paths}\")\n",
-    "    print(f\"    Primitive: {r.primitive}\")\n",
-    "    print(f\"    Hidden groups: {[g.index for g in r.hidden_groups]}\")\n",
-    "\n",
-    "print(f\"\\n=== Perturbation ===\")\n",
-    "print(f\"  Has perturbation: {graph.hidden_perturb is not None}\")"
-   ]
+   "outputs": [],
+   "source": "graph = learner.graph\n\nprint(\"=== Hidden Groups ===\")\nfor g in graph.hidden_groups:\n    print(f\"  Group {g.index}: {g.num_state} state(s), shape {g.varshape}\")\n    print(f\"    Paths: {g.hidden_paths}\")\n\nprint(\"\\n=== Weight-Primitive-Hidden Relations ===\")\nfor i, r in enumerate(graph.hidden_param_op_relations):\n    print(f\"  Relation {i}:\")\n    # ``trainable_paths`` is a dict {trainable key -> owning ParamState path};\n    # a single primitive may own several (e.g. {weight, bias}).\n    print(f\"    Trainable paths: {r.trainable_paths}\")\n    print(f\"    Primitive: {r.primitive}\")\n    print(f\"    Hidden groups: {[g.index for g in r.hidden_groups]}\")\n\nprint(f\"\\n=== Perturbation ===\")\nprint(f\"  Has perturbation: {graph.hidden_perturb is not None}\")"
   },
   {
    "cell_type": "markdown",
@@ -200,7 +162,7 @@
     }
    },
    "outputs": [],
-   "source": "class TwoLayerRNN(brainstate.nn.Module):\n    def __init__(self, n_in, n_rec, n_out):\n        super().__init__()\n        self.rnn1 = braintrace.nn.GRUCell(n_in, n_rec)\n        self.rnn2 = braintrace.nn.GRUCell(n_rec, n_rec)\n        self.out = braintrace.nn.Linear(n_rec, n_out)\n\n    def update(self, x):\n        h1 = self.rnn1(x)\n        h2 = self.rnn2(h1)\n        return self.out(h2)\n\n\nmodel2 = TwoLayerRNN(10, 32, 5)\n\nlearner2 = braintrace.compile(model2, braintrace.D_RTRL, jnp.zeros(10), batch_size=1)\nlearner2.show_graph()"
+   "source": "class TwoLayerRNN(brainstate.nn.Module):\n    def __init__(self, n_in, n_rec, n_out):\n        super().__init__()\n        self.rnn1 = braintrace.nn.GRUCell(n_in, n_rec)\n        self.rnn2 = braintrace.nn.GRUCell(n_rec, n_rec)\n        self.out = braintrace.nn.Linear(n_rec, n_out)\n\n    def update(self, x):\n        h1 = self.rnn1(x)\n        h2 = self.rnn2(h1)\n        return self.out(h2)\n\n\nmodel2 = TwoLayerRNN(10, 32, 5)\n\n# Compile for a single unbatched sample (no batch_size).\nlearner2 = braintrace.compile(model2, braintrace.D_RTRL, jnp.zeros(10))\nlearner2.show_graph()"
   },
   {
    "cell_type": "markdown",


### PR DESCRIPTION
## Summary

Makes `braintrace.compile` the canonical entry point in **every** example and fixes broken documentation examples, backing each with executable tests.

### Docstrings (Python)
- Fix the `compile()` docstring — the example referenced an undefined `MyRNN()`; replaced with a self-contained `braintrace.nn` RNN.
- Migrate all per-algorithm class docstrings (`pp_prop`, `IODimVjpAlgorithm`, `ParamDimVjpAlgorithm`/`D_RTRL`, `EProp`, `OTTT`, `OTPE`, `OSTTP`, `OSTLRecurrent`, `OSTLFeedforward`) from the old manual `learner.compile_graph(x0)` pattern to `braintrace.compile(...)`.

### Docs (notebooks / rst)
- Found and fixed **broken** examples that paired a built-in RNN cell (`GRUCell`/`ValinaRNNCell`, which re-batch on `init_state`) with an unbatched example input plus `batch_size`/`vmap` — these raised a shape/concat error at compile time. Fixed `concepts`, `batching`, `graph_visualization` notebooks and `index.rst` to carry the batch axis (or run unbatched) consistently.
- Fixed a stale `algo` → `learner` reference in `graph_visualization`.
- `rnn_online_learning` / `snn_online_learning` already passed batched `inputs[0]` for vmap — left unchanged.

### Tests
- Added co-located docstring-example tests in each algorithm `*_test.py` and `_compile_test.py`.
- Added `braintrace/_docs_examples_test.py` executing the distinct documented architectures not covered elsewhere: `jax.lax.select` control-flow, recurrent `Conv2d`, mixed ETP/plain selection, GRU via `compile` (batched/unbatched/vmap), and manual multi-group RNNs. (Docs notebooks aren't executed by the Sphinx build, so these are the only place the doc code runs.)

## Test plan
- `JAX_PLATFORMS=cpu pytest braintrace/` → **1604 passed, 3 skipped**.

## Summary by Sourcery

Standardize documentation examples around braintrace.compile and add tests to ensure they remain executable and aligned with the public API.

New Features:
- Introduce executable tests for docstring examples of core online-learning algorithms using braintrace.compile.
- Add regression tests that reconstruct distinct tutorial architectures and run them through braintrace.compile to guard against documentation/API drift.

Enhancements:
- Update algorithm docstrings to use braintrace.compile as the canonical entry point instead of manual state initialization and compile_graph.
- Revise compile() docstring with a self-contained RNN example built from braintrace.nn components.
- Clarify batching and vmap semantics in quickstart and batching tutorials, ensuring example inputs consistently carry the batch axis when batch_size is used.
- Adjust graph visualization and related docs to use unbatched compile examples and correct references to learner objects and fields.

Tests:
- Extend existing algorithm test modules with docstring-example tests that assert outputs are finite and graph relations are present for each compile usage.
- Add braintrace/_docs_examples_test.py to execute key notebook examples (control-flow with lax.select, Conv2d RNN, mixed ETP/plain primitives, GRU batching modes, multi-group RNNs) via braintrace.compile.