### PR TITLE
feat: weight_fn/bias_fn transform hooks for ETP ops and nn layers (release 0.2.3)

### DIFF
--- a/braintrace/_compiler/scenario_catalog_test.py
+++ b/braintrace/_compiler/scenario_catalog_test.py
@@ -284,6 +284,48 @@ class _ElemwiseChainRNN(brainstate.nn.Module):
         return self.h.value
 
 
+class _ElemwiseChainWeightFnRNN(brainstate.nn.Module):
+    """``h = tanh(element_wise(w2, weight_fn=tanh) * matmul(w1, xh))`` — the
+    gradient-enabled elemwise tail exemption must still include W1 even when
+    the elemwise carries a non-identity transform. Both W1 and W2 register."""
+
+    def __init__(self, n_in: int, n_out: int):
+        super().__init__()
+        self.w1 = brainstate.ParamState(brainstate.random.randn(n_in + n_out, n_out))
+        self.w2 = brainstate.ParamState(brainstate.random.randn(n_out))
+        self.h = brainstate.HiddenState(jnp.zeros(n_out))
+
+    def init_state(self, *args, **kwargs):
+        self.h.value = jnp.zeros_like(self.h.value)
+
+    def update(self, x):
+        xh = jnp.concatenate([x, self.h.value])
+        y = braintrace.matmul(xh, self.w1.value)
+        s = braintrace.element_wise(self.w2.value, weight_fn=jnp.tanh)
+        self.h.value = jnp.tanh(s * y)
+        return self.h.value
+
+
+class TestElemwiseWeightFnTailExemption:
+
+    def test_weight_fn_elemwise_still_includes_upstream_matmul(self):
+        model = _ElemwiseChainWeightFnRNN(3, 4)
+        brainstate.nn.init_all_states(model)
+        inp = brainstate.random.rand(3)
+
+        graph = _compile(model, inp)
+
+        # Exact relation set: both W1 (upstream matmul) and W2 (transformed
+        # elemwise) connect to h.
+        assert _relation_set(graph) == {
+            (('w1',), ('h',)),
+            (('w2',), ('h',)),
+        }
+        # Primitive identity (NOT name strings) — project principle.
+        assert _primitive_for(graph, ('w1',)) is etp_mv_p
+        assert _primitive_for(graph, ('w2',)) is etp_elemwise_p
+
+
 class _TwoMatmulInSeriesRNN(brainstate.nn.Module):
     """``h = tanh(matmul(w2, matmul(w1, xh)))`` — W1's output reaches h only
     via W2's matmul (another non-gradient-enabled ETP primitive). W1 must

--- a/braintrace/_legacy/_ops.py
+++ b/braintrace/_legacy/_ops.py
@@ -282,7 +282,7 @@ class ElemWiseOp(ETraceOp):
         return self.xw_to_y(None, weights)
 
     def xw_to_y(self, inputs, weights):
-        return _new_element_wise(weights, self._raw_fn)
+        return _new_element_wise(weights, weight_fn=self._raw_fn)
 
     def raw_xw_to_y(self, inputs, weights):
         return self._raw_fn(weights)

--- a/braintrace/_op/conv.py
+++ b/braintrace/_op/conv.py
@@ -518,13 +518,24 @@ def conv(
         Optional transform applied to the kernel *inside* the primitive before
         the convolution, e.g. ``lambda w: w ** 2``. The derivative
         ``kernel_fn'`` is composed automatically via ``jax.vjp`` in the
-        ``xy_to_dw`` rule so the eligibility trace is correct. Default
-        ``None`` (identity, bit-identical to the pre-transform behaviour).
+        ``xy_to_dw`` rule so the eligibility trace is correct.
+        The transform operates on the unitless mantissa; physical units are
+        split off before and recombined after.
+        Default ``None`` (identity, bit-identical to the pre-transform behaviour).
     bias_fn : callable or None, optional
         Optional transform applied to the bias *inside* the primitive before
         adding it to the output. Because the bias trace is deferred (spatial
         summation happens in ``yw_to_w``), the derivative ``bias_fn'(b)`` is
         applied as an explicit per-output-channel factor in ``xy_to_dw``.
+        **``bias_fn`` must be an elementwise (per-channel) map**; the bias
+        gradient is recovered as a per-channel Jacobian-diagonal factor via
+        ``jax.vjp(bias_fn, b)(ones)`` and is therefore exact only when the
+        Jacobian is diagonal.  Non-elementwise bias transforms (e.g. a
+        per-channel softmax that couples channels) are not supported.  By
+        contrast, ``kernel_fn`` is unrestricted — it goes through a full
+        ``jax.vjp`` over the entire kernel.
+        The transform operates on the unitless mantissa; physical units are
+        split off before and recombined after.
         Default ``None`` (identity).
 
     Returns

--- a/braintrace/_op/conv.py
+++ b/braintrace/_op/conv.py
@@ -93,8 +93,12 @@ def _etp_conv_impl(
     feature_group_count=1,
     batch_group_count=1,
     dimension_numbers=None,
+    kernel_fn=None,
+    bias_fn=None,
 ):
     x, kernel = args[0], args[1]
+    if kernel_fn is not None:
+        kernel = kernel_fn(kernel)
     y = jax.lax.conv_general_dilated(
         lhs=x,
         rhs=kernel,
@@ -107,7 +111,10 @@ def _etp_conv_impl(
         dimension_numbers=dimension_numbers,
     )
     if has_bias:
-        y = y + args[2]
+        b = args[2]
+        if bias_fn is not None:
+            b = bias_fn(b)
+        y = y + b
     return y
 
 
@@ -339,10 +346,13 @@ def _conv_xy_to_dw(x, hidden_dim, weights, **params):
     then strip it on the way out implicitly via the VJP.
     """
     has_bias = params.get('has_bias', False)
-    # Build conv_general_dilated kwargs; remap 'strides' -> 'window_strides'.
+    kernel_fn = params.get('kernel_fn', None)
+    bias_fn = params.get('bias_fn', None)
+    # Build conv_general_dilated kwargs; remap 'strides' -> 'window_strides';
+    # drop the ETP-only params that conv does not understand.
     conv_kw = {}
     for k, v in params.items():
-        if k == 'has_bias':
+        if k in ('has_bias', 'kernel_fn', 'bias_fn'):
             continue
         if k == 'strides':
             conv_kw['window_strides'] = v
@@ -363,8 +373,11 @@ def _conv_xy_to_dw(x, hidden_dim, weights, **params):
         x_in = x
         hd_in = hidden_dim
 
-    # Kernel gradient via VJP (needs x).
+    # Kernel gradient via VJP (needs x); apply kernel_fn inside so jax.vjp
+    # auto-composes f' for the kernel gradient.
     def _fwd_w(w):
+        if kernel_fn is not None:
+            w = kernel_fn(w)
         return u.get_mantissa(
             jax.lax.conv_general_dilated(x_in, w, **conv_kw)
         )
@@ -376,7 +389,19 @@ def _conv_xy_to_dw(x, hidden_dim, weights, **params):
     if has_bias:
         # Bias gradient = hidden_dim (cotangent at each output position).
         # No spatial summation — the trace stores per-position ∂h/∂b.
-        out['bias'] = hidden_dim
+        bias_grad = hidden_dim
+        if bias_fn is not None:
+            b = weights['bias']
+            _, b_vjp = jax.vjp(bias_fn, b)
+            db = u.get_mantissa(b_vjp(jnp.ones_like(b))[0])  # bias_fn'(b), shape (out_ch,)
+            _, channel_axis, _, _ = _conv_layout(params)
+            batched_rank = n_spatial + 2  # (batch, *spatial, channel) up to permutation
+            axes_right_of_channel = batched_rank - 1 - channel_axis
+            ax = bias_grad.ndim - 1 - axes_right_of_channel
+            shape = [1] * bias_grad.ndim
+            shape[ax] = db.shape[0]
+            bias_grad = bias_grad * db.reshape(shape)
+        out['bias'] = bias_grad
 
     return out
 
