### PR TITLE
refactor: rename sparse_matmul parameter weight_data to weight

### DIFF
--- a/braintrace/_op/sparse.py
+++ b/braintrace/_op/sparse.py
@@ -315,11 +315,11 @@ etp_sp_mv_p.register_etp_rules(
 )
 
 
-def sparse_matmul(x, weight_data, *, sparse_mat, bias=None):
+def sparse_matmul(x, weight, *, sparse_mat, bias=None):
     r"""ETP-aware sparse matrix multiplication.
 
     Computes :math:`y = x \mathbin{@} \mathrm{sparse}(w) \; (+ b)`, where
-    only the non-zero entries (``weight_data``) of the fixed sparse pattern
+    only the non-zero entries (``weight``) of the fixed sparse pattern
     are trainable and participate in eligibility-trace computation.
     Auto-dispatches batched/unbatched based on ``x.ndim``.
 
@@ -327,7 +327,7 @@ def sparse_matmul(x, weight_data, *, sparse_mat, bias=None):
     ----------
     x : ArrayLike
         Input array.
-    weight_data : ArrayLike
+    weight : ArrayLike
         Sparse-matrix data, i.e. the non-zero values, shape ``(nnz,)``.
     sparse_mat : object
         Sparse-matrix structure (e.g. a ``brainunit.sparse`` matrix object).
@@ -344,7 +344,7 @@ def sparse_matmul(x, weight_data, *, sparse_mat, bias=None):
     """
     p = etp_sp_mm_p if x.ndim >= 2 else etp_sp_mv_p
     x_v, x_u = u.split_mantissa_unit(x)
-    w_v, w_u = u.split_mantissa_unit(weight_data)
+    w_v, w_u = u.split_mantissa_unit(weight)
     unit = x_u * w_u
     if bias is not None:
         bias_v = u.Quantity(bias).to_decimal(unit)


### PR DESCRIPTION
Renames the public parameter of `braintrace.sparse_matmul` from `weight_data` to `weight` for a cleaner, more consistent API.

## Changes
- `braintrace/_op/sparse.py`: signature, body usage, and docstring (inline mention + Parameters entry).

## Scope notes
- **Public API only.** The internal primitive invar named `weight_data` (`_etp_sp_matmul_impl`, module docstring) is intentionally left unchanged.
- **No caller changes needed.** Every call site (`nn/_linear.py`, `_legacy/_ops.py`, tests) passes the argument positionally; a repo-wide grep found no `weight_data=` keyword usage.

## Verification
- `braintrace/_op/sparse_test.py`: 20 passed.

## Summary by Sourcery

Enhancements:
- Update sparse_matmul docstring and internal usage to reflect the new weight parameter name.