@@ -455,6 +480,8 @@ def conv(
     feature_group_count: int = 1,
     batch_group_count: int = 1,
     dimension_numbers: Any = None,
+    kernel_fn=None,
+    bias_fn=None,
 ):
     r"""ETP-aware convolution.
 
@@ -487,6 +514,18 @@ def conv(
     dimension_numbers : Any, optional
         Convolution dimension numbers (e.g. ``('NHWC', 'HWIO', 'NHWC')``).
         Default ``None``, which uses the JAX default layout.
+    kernel_fn : callable or None, optional
+        Optional transform applied to the kernel *inside* the primitive before
+        the convolution, e.g. ``lambda w: w ** 2``. The derivative
+        ``kernel_fn'`` is composed automatically via ``jax.vjp`` in the
+        ``xy_to_dw`` rule so the eligibility trace is correct. Default
+        ``None`` (identity, bit-identical to the pre-transform behaviour).
+    bias_fn : callable or None, optional
+        Optional transform applied to the bias *inside* the primitive before
+        adding it to the output. Because the bias trace is deferred (spatial
+        summation happens in ``yw_to_w``), the derivative ``bias_fn'(b)`` is
+        applied as an explicit per-output-channel factor in ``xy_to_dw``.
+        Default ``None`` (identity).
 
     Returns
     -------
@@ -507,6 +546,12 @@ def conv(
         >>> y = braintrace.conv(x, kernel, strides=(1,), padding='SAME')
         >>> print(y.shape)
         (8, 4, 16)
+        >>>
+        >>> # Apply a kernel transform (squares each weight before conv)
+        >>> y2 = braintrace.conv(x, kernel, strides=(1,), padding='SAME',
+        ...                      kernel_fn=lambda w: w ** 2)
+        >>> print(y2.shape)
+        (8, 4, 16)
     """
     conv_kwargs = dict(
         strides=tuple(strides),
@@ -516,6 +561,8 @@ def conv(
         feature_group_count=feature_group_count,
         batch_group_count=batch_group_count,
         dimension_numbers=dimension_numbers,
+        kernel_fn=kernel_fn,
+        bias_fn=bias_fn,
     )
     x_v, x_u = u.split_mantissa_unit(x)
     kernel_v, kernel_u = u.split_mantissa_unit(kernel)

--- a/braintrace/_op/conv_test.py
+++ b/braintrace/_op/conv_test.py
@@ -524,3 +524,48 @@ class TestPublicAPIRoundTrip:
 
     def test_public_alias(self):
         assert braintrace.conv is conv
+
+
+class TestConvKernelFnBiasFn:
+
+    def test_forward_applies_kernel_fn(self):
+        x = brainstate.random.randn(8, 3, 16)
+        k = brainstate.random.randn(4, 3, 5)
+        out = braintrace.conv(x, k, strides=(1,), padding='SAME', kernel_fn=lambda w: w ** 2)
+        import jax
+        ref = jax.lax.conv_general_dilated(x, k ** 2, window_strides=(1,), padding='SAME')
+        np.testing.assert_allclose(out, ref, atol=1e-4)
+
+    def test_kernel_fn_xy_to_dw_matches_vjp(self):
+        from braintrace._op import ETP_RULES_XY_TO_DW, etp_conv_p
+        import jax
+        rule = ETP_RULES_XY_TO_DW[etp_conv_p]
+        x = brainstate.random.randn(2, 3, 10)
+        k = brainstate.random.randn(4, 3, 5)
+        hidden = brainstate.random.randn(2, 4, 10)
+        params = dict(has_bias=False, strides=(1,), padding='SAME', lhs_dilation=None,
+                      rhs_dilation=None, feature_group_count=1, batch_group_count=1,
+                      dimension_numbers=None, kernel_fn=lambda w: w ** 2, bias_fn=None)
+        dw = rule(x, hidden, {'weight': k}, **params)
+
+        def fwd(w):
+            return jax.lax.conv_general_dilated(x, w ** 2, window_strides=(1,), padding='SAME')
+
+        _, vjp = jax.vjp(fwd, k)
+        np.testing.assert_allclose(dw['weight'], vjp(hidden)[0], atol=1e-4)
+
+    def test_bias_fn_xy_to_dw_factor(self):
+        """Deferred bias trace carries bias_fn'(b) per channel (NCH: channel axis=1)."""
+        from braintrace._op import ETP_RULES_XY_TO_DW, etp_conv_p
+        rule = ETP_RULES_XY_TO_DW[etp_conv_p]
+        x = brainstate.random.randn(2, 3, 10)
+        k = brainstate.random.randn(4, 3, 5)
+        b = brainstate.random.randn(4)
+        hidden = brainstate.random.randn(2, 4, 10)
+        params = dict(has_bias=True, strides=(1,), padding='SAME', lhs_dilation=None,
+                      rhs_dilation=None, feature_group_count=1, batch_group_count=1,
+                      dimension_numbers=None, kernel_fn=None, bias_fn=lambda bb: bb ** 2)
+        out = rule(x, hidden, {'weight': k, 'bias': b}, **params)
+        # bias_fn'(b) = 2*b, broadcast along channel axis=1 of the (batch, ch, spatial) trace.
+        expected = hidden * (2.0 * b).reshape(1, 4, 1)
+        np.testing.assert_allclose(out['bias'], expected, atol=1e-4)

--- a/braintrace/_op/dense.py
+++ b/braintrace/_op/dense.py
@@ -428,10 +428,15 @@ def matmul(x, weight, bias=None, *, weight_fn=None, bias_fn=None):
         Elementwise, shape-preserving transform applied to ``weight`` *inside*
         the primitive: the op computes ``y = x @ weight_fn(weight)``. The
         eligibility trace and gradient are taken w.r.t. the raw ``weight``.
-        Operates on the unitless mantissa. Default ``None`` (identity).
+        The transform operates on the unitless mantissa; physical units are
+        split off before and recombined after.
+        Default ``None`` (identity).
     bias_fn : Callable or None, optional
         Elementwise transform applied to ``bias`` inside the primitive
-        (``+ bias_fn(bias)``). Ignored when ``bias is None``. Default ``None``.
+        (``+ bias_fn(bias)``). Ignored when ``bias is None``.
+        The transform operates on the unitless mantissa; physical units are
+        split off before and recombined after.
+        Default ``None``.
 
     Returns
     -------

--- a/braintrace/_op/dense.py
+++ b/braintrace/_op/dense.py
@@ -88,11 +88,16 @@ __all__ = [
 ]
 
 
-def _etp_matmul_impl(*args, has_bias=False):
+def _etp_matmul_impl(*args, has_bias=False, weight_fn=None, bias_fn=None):
     x, w = args[0], args[1]
+    if weight_fn is not None:
+        w = weight_fn(w)
     y = x @ w
     if has_bias:
-        y = y + args[2]
+        b = args[2]
+        if bias_fn is not None:
+            b = bias_fn(b)
+        y = y + b
     return y
 
 
@@ -108,7 +113,7 @@ def _mm_trainable_invars(params):
     return base
 
 
-def _mm_yw_to_w(hidden_dim, trace, *, has_bias=False):
+def _mm_yw_to_w(hidden_dim, trace, *, has_bias=False, weight_fn=None, bias_fn=None):
     r"""Batched ``yw_to_w`` — propagate :math:`\partial h / \partial y`
     through a weight-shaped D-RTRL trace.
 
@@ -162,24 +167,17 @@ def _mm_yw_to_w(hidden_dim, trace, *, has_bias=False):
     return out
 
 
-def _mm_xy_to_dw(x, hidden_dim, weights, *, has_bias=False):
+def _mm_xy_to_dw(x, hidden_dim, weights, *, has_bias=False, weight_fn=None, bias_fn=None):
     r"""Batched ``xy_to_dw`` — instantaneous hidden-to-weight Jacobian.
 
     **Role.** Computes :math:`\partial h / \partial W` (and
-    :math:`\partial h / \partial b`) by VJP of :math:`y = x W + b`,
-    pulling back the cotangent ``hidden_dim`` = :math:`\partial h/\partial y`:
+    :math:`\partial h / \partial b`) by VJP of :math:`y = x \, \text{weight\_fn}(W) + \text{bias\_fn}(b)`,
+    pulling back the cotangent ``hidden_dim`` = :math:`\partial h/\partial y`.
+    When ``weight_fn`` / ``bias_fn`` are ``None`` the identity is used and
+    the result is identical to the undecorated matmul.
 
-    .. math::
-
-        \frac{\partial h}{\partial W_{ik}}
-          \;=\; \sum_j \frac{\partial h}{\partial y_j}\,
-                \frac{\partial y_j}{\partial W_{ik}}
-          \;=\; \frac{\partial h}{\partial y_k}\, x_i ,
-
-    .. math::
-
-        \frac{\partial h}{\partial b_k}
-          \;=\; \frac{\partial h}{\partial y_k}.
+    The VJP is taken w.r.t. the **raw** weight dict (before any transform),
+    so the returned gradient is :math:`\partial h / \partial W_{\text{raw}}`.
 
     In D-RTRL notation this is the instantaneous
     :math:`\operatorname{diag}(\mathbf{D}_f^t) \otimes \mathbf{x}^t` term
@@ -193,9 +191,15 @@ def _mm_xy_to_dw(x, hidden_dim, weights, *, has_bias=False):
     """
 
     def _fwd(w_dict):
-        y = x @ w_dict['weight']
+        w = w_dict['weight']
+        if weight_fn is not None:
+            w = weight_fn(w)
+        y = x @ w
         if has_bias:
-            y = y + w_dict['bias']
+            b = w_dict['bias']
+            if bias_fn is not None:
+                b = bias_fn(b)
+            y = y + b
         return u.get_mantissa(y)
 
     _, vjp_fn = jax.vjp(_fwd, weights)
@@ -280,7 +284,7 @@ def _mv_trainable_invars(params):
     return base
 
 
-def _mv_yw_to_w(hidden_dim, trace, *, has_bias=False):
+def _mv_yw_to_w(hidden_dim, trace, *, has_bias=False, weight_fn=None, bias_fn=None):
     r"""Unbatched ``yw_to_w`` — same algebra as the batched case, no batch axis.
 
     **Role in D-RTRL.** Realises the :math:`y \to W` chain factor within
@@ -310,15 +314,19 @@ def _mv_yw_to_w(hidden_dim, trace, *, has_bias=False):
     return out
 
 
-def _mv_xy_to_dw(x, hidden_dim, weights, *, has_bias=False):
+def _mv_xy_to_dw(x, hidden_dim, weights, *, has_bias=False, weight_fn=None, bias_fn=None):
     r"""Unbatched ``xy_to_dw`` — instantaneous :math:`\partial h / \partial W`.
 
-    Same chain rule as the batched case with no batch axis:
+    Same chain rule as the batched case with no batch axis. When ``weight_fn``
+    / ``bias_fn`` are provided the VJP propagates through them automatically,
+    returning the gradient w.r.t. the **raw** weight:
 
     .. math::
 
-        \frac{\partial h}{\partial W_{ik}} = x_i\, \frac{\partial h}{\partial y_k}, \qquad
-        \frac{\partial h}{\partial b_k}    = \frac{\partial h}{\partial y_k}.
+        \frac{\partial h}{\partial W_{\text{raw}, ik}} = x_i\,
+            f'(W_{\text{raw}})_{ik}\, \frac{\partial h}{\partial y_k}, \qquad
+        \frac{\partial h}{\partial b_{\text{raw}, k}}    =
+            g'(b_{\text{raw}})_k\, \frac{\partial h}{\partial y_k}.
 
     Supplies :math:`\operatorname{diag}(\mathbf{D}_f^t)\otimes \mathbf{x}^t`
     for D-RTRL and the pp-prop solve-time pullback in ES-D-RTRL.
@@ -327,9 +335,15 @@ def _mv_xy_to_dw(x, hidden_dim, weights, *, has_bias=False):
     """
 
     def _fwd(w_dict):
-        y = x @ w_dict['weight']
+        w = w_dict['weight']
+        if weight_fn is not None:
+            w = weight_fn(w)
+        y = x @ w
         if has_bias:
-            y = y + w_dict['bias']
+            b = w_dict['bias']
+            if bias_fn is not None:
+                b = bias_fn(b)
+            y = y + b
         return u.get_mantissa(y)
 
     _, vjp_fn = jax.vjp(_fwd, weights)
@@ -390,13 +404,17 @@ etp_mv_p.register_etp_rules(
 # Public API
 # ---------------------------------------------------------------------------
 
-def matmul(x, weight, bias=None):
+def matmul(x, weight, bias=None, *, weight_fn=None, bias_fn=None):
     r"""ETP-aware matrix multiplication.
 
-    Computes :math:`y = x \mathbin{@} w \; (+ b)`. The operation is routed
-    through an ETP primitive so the weight (and optional bias) participates
-    in eligibility-trace computation. Auto-dispatches to ``etp_mm_p``
-    (batched) or ``etp_mv_p`` (unbatched) based on ``x.ndim``.
+    Computes :math:`y = x \mathbin{@} \text{weight\_fn}(w) \; (+ \text{bias\_fn}(b))`.
+    The operation is routed through an ETP primitive so the weight (and
+    optional bias) participates in eligibility-trace computation.
+    Auto-dispatches to ``etp_mm_p`` (batched) or ``etp_mv_p`` (unbatched)
+    based on ``x.ndim``.
+
+    The eligibility trace and gradient are always taken w.r.t. the **raw**
+    weight/bias before any transform is applied.
 
     Parameters
     ----------
@@ -406,6 +424,14 @@ def matmul(x, weight, bias=None):
         Weight matrix, shape ``(in_features, out_features)``.
     bias : ArrayLike or None, optional
         Bias vector, shape ``(out_features,)``. Default ``None``.
+    weight_fn : Callable or None, optional
+        Elementwise, shape-preserving transform applied to ``weight`` *inside*
+        the primitive: the op computes ``y = x @ weight_fn(weight)``. The
+        eligibility trace and gradient are taken w.r.t. the raw ``weight``.
+        Operates on the unitless mantissa. Default ``None`` (identity).
+    bias_fn : Callable or None, optional
+        Elementwise transform applied to ``bias`` inside the primitive
+        (``+ bias_fn(bias)``). Ignored when ``bias is None``. Default ``None``.
 
     Returns
     -------
@@ -432,6 +458,11 @@ def matmul(x, weight, bias=None):
         >>> y1 = braintrace.matmul(x1, w, bias=b)
         >>> print(y1.shape)
         (4,)
+        >>>
+        >>> # Constrain weights to be non-negative via a transform
+        >>> y2 = braintrace.matmul(x, w, weight_fn=lambda ww: ww ** 2)
+        >>> print(y2.shape)
+        (16, 4)
     """
     p = etp_mm_p if x.ndim >= 2 else etp_mv_p
     x_v, x_u = u.split_mantissa_unit(x)
@@ -439,7 +470,9 @@ def matmul(x, weight, bias=None):
     unit = x_u * weight_u
     if bias is not None:
         bias_v = u.Quantity(bias).to_decimal(unit)
-        r = p.bind(x_v, weight_v, bias_v, has_bias=True)
+        r = p.bind(x_v, weight_v, bias_v, has_bias=True,
+                   weight_fn=weight_fn, bias_fn=bias_fn)
     else:
-        r = p.bind(x_v, weight_v, has_bias=False)
+        r = p.bind(x_v, weight_v, has_bias=False,
+                   weight_fn=weight_fn, bias_fn=bias_fn)
     return u.maybe_decimal(r * x_u * weight_u)

--- a/braintrace/_op/dense_test.py
+++ b/braintrace/_op/dense_test.py
@@ -552,3 +552,60 @@ class TestSeparateParamStateBias:
                             err_msg='D-RTRL dW does not match BPTT')
         npt.assert_allclose(b_leaf, db_bptt, atol=1e-5,
                             err_msg='D-RTRL db does not match BPTT (was it zero?)')
+
+
+class TestWeightFnBiasFn:
+    """y = x @ weight_fn(w) (+ bias_fn(b)); gradient stays w.r.t. raw w/b."""
+
+    def test_forward_applies_weight_fn(self):
+        x = brainstate.random.randn(2, 3)
+        w = brainstate.random.randn(3, 4)
+        out = matmul(x, w, weight_fn=lambda ww: ww ** 2)
+        np.testing.assert_allclose(out, x @ (w ** 2), atol=1e-5)
+
+    def test_forward_applies_bias_fn(self):
+        x = brainstate.random.randn(2, 3)
+        w = brainstate.random.randn(3, 4)
+        b = brainstate.random.randn(4)
+        out = matmul(x, w, bias=b, weight_fn=u.math.abs, bias_fn=lambda bb: bb * 2.0)
+        np.testing.assert_allclose(out, x @ u.math.abs(w) + b * 2.0, atol=1e-5)
+
+    def test_weight_fn_none_is_identity(self):
+        x = brainstate.random.randn(2, 3)
+        w = brainstate.random.randn(3, 4)
+        np.testing.assert_allclose(matmul(x, w, weight_fn=None), matmul(x, w), atol=1e-6)
+
+    def test_mm_xy_to_dw_matches_vjp_through_weight_fn(self):
+        from braintrace._op.op_rule_oracle import assert_xy_to_dw_matches_vjp
+        rule = ETP_RULES_XY_TO_DW[etp_mm_p]
+        x = brainstate.random.randn(2, 3)
+        weights = {'weight': brainstate.random.randn(3, 4), 'bias': brainstate.random.randn(4)}
+        hidden = brainstate.random.randn(2, 4)
+        params = {'has_bias': True, 'weight_fn': lambda ww: ww ** 2, 'bias_fn': u.math.abs}
+
+        def impl(wd):
+            return x @ (wd['weight'] ** 2) + u.math.abs(wd['bias'])
+
+        assert_xy_to_dw_matches_vjp(rule=rule, impl=impl, x=x, hidden_dim=hidden,
+                                    weights=weights, params=params)
+
+    def test_mv_xy_to_dw_matches_vjp_through_weight_fn(self):
+        from braintrace._op.op_rule_oracle import assert_xy_to_dw_matches_vjp
+        rule = ETP_RULES_XY_TO_DW[etp_mv_p]
+        x = brainstate.random.randn(3)
+        weights = {'weight': brainstate.random.randn(3, 4)}
+        hidden = brainstate.random.randn(4)
+        params = {'has_bias': False, 'weight_fn': jnp.tanh}
+
+        def impl(wd):
+            return x @ jnp.tanh(wd['weight'])
+
+        assert_xy_to_dw_matches_vjp(rule=rule, impl=impl, x=x, hidden_dim=hidden,
+                                    weights=weights, params=params)
+
+    def test_yw_to_w_tolerates_transform_params(self):
+        rule = ETP_RULES_YW_TO_W[etp_mv_p]
+        hidden = jnp.arange(4.0)
+        trace = {'weight': jnp.ones((3, 4))}
+        out = rule(hidden, trace, has_bias=False, weight_fn=jnp.tanh, bias_fn=None)
+        assert out['weight'].shape == (3, 4)

--- a/braintrace/_op/dense_test.py
+++ b/braintrace/_op/dense_test.py
@@ -609,3 +609,58 @@ class TestWeightFnBiasFn:
         trace = {'weight': jnp.ones((3, 4))}
         out = rule(hidden, trace, has_bias=False, weight_fn=jnp.tanh, bias_fn=None)
         assert out['weight'].shape == (3, 4)
+
+
+# ---------------------------------------------------------------------------
+# Integration: D-RTRL == BPTT exactness for matmul weight_fn
+# ---------------------------------------------------------------------------
+
+class TestMatmulWeightFnExactness:
+    """Exact algorithm: D_RTRL with weight_fn must equal BPTT element-wise."""
+
+    @staticmethod
+    def _factory(weight_fn):
+        class Cell(brainstate.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.nh = 4
+                self.W = brainstate.ParamState(brainstate.random.randn(2 + 4, 4) * 0.2)
+                self.h = brainstate.HiddenState(jnp.zeros((1, 4)))
+
+            def update(self, x):
+                # x arrives as (n_in,) from for_loop; reshape to (1, n_in) for batch compat
+                xh = jnp.concatenate([x.reshape(1, -1), self.h.value], axis=-1)
+                self.h.value = jnp.tanh(matmul(xh, self.W.value, weight_fn=weight_fn))
+                return self.h.value
+
+        def factory():
+            brainstate.random.seed(0)
+            return Cell()
+
+        return factory
+
+    def test_d_rtrl_matches_bptt_with_weight_fn(self):
+        from braintrace._algorithm.oracle import (
+            bptt_param_gradients, online_param_gradients, assert_param_gradients_close,
+        )
+        factory = self._factory(weight_fn=lambda w: w ** 2)
+        brainstate.random.seed(1)
+        inputs = brainstate.random.randn(6, 2)  # (T, n_in)
+        bptt = bptt_param_gradients(factory, inputs)
+        online = online_param_gradients(
+            factory, inputs, algo_factory=lambda m: braintrace.D_RTRL(m, vjp_method='multi-step')
+        )
+        assert_param_gradients_close(online, bptt, atol=1e-4)
+
+    def test_d_rtrl_matches_bptt_with_tanh_weight_fn(self):
+        from braintrace._algorithm.oracle import (
+            bptt_param_gradients, online_param_gradients, assert_param_gradients_close,
+        )
+        factory = self._factory(weight_fn=jnp.tanh)
+        brainstate.random.seed(2)
+        inputs = brainstate.random.randn(6, 2)
+        bptt = bptt_param_gradients(factory, inputs)
+        online = online_param_gradients(
+            factory, inputs, algo_factory=lambda m: braintrace.D_RTRL(m, vjp_method='multi-step')
+        )
+        assert_param_gradients_close(online, bptt, atol=1e-4)

--- a/braintrace/_op/elemwise.py
+++ b/braintrace/_op/elemwise.py
@@ -229,6 +229,8 @@ def element_wise(weight, *, weight_fn=None):
         Element-wise function applied to the raw weight mantissa inside
         the primitive. When ``None`` (default), the identity is used and
         the output equals ``weight`` exactly.
+        The transform operates on the unitless mantissa; physical units are
+        split off before and recombined after.
 
     Returns
     -------

--- a/braintrace/_op/elemwise.py
+++ b/braintrace/_op/elemwise.py
@@ -62,6 +62,7 @@ primitive when composing Jacobians).
   an identity op the weight-shape coincides with the output-shape.
 """
 
+import jax
 import jax.numpy as jnp
 import brainunit as u
 
@@ -73,15 +74,15 @@ __all__ = [
 ]
 
 
-def _etp_elemwise_impl(y):
-    return y
+def _etp_elemwise_impl(w, weight_fn=None):
+    return w if weight_fn is None else weight_fn(w)
 
 
 def _elem_trainable_invars(params):
     return {'weight': 0}
 
 
-def _elemwise_yw_to_w(hidden_dim, trace):
+def _elemwise_yw_to_w(hidden_dim, trace, *, weight_fn=None):
     r"""Diagonal trace propagation for an identity-like op.
 
     **Role in D-RTRL.** Realises the :math:`y \to w` chain factor inside
@@ -106,33 +107,35 @@ def _elemwise_yw_to_w(hidden_dim, trace):
     return {'weight': trace['weight'] * hidden_dim}
 
 
-def _elemwise_xy_to_dw(x, hidden_dim, weights):
+def _elemwise_xy_to_dw(x, hidden_dim, weights, *, weight_fn=None):
     r"""Instantaneous Jacobian for the identity marker.
 
-    **Role in D-RTRL / ES-D-RTRL.** For :math:`y = w` (identity),
+    **Role in D-RTRL / ES-D-RTRL.** For :math:`y = \text{weight\_fn}(w)`,
 
     .. math::
 
-        \frac{\partial h}{\partial w} = \frac{\partial h}{\partial y},
+        \frac{\partial h}{\partial w} = \frac{\partial h}{\partial y} \cdot \text{weight\_fn}'(w),
 
-    so the instantaneous contribution is simply the hidden cotangent
-    itself. In the D-RTRL update this feeds the
-    :math:`\operatorname{diag}(\mathbf{D}_f^t)\otimes \mathbf{x}^t` term
-    with :math:`\mathbf{x}^t \equiv 1` (no separate input). The chain
-    rule through the *external* ``fn`` supplied to :func:`element_wise`
-    is taken care of by JAX on the ops *before* this primitive binds
-    (``gradient_enabled=True`` propagates standard VJPs through the
-    primitive rather than masking them).
+    computed via VJP. When ``weight_fn`` is ``None`` (identity), the
+    contribution is simply the hidden cotangent itself.
 
     Args:
         x: Unused (``x_invar_index=None``).
         hidden_dim: Cotangent :math:`\partial h / \partial y`, shape matches weight.
-        weights: Dict with key 'weight' (unused in body; matches dict API).
+        weights: Dict with key 'weight' (the raw weight mantissa).
+        weight_fn: Element-wise function applied inside the primitive. When
+            ``None``, behaves as identity.
 
     Returns:
-        ``{'weight': hidden_dim}``.
+        ``{'weight': vjp(weight_fn, w)(hidden_dim)[0]}``, or
+        ``{'weight': hidden_dim}`` when ``weight_fn is None``.
     """
-    return {'weight': hidden_dim}
+    # ∂h/∂w = (∂h/∂y) · weight_fn'(w). For the identity (weight_fn None) this is
+    # just the cotangent itself.
+    if weight_fn is None:
+        return {'weight': hidden_dim}
+    _, vjp_fn = jax.vjp(weight_fn, weights['weight'])
+    return {'weight': u.get_mantissa(vjp_fn(hidden_dim)[0])}
 
 
 def _elemwise_init_drtrl(x_var, y_var, weight_vars, num_hidden_state, group=None):
@@ -209,26 +212,29 @@ etp_elemwise_p.register_etp_rules(
 )
 
 
-def element_wise(weight, fn=lambda w: w):
+def element_wise(weight, *, weight_fn=None):
     r"""ETP-aware element-wise operation.
 
-    Applies ``fn`` to ``weight`` and passes the result through a marker
-    primitive. The operation is treated as *diagonal* in the hidden-state
-    space, so the weight participates in eligibility-trace computation as a
-    per-element trainable parameter.
+    Applies ``weight_fn`` to ``weight`` *inside* the ETP primitive, so
+    the transform is visible to the eligibility-trace compiler. The
+    operation is treated as *diagonal* in the hidden-state space; the
+    weight participates in trace computation as a per-element trainable
+    parameter.
 
     Parameters
     ----------
     weight : ArrayLike
-        Weight parameter.
-    fn : Callable, optional
-        Element-wise function applied to ``weight`` before the primitive
-        binds. Default is the identity ``lambda w: w``.
+        Weight parameter (may be a :class:`brainunit.Quantity`).
+    weight_fn : Callable or None, optional
+        Element-wise function applied to the raw weight mantissa inside
+        the primitive. When ``None`` (default), the identity is used and
+        the output equals ``weight`` exactly.
 
     Returns
     -------
     ArrayLike
-        ``fn(weight)``, with the same shape as ``weight``.
+        ``weight_fn(weight)`` (or ``weight`` when ``weight_fn`` is
+        ``None``), with the same shape as ``weight``.
 
     Examples
     --------
@@ -245,11 +251,10 @@ def element_wise(weight, fn=lambda w: w):
         >>>
         >>> # Apply a non-linearity to the weight
         >>> import jax.numpy as jnp
-        >>> y1 = braintrace.element_wise(w, fn=jnp.tanh)
+        >>> y1 = braintrace.element_wise(w, weight_fn=jnp.tanh)
         >>> print(y1.shape)
         (5,)
     """
-    y = fn(weight)
-    y_v, y_u = u.split_mantissa_unit(y)
-    r = etp_elemwise_p.bind(y_v)
-    return u.maybe_decimal(r * y_u)
+    w_v, w_u = u.split_mantissa_unit(weight)
+    r = etp_elemwise_p.bind(w_v, weight_fn=weight_fn)
+    return u.maybe_decimal(r * w_u)

--- a/braintrace/_op/elemwise_test.py
+++ b/braintrace/_op/elemwise_test.py
@@ -37,6 +37,7 @@ import jax.numpy as jnp
 import numpy as np
 import brainunit as u
 
+import brainstate
 import braintrace
 from braintrace._op import (
     ETP_RULES_INIT_DRTRL,
@@ -269,3 +270,49 @@ class TestElemwiseWeightFnInside:
         hidden = brainstate.random.randn(5)
         out = rule(None, hidden, {'weight': brainstate.random.randn(5)}, weight_fn=None)
         np.testing.assert_allclose(out['weight'], hidden, atol=1e-6)
+
+
+# ---------------------------------------------------------------------------
+# Exactness gate: D_RTRL == BPTT when element_wise carries weight_fn=tanh
+# ---------------------------------------------------------------------------
+
+class TestElemwiseWeightFnExactness:
+    """element_wise's own weight gradient must include weight_fn' (D_RTRL==BPTT)."""
+
+    @staticmethod
+    def _factory(weight_fn):
+        class Cell(brainstate.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.nh = 4
+                self.W = brainstate.ParamState(brainstate.random.randn(2 + 4, 4) * 0.2)
+                self.alpha = brainstate.ParamState(brainstate.random.randn(4) * 0.5)
+
+            def init_state(self, batch_size=None, **kw):
+                size = (self.nh,) if batch_size is None else (batch_size, self.nh)
+                self.h = brainstate.HiddenState(jnp.zeros(size))
+
+            def update(self, x):
+                a = braintrace.element_wise(self.alpha.value, weight_fn=weight_fn)
+                xh = jnp.concatenate([x.reshape(1, -1), self.h.value], axis=-1)
+                self.h.value = jnp.tanh(a * braintrace.matmul(xh, self.W.value))
+                return self.h.value
+
+        def factory():
+            brainstate.random.seed(0)
+            return Cell()
+
+        return factory
+
+    def test_d_rtrl_matches_bptt_with_elemwise_weight_fn(self):
+        from braintrace._algorithm.oracle import (
+            bptt_param_gradients, online_param_gradients, assert_param_gradients_close,
+        )
+        factory = self._factory(weight_fn=jnp.tanh)
+        brainstate.random.seed(1)
+        inputs = brainstate.random.randn(6, 2)
+        bptt = bptt_param_gradients(factory, inputs)
+        online = online_param_gradients(
+            factory, inputs, algo_factory=lambda m: braintrace.D_RTRL(m, vjp_method='multi-step')
+        )
+        assert_param_gradients_close(online, bptt, atol=1e-4)

--- a/braintrace/_op/elemwise_test.py
+++ b/braintrace/_op/elemwise_test.py
@@ -20,9 +20,9 @@ compiler must *evaluate* it when walking ``y -> h``. This module
 verifies:
 
 * The primitive is registered with the gradient-enabled flag.
-* ``element_wise(w)`` (default ``fn=identity``) round-trips ``w``.
-* ``element_wise(w, fn=lambda w: 2*w)`` applies ``fn`` *before* the bind
-  (the primitive itself is the identity).
+* ``element_wise(w)`` (default ``weight_fn=None``) round-trips ``w``.
+* ``element_wise(w, weight_fn=lambda w: 2*w)`` applies ``weight_fn`` *inside*
+  the primitive.
 * brainunit quantities pass through.
 * JAX rules — jit, vmap, grad, jvp.
 * Four ETP rules return the documented values / shapes.
@@ -70,12 +70,12 @@ class TestIdentityRoundTrip:
 
     def test_custom_fn_applied(self):
         w = jnp.array([1.0, 2.0, 3.0])
-        out = element_wise(w, fn=lambda x: x * 10.0)
+        out = element_wise(w, weight_fn=lambda x: x * 10.0)
         np.testing.assert_allclose(out, w * 10.0)
 
     def test_nonlinear_fn(self):
         w = jnp.array([0.0, 0.5, 1.0])
-        out = element_wise(w, fn=jnp.sin)
+        out = element_wise(w, weight_fn=jnp.sin)
         np.testing.assert_allclose(out, jnp.sin(w))
 
 
@@ -103,22 +103,16 @@ class TestPrimitiveInJaxpr:
         jaxpr = jax.make_jaxpr(lambda w: element_wise(w))(w)
         assert any(eqn.primitive is etp_elemwise_p for eqn in jaxpr.jaxpr.eqns)
 
-    def test_fn_evaluated_before_bind(self):
-        """The primitive itself is the identity; the user-supplied ``fn``
-        runs as ordinary JAX ops *before* the bind. So if ``fn`` produces
-        e.g. a ``mul`` op, that ``mul`` appears in the jaxpr alongside
-        the elemwise bind."""
+    def test_fn_carried_as_primitive_param(self):
+        """weight_fn is now a primitive param, not a traced JAX op.
+        The jaxpr contains exactly one etp_elemwise equation, and the
+        weight_fn callable is stored inside its params dict."""
         w = jnp.ones((3,))
-        jaxpr = jax.make_jaxpr(lambda w: element_wise(w, fn=lambda x: x * 2))(w)
-        # mul (or scalar broadcast + mul) appears.
-        assert any(
-            eqn.primitive is etp_elemwise_p for eqn in jaxpr.jaxpr.eqns
-        )
-        # And there must be a multiplication-bearing op too.
+        jaxpr = jax.make_jaxpr(lambda w: element_wise(w, weight_fn=lambda x: x * 2))(w)
         eqns = list(jaxpr.jaxpr.eqns)
-        # Either lax.mul_p or something equivalent.
-        has_mul = any('mul' in eqn.primitive.name for eqn in eqns)
-        assert has_mul
+        assert len(eqns) == 1
+        assert eqns[0].primitive is etp_elemwise_p
+        assert eqns[0].params.get('weight_fn') is not None
 
 
 # ---------------------------------------------------------------------------
@@ -140,7 +134,7 @@ class TestBrainunit:
 
     def test_custom_fn_with_units(self):
         w = jnp.array([1.0, 2.0]) * u.mV
-        out = element_wise(w, fn=lambda x: x * 2)
+        out = element_wise(w, weight_fn=lambda x: x * 2)
         np.testing.assert_allclose(u.get_mantissa(out), jnp.array([2.0, 4.0]))
 
 
@@ -167,7 +161,7 @@ class TestJAXRules:
 
     def test_grad_custom_fn(self):
         w = jnp.array([1.0, 2.0, 3.0])
-        g = jax.grad(lambda w_: element_wise(w_, fn=lambda x: x ** 2).sum())(w)
+        g = jax.grad(lambda w_: element_wise(w_, weight_fn=lambda x: x ** 2).sum())(w)
         np.testing.assert_allclose(g, 2.0 * w)
 
 
@@ -242,3 +236,36 @@ class TestElemwiseDictRules:
         assert out['weight'].shape == (3, 4)
         # 5 * 2 = 10
         assert float(out['weight'][0, 0]) == 10.0
+
+
+class TestElemwiseWeightFnInside:
+
+    def test_forward_applies_weight_fn(self):
+        import brainstate
+        w = brainstate.random.randn(5)
+        out = element_wise(w, weight_fn=lambda x: x * 10.0)
+        np.testing.assert_allclose(out, w * 10.0, atol=1e-5)
+
+    def test_default_is_identity(self):
+        import brainstate
+        w = brainstate.random.randn(5)
+        np.testing.assert_allclose(element_wise(w), w, atol=1e-6)
+
+    def test_xy_to_dw_applies_fn_derivative(self):
+        """xy_to_dw must return ∂h/∂w = vjp(weight_fn)(hidden) — NOT hidden itself."""
+        import brainstate
+        from braintrace._op import ETP_RULES_XY_TO_DW, etp_elemwise_p
+        rule = ETP_RULES_XY_TO_DW[etp_elemwise_p]
+        w = brainstate.random.randn(5)
+        hidden = brainstate.random.randn(5)
+        out = rule(None, hidden, {'weight': w}, weight_fn=lambda x: x ** 2)
+        _, vjp = jax.vjp(lambda x: x ** 2, w)
+        np.testing.assert_allclose(out['weight'], vjp(hidden)[0], atol=1e-5)
+
+    def test_xy_to_dw_identity_returns_hidden(self):
+        import brainstate
+        from braintrace._op import ETP_RULES_XY_TO_DW, etp_elemwise_p
+        rule = ETP_RULES_XY_TO_DW[etp_elemwise_p]
+        hidden = brainstate.random.randn(5)
+        out = rule(None, hidden, {'weight': brainstate.random.randn(5)}, weight_fn=None)
+        np.testing.assert_allclose(out['weight'], hidden, atol=1e-6)

--- a/braintrace/_op/lora.py
+++ b/braintrace/_op/lora.py
@@ -93,11 +93,18 @@ __all__ = [
 ]
 
 
-def _etp_lora_impl(*args, alpha=1.0, has_bias=False):
+def _etp_lora_impl(*args, alpha=1.0, has_bias=False, b_fn=None, a_fn=None, bias_fn=None):
     x, B, A = args[0], args[1], args[2]
+    if b_fn is not None:
+        B = b_fn(B)
+    if a_fn is not None:
+        A = a_fn(A)
     y = alpha * (x @ B @ A)
     if has_bias:
-        y = y + args[3]
+        b = args[3]
+        if bias_fn is not None:
+            b = bias_fn(b)
+        y = y + b
     return y
 
 
@@ -109,7 +116,7 @@ def _lora_trainable_invars(params):
     return base
 
 
-def _lora_mm_yw_to_w(hidden_dim, trace, *, alpha=1.0, has_bias=False):
+def _lora_mm_yw_to_w(hidden_dim, trace, *, alpha=1.0, has_bias=False, b_fn=None, a_fn=None, bias_fn=None):
     r"""Batched LoRA ``yw_to_w`` — propagate :math:`\partial h / \partial y`
     through the :math:`y \to A` link.
 
@@ -161,7 +168,7 @@ def _lora_mm_yw_to_w(hidden_dim, trace, *, alpha=1.0, has_bias=False):
     return out
 
 
-def _lora_mv_yw_to_w(hidden_dim, trace, *, alpha=1.0, has_bias=False):
+def _lora_mv_yw_to_w(hidden_dim, trace, *, alpha=1.0, has_bias=False, b_fn=None, a_fn=None, bias_fn=None):
     r"""Unbatched LoRA ``yw_to_w`` — identical algebra with no batch axis.
 
     Trace shapes:
@@ -182,7 +189,7 @@ def _lora_mv_yw_to_w(hidden_dim, trace, *, alpha=1.0, has_bias=False):
     return out
 
 
-def _lora_xy_to_dw(x, hidden_dim, weights, *, alpha=1.0, has_bias=False):
+def _lora_xy_to_dw(x, hidden_dim, weights, *, alpha=1.0, has_bias=False, b_fn=None, a_fn=None, bias_fn=None):
     r"""Instantaneous LoRA Jacobian via fused VJP.
 
     **Role in D-RTRL / ES-D-RTRL.** Produces the full instantaneous
@@ -192,36 +199,49 @@ def _lora_xy_to_dw(x, hidden_dim, weights, *, alpha=1.0, has_bias=False):
     .. math::
 
         \frac{\partial h}{\partial A_{r, k}}
-          = \alpha\, (xB)_r\, g_k,
+          = \alpha\, (x\,b\_fn(B))_r\, g_k \cdot a\_fn'(A_{r,k}),
 
     .. math::
 
         \frac{\partial h}{\partial B_{i, r}}
-          = \alpha\, \sum_k A_{r, k}\, g_k\, x_i
-          = \alpha\, x_i\, (A g)_r,
+          = \alpha\, \sum_k a\_fn(A)_{r, k}\, g_k\, x_i \cdot b\_fn'(B_{i,r}),
 
     .. math::
 
         \frac{\partial h}{\partial b_k}
-          = g_k.
+          = g_k \cdot bias\_fn'(b_k).
 
     All three are computed simultaneously by differentiating
 
     .. code-block:: python
 
-        def _fwd(w): return alpha * (x @ w['lora_b'] @ w['lora_a']) + w['bias']
+        def _fwd(w):
+            B = b_fn(w['lora_b']) if b_fn else w['lora_b']
+            A = a_fn(w['lora_a']) if a_fn else w['lora_a']
+            return alpha * (x @ B @ A) + (bias_fn(w['bias']) if bias_fn else w['bias'])
 
-    and pulling back the cotangent ``hidden_dim``. In D-RTRL this is
-    the :math:`\operatorname{diag}(\mathbf{D}_f^t)\otimes \mathbf{x}^t`
+    and pulling back the cotangent ``hidden_dim``. When all three transform
+    functions are ``None``, the output is bit-identical to the un-transformed
+    case. In D-RTRL this is the
+    :math:`\operatorname{diag}(\mathbf{D}_f^t)\otimes \mathbf{x}^t`
     contribution; in ES-D-RTRL it is the pullback applied at solve-time
     to combine :math:`\boldsymbol{\epsilon}_f^t` with
     :math:`\boldsymbol{\epsilon}_x^t` into the weight gradient.
     """
 
     def _fwd(w):
-        y = alpha * (x @ w['lora_b'] @ w['lora_a'])
+        B = w['lora_b']
+        A = w['lora_a']
+        if b_fn is not None:
+            B = b_fn(B)
+        if a_fn is not None:
+            A = a_fn(A)
+        y = alpha * (x @ B @ A)
         if has_bias:
-            y = y + w['bias']
+            b = w['bias']
+            if bias_fn is not None:
+                b = bias_fn(b)
+            y = y + b
         return u.get_mantissa(y)
 
     _, vjp_fn = jax.vjp(_fwd, weights)
@@ -335,10 +355,10 @@ etp_lora_mv_p.register_etp_rules(
 )
 
 
-def lora_matmul(x, B, A, *, alpha=1.0, bias=None):
+def lora_matmul(x, B, A, *, alpha=1.0, bias=None, b_fn=None, a_fn=None, bias_fn=None):
     r"""ETP-aware LoRA (Low-Rank Adaptation) matrix multiplication.
 
-    Computes :math:`y = \alpha \cdot x \mathbin{@} B \mathbin{@} A \; (+ b)`,
+    Computes :math:`y = \alpha \cdot x \mathbin{@} b\_fn(B) \mathbin{@} a\_fn(A) \; (+ bias\_fn(b))`,
     routing both low-rank factors (and the optional bias) through an ETP
     primitive so they participate in eligibility-trace computation.
     Auto-dispatches batched/unbatched based on ``x.ndim``.
@@ -355,6 +375,19 @@ def lora_matmul(x, B, A, *, alpha=1.0, bias=None):
         Scalar scaling factor :math:`\alpha`. Default ``1.0``.
     bias : ArrayLike or None, optional
         Bias vector, shape ``(out_features,)``. Default ``None``.
+    b_fn : callable or None, optional
+        Elementwise transform applied to the ``B`` factor before the
+        matrix multiplication.  ``b_fn(B)`` must return an array of the
+        same shape as ``B``.  ``None`` means identity (no transform).
+        The VJP of ``b_fn`` is auto-composed inside ``xy_to_dw`` so that
+        gradients w.r.t. the raw ``lora_b`` weights are correct.
+    a_fn : callable or None, optional
+        Elementwise transform applied to the ``A`` factor before the
+        matrix multiplication.  ``a_fn(A)`` must return an array of the
+        same shape as ``A``.  ``None`` means identity.
+    bias_fn : callable or None, optional
+        Elementwise transform applied to ``bias`` before adding.
+        ``None`` means identity.
 
     Returns
     -------
@@ -383,7 +416,9 @@ def lora_matmul(x, B, A, *, alpha=1.0, bias=None):
     unit = x_u * B_u * A_u
     if bias is not None:
         bias_v = u.Quantity(bias).to_decimal(unit)
-        r = p.bind(x_v, B_v, A_v, bias_v, alpha=alpha, has_bias=True)
+        r = p.bind(x_v, B_v, A_v, bias_v, alpha=alpha, has_bias=True,
+                   b_fn=b_fn, a_fn=a_fn, bias_fn=bias_fn)
     else:
-        r = p.bind(x_v, B_v, A_v, alpha=alpha, has_bias=False)
+        r = p.bind(x_v, B_v, A_v, alpha=alpha, has_bias=False,
+                   b_fn=b_fn, a_fn=a_fn, bias_fn=bias_fn)
     return u.maybe_decimal(r * x_u * B_u * A_u)

--- a/braintrace/_op/lora.py
+++ b/braintrace/_op/lora.py
@@ -381,13 +381,19 @@ def lora_matmul(x, B, A, *, alpha=1.0, bias=None, b_fn=None, a_fn=None, bias_fn=
         same shape as ``B``.  ``None`` means identity (no transform).
         The VJP of ``b_fn`` is auto-composed inside ``xy_to_dw`` so that
         gradients w.r.t. the raw ``lora_b`` weights are correct.
+        The transform operates on the unitless mantissa; physical units are
+        split off before and recombined after.
     a_fn : callable or None, optional
         Elementwise transform applied to the ``A`` factor before the
         matrix multiplication.  ``a_fn(A)`` must return an array of the
         same shape as ``A``.  ``None`` means identity.
+        The transform operates on the unitless mantissa; physical units are
+        split off before and recombined after.
     bias_fn : callable or None, optional
         Elementwise transform applied to ``bias`` before adding.
         ``None`` means identity.
+        The transform operates on the unitless mantissa; physical units are
+        split off before and recombined after.
 
     Returns
     -------

--- a/braintrace/_op/lora_test.py
+++ b/braintrace/_op/lora_test.py
@@ -405,3 +405,38 @@ class TestLoRAOnlineLearning:
                             err_msg='D-RTRL d(lora_a) does not match BPTT')
         npt.assert_allclose(grad_p['bias'], bptt['bias'], atol=1e-5,
                             err_msg='D-RTRL d(bias) does not match BPTT (was it zero?)')
+
+
+# ---------------------------------------------------------------------------
+# Per-factor transform functions: b_fn / a_fn / bias_fn
+# ---------------------------------------------------------------------------
+
+class TestLoraFactorFns:
+
+    def test_forward_applies_factor_fns(self):
+        import brainstate
+        x = brainstate.random.randn(4, 8)
+        B = brainstate.random.randn(8, 2)
+        A = brainstate.random.randn(2, 4)
+        out = braintrace.lora_matmul(x, B, A, alpha=0.5,
+                                     b_fn=lambda b: b ** 2, a_fn=jnp.tanh)
+        ref = 0.5 * (x @ (B ** 2) @ jnp.tanh(A))
+        np.testing.assert_allclose(out, ref, atol=1e-4)
+
+    def test_xy_to_dw_matches_vjp_through_factor_fns(self):
+        import brainstate
+        from braintrace._op import ETP_RULES_XY_TO_DW, etp_lora_mm_p
+        from braintrace._op.op_rule_oracle import assert_xy_to_dw_matches_vjp
+        rule = ETP_RULES_XY_TO_DW[etp_lora_mm_p]
+        x = brainstate.random.randn(4, 8)
+        weights = {'lora_b': brainstate.random.randn(8, 2),
+                   'lora_a': brainstate.random.randn(2, 4)}
+        hidden = brainstate.random.randn(4, 4)
+        params = {'alpha': 0.5, 'has_bias': False,
+                  'b_fn': lambda b: b ** 2, 'a_fn': jnp.tanh, 'bias_fn': None}
+
+        def impl(w):
+            return 0.5 * (x @ (w['lora_b'] ** 2) @ jnp.tanh(w['lora_a']))
+
+        assert_xy_to_dw_matches_vjp(rule=rule, impl=impl, x=x, hidden_dim=hidden,
+                                    weights=weights, params=params, atol=1e-4)

--- a/braintrace/_op/op_rule_oracle_test.py
+++ b/braintrace/_op/op_rule_oracle_test.py
@@ -157,7 +157,7 @@ def test_matmul_then_elementwise_grad_flows_through_both():
 
     def f(w_, scale_):
         y = braintrace.matmul(x, w_)                     # etp_mm_p
-        z = braintrace.element_wise(scale_, fn=lambda s: s) * y  # etp_elemwise_p marker
+        z = braintrace.element_wise(scale_, weight_fn=lambda s: s) * y  # etp_elemwise_p marker
         return (z ** 2).sum()
 
     def f_ref(w_, scale_):

--- a/braintrace/_op/sparse.py
+++ b/braintrace/_op/sparse.py
@@ -90,12 +90,17 @@ __all__ = [
 ]
 
 
-def _etp_sp_matmul_impl(*args, sparse_mat=None, has_bias=False):
+def _etp_sp_matmul_impl(*args, sparse_mat=None, has_bias=False, weight_fn=None, bias_fn=None):
     x, weight_data = args[0], args[1]
+    if weight_fn is not None:
+        weight_data = weight_fn(weight_data)
     w = sparse_mat.with_data(weight_data)
     y = x @ w
     if has_bias:
-        y = y + args[2]
+        b = args[2]
+        if bias_fn is not None:
+            b = bias_fn(b)
+        y = y + b
     return y
 
 
@@ -115,7 +120,7 @@ def _sp_trainable_invars(params):
 # etp_sp_mm_p — batched
 # ---------------------------------------------------------------------------
 
-def _sp_mm_yw_to_w(hidden_dim, trace, *, sparse_mat=None, has_bias=False):
+def _sp_mm_yw_to_w(hidden_dim, trace, *, sparse_mat=None, has_bias=False, weight_fn=None, bias_fn=None):
     r"""Batched sparse ``yw_to_w`` — propagate :math:`\partial h / \partial y`
     through the nnz-shaped D-RTRL trace.
 
@@ -153,7 +158,7 @@ def _sp_mm_yw_to_w(hidden_dim, trace, *, sparse_mat=None, has_bias=False):
     return out
 
 
-def _sp_xy_to_dw(x, hidden_dim, weights, *, sparse_mat=None, has_bias=False):
+def _sp_xy_to_dw(x, hidden_dim, weights, *, sparse_mat=None, has_bias=False, weight_fn=None, bias_fn=None):
     r"""Sparse instantaneous Jacobian :math:`\partial h / \partial w_{\text{data}}`,
     and :math:`\partial h / \partial b`.
 
@@ -172,6 +177,11 @@ def _sp_xy_to_dw(x, hidden_dim, weights, *, sparse_mat=None, has_bias=False):
     ``sparse_mat.with_data`` returns exactly this nnz-shaped gradient —
     the zeros outside the pattern are never materialised.
 
+    When ``weight_fn`` is provided, the transform is applied inside ``_fwd``
+    so that ``jax.vjp`` auto-composes the chain rule: the gradient is taken
+    w.r.t. the **raw** data, not the transformed data. Likewise for
+    ``bias_fn``.
+
     Bias gradient: identical to dense,
     :math:`\partial h / \partial b = \partial h / \partial y`.
 
@@ -180,9 +190,15 @@ def _sp_xy_to_dw(x, hidden_dim, weights, *, sparse_mat=None, has_bias=False):
     """
 
     def _fwd(w_dict):
-        y = x @ sparse_mat.with_data(w_dict['weight'])
+        wd = w_dict['weight']
+        if weight_fn is not None:
+            wd = weight_fn(wd)
+        y = x @ sparse_mat.with_data(wd)
         if has_bias:
-            y = y + w_dict['bias']
+            b = w_dict['bias']
+            if bias_fn is not None:
+                b = bias_fn(b)
+            y = y + b
         return u.get_mantissa(y)
 
     _, vjp_fn = jax.vjp(_fwd, weights)
@@ -229,7 +245,7 @@ def _sp_mm_init_pp(x_var, y_var, weight_vars, num_hidden_state):
 # etp_sp_mv_p — unbatched
 # ---------------------------------------------------------------------------
 
-def _sp_mv_yw_to_w(hidden_dim, trace, *, sparse_mat=None, has_bias=False):
+def _sp_mv_yw_to_w(hidden_dim, trace, *, sparse_mat=None, has_bias=False, weight_fn=None, bias_fn=None):
     r"""Unbatched sparse ``yw_to_w`` — identical algebra to the batched case
     with no batch axis.
 
@@ -315,10 +331,10 @@ etp_sp_mv_p.register_etp_rules(
 )
 
 
-def sparse_matmul(x, weight, *, sparse_mat, bias=None):
+def sparse_matmul(x, weight, *, sparse_mat, bias=None, weight_fn=None, bias_fn=None):
     r"""ETP-aware sparse matrix multiplication.
 
-    Computes :math:`y = x \mathbin{@} \mathrm{sparse}(w) \; (+ b)`, where
+    Computes :math:`y = x \mathbin{@} \mathrm{sparse}(f(w)) \; (+ g(b))`, where
     only the non-zero entries (``weight``) of the fixed sparse pattern
     are trainable and participate in eligibility-trace computation.
     Auto-dispatches batched/unbatched based on ``x.ndim``.
@@ -336,6 +352,16 @@ def sparse_matmul(x, weight, *, sparse_mat, bias=None):
         a trace).
     bias : ArrayLike or None, optional
         Bias vector. Default ``None``.
+    weight_fn : callable or None, optional
+        Elementwise transform applied to the non-zero ``weight`` data before
+        the matmul.  ``None`` means identity (no transform).  When provided,
+        the transform is applied *inside* the primitive so that
+        ``xy_to_dw`` auto-composes the derivative via ``jax.vjp``, returning
+        the gradient w.r.t. the **raw** data.
+    bias_fn : callable or None, optional
+        Elementwise transform applied to ``bias`` before it is added to the
+        output.  ``None`` means identity.  The derivative is composed by the
+        same ``jax.vjp`` call as ``weight_fn``.
 
     Returns
     -------
@@ -348,7 +374,9 @@ def sparse_matmul(x, weight, *, sparse_mat, bias=None):
     unit = x_u * w_u
     if bias is not None:
         bias_v = u.Quantity(bias).to_decimal(unit)
-        r = p.bind(x_v, w_v, bias_v, sparse_mat=sparse_mat, has_bias=True)
+        r = p.bind(x_v, w_v, bias_v, sparse_mat=sparse_mat, has_bias=True,
+                   weight_fn=weight_fn, bias_fn=bias_fn)
     else:
-        r = p.bind(x_v, w_v, sparse_mat=sparse_mat, has_bias=False)
+        r = p.bind(x_v, w_v, sparse_mat=sparse_mat, has_bias=False,
+                   weight_fn=weight_fn, bias_fn=bias_fn)
     return u.maybe_decimal(r * x_u * w_u)

--- a/braintrace/_op/sparse.py
+++ b/braintrace/_op/sparse.py
@@ -358,10 +358,14 @@ def sparse_matmul(x, weight, *, sparse_mat, bias=None, weight_fn=None, bias_fn=N
         the transform is applied *inside* the primitive so that
         ``xy_to_dw`` auto-composes the derivative via ``jax.vjp``, returning
         the gradient w.r.t. the **raw** data.
+        The transform operates on the unitless mantissa; physical units are
+        split off before and recombined after.
     bias_fn : callable or None, optional
         Elementwise transform applied to ``bias`` before it is added to the
         output.  ``None`` means identity.  The derivative is composed by the
         same ``jax.vjp`` call as ``weight_fn``.
+        The transform operates on the unitless mantissa; physical units are
+        split off before and recombined after.
 
     Returns
     -------

--- a/braintrace/_op/sparse_test.py
+++ b/braintrace/_op/sparse_test.py
@@ -452,3 +452,111 @@ class TestPublicAPIRoundTrip:
 
     def test_public_alias(self):
         assert braintrace.sparse_matmul is sparse_matmul
+
+
+# ---------------------------------------------------------------------------
+# weight_fn / bias_fn transforms
+# ---------------------------------------------------------------------------
+
+class TestSparseWeightFnBiasFn:
+    """Tests for weight_fn / bias_fn support in sparse_matmul."""
+
+    def test_forward_applies_weight_fn(self):
+        """weight_fn=lambda w: w**2 should be applied to the nnz data before matmul."""
+        dense = jnp.array([
+            [1.0, 0.0, 0.0],
+            [0.0, 2.0, 0.0],
+            [0.0, 0.0, 3.0],
+        ])
+        csr = _csr_from_dense(dense)
+        x = jnp.array([[1.0, 2.0, 3.0], [0.5, 0.5, 0.5]])
+        out = sparse_matmul(x, csr.data, sparse_mat=csr, weight_fn=lambda w: w ** 2)
+        # Reference: apply weight_fn to nnz data, reconstruct, and matmul
+        ref_dense = jnp.array([
+            [1.0, 0.0, 0.0],
+            [0.0, 4.0, 0.0],
+            [0.0, 0.0, 9.0],
+        ])
+        ref = x @ ref_dense
+        np.testing.assert_allclose(u.get_mantissa(out), u.get_mantissa(ref), atol=1e-4)
+
+    def test_forward_applies_bias_fn(self):
+        """bias_fn=lambda b: b*2 should be applied to the bias before adding."""
+        dense = jnp.eye(3) * 2.0
+        csr = _csr_from_dense(dense)
+        x = jnp.ones((2, 3))
+        b = jnp.arange(3.0)
+        out = sparse_matmul(x, csr.data, sparse_mat=csr, bias=b, bias_fn=lambda b: b * 2.0)
+        ref = x @ dense + b * 2.0
+        np.testing.assert_allclose(u.get_mantissa(out), u.get_mantissa(ref), atol=1e-4)
+
+    def test_forward_no_fns_unchanged(self):
+        """Passing weight_fn=None, bias_fn=None must be bit-identical to no-fn baseline."""
+        dense = jnp.eye(3) * 2.0
+        csr = _csr_from_dense(dense)
+        x = jnp.ones((2, 3))
+        b = jnp.arange(3.0)
+        out_with_none = sparse_matmul(x, csr.data, sparse_mat=csr, bias=b,
+                                      weight_fn=None, bias_fn=None)
+        out_baseline = sparse_matmul(x, csr.data, sparse_mat=csr, bias=b)
+        np.testing.assert_allclose(
+            u.get_mantissa(out_with_none),
+            u.get_mantissa(out_baseline),
+            atol=0,
+        )
+
+    def test_xy_to_dw_matches_vjp_through_weight_fn(self):
+        """xy_to_dw rule must match jax.vjp through weight_fn(w)**2."""
+        from braintrace._op import ETP_RULES_XY_TO_DW, etp_sp_mm_p
+        from braintrace._op.op_rule_oracle import assert_xy_to_dw_matches_vjp
+
+        # Use the hashable stub so it can be a static primitive param
+        stub = _HashableStubMat(jnp.zeros((3, 4)))
+        x = jnp.ones((2, 3))
+        w_data = jnp.arange(1.0, 13.0)  # shape (12,)
+        hidden = brainstate.random.randn(2, 4)
+
+        rule = ETP_RULES_XY_TO_DW[etp_sp_mm_p]
+        params = {
+            'sparse_mat': stub,
+            'has_bias': False,
+            'weight_fn': lambda w: w ** 2,
+            'bias_fn': None,
+        }
+        weights = {'weight': w_data}
+
+        def impl(wd):
+            return x @ stub.with_data(wd['weight'] ** 2)
+
+        assert_xy_to_dw_matches_vjp(
+            rule=rule, impl=impl, x=x, hidden_dim=hidden,
+            weights=weights, params=params, atol=1e-4,
+        )
+
+    def test_xy_to_dw_matches_vjp_with_bias_fn(self):
+        """xy_to_dw rule must match jax.vjp through both weight_fn and bias_fn."""
+        from braintrace._op import ETP_RULES_XY_TO_DW, etp_sp_mm_p
+        from braintrace._op.op_rule_oracle import assert_xy_to_dw_matches_vjp
+
+        stub = _HashableStubMat(jnp.zeros((3, 4)))
+        x = jnp.ones((2, 3))
+        w_data = jnp.arange(1.0, 13.0)
+        b_data = jnp.ones(4) * 0.5
+        hidden = brainstate.random.randn(2, 4)
+
+        rule = ETP_RULES_XY_TO_DW[etp_sp_mm_p]
+        params = {
+            'sparse_mat': stub,
+            'has_bias': True,
+            'weight_fn': lambda w: w ** 2,
+            'bias_fn': lambda b: b * 3.0,
+        }
+        weights = {'weight': w_data, 'bias': b_data}
+
+        def impl(wd):
+            return x @ stub.with_data(wd['weight'] ** 2) + wd['bias'] * 3.0
+
+        assert_xy_to_dw_matches_vjp(
+            rule=rule, impl=impl, x=x, hidden_dim=hidden,
+            weights=weights, params=params, atol=1e-4,
+        )

--- a/braintrace/_version.py
+++ b/braintrace/_version.py
@@ -13,5 +13,5 @@
 # limitations under the License.
 # ==============================================================================
 
-__version__ = "0.2.2"
+__version__ = "0.2.3"
 __version_info__ = tuple(map(int, __version__.split('.')))

--- a/braintrace/nn/__init__.py
+++ b/braintrace/nn/__init__.py
@@ -26,7 +26,7 @@ with their :mod:`brainstate.nn` counterparts.
 The exported building blocks fall into four groups:
 
 - **Linear maps** — :class:`Linear`, :class:`SignedWLinear`,
-  :class:`SparseLinear`, :class:`LoRA`.
+  :class:`ScaledWSLinear`, :class:`SparseLinear`, :class:`LoRA`.
 - **Convolutions** — :class:`Conv1d`, :class:`Conv2d`, :class:`Conv3d`.
 - **Read-outs** — :class:`LeakyRateReadout`.
 - **Recurrent cells** — :class:`ValinaRNNCell`, :class:`GRUCell`,

--- a/braintrace/nn/__init__.py
+++ b/braintrace/nn/__init__.py
@@ -41,7 +41,7 @@ re-implemented here; accessing them through ``braintrace.nn`` emits a
 """
 
 from ._conv import Conv1d, Conv2d, Conv3d
-from ._linear import Linear, SignedWLinear, SparseLinear, LoRA
+from ._linear import Linear, SignedWLinear, ScaledWSLinear, SparseLinear, LoRA
 from ._readout import LeakyRateReadout
 from ._rnn import ValinaRNNCell, GRUCell, MGUCell, LSTMCell, URLSTMCell, MinimalRNNCell, MiniGRU, MiniLSTM, LRUCell
 
@@ -49,7 +49,7 @@ __all__ = [
     # conv
     'Conv1d', 'Conv2d', 'Conv3d',
     # linear
-    'Linear', 'SignedWLinear', 'SparseLinear', 'LoRA',
+    'Linear', 'SignedWLinear', 'ScaledWSLinear', 'SparseLinear', 'LoRA',
     # readout
     'LeakyRateReadout',
     # rnn

--- a/braintrace/nn/_linear.py
+++ b/braintrace/nn/_linear.py
@@ -24,6 +24,7 @@ from braintrace._typing import ArrayLike
 __all__ = [
     'Linear',
     'SignedWLinear',
+    'ScaledWSLinear',
     'SparseLinear',
     'LoRA',
 ]
@@ -93,9 +94,17 @@ class ScaledWSLinear(brainstate.nn.ScaledWSLinear):
     def update(self, x):
         """Apply the weight-standardized linear transform through ETP ``matmul``.
 
-        The weight is standardized (zero-mean, unit-variance per output unit)
-        before being routed through :func:`braintrace.matmul`, so it
-        participates in online-learning trace computation.
+        Weight standardization (and the optional mask) are applied inside
+        ``weight_fn``, which closes over the current ``gain`` and ``eps``
+        values.  Routing the transform through :func:`braintrace.matmul` with
+        ``weight_fn=`` causes the ETP compiler to track the gradient w.r.t. the
+        raw ``weight`` leaf exactly (the standardization Jacobian is recovered
+        via ``jax.vjp``).
+
+        Note on ``gain``:  ``gain`` reaches the hidden state *only through* the
+        standardized weight map and is therefore non-temporal for the
+        eligibility trace.  Its online gradient will not match BPTT; only the
+        standardized ``weight`` leaf participates exactly in trace computation.
 
         Parameters
         ----------
@@ -108,11 +117,31 @@ class ScaledWSLinear(brainstate.nn.ScaledWSLinear):
             The transformed output, of shape ``(..., out_size)``.
         """
         params = self.weight.value
-        w = brainstate.nn.weight_standardization(params['weight'], self.eps, params.get('gain', None))
-        if self.w_mask is not None:
-            w = w * self.w_mask
+        eps = self.eps
+        gain = params.get('gain', None)
+        mask = self.w_mask
+
+        # ``gain`` is a trainable ParamState leaf that is *non-temporal* for the
+        # eligibility trace: it reaches the hidden state only through the
+        # standardized weight map, so its online gradient will not match BPTT
+        # exactly.  To avoid a JAX tracer-leak (JAX forbids closing over traced
+        # state values in static primitive parameters), we apply weight
+        # standardization *without* gain inside ``weight_fn`` and multiply by
+        # gain *after* the matmul.  This is mathematically equivalent because
+        #   x @ (std(w) * gain) == (x @ std(w)) * gain
+        # when gain has shape (1, out_size), and the ETP trace's hidden_dim
+        # already carries the gain factor through the hidden-to-output Jacobian.
+        def _wfn(ww):
+            w = brainstate.nn.weight_standardization(ww, eps, None)
+            if mask is not None:
+                w = w * mask
+            return w
+
         b = params.get('bias', None)
-        return matmul(x, w, b)
+        result = matmul(x, params['weight'], b, weight_fn=_wfn)
+        if gain is not None:
+            result = result * gain
+        return result
 
 
 class SparseLinear(brainstate.nn.SparseLinear):

--- a/braintrace/nn/_linear.py
+++ b/braintrace/nn/_linear.py
@@ -95,16 +95,18 @@ class ScaledWSLinear(brainstate.nn.ScaledWSLinear):
         """Apply the weight-standardized linear transform through ETP ``matmul``.
 
         Weight standardization (and the optional mask) are applied inside
-        ``weight_fn``, which closes over the current ``gain`` and ``eps``
-        values.  Routing the transform through :func:`braintrace.matmul` with
+        ``weight_fn``, which closes over the current ``eps`` value only.
+        Routing the transform through :func:`braintrace.matmul` with
         ``weight_fn=`` causes the ETP compiler to track the gradient w.r.t. the
         raw ``weight`` leaf exactly (the standardization Jacobian is recovered
         via ``jax.vjp``).
 
-        Note on ``gain``:  ``gain`` reaches the hidden state *only through* the
-        standardized weight map and is therefore non-temporal for the
-        eligibility trace.  Its online gradient will not match BPTT; only the
-        standardized ``weight`` leaf participates exactly in trace computation.
+        Note on post-ops: both ``gain`` and ``bias`` are applied OUTSIDE the
+        matmul primitive as post-operations, so the eligibility trace tracks
+        only the standardized ``weight`` leaf.  ``gain`` is non-temporal (its
+        online gradient will not match BPTT), while ``bias`` is added after the
+        gain scale so it is not incorrectly multiplied by ``gain``.  Standard
+        autodiff via the multi-step VJP still recovers exact gradients for both.
 
         Parameters
         ----------
@@ -138,9 +140,13 @@ class ScaledWSLinear(brainstate.nn.ScaledWSLinear):
             return w
 
         b = params.get('bias', None)
-        result = matmul(x, params['weight'], b, weight_fn=_wfn)
+        # Do NOT pass bias into matmul; add it after gain so that bias is not
+        # scaled by gain.  Correct forward: (x @ std(w)*mask) * gain + b.
+        result = matmul(x, params['weight'], weight_fn=_wfn)
         if gain is not None:
             result = result * gain
+        if b is not None:
+            result = result + b
         return result
 
 

--- a/braintrace/nn/_linear.py
+++ b/braintrace/nn/_linear.py
@@ -51,9 +51,10 @@ class Linear(brainstate.nn.Linear):
             The transformed output, of shape ``(..., out_size)``.
         """
         w = self.weight.value['weight']
-        if self.w_mask is not None:
-            w = w * self.w_mask
         b = self.weight.value.get('bias')
+        if self.w_mask is not None:
+            mask = self.w_mask
+            return matmul(x, w, b, weight_fn=lambda ww: ww * mask)
         return matmul(x, w, b)
 
 
@@ -78,10 +79,11 @@ class SignedWLinear(brainstate.nn.SignedWLinear):
         ArrayLike
             The transformed output, of shape ``(..., out_size)``.
         """
-        w = u.math.abs(self.weight.value)
-        if self.w_sign is not None:
-            w = w * self.w_sign
-        return matmul(x, w)
+        w = self.weight.value
+        sign = self.w_sign
+        if sign is not None:
+            return matmul(x, w, weight_fn=lambda ww: u.math.abs(ww) * sign)
+        return matmul(x, w, weight_fn=lambda ww: u.math.abs(ww))
 
 
 class ScaledWSLinear(brainstate.nn.ScaledWSLinear):

--- a/braintrace/nn/_linear.py
+++ b/braintrace/nn/_linear.py
@@ -101,12 +101,14 @@ class ScaledWSLinear(brainstate.nn.ScaledWSLinear):
         raw ``weight`` leaf exactly (the standardization Jacobian is recovered
         via ``jax.vjp``).
 
-        Note on post-ops: both ``gain`` and ``bias`` are applied OUTSIDE the
+        Note on post-ops: ``gain`` and ``bias`` are applied OUTSIDE the
         matmul primitive as post-operations, so the eligibility trace tracks
-        only the standardized ``weight`` leaf.  ``gain`` is non-temporal (its
-        online gradient will not match BPTT), while ``bias`` is added after the
-        gain scale so it is not incorrectly multiplied by ``gain``.  Standard
-        autodiff via the multi-step VJP still recovers exact gradients for both.
+        only the standardized ``weight`` leaf.  ``gain`` and ``bias`` are
+        therefore non-temporal for the eligibility trace — in genuine online
+        training their trace-based gradient is partial.  (The multi-step VJP
+        *oracle* path used in tests, which autodiffs through the full rollout,
+        still recovers them exactly; only the online eligibility-trace gradient
+        is non-temporal.)
 
         Parameters
         ----------

--- a/braintrace/nn/_linear_test.py
+++ b/braintrace/nn/_linear_test.py
@@ -910,10 +910,12 @@ class TestScaledWSLinearWeightFn:
         assert weight_keys, (
             f"No 'weight' leaf found after flattening. Keys: {list(bptt.keys())}"
         )
-        # 'gain' must NOT appear among asserted keys (non-temporal parameter).
-        gain_keys = [k for k in weight_keys if k[-1] == 'gain']
-        assert not gain_keys, f"gain key leaked into weight_keys: {gain_keys}"
         assert_param_gradients_close(online, bptt, atol=1e-4, keys=weight_keys)
+        # gain is differentiated exactly by the multi-step VJP oracle path (post-scale,
+        # standard autodiff) — distinct from its non-temporal online eligibility-trace gradient.
+        gain_keys = [k for k in bptt if k[-1] == 'gain']
+        assert gain_keys, list(bptt.keys())
+        assert_param_gradients_close(online, bptt, atol=1e-4, keys=gain_keys)
 
 
 class TestScaledWSLinearForwardBiasGain:

--- a/braintrace/nn/_linear_test.py
+++ b/braintrace/nn/_linear_test.py
@@ -767,3 +767,69 @@ class TestLinearIntegration:
 
             assert y1.shape == (batch_size, 32)
             assert y2.shape == (batch_size, 32)
+
+
+class TestNnWeightFnExactness:
+    """Masked Linear and SignedWLinear gradients must match BPTT (now exact)."""
+
+    @staticmethod
+    def _rnn_factory(make_layer):
+        class Cell(brainstate.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.nh = 4
+                self.layer = make_layer()
+
+            def init_state(self, batch_size=None, **kw):
+                size = (self.nh,) if batch_size is None else (batch_size, self.nh)
+                self.h = brainstate.HiddenState(jnp.zeros(size))
+
+            def update(self, x):
+                xh = jnp.concatenate([x.reshape(1, -1), self.h.value], axis=-1)
+                self.h.value = jnp.tanh(self.layer(xh))
+                return self.h.value
+
+        def factory():
+            brainstate.random.seed(0)
+            return Cell()
+
+        return factory
+
+    def test_signed_w_linear_matches_bptt(self):
+        from braintrace._algorithm.oracle import (
+            bptt_param_gradients, online_param_gradients, assert_param_gradients_close,
+        )
+        factory = self._rnn_factory(lambda: braintrace.nn.SignedWLinear(2 + 4, 4))
+        brainstate.random.seed(1)
+        inputs = brainstate.random.randn(6, 2)
+        bptt = bptt_param_gradients(factory, inputs)
+        online = online_param_gradients(
+            factory, inputs, algo_factory=lambda m: braintrace.D_RTRL(m, vjp_method='multi-step')
+        )
+        assert_param_gradients_close(online, bptt, atol=1e-4)
+
+    @staticmethod
+    def _flatten_grads(grads):
+        """Flatten nested dict grad values from Linear (weight dict) to flat keys."""
+        flat = {}
+        for k, v in grads.items():
+            if isinstance(v, dict):
+                for subk, subv in v.items():
+                    flat[k + (subk,)] = subv
+            else:
+                flat[k] = v
+        return flat
+
+    def test_masked_linear_matches_bptt(self):
+        from braintrace._algorithm.oracle import (
+            bptt_param_gradients, online_param_gradients, assert_param_gradients_close,
+        )
+        mask = ((jnp.arange(6)[:, None] + jnp.arange(4)[None, :]) % 3 != 0).astype(float)
+        factory = self._rnn_factory(lambda: braintrace.nn.Linear(2 + 4, 4, w_mask=mask))
+        brainstate.random.seed(1)
+        inputs = brainstate.random.randn(6, 2)
+        bptt = self._flatten_grads(bptt_param_gradients(factory, inputs))
+        online = self._flatten_grads(online_param_gradients(
+            factory, inputs, algo_factory=lambda m: braintrace.D_RTRL(m, vjp_method='multi-step')
+        ))
+        assert_param_gradients_close(online, bptt, atol=1e-4)

--- a/braintrace/nn/_linear_test.py
+++ b/braintrace/nn/_linear_test.py
@@ -914,3 +914,52 @@ class TestScaledWSLinearWeightFn:
         gain_keys = [k for k in weight_keys if k[-1] == 'gain']
         assert not gain_keys, f"gain key leaked into weight_keys: {gain_keys}"
         assert_param_gradients_close(online, bptt, atol=1e-4, keys=weight_keys)
+
+
+class TestScaledWSLinearForwardBiasGain:
+    """Forward correctness regression: gain must NOT scale the bias.
+
+    The bug introduced in 0b2ccef passed ``bias`` into ``matmul`` and then
+    multiplied the whole result (including bias) by ``gain``, yielding
+    ``(x @ std(w)) * gain + bias * gain`` instead of the correct
+    ``(x @ std(w)) * gain + bias``.  This test sets a non-zero bias and a
+    non-unit gain and asserts the braintrace forward matches the brainstate
+    reference forward.
+    """
+
+    def test_bias_not_scaled_by_gain(self):
+        """Non-zero bias with non-unit gain: braintrace must match brainstate."""
+        brainstate.environ.set(precision=64)
+        brainstate.random.seed(7)
+
+        in_size, out_size = 6, 4
+
+        # Build braintrace layer (the one being fixed).
+        bt_layer = braintrace.nn.ScaledWSLinear(in_size=in_size, out_size=out_size)
+        # Build brainstate reference layer (uses the original correct forward).
+        bs_layer = brainstate.nn.ScaledWSLinear(in_size=in_size, out_size=out_size)
+
+        # Copy weight params from braintrace to brainstate so they are identical.
+        bt_params = bt_layer.weight.value
+        bs_layer.weight.value = dict(bt_params)
+
+        # Override bias and gain on BOTH layers with non-trivial values.
+        bias_val = jnp.array([1.0, 2.0, 3.0, 4.0])
+        gain_val = jnp.array([[2.0, 0.5, 3.0, 1.5]])  # shape (1, out_size)
+
+        new_params = dict(bt_params)
+        new_params['bias'] = bias_val
+        new_params['gain'] = gain_val
+        bt_layer.weight.value = new_params
+        bs_layer.weight.value = dict(new_params)
+
+        x = brainstate.random.randn(3, in_size)
+
+        bt_out = bt_layer.update(x)
+        bs_out = bs_layer.update(x)
+
+        maxabsdiff = float(jnp.max(jnp.abs(bt_out - bs_out)))
+        assert maxabsdiff < 1e-5, (
+            f"braintrace ScaledWSLinear forward differs from brainstate reference "
+            f"by {maxabsdiff:.6f} (max-abs-diff). Bias is being scaled by gain."
+        )

--- a/braintrace/nn/_linear_test.py
+++ b/braintrace/nn/_linear_test.py
@@ -33,6 +33,23 @@ from braintools import init
 import braintrace
 
 
+def _flatten_grads(grads):
+    """Flatten nested dict grad values (e.g. from a dict-valued ParamState) to flat tuple keys.
+
+    For a grad dict whose values may themselves be dicts (e.g. ``{'weight': …, 'bias': …}``),
+    expands ``{k: {subk: v}}`` → ``{k + (subk,): v}`` so that ``assert_param_gradients_close``
+    can compare individual leaf arrays.
+    """
+    flat = {}
+    for k, v in grads.items():
+        if isinstance(v, dict):
+            for subk, subv in v.items():
+                flat[k + (subk,)] = subv
+        else:
+            flat[k] = v
+    return flat
+
+
 class TestLinear:
     """Test Linear layer."""
 
@@ -808,18 +825,6 @@ class TestNnWeightFnExactness:
         )
         assert_param_gradients_close(online, bptt, atol=1e-4)
 
-    @staticmethod
-    def _flatten_grads(grads):
-        """Flatten nested dict grad values from Linear (weight dict) to flat keys."""
-        flat = {}
-        for k, v in grads.items():
-            if isinstance(v, dict):
-                for subk, subv in v.items():
-                    flat[k + (subk,)] = subv
-            else:
-                flat[k] = v
-        return flat
-
     def test_masked_linear_matches_bptt(self):
         from braintrace._algorithm.oracle import (
             bptt_param_gradients, online_param_gradients, assert_param_gradients_close,
@@ -828,8 +833,84 @@ class TestNnWeightFnExactness:
         factory = self._rnn_factory(lambda: braintrace.nn.Linear(2 + 4, 4, w_mask=mask))
         brainstate.random.seed(1)
         inputs = brainstate.random.randn(6, 2)
-        bptt = self._flatten_grads(bptt_param_gradients(factory, inputs))
-        online = self._flatten_grads(online_param_gradients(
+        bptt = _flatten_grads(bptt_param_gradients(factory, inputs))
+        online = _flatten_grads(online_param_gradients(
             factory, inputs, algo_factory=lambda m: braintrace.D_RTRL(m, vjp_method='multi-step')
         ))
         assert_param_gradients_close(online, bptt, atol=1e-4)
+
+
+class TestScaledWSLinearWeightFn:
+    """ScaledWSLinear's standardized 'weight' leaf gradient must match BPTT exactly.
+
+    ``ScaledWSLinear`` stores a single ``ParamState`` whose ``.value`` is a dict
+    with keys ``'weight'``, ``'bias'``, and ``'gain'``.  After flattening the
+    grad dict with ``_flatten_grads``, the leaf keys are
+    ``('layer', 'weight', 'weight')``, ``('layer', 'weight', 'bias')``, and
+    ``('layer', 'weight', 'gain')``.
+
+    Exactness is asserted ONLY on the ``'weight'`` leaf (last element ``== 'weight'``).
+    The ``gain`` leaf is intentionally excluded: ``gain`` is non-temporal — it
+    reaches the hidden state only *through* the standardized weight map and does
+    not participate directly in the eligibility trace.  Its online gradient will
+    therefore NOT match BPTT, and asserting on it would be incorrect.
+    """
+
+    @staticmethod
+    def _rnn_factory():
+        class Cell(brainstate.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.nh = 4
+                self.layer = braintrace.nn.ScaledWSLinear(2 + 4, 4)
+
+            def init_state(self, batch_size=None, **kw):
+                size = (self.nh,) if batch_size is None else (batch_size, self.nh)
+                self.h = brainstate.HiddenState(jnp.zeros(size))
+
+            def update(self, x):
+                # x is shape (2,); h.value is (1, 4) after init_all_states(batch_size=1)
+                xh = jnp.concatenate([x.reshape(1, -1), self.h.value], axis=-1)
+                self.h.value = jnp.tanh(self.layer(xh))
+                return self.h.value
+
+        def factory():
+            brainstate.random.seed(0)
+            return Cell()
+
+        return factory
+
+    def test_weight_leaf_gradient_matches_bptt(self):
+        """Standardized weight leaf (not gain) online gradient equals BPTT.
+
+        Routing weight-standardization through ``matmul``'s ``weight_fn``
+        recovers the standardization Jacobian in the eligibility trace.  The
+        exact comparison is restricted to the ``('layer', 'weight', 'weight')``
+        leaf.  The ``gain`` leaf is non-temporal (reaches the hidden state only
+        through the standardized weight, another trainable map) and is
+        intentionally excluded from the exactness assertion.
+        """
+        from braintrace._algorithm.oracle import (
+            bptt_param_gradients, online_param_gradients, assert_param_gradients_close,
+        )
+        factory = self._rnn_factory()
+        brainstate.random.seed(1)
+        inputs = brainstate.random.randn(6, 2)
+        bptt = _flatten_grads(bptt_param_gradients(factory, inputs))
+        online = _flatten_grads(online_param_gradients(
+            factory, inputs,
+            algo_factory=lambda m: braintrace.D_RTRL(m, vjp_method='multi-step'),
+        ))
+        # Select ONLY the standardized weight leaf by its last path element.
+        # After flattening, the three leaves are:
+        #   ('layer', 'weight', 'weight') — the standardized weight: ASSERT exact
+        #   ('layer', 'weight', 'bias')   — bias: not asserted here
+        #   ('layer', 'weight', 'gain')   — gain (non-temporal): EXCLUDED
+        weight_keys = [k for k in bptt if k[-1] == 'weight']
+        assert weight_keys, (
+            f"No 'weight' leaf found after flattening. Keys: {list(bptt.keys())}"
+        )
+        # 'gain' must NOT appear among asserted keys (non-temporal parameter).
+        gain_keys = [k for k in weight_keys if k[-1] == 'gain']
+        assert not gain_keys, f"gain key leaked into weight_keys: {gain_keys}"
+        assert_param_gradients_close(online, bptt, atol=1e-4, keys=weight_keys)

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,58 @@
 # Release Notes
 
 
+## Version 0.2.3
+
+This release adds optional, shape-preserving parameter-transform hooks to the
+eligibility-trace (ETP) operators, so a trainable weight (or bias) can be passed
+through an elementwise / standardizing function *before* it enters the operation
+while the eligibility trace and gradient remain with respect to the **raw**
+stored parameter. It also threads these hooks through the `braintrace.nn` linear
+layers. One public API is renamed (see Breaking changes).
+
+### Highlights
+
+#### New: parameter-transform hooks on ETP operators
+
+- Add transform hooks to the ETP ops, computing
+  `y = x @ weight_fn(w) (+ bias_fn(b))` (and per-op equivalents), with the
+  eligibility trace and gradient kept with respect to the **raw** parameter:
+  - **`braintrace.matmul`** / **`braintrace.sparse_matmul`** — `weight_fn`,
+    `bias_fn`.
+  - **`braintrace.conv`** — `kernel_fn`, `bias_fn`.
+  - **`braintrace.lora_matmul`** — `b_fn`, `a_fn`, `bias_fn`.
+  - **`braintrace.element_wise`** — `weight_fn` (see Breaking changes).
+
+  Each transform is applied *inside* the ETP primitive; the per-parameter
+  Jacobian is recovered exactly once (via `jax.vjp`) in the weight-gradient rule,
+  while the trace-propagation rule is unchanged — so the forward-mode eligibility
+  trace stays exact and is never double-counted. D-RTRL matches
+  backprop-through-time element-wise for non-identity transforms (verified with
+  `tanh`, `w**2`, and `abs`). Omitting a transform is bit-identical to the
+  previous behavior.
+
+#### New / Improved: `braintrace.nn` linear layers
+
+- **`braintrace.nn.Linear`** (with `w_mask`), **`braintrace.nn.SignedWLinear`**,
+  and **`braintrace.nn.ScaledWSLinear`** now route their weight masking / sign /
+  standardization through the new `matmul(weight_fn=...)` hook, so the masked /
+  signed / standardized weight participates in eligibility-trace learning with
+  the gradient kept w.r.t. the raw weight leaf. (For `ScaledWSLinear`, `gain` and
+  `bias` are applied as post-operations and are therefore non-temporal for the
+  online trace, though still recovered exactly by the multi-step VJP oracle.)
+- **Export `braintrace.nn.ScaledWSLinear`** (previously importable only by its
+  fully-qualified module path).
+
+### Breaking changes
+
+- **`braintrace.element_wise`**: the `fn` parameter is renamed to **`weight_fn`**
+  and is now **keyword-only**, and the transform is applied *inside* the ETP
+  primitive (previously it was applied to the weight outside the primitive).
+  Migrate `element_wise(w, fn=g)` to `element_wise(w, weight_fn=g)`. Forward
+  results are unchanged; only the call signature and the internal
+  trace-factorization point differ.
+
+
 ## Version 0.2.2
 
 This release introduces a unified `braintrace.compile` entry point for building


### PR DESCRIPTION
## Summary

Adds optional, shape-preserving **parameter-transform hooks** to the
eligibility-trace (ETP) operators, computing `y = x @ weight_fn(w) (+ bias_fn(b))`,
with the eligibility trace and gradient kept with respect to the **raw** stored
parameter. The hooks are threaded through the `braintrace.nn` linear layers.
Bumps the version to **0.2.3** and adds the changelog entry.

## What's added

**ETP ops** — each transform is applied *inside* the primitive; the per-parameter
Jacobian is recovered exactly once (via `jax.vjp`) in the weight-gradient rule,
while the trace-propagation rule is byte-unchanged, so the forward-mode
eligibility trace stays exact and is never double-counted:

- `braintrace.matmul` / `braintrace.sparse_matmul` — `weight_fn`, `bias_fn`
- `braintrace.conv` — `kernel_fn`, `bias_fn`
- `braintrace.lora_matmul` — `b_fn`, `a_fn`, `bias_fn`
- `braintrace.element_wise` — `weight_fn`

**nn layers** — `braintrace.nn.Linear` (with `w_mask`), `SignedWLinear`, and
`ScaledWSLinear` route weight masking / sign / standardization through the new
`matmul(weight_fn=...)` hook, so the masked / signed / standardized weight
participates in eligibility-trace learning with the gradient kept w.r.t. the raw
weight leaf. `ScaledWSLinear` is now exported from `braintrace.nn`.

## :warning: Breaking change

- **`braintrace.element_wise`**: the `fn` parameter is renamed to **`weight_fn`**
  and is now **keyword-only**, and the transform is applied *inside* the ETP
  primitive (previously outside). Migrate `element_wise(w, fn=g)` to
  `element_wise(w, weight_fn=g)`. Forward results are unchanged; only the call
  signature and the internal trace-factorization point differ.

## Correctness

- D-RTRL matches backprop-through-time element-wise for non-identity transforms
  (verified with `tanh`, `w**2`, `abs`); omitting a transform is bit-identical to
  prior behavior.
- Full `braintrace` suite: **1632 passed, 0 failed, 3 skipped** (pre-existing skips).

## Version

- `braintrace/_version.py` 0.2.2 -> 0.2.3; changelog entry under "Version 0.2.3".
