### PR TITLE
types: inline type annotations for the public API + enforced mypy gate

### DIFF
--- a/braintrace/__init__.py
+++ b/braintrace/__init__.py
@@ -66,7 +66,9 @@ Examples
 """
 
 
-from typing import TYPE_CHECKING
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
 
 from . import nn
 from ._compile import compile
@@ -244,7 +246,7 @@ _DEPRECATED_LEGACY = {
 }
 
 
-def __getattr__(name):
+def __getattr__(name: str) -> Any:
     if name in _DEPRECATED_LEGACY:
         import warnings
         warnings.warn(
@@ -258,5 +260,5 @@ def __getattr__(name):
     raise AttributeError(f'module {__name__!r} has no attribute {name!r}')
 
 
-def __dir__():
+def __dir__() -> list[str]:
     return sorted(list(__all__) + list(_DEPRECATED_LEGACY))

--- a/braintrace/_algorithm/__init__.py
+++ b/braintrace/_algorithm/__init__.py
@@ -21,6 +21,8 @@ and paper-faithful SNN algorithms (EProp, OSTLRecurrent, OSTLFeedforward, OTPE,
 OTTT, OSTTP).
 """
 
+from __future__ import annotations
+
 from ._common import FixedRandomFeedback, KappaFilter, PresynapticTrace
 from .base import ETraceAlgorithm, EligibilityTrace
 from .d_rtrl import D_RTRL

--- a/braintrace/_algorithm/_common.py
+++ b/braintrace/_algorithm/_common.py
@@ -15,6 +15,8 @@
 
 """Shared helpers for the SNN online-learning algorithms."""
 
+from __future__ import annotations
+
 from functools import partial
 from typing import Any, Dict, Optional
 
@@ -23,7 +25,7 @@ import jax
 import jax.numpy as jnp
 import brainunit as u
 
-from braintrace._typing import PyTree
+from braintrace._typing import ArrayLike, PyTree
 
 __all__ = [
     'PresynapticTrace',
@@ -42,12 +44,12 @@ class _ZeroResetState(brainstate.ShortTermState):
     for ``batch_size`` (or prepended for scalar-shaped states).
     """
 
-    def __init__(self, init_value):
+    def __init__(self, init_value: Any) -> None:
         super().__init__(init_value)
         self._init_shape = jnp.shape(init_value)
         self._init_dtype = init_value.dtype
 
-    def reset_state(self, batch_size: Optional[int] = None, **kwargs):
+    def reset_state(self, batch_size: Optional[int] = None, **kwargs: Any) -> None:
         """Re-zero the state at its original shape.
 
         Parameters
@@ -105,13 +107,13 @@ class PresynapticTrace(_ZeroResetState):
 
     __module__ = 'braintrace'
 
-    def __init__(self, init_value, leak: float):
+    def __init__(self, init_value: Any, leak: float) -> None:
         super().__init__(init_value)
         if not (0.0 < leak < 1.0):
             raise ValueError(f'leak must be in (0, 1); got {leak}')
         self.leak = float(leak)
 
-    def update(self, x):
+    def update(self, x: ArrayLike) -> Any:
         r"""Apply one accumulation step :math:`\hat{a} \leftarrow \lambda \cdot \hat{a} + x`.
 
         Parameters
@@ -163,13 +165,13 @@ class KappaFilter(_ZeroResetState):
 
     __module__ = 'braintrace'
 
-    def __init__(self, init_value, kappa: float):
+    def __init__(self, init_value: Any, kappa: float) -> None:
         super().__init__(init_value)
         if not (0.0 <= kappa < 1.0):
             raise ValueError(f'kappa must be in [0, 1); got {kappa}')
         self.kappa = float(kappa)
 
-    def update(self, x):
+    def update(self, x: ArrayLike) -> Any:
         r"""Apply one low-pass step :math:`x_{\mathrm{filt}} \leftarrow (1-\kappa) x + \kappa\, x_{\mathrm{filt}}`.
 
         Parameters
@@ -230,14 +232,14 @@ class FixedRandomFeedback:
 
     __module__ = 'braintrace'
 
-    def __init__(self, n_target: int, n_layer: int, key, init_scale: float = 0.1):
+    def __init__(self, n_target: int, n_layer: int, key: Any, init_scale: float = 0.1) -> None:
         self.B = jax.lax.stop_gradient(
             init_scale * jax.random.normal(key, (n_target, n_layer))
         )
         self.n_target = int(n_target)
         self.n_layer = int(n_layer)
 
-    def project(self, y_target):
+    def project(self, y_target: Any) -> Any:
         """Project the target onto the frozen feedback matrix.
 
         Parameters
@@ -267,7 +269,7 @@ def extract_y_target(args: tuple, *, index: int = -1) -> Optional[jax.Array]:
 def _reset_state_in_a_dict(
     state_dict: Dict[Any, brainstate.State],
     batch_size: Optional[int],
-):
+) -> None:
     """
     Reset the values in a dictionary of states to zero.
 
@@ -293,7 +295,7 @@ def _reset_state_in_a_dict(
 def _zeros_like_batch_or_not(
     batch_size: Optional[int],
     x: jax.Array
-):
+) -> Any:
     """
     Create a zeros array with the same shape and type as the input array,
     optionally including a batch dimension.
@@ -325,7 +327,7 @@ def _batched_zeros_like(
     batch_size: Optional[int],
     num_state: int,  # the number of hidden states
     x: jax.Array  # the input array
-):
+) -> Any:
     """
     Create a batched zeros array with the same shape as the input array,
     extended by the number of hidden states.
@@ -354,7 +356,7 @@ def _batched_zeros_like(
         return u.math.zeros((batch_size, *x.shape, num_state), x.dtype)
 
 
-def _sum_dim(xs: jax.Array, axis: int = -1):
+def _sum_dim(xs: jax.Array, axis: int = -1) -> Any:
     """
     Sums the elements along the last dimension of each array in a PyTree.
 
@@ -373,7 +375,7 @@ def _sum_dim(xs: jax.Array, axis: int = -1):
     return jax.tree.map(lambda x: u.math.sum(x, axis=axis), xs)
 
 
-def _unit_safe_add(a, b):
+def _unit_safe_add(a: Any, b: Any) -> Any:
     """Add two leaves, stripping units only when one side has units and the other does not.
 
     Gradient contributions for the same weight may come from paths that
@@ -390,7 +392,7 @@ def _unit_safe_add(a, b):
     return u.math.add(a, b)
 
 
-def _extract_leaf(pytree_val: PyTree, leaf_idx: int):
+def _extract_leaf(pytree_val: PyTree, leaf_idx: int) -> Any:
     """Return the leaf at ``leaf_idx`` in ``jax.tree.leaves(pytree_val)``.
 
     Bare arrays (treedef with a single leaf) return the array unchanged.
@@ -409,7 +411,7 @@ def _extract_leaf(pytree_val: PyTree, leaf_idx: int):
 def _wrap_leaves_as_pytree(
     reference_pytree: PyTree,
     leaf_grads: Dict[int, jax.Array],
-):
+) -> Any:
     """Build a pytree matching ``reference_pytree`` with ``leaf_grads``
     inserted at the given leaf indices; any other leaf is zero-filled.
 
@@ -441,7 +443,7 @@ def _wrap_leaves_as_pytree(
 
 
 def _route_grads_by_path(
-    relation,
+    relation: Any,
     per_key_grads: Dict[str, jax.Array],
     weight_vals: Dict[Any, PyTree],
     target_dict: Dict[Any, PyTree],
@@ -478,7 +480,7 @@ def _update_dict(
     key: Any,
     value: PyTree,
     error_when_no_key: Optional[bool] = False
-):
+) -> None:
     """Update the dictionary.
 
     If the key exists, then add the value to the existing value.

--- a/braintrace/_algorithm/base.py
+++ b/braintrace/_algorithm/base.py
@@ -19,6 +19,8 @@
 
 # -*- coding: utf-8 -*-
 
+from __future__ import annotations
+
 from typing import Dict, Any, Optional
 
 import brainstate
@@ -89,7 +91,7 @@ class ETraceAlgorithm(brainstate.nn.Module):
         model: brainstate.nn.Module,
         graph_executor: ETraceGraphExecutor,
         name: Optional[str] = None,
-    ):
+    ) -> None:
         super().__init__(name=name)  # type: ignore[call-arg]  # brainstate hides Module.__init__ from type checkers
 
         # the model
@@ -210,7 +212,7 @@ class ETraceAlgorithm(brainstate.nn.Module):
         assert self._other_states is not None
         return self._other_states
 
-    def _split_state(self):
+    def _split_state(self) -> None:
         # --- the state separation --- #
         #
         # [NOTE]
@@ -228,7 +230,7 @@ class ETraceAlgorithm(brainstate.nn.Module):
             self._other_states
         ) = self.graph.module_info.retrieved_model_states.split(brainstate.ParamState, brainstate.HiddenState, ...)
 
-    def compile_graph(self, *args) -> None:
+    def compile_graph(self, *args: Any) -> None:
         r"""
         Compile the eligibility trace graph of the relationship between etrace weights, states and operators.
 
@@ -318,7 +320,7 @@ class ETraceAlgorithm(brainstate.nn.Module):
         """
         return self.graph_executor.show_graph(verbose=verbose, return_msg=return_msg)
 
-    def __call__(self, *args) -> Any:
+    def __call__(self, *args: Any) -> Any:
         """
         Update the model and the eligibility trace states.
 
@@ -334,7 +336,7 @@ class ETraceAlgorithm(brainstate.nn.Module):
         """
         return self.update(*args)
 
-    def update(self, *args) -> Any:
+    def update(self, *args: Any) -> Any:
         """
         Update the model and the eligibility trace states.
 
@@ -355,7 +357,7 @@ class ETraceAlgorithm(brainstate.nn.Module):
         """
         raise NotImplementedError
 
-    def init_etrace_state(self, *args, **kwargs) -> None:
+    def init_etrace_state(self, *args: Any, **kwargs: Any) -> None:
         """
         Initialize the eligibility trace states of the etrace algorithm.
 

--- a/braintrace/_algorithm/d_rtrl.py
+++ b/braintrace/_algorithm/d_rtrl.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 # ==============================================================================
 
+from __future__ import annotations
+
 from .param_dim_vjp import ParamDimVjpAlgorithm
 
 __all__ = [

--- a/braintrace/_algorithm/e_prop.py
+++ b/braintrace/_algorithm/e_prop.py
@@ -29,7 +29,9 @@ that make the rule biologically plausible:
 See :class:`EProp` for the mathematical formulation, references, and an example.
 """
 
-from typing import Dict, Optional
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
 
 import brainstate
 import jax
@@ -158,8 +160,8 @@ class EProp(ParamDimVjpAlgorithm):
         name: Optional[str] = None,
         vjp_method: str = 'single-step',
         fast_solve: bool = True,
-        **kwargs,
-    ):
+        **kwargs: Any,
+    ) -> None:
         if feedback not in ('symmetric', 'random'):
             raise ValueError(
                 f"feedback must be 'symmetric' or 'random'; got {feedback!r}"
@@ -181,7 +183,7 @@ class EProp(ParamDimVjpAlgorithm):
         self._kappa_filters: Dict[int, KappaFilter] = {}
         self._random_feedback: Dict[int, FixedRandomFeedback] = {}
 
-    def init_etrace_state(self, *args, **kwargs):
+    def init_etrace_state(self, *args: Any, **kwargs: Any) -> None:
         super().init_etrace_state(*args, **kwargs)
         self._kappa_filters = {}
         self._random_feedback = {}
@@ -197,6 +199,7 @@ class EProp(ParamDimVjpAlgorithm):
                     )
         if self.feedback == 'random':
             key = self._random_feedback_key
+            assert key is not None  # constructor enforces a key when feedback='random'
             for rel in self.graph.hidden_param_op_relations:
                 for group in rel.hidden_groups:
                     gid = group.index
@@ -209,17 +212,17 @@ class EProp(ParamDimVjpAlgorithm):
                         n_target=n_layer, n_layer=n_layer, key=sub, init_scale=0.1
                     )
 
-    def reset_state(self, batch_size: Optional[int] = None, **kwargs):
+    def reset_state(self, batch_size: Optional[int] = None, **kwargs: Any) -> None:
         super().reset_state(batch_size=batch_size, **kwargs)
         for flt in self._kappa_filters.values():
             flt.reset_state(batch_size=batch_size)
 
-    def _compute_learning_signal(self, dl_autodiff, args):
+    def _compute_learning_signal(self, dl_autodiff: Any, args: Any) -> Any:
         signals = list(dl_autodiff)
         if self.feedback == 'random' and self._random_feedback:
             # dl_autodiff[g].shape == (*varshape, num_state). Project over the
             # trailing n_layer axis (-2), preserving num_state on the tail.
-            def _project(B, s):
+            def _project(B: Any, s: Any) -> Any:
                 return jnp.einsum('...lj,lk->...kj', s, B)
 
             signals = [
@@ -231,7 +234,7 @@ class EProp(ParamDimVjpAlgorithm):
             # KappaFilter state carries varshape, but signal has an extra
             # trailing num_state axis. Collapse num_state for filter purposes;
             # broadcast the filtered value back.
-            def _filter(flt, s):
+            def _filter(flt: Any, s: Any) -> Any:
                 # collapse num_state tail: sum over last axis produces shape (*varshape,)
                 collapsed = s.sum(axis=-1)
                 filtered = flt.update(collapsed)

--- a/braintrace/_algorithm/graph_executor.py
+++ b/braintrace/_algorithm/graph_executor.py
@@ -35,6 +35,8 @@
 
 # -*- coding: utf-8 -*-
 
+from __future__ import annotations
+
 from typing import Dict, Any, Optional
 
 import brainstate
@@ -70,7 +72,7 @@ class ETraceGraphExecutor:
         self,
         model: brainstate.nn.Module,
         include_recurrent_mixing: bool = False,
-    ):
+    ) -> None:
         # The original model
         if not isinstance(model, brainstate.nn.Module):
             raise TypeError(
@@ -152,7 +154,7 @@ class ETraceGraphExecutor:
             self._state_id_to_path = {id(state): path for path, state in self.states.items()}
         return self._state_id_to_path
 
-    def compile_graph(self, *args) -> None:
+    def compile_graph(self, *args: Any) -> None:
         r"""
         Build the eligibility trace graph for the model based on the provided inputs.
 
@@ -217,7 +219,7 @@ class ETraceGraphExecutor:
 
     def solve_h2w_h2h_jacobian(
         self,
-        *args,
+        *args: Any,
     ) -> Any:
         r"""
         Compute the hidden-to-weight and hidden-to-hidden Jacobian matrices.
@@ -262,7 +264,7 @@ class ETraceGraphExecutor:
                                   'implemented in the subclass.')
 
     def solve_h2w_h2h_l2h_jacobian(
-        self, *args,
+        self, *args: Any,
     ) -> Any:
         r"""
         Compute the hidden-to-weight and hidden-to-hidden Jacobian matrices, along with the VJP transformed

--- a/braintrace/_algorithm/io_dim_vjp.py
+++ b/braintrace/_algorithm/io_dim_vjp.py
@@ -24,6 +24,8 @@
 
 # -*- coding: utf-8 -*-
 
+from __future__ import annotations
+
 from functools import partial
 from typing import Callable, Dict, Tuple, Optional, Sequence, Any
 
@@ -69,7 +71,7 @@ __all__ = [
 ]
 
 
-def _format_decay_and_rank(decay_or_rank) -> Tuple[float, int]:
+def _format_decay_and_rank(decay_or_rank: Any) -> Tuple[float, int]:
     """
     Determines the decay factor and the number of approximation ranks based on the input.
 
@@ -104,7 +106,7 @@ def _format_decay_and_rank(decay_or_rank) -> Tuple[float, int]:
     return decay, num_rank
 
 
-def _expon_smooth(old, new, decay):
+def _expon_smooth(old: Any, new: Any, decay: Any) -> Any:
     """
     Apply exponential smoothing to update a value.
 
@@ -129,7 +131,7 @@ def _expon_smooth(old, new, decay):
     return decay * old + (1 - decay) * new
 
 
-def _low_pass_filter(old, new, alpha):
+def _low_pass_filter(old: Any, new: Any, alpha: Any) -> Any:
     """
     Apply a low-pass filter to smooth the transition between old and new values.
 
@@ -164,7 +166,7 @@ def _init_IO_dim_state(
     etrace_xs: Dict[ETraceX_Key, brainstate.State],
     etrace_dfs: Dict[ETraceDF_Key, brainstate.State],
     relation: HiddenParamOpRelation,
-):
+) -> None:
     """
     Initialize the eligibility trace states for input-output dimensions.
 
@@ -264,7 +266,7 @@ def _update_IO_dim_etrace_scan_fn(
     ],
     hid_weight_op_relations: Sequence[HiddenParamOpRelation],
     decay: float,
-):
+) -> Any:
     """
     Update the eligibility trace values for input-output dimensions.
 
@@ -394,7 +396,7 @@ def _solve_IO_dim_weight_gradients(
     running_index: int,
     decay: float,
     fast_solve: bool = True,
-):
+) -> None:
     """
     Compute and update the weight gradients for input-output dimensions using eligibility trace data.
 
@@ -456,7 +458,7 @@ def _solve_IO_dim_weight_gradients(
         eqn_params = relation.eqn_params
         batched = is_batched_primitive(relation.primitive)
 
-        def _call(df_, w_, _rule=xy_to_dw_rule, _params=eqn_params, _x=x):
+        def _call(df_: Any, w_: Any, _rule: Any = xy_to_dw_rule, _params: Any = eqn_params, _x: Any = x) -> Any:
             return _rule(_x, df_, w_, **_params)
 
         group: HiddenGroup
@@ -625,13 +627,13 @@ class IODimVjpAlgorithm(ETraceVjpAlgorithm):
         name: Optional[str] = None,
         vjp_method: str = 'single-step',
         fast_solve: bool = True,
-        **kwargs,
-    ):
+        **kwargs: Any,
+    ) -> None:
         super().__init__(model, name=name, vjp_method=vjp_method)
         self.decay, num_rank = _format_decay_and_rank(decay_or_rank)
         self.fast_solve = fast_solve
 
-    def init_etrace_state(self, *args, **kwargs):
+    def init_etrace_state(self, *args: Any, **kwargs: Any) -> None:
         """Initialize the eligibility trace states of the etrace algorithm.
 
         This method is needed after compiling the etrace graph. See
@@ -642,11 +644,11 @@ class IODimVjpAlgorithm(ETraceVjpAlgorithm):
         #   2. df
         self.etrace_xs = dict()
         self.etrace_dfs = dict()
+        relation: HiddenParamOpRelation
         for relation in self.graph.hidden_param_op_relations:
-            relation: HiddenParamOpRelation
             _init_IO_dim_state(self.etrace_xs, self.etrace_dfs, relation)
 
-    def reset_state(self, batch_size: int = None, **kwargs):
+    def reset_state(self, batch_size: int | None = None, **kwargs: Any) -> None:
         """Reset the eligibility trace states.
 
         Parameters
@@ -738,7 +740,7 @@ class IODimVjpAlgorithm(ETraceVjpAlgorithm):
             Dict[ETraceX_Key, jax.Array],
             Dict[ETraceDF_Key, jax.Array]
         ]
-    ):
+    ) -> None:
         """Assign the eligibility trace data to the states at the current time-step.
 
         .. note::
@@ -880,7 +882,7 @@ class IODimVjpAlgorithm(ETraceVjpAlgorithm):
         weight_vals: Dict[Path, PyTree],
         dl_to_nonetws_at_t: Dict[Path, PyTree],
         dl_to_etws_at_t: Optional[Dict[Path, PyTree]],
-    ):
+    ) -> Any:
         """Compute weight gradients using eligibility trace data and loss gradients.
 
         This method implements the final stage of the eligibility trace algorithm, where

--- a/braintrace/_algorithm/ostl.py
+++ b/braintrace/_algorithm/ostl.py
@@ -34,7 +34,9 @@ Networks and Learning Systems*, 34(11), 8894-8908.
 https://doi.org/10.1109/TNNLS.2022.3153985 (arXiv:2007.12723)
 """
 
-from typing import Optional
+from __future__ import annotations
+
+from typing import Any, Optional
 
 import brainstate
 
@@ -185,6 +187,6 @@ class OSTLFeedforward(pp_prop):
         model: brainstate.nn.Module,
         decay_or_rank: float | int = 1e-6,
         name: Optional[str] = None,
-        **kwargs,
-    ):
+        **kwargs: Any,
+    ) -> None:
         super().__init__(model, decay_or_rank=decay_or_rank, name=name, **kwargs)

--- a/braintrace/_algorithm/osttp.py
+++ b/braintrace/_algorithm/osttp.py
@@ -25,12 +25,15 @@ weight-transport requirement and the backward pass, so learning is forward-only.
 See :class:`OSTTP` for the mathematical formulation, references, and an example.
 """
 
-from typing import Optional, Sequence
+from __future__ import annotations
+
+from typing import Any, Optional, Sequence
 
 import brainstate
 import jax
 import jax.numpy as jnp
 
+from braintrace._typing import ArrayLike
 from .param_dim_vjp import ParamDimVjpAlgorithm
 
 __all__ = ['OSTTP']
@@ -143,8 +146,8 @@ class OSTTP(ParamDimVjpAlgorithm):
         name: Optional[str] = None,
         vjp_method: str = 'single-step',
         fast_solve: bool = True,
-        **kwargs,
-    ):
+        **kwargs: Any,
+    ) -> None:
         if target_timing not in ('per-step', 'sequence-end'):
             raise ValueError(
                 f"target_timing must be 'per-step' or 'sequence-end'; got {target_timing!r}"
@@ -154,9 +157,9 @@ class OSTTP(ParamDimVjpAlgorithm):
         )
         self._B_list = tuple(jax.lax.stop_gradient(B) for B in B_list)
         self.target_timing = target_timing
-        self._current_y_target: Optional[jax.Array] = None
+        self._current_y_target: Optional[ArrayLike] = None
 
-    def compile_graph(self, *args) -> None:
+    def compile_graph(self, *args: Any) -> None:
         super().compile_graph(*args)
         n_groups = len(self.graph.hidden_groups)
         if len(self._B_list) != n_groups:
@@ -172,7 +175,7 @@ class OSTTP(ParamDimVjpAlgorithm):
                     f'{group.index} has n_l={n_l}.'
                 )
 
-    def update(self, x, y_target=None):
+    def update(self, x: ArrayLike, y_target: ArrayLike | None = None) -> Any:
         """Call ``super().update(x)`` after stashing ``y_target`` for the hook."""
         if self.target_timing == 'per-step' and y_target is None:
             raise ValueError(
@@ -184,7 +187,7 @@ class OSTTP(ParamDimVjpAlgorithm):
         finally:
             self._current_y_target = None
 
-    def _compute_learning_signal(self, dl_autodiff, args):
+    def _compute_learning_signal(self, dl_autodiff: Any, args: Any) -> Any:
         """Replace reverse-AD ``dL/dh`` with ``B_l @ y_target`` per HiddenGroup."""
         y_target = self._current_y_target
         if y_target is None:

--- a/braintrace/_algorithm/otpe.py
+++ b/braintrace/_algorithm/otpe.py
@@ -26,8 +26,10 @@ invariant.
 See :class:`OTPE` for the mathematical formulation, references, and an example.
 """
 
+from __future__ import annotations
+
 import warnings
-from typing import Dict, Optional
+from typing import Any, Dict, Optional
 
 import brainstate
 import jax.numpy as jnp
@@ -198,8 +200,8 @@ class OTPE(ETraceVjpAlgorithm):
         name: Optional[str] = None,
         vjp_method: str = 'single-step',
         trace_clip_abs: Optional[float] = None,
-        **kwargs,
-    ):
+        **kwargs: Any,
+    ) -> None:
         if mode not in ('full', 'approx'):
             raise ValueError(f"mode must be 'full' or 'approx'; got {mode!r}")
         if not (0.0 < float(leak) < 1.0):
@@ -212,7 +214,7 @@ class OTPE(ETraceVjpAlgorithm):
         self._R_hat_x: Dict[int, brainstate.ShortTermState] = {}
         self._R_hat_g: Dict[int, brainstate.ShortTermState] = {}
 
-    def compile_graph(self, *args) -> None:
+    def compile_graph(self, *args: Any) -> None:
         super().compile_graph(*args)
         if self.mode == 'approx':
             n_groups = len(self.graph.hidden_groups)
@@ -245,12 +247,13 @@ class OTPE(ETraceVjpAlgorithm):
                     f'are outside the regime where OTPE is derived.'
                 )
 
-    def init_etrace_state(self, *args, **kwargs):
+    def init_etrace_state(self, *args: Any, **kwargs: Any) -> None:
         self._R_hat = {}
         self._R_hat_x = {}
         self._R_hat_g = {}
         for rel in self.graph.hidden_param_op_relations:
             rid = id(rel.y_var)
+            assert rel.x_var is not None  # non-elemwise primitives always have an x_var
             in_shape = rel.x_var.aval.shape
             out_shape = rel.y_var.aval.shape
             if self.mode == 'full':
@@ -272,10 +275,10 @@ class OTPE(ETraceVjpAlgorithm):
                     jnp.zeros(out_shape, dtype=jnp.float32)
                 )
 
-    def reset_state(self, batch_size: Optional[int] = None, **kwargs):
+    def reset_state(self, batch_size: Optional[int] = None, **kwargs: Any) -> None:
         self.running_index.value = 0
 
-        def _rezero(state):
+        def _rezero(state: Any) -> None:
             shape = state.value.shape
             new_shape = (batch_size, *shape[1:]) if batch_size is not None else shape
             state.value = jnp.zeros(new_shape, dtype=state.value.dtype)
@@ -284,7 +287,7 @@ class OTPE(ETraceVjpAlgorithm):
             for r in store.values():
                 _rezero(r)
 
-    def _get_etrace_data(self):
+    def _get_etrace_data(self) -> Any:
         if self.mode == 'full':
             return {rid: r.value for rid, r in self._R_hat.items()}
         return (
@@ -292,7 +295,7 @@ class OTPE(ETraceVjpAlgorithm):
             {rid: r.value for rid, r in self._R_hat_g.items()},
         )
 
-    def _assign_etrace_data(self, vals):
+    def _assign_etrace_data(self, vals: Any) -> None:
         if self.mode == 'full':
             for rid, v in vals.items():
                 self._R_hat[rid].value = v
@@ -304,9 +307,9 @@ class OTPE(ETraceVjpAlgorithm):
                 self._R_hat_g[rid].value = v
 
     def _update_etrace_data(
-        self, running_index, hist_vals,
-        hid2weight_jac, hid2hid_jac, weight_vals, input_is_multi_step,
-    ):
+        self, running_index: Any, hist_vals: Any,
+        hid2weight_jac: Any, hid2hid_jac: Any, weight_vals: Any, input_is_multi_step: Any,
+    ) -> Any:
         """``R_hat ← λ·R_hat + ∂s/∂θ_local``. Ignores ``hid2hid_jac``."""
         if input_is_multi_step:
             raise NotImplementedError('OTPE v1 supports single-step only')
@@ -346,9 +349,9 @@ class OTPE(ETraceVjpAlgorithm):
             return (new_Rx, new_Rg)
 
     def _solve_weight_gradients(
-        self, running_index, etrace_at_t, dl_to_hidden_groups,
-        weight_vals, dl_to_nonetws_at_t, dl_to_etws_at_t,
-    ):
+        self, running_index: Any, etrace_at_t: Any, dl_to_hidden_groups: Any,
+        weight_vals: Any, dl_to_nonetws_at_t: Any, dl_to_etws_at_t: Any,
+    ) -> Any:
         dG = {path: None for path in self.param_states}
         if self.mode == 'full':
             for rel in self.graph.hidden_param_op_relations:

--- a/braintrace/_algorithm/ottt.py
+++ b/braintrace/_algorithm/ottt.py
@@ -25,7 +25,9 @@ This yields constant training memory, independent of the number of time steps.
 See :class:`OTTT` for the mathematical formulation, references, and an example.
 """
 
-from typing import Dict, Optional
+from __future__ import annotations
+
+from typing import Any, Dict, Optional
 
 import brainstate
 import jax.numpy as jnp
@@ -163,8 +165,8 @@ class OTTT(ETraceVjpAlgorithm):
         leak: float,
         name: Optional[str] = None,
         vjp_method: str = 'single-step',
-        **kwargs,
-    ):
+        **kwargs: Any,
+    ) -> None:
         if mode not in ('A', 'O'):
             raise ValueError(f"mode must be 'A' or 'O'; got {mode!r}")
         if not (0.0 < float(leak) < 1.0):
@@ -174,7 +176,7 @@ class OTTT(ETraceVjpAlgorithm):
         self.leak = float(leak)
         self._pre_traces: Dict[int, PresynapticTrace] = {}
 
-    def init_etrace_state(self, *args, **kwargs):
+    def init_etrace_state(self, *args: Any, **kwargs: Any) -> None:
         self._pre_traces = {}
         for rel in self.graph.hidden_param_op_relations:
             for group in rel.hidden_groups:
@@ -191,28 +193,29 @@ class OTTT(ETraceVjpAlgorithm):
             rid = id(rel.x_var)
             if rid in self._pre_traces:
                 continue
+            assert rel.x_var is not None  # non-elemwise primitives always have an x_var
             shape = rel.x_var.aval.shape
             dtype = rel.x_var.aval.dtype
             self._pre_traces[rid] = PresynapticTrace(
                 jnp.zeros(shape, dtype=dtype), leak=self.leak
             )
 
-    def reset_state(self, batch_size: Optional[int] = None, **kwargs):
+    def reset_state(self, batch_size: Optional[int] = None, **kwargs: Any) -> None:
         self.running_index.value = 0
         for t in self._pre_traces.values():
             t.reset_state(batch_size=batch_size)
 
-    def _get_etrace_data(self):
+    def _get_etrace_data(self) -> Any:
         return {rid: t.value for rid, t in self._pre_traces.items()}
 
-    def _assign_etrace_data(self, vals):
+    def _assign_etrace_data(self, vals: Any) -> None:
         for rid, v in vals.items():
             self._pre_traces[rid].value = v
 
     def _update_etrace_data(
-        self, running_index, hist_vals,
-        hid2weight_jac, hid2hid_jac, weight_vals, input_is_multi_step,
-    ):
+        self, running_index: Any, hist_vals: Any,
+        hid2weight_jac: Any, hid2hid_jac: Any, weight_vals: Any, input_is_multi_step: Any,
+    ) -> Any:
         """``â ← λ·â + x_t`` (mode='A') or ``â := x_t`` (mode='O').
 
         Ignores ``hid2hid_jac`` — OTTT's core approximation.
@@ -231,9 +234,9 @@ class OTTT(ETraceVjpAlgorithm):
         return new_vals
 
     def _solve_weight_gradients(
-        self, running_index, etrace_at_t, dl_to_hidden_groups,
-        weight_vals, dl_to_nonetws_at_t, dl_to_etws_at_t,
-    ):
+        self, running_index: Any, etrace_at_t: Any, dl_to_hidden_groups: Any,
+        weight_vals: Any, dl_to_nonetws_at_t: Any, dl_to_etws_at_t: Any,
+    ) -> Any:
         """``ΔW = outer(â, L)`` where ``L`` is the (already σ'-propagated) signal."""
         dG = {path: None for path in self.param_states}
         for rel in self.graph.hidden_param_op_relations:

--- a/braintrace/_algorithm/param_dim_vjp.py
+++ b/braintrace/_algorithm/param_dim_vjp.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 # ==============================================================================
 
+from __future__ import annotations
+
 from functools import partial
 from typing import Callable, Dict, Tuple, Optional, Sequence, Any
 
@@ -66,7 +68,7 @@ __all__ = [
 _ELEMENTWISE_YW_PRIMITIVES = (etp_mm_p, etp_mv_p, etp_elemwise_p)
 
 
-def _cast_to_dtype(tree, dtype):
+def _cast_to_dtype(tree: Any, dtype: Any) -> Any:
     """Cast every array leaf of ``tree`` to ``dtype`` (unit-safe; ``None`` -> no-op).
 
     Used to store the eligibility trace — and the inputs to its update — at a
@@ -83,7 +85,7 @@ def _init_param_dim_state(
     etrace_bwg: Dict[ETraceWG_Key, brainstate.State],
     relation: HiddenParamOpRelation,
     trace_dtype: Optional[DTypeLike] = None,
-):
+) -> None:
     """
     Initialize the eligibility trace states for parameter dimensions.
 
@@ -120,7 +122,7 @@ def _init_param_dim_state(
         etrace_bwg[bwg_key] = EligibilityTrace(init_val)
 
 
-def _fast_recurrent_term(primitive, diag, old_bwg, num_state):
+def _fast_recurrent_term(primitive: Any, diag: Any, old_bwg: Any, num_state: Any) -> Any:
     """Closed-form ``D^t * eps^{t-1}`` for primitives with an elementwise
     ``yw_to_w`` rule.
 
@@ -165,7 +167,7 @@ def _fast_recurrent_term(primitive, diag, old_bwg, num_state):
     return out
 
 
-def _fast_instant_term(primitive, x, df, has_bias):
+def _fast_instant_term(primitive: Any, x: Any, df: Any, has_bias: Any) -> Any:
     """Closed-form ``diag(D_f^t) ⊗ x^t`` for mm/mv/elemwise primitives.
 
     For mm/mv the instantaneous gradient of ``y = x @ W + b`` w.r.t. ``W``
@@ -191,10 +193,10 @@ def _update_param_dim_etrace_scan_fn(
         Sequence[jax.Array],  # the hidden group Jacobians
     ],
     weight_path_to_vals: Dict[Path, PyTree],
-    hidden_param_op_relations,
+    hidden_param_op_relations: Any,
     fast_solve: bool = True,
     trace_dtype: Optional[DTypeLike] = None,
-):
+) -> Any:
     """
     Update the eligibility trace values for parameter dimensions.
 
@@ -276,20 +278,20 @@ def _update_param_dim_etrace_scan_fn(
         else:
             x = etrace_xs_at_t[id(relation.x_var)]
 
-        def _call_xy_to_dw_dict(x_, df_, weights_, _rule=xy_to_dw_rule, _params=eqn_params):
+        def _call_xy_to_dw_dict(x_: Any, df_: Any, weights_: Any, _rule: Any = xy_to_dw_rule, _params: Any = eqn_params) -> Any:
             return _rule(x_, df_, weights_, **_params)
 
-        def _call_yw_to_w_dict(d, trace_, _rule=yw_to_w_rule, _params=eqn_params):
+        def _call_yw_to_w_dict(d: Any, trace_: Any, _rule: Any = yw_to_w_rule, _params: Any = eqn_params) -> Any:
             return _rule(d, trace_, **_params)
 
-        def comp_dw_with_x(x_, df_, _wdict=weights_dict):
+        def comp_dw_with_x(x_: Any, df_: Any, _wdict: Any = weights_dict) -> Any:
             return _call_xy_to_dw_dict(x_, df_, _wdict)
 
-        def _comp_instant_legacy(df_all):
+        def _comp_instant_legacy(df_all: Any) -> Any:
             """Legacy nested-vmap path: vmap xy_to_dw over num_state (and batch)."""
 
             @partial(jax.vmap, in_axes=-1, out_axes=-1)
-            def _inner(df_slice):
+            def _inner(df_slice: Any) -> Any:
                 if batched:
                     df_b = df_slice
                     # Under ``brainstate.nn.Vmap(vmap_states='new')`` the hidden-
@@ -305,7 +307,7 @@ def _update_param_dim_etrace_scan_fn(
 
             return _inner(df_all)
 
-        def _comp_recurrent_legacy(diag_, old_bwg_, num_state_):
+        def _comp_recurrent_legacy(diag_: Any, old_bwg_: Any, num_state_: Any) -> Any:
             """Legacy nested-vmap yw_to_w + sum path."""
 
             # Under ``brainstate.nn.Vmap(vmap_states='new')`` the hidden-state
@@ -318,7 +320,7 @@ def _update_param_dim_etrace_scan_fn(
             if batched and x is not None and diag_.ndim == x.ndim + 1:
                 diag_ = diag_[None]
 
-            def fn_bwg_pre(d, _old=old_bwg_):
+            def fn_bwg_pre(d: Any, _old: Any = old_bwg_) -> Any:
                 return jax.tree.map(
                     lambda arr: _sum_dim(arr, axis=-1),
                     jax.vmap(_call_yw_to_w_dict, in_axes=-1, out_axes=-1)(d, _old),
@@ -376,7 +378,7 @@ def _update_param_dim_etrace_scan_fn(
     return new_etrace_bwg, None
 
 
-def _fast_solve_contract(primitive, diag_like, etrace_data, fold_batch=False):
+def _fast_solve_contract(primitive: Any, diag_like: Any, etrace_data: Any, fold_batch: Any = False) -> Any:
     """Solve-time closed-form contraction for mm/mv/elemwise.
 
     ``diag_like`` is the dl/dh group gradient with shape ``(*y_shape, num_state)``;
@@ -412,7 +414,7 @@ def _solve_param_dim_weight_gradients(
     weight_hidden_relations: Sequence[HiddenParamOpRelation],
     weight_vals: Dict[Path, PyTree],  # current ParamState pytree values for structure
     fast_solve: bool = True,
-):
+) -> None:
     """
     Compute and update the weight gradients for parameter dimensions using eligibility trace data.
 
@@ -454,7 +456,7 @@ def _solve_param_dim_weight_gradients(
             batched_paths.update(relation.trainable_paths.values())
         use_fast = fast_solve and (relation.primitive in _ELEMENTWISE_YW_PRIMITIVES)
 
-        def _call_yw_to_w_dict(d, trace_, _rule=yw_to_w_rule, _params=eqn_params):
+        def _call_yw_to_w_dict(d: Any, trace_: Any, _rule: Any = yw_to_w_rule, _params: Any = eqn_params) -> Any:
             return _rule(d, trace_, **_params)
 
         yw_to_w = (
@@ -568,7 +570,7 @@ def _solve_param_dim_weight_gradients(
         _update_dict(dG_weights, key, val)
 
 
-def _remove_units(xs_maybe_quantity: PyTree):
+def _remove_units(xs_maybe_quantity: PyTree) -> Any:
     """
     Removes units from a PyTree of quantities, returning a unitless PyTree and a function to restore the units.
 
@@ -591,7 +593,7 @@ def _remove_units(xs_maybe_quantity: PyTree):
         new_leaves.append(leaf)
         units.append(unit)
 
-    def restore_units(xs_unitless: PyTree):
+    def restore_units(xs_unitless: PyTree) -> Any:
         leaves, treedef2 = jax.tree.flatten(xs_unitless)
         # jax's PyTreeDef stubs omit __eq__; the comparison is valid at runtime.
         assert treedef == treedef2, 'The tree structure should be the same. '  # type: ignore[operator]
@@ -713,8 +715,8 @@ class ParamDimVjpAlgorithm(ETraceVjpAlgorithm):
         vjp_method: str = 'single-step',
         fast_solve: bool = True,
         trace_dtype: Optional[DTypeLike] = None,
-        **kwargs,
-    ):
+        **kwargs: Any,
+    ) -> None:
         super().__init__(model, name=name, vjp_method=vjp_method)
         # ``fast_solve=True`` enables closed-form einsum kernels for
         # mm/mv/elemwise primitives, replacing the nested-vmap legacy path.
@@ -725,7 +727,7 @@ class ParamDimVjpAlgorithm(ETraceVjpAlgorithm):
         # the mm/mv/elemwise fast path honors it.
         self.trace_dtype = trace_dtype
 
-    def init_etrace_state(self, *args, **kwargs):
+    def init_etrace_state(self, *args: Any, **kwargs: Any) -> None:
         """Initialize the eligibility trace states of the etrace algorithm.
 
         This method is needed after compiling the etrace graph. See
@@ -736,7 +738,7 @@ class ParamDimVjpAlgorithm(ETraceVjpAlgorithm):
         for relation in self.graph.hidden_param_op_relations:
             _init_param_dim_state(self.etrace_bwg, relation, self.trace_dtype)
 
-    def reset_state(self, batch_size: int = None, **kwargs):
+    def reset_state(self, batch_size: int | None = None, **kwargs: Any) -> None:
         """Reset the eligibility trace states.
 
         Parameters
@@ -930,7 +932,7 @@ class ParamDimVjpAlgorithm(ETraceVjpAlgorithm):
         weight_vals: Dict[Path, PyTree],
         dl_to_nonetws_at_t: Dict[Path, PyTree],
         dl_to_etws_at_t: Optional[Dict[Path, PyTree]],
-    ):
+    ) -> Any:
         """Compute weight gradients using parameter dimension eligibility traces.
 
         This method implements the parameter dimension D-RTRL algorithm's weight gradient

--- a/braintrace/_algorithm/pp_prop.py
+++ b/braintrace/_algorithm/pp_prop.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 # ==============================================================================
 
+from __future__ import annotations
+
 from .io_dim_vjp import IODimVjpAlgorithm
 
 __all__ = [

--- a/braintrace/_algorithm/vjp_base.py
+++ b/braintrace/_algorithm/vjp_base.py
@@ -14,6 +14,8 @@
 # ==============================================================================
 
 
+from __future__ import annotations
+
 from typing import Callable, Dict, Tuple, Any, List, Optional, Sequence
 
 import brainstate
@@ -140,11 +142,11 @@ class ETraceVjpAlgorithm(ETraceAlgorithm):
             bwd=self._update_fn_bwd
         )
 
-    def _assert_compiled(self):
+    def _assert_compiled(self) -> None:
         if not self.is_compiled:
             raise ValueError('The etrace algorithm has not been compiled. Please call `compile_graph()` first. ')
 
-    def update(self, *args) -> Any:
+    def update(self, *args: Any) -> Any:
         r"""
         Update the model states and the eligibility trace.
 
@@ -302,12 +304,12 @@ class ETraceVjpAlgorithm(ETraceAlgorithm):
 
     def _update_fn(
         self,
-        args,
+        args: Any,
         weight_vals: WeightVals,
         hidden_vals: HiddenVals,
         oth_state_vals: StateVals,
         etrace_vals: ETraceVals,
-        running_index,
+        running_index: Any,
     ) -> Tuple[Outputs, HiddenVals, StateVals, ETraceVals]:
         """
         The main function to update the [model] and the [eligibility trace] states.
@@ -378,7 +380,7 @@ class ETraceVjpAlgorithm(ETraceAlgorithm):
 
     def _update_fn_fwd(
         self,
-        args,
+        args: Any,
         weight_vals: WeightVals,
         hidden_vals: HiddenVals,
         othstate_vals: StateVals,
@@ -477,8 +479,8 @@ class ETraceVjpAlgorithm(ETraceAlgorithm):
 
     def _update_fn_bwd(
         self,
-        fwd_res,
-        grads,
+        fwd_res: Any,
+        grads: Any,
     ) -> Tuple[dG_Inputs, dG_Weight, dG_Hidden, dG_State, None, None]:
         """
         The backward function to compute the VJP gradients when the learning signal is arrived at
@@ -666,7 +668,7 @@ class ETraceVjpAlgorithm(ETraceAlgorithm):
         weight_vals: Any,
         dl_to_nonetws_at_t: Dict[Path, PyTree],
         dl_to_etws_at_t: Optional[Dict[Path, PyTree]],
-    ):
+    ) -> Any:
         r"""
         The method to solve the weight gradients, i.e., :math:`\partial L / \partial W`.
 

--- a/braintrace/_algorithm/vjp_graph_executor.py
+++ b/braintrace/_algorithm/vjp_graph_executor.py
@@ -37,6 +37,8 @@
 
 # -*- coding: utf-8 -*-
 
+from __future__ import annotations
+
 from typing import Any, Callable, Dict, Optional, Tuple
 
 import brainstate
@@ -104,24 +106,24 @@ class VjpResiduals:
 
     def __init__(
         self,
-        jaxpr,
-        in_tree,
-        out_tree,
-        consts
-    ):
+        jaxpr: Any,
+        in_tree: Any,
+        out_tree: Any,
+        consts: Any,
+    ) -> None:
         self.jaxpr = jaxpr
         self.in_tree = in_tree
         self.out_tree = out_tree
         self.consts = consts
 
-    def __iter__(self):
+    def __iter__(self) -> Any:
         return iter((self.jaxpr, self.in_tree, self.out_tree, self.consts))
 
-    def tree_flatten(self):
+    def tree_flatten(self) -> tuple[Any, Any]:
         return self.consts, (self.jaxpr, self.in_tree, self.out_tree)
 
     @classmethod
-    def tree_unflatten(cls, aux, consts):
+    def tree_unflatten(cls, aux: Any, consts: Any) -> Any:
         jaxpr, in_tree, out_tree = aux
         return cls(jaxpr, in_tree, out_tree, consts)
 
@@ -193,7 +195,7 @@ class ETraceVjpGraphExecutor(ETraceGraphExecutor):
         """
         return self.vjp_method == 'multi-step'
 
-    def compile_graph(self, *args) -> None:
+    def compile_graph(self, *args: Any) -> None:
         r"""
         Building the eligibility trace graph for the model according to the given inputs.
 
@@ -270,7 +272,7 @@ class ETraceVjpGraphExecutor(ETraceGraphExecutor):
             # ``rsqrt(var+eps)`` factor amplify into an overflow. Build norm layers
             # feeding an etrace op with ``use_fast_variance=False``.
             #
-            def _y_to_hidden(y_val, _rel=relation):
+            def _y_to_hidden(y_val: Any, _rel: Any = relation) -> Any:
                 return _rel.y_to_hidden_groups(
                     y_val, intermediate_values, concat_hidden_vals=True,
                 )
@@ -315,7 +317,7 @@ class ETraceVjpGraphExecutor(ETraceGraphExecutor):
 
     def solve_h2w_h2h_jacobian(
         self,
-        *args,
+        *args: Any,
         etrace_stepper: Optional[Callable] = None,
         init_etrace: Any = None,
     ) -> Tuple[
@@ -391,7 +393,7 @@ class ETraceVjpGraphExecutor(ETraceGraphExecutor):
 
         # --- call the model --- #
 
-        def scan_fn(carray, single_step_of_multistep_arg):
+        def scan_fn(carray: Any, single_step_of_multistep_arg: Any) -> Any:
             args_ = merge_data(tree_def, single_step_of_multistep_arg, args_single_step)
 
             _etrace_state_vals, _oth_state_vals, _etrace_carry = carray
@@ -476,7 +478,7 @@ class ETraceVjpGraphExecutor(ETraceGraphExecutor):
 
     def solve_h2w_h2h_l2h_jacobian(
         self,
-        *args,
+        *args: Any,
         etrace_stepper: Optional[Callable] = None,
         init_etrace: Any = None,
     ) -> Tuple[
@@ -576,13 +578,13 @@ class ETraceVjpGraphExecutor(ETraceGraphExecutor):
         other_state_vals = {path: st.value for path, st in other_states.items()}
 
         def fun_for_vjp(
-            inputs,  # functional inputs, original inputs
-            etrace_hidden_vals_,  # etrace hidden states
-            non_etrace_param_vals_,  # non-etrace weights
-            etrace_param_vals_,  # etrace weights
-            oth_state_vals_,  # other states
-            perturb_vals_  # hidden perturbations, useful when computing \partial L / \partial h
-        ):
+            inputs: Any,  # functional inputs, original inputs
+            etrace_hidden_vals_: Any,  # etrace hidden states
+            non_etrace_param_vals_: Any,  # non-etrace weights
+            etrace_param_vals_: Any,  # etrace weights
+            oth_state_vals_: Any,  # other states
+            perturb_vals_: Any  # hidden perturbations, useful when computing \partial L / \partial h
+        ) -> Any:
             # assign state values
             if len(etrace_param_vals_) > 0:
                 assign_dict_state_values(etrace_param_states, etrace_param_vals_, write=False)
@@ -635,12 +637,12 @@ class ETraceVjpGraphExecutor(ETraceGraphExecutor):
 
         def scan_over_multiple_steps(
             inputs_single_or_multi: Dict,  # the inputs for single/multiple time steps
-            hidden_vals_ss,  # the initial hidden states
-            non_etrace_weight_vals_ss,  # the non-etrace weights
-            etrace_weight_vals_ss,  # the etrace weights
-            other_vals_ss,  # the initial other states
-            hidden_perturbs_ss  # the hidden perturbations, only used when is_single_step_vjp is True
-        ):
+            hidden_vals_ss: Any,  # the initial hidden states
+            non_etrace_weight_vals_ss: Any,  # the non-etrace weights
+            etrace_weight_vals_ss: Any,  # the etrace weights
+            other_vals_ss: Any,  # the initial other states
+            hidden_perturbs_ss: Any  # the hidden perturbations, only used when is_single_step_vjp is True
+        ) -> Any:
 
             # processing the inputs information
             args_single_step, args_multi_steps, tree_def = split_input_data_types(*inputs_single_or_multi)
@@ -652,7 +654,7 @@ class ETraceVjpGraphExecutor(ETraceGraphExecutor):
                 raise ValueError(f'The sequence size should be the same for all inputs. But we got {args_dim}.')
 
             # scan function
-            def scan_fn(carray, x_ss: Dict):
+            def scan_fn(carray: Any, x_ss: Dict) -> Any:
                 args_ss = merge_data(tree_def, x_ss, args_single_step)
 
                 hidden_vals_iter, other_vals_iter, etrace_carry_iter = carray
@@ -713,12 +715,12 @@ class ETraceVjpGraphExecutor(ETraceGraphExecutor):
 
         def call_over_single_step(
             inputs_single_or_multi: Dict,  # the inputs for single/multiple time steps
-            hidden_vals_ss,  # the initial hidden states
-            non_etrace_weight_vals_ss,  # the non-etrace weights
-            etrace_weight_vals_ss,  # the etrace weights
-            other_vals_ss,  # the initial other states
-            hidden_perturbs_ss  # the hidden perturbations, only used when is_single_step_vjp is True
-        ):
+            hidden_vals_ss: Any,  # the initial hidden states
+            non_etrace_weight_vals_ss: Any,  # the non-etrace weights
+            etrace_weight_vals_ss: Any,  # the etrace weights
+            other_vals_ss: Any,  # the initial other states
+            hidden_perturbs_ss: Any  # the hidden perturbations, only used when is_single_step_vjp is True
+        ) -> Any:
             (
                 out,
                 hidden_vals_iter,

--- a/braintrace/_compile.py
+++ b/braintrace/_compile.py
@@ -13,7 +13,9 @@
 # limitations under the License.
 # ==============================================================================
 
-from typing import Type, Union
+from __future__ import annotations
+
+from typing import Any, Type, Union
 
 import jax
 import brainstate
@@ -99,15 +101,15 @@ def _resolve_algorithm(
 
 
 def compile(
-    model,
-    algorithm,
-    *example_inputs,
-    batch_size=None,
-    seed=None,
-    verbose=0,
-    vmap=False,
-    **options,
-):
+    model: brainstate.nn.Module,
+    algorithm: Union[str, Type[ETraceAlgorithm]],
+    *example_inputs: Any,
+    batch_size: int | None = None,
+    seed: int | None = None,
+    verbose: int = 0,
+    vmap: bool = False,
+    **options: Any,
+) -> ETraceAlgorithm | brainstate.nn.Vmap:
     """Define an eligibility-trace online-learning model in one call.
 
     This is the unified entry point. It initializes the model's states, builds
@@ -259,7 +261,7 @@ def compile(
         unbatched = jax.tree.map(lambda a: a[0], example_inputs)
 
         @brainstate.transform.vmap_new_states(state_tag='new', axis_size=batch_size)
-        def _init():
+        def _init() -> None:
             brainstate.nn.init_all_states(model)
             learner.compile_graph(*unbatched)
 
@@ -268,7 +270,7 @@ def compile(
                 _init()
         else:
             _init()
-        result = brainstate.nn.Vmap(learner, vmap_states='new')
+        result: ETraceAlgorithm | brainstate.nn.Vmap = brainstate.nn.Vmap(learner, vmap_states='new')
     else:
         # --- state initialization (always) --- #
         if seed is not None:

--- a/braintrace/_grad_exponential.py
+++ b/braintrace/_grad_exponential.py
@@ -14,6 +14,8 @@
 # ==============================================================================
 
 
+from __future__ import annotations
+
 import brainstate
 import jax.tree
 import brainunit as u
@@ -73,7 +75,7 @@ class GradExpon(brainstate.nn.Module):
         self,
         grad_shape: PyTree,
         tau_or_decay: u.Quantity | float,
-    ):
+    ) -> None:
         super().__init__()
 
         # gradients (stored as LongTermState for proper JAX transform tracking)
@@ -92,7 +94,7 @@ class GradExpon(brainstate.nn.Module):
             raise TypeError(f"tau_or_decay must be a Quantity or a float, but got {tau_or_decay}")
         self.decay = decay
 
-    def update(self, grads: PyTree):
+    def update(self, grads: PyTree) -> None:
         r"""Update the accumulated gradients with the exponential decay rule.
 
         Applies :math:`g_{t+1} = \mathrm{decay} \cdot g_t + \mathrm{grads}`,

--- a/braintrace/_input_data.py
+++ b/braintrace/_input_data.py
@@ -14,6 +14,8 @@
 # ==============================================================================
 
 
+from __future__ import annotations
+
 from typing import Any
 
 import jax
@@ -28,7 +30,7 @@ __all__ = [
 class ETraceInputData:
     __module__ = 'braintrace'
 
-    def __init__(self, data: Any):
+    def __init__(self, data: Any) -> None:
         """
         Initializes an instance of ETraceInputData.
 
@@ -37,7 +39,7 @@ class ETraceInputData:
         """
         self.data = data
 
-    def tree_flatten(self):
+    def tree_flatten(self) -> tuple[tuple[Any], tuple[()]]:
         """
         Flattens the data for processing with JAX's tree utilities.
 
@@ -47,7 +49,7 @@ class ETraceInputData:
         return (self.data,), ()
 
     @classmethod
-    def tree_unflatten(cls, aux, data):
+    def tree_unflatten(cls, aux: Any, data: Any) -> ETraceInputData:
         """
         Reconstructs an instance of ETraceInputData from flattened data.
 
@@ -125,11 +127,11 @@ class MultiStepData(ETraceInputData):
     __module__ = 'braintrace'
 
 
-def is_input(x):
+def is_input(x: Any) -> bool:
     return isinstance(x, (SingleStepData, MultiStepData))
 
 
-def split_input_data_types(*args) -> tuple[dict[int, SingleStepData], dict[int, MultiStepData], dict]:
+def split_input_data_types(*args: Any) -> tuple[dict[int, SingleStepData], dict[int, MultiStepData], dict]:
     """
     Splits input data into dictionaries based on their type, distinguishing between
     SingleStepData and MultiStepData instances.
@@ -158,7 +160,7 @@ def split_input_data_types(*args) -> tuple[dict[int, SingleStepData], dict[int, 
     return data_at_single_step, data_at_multi_step, tree_def
 
 
-def merge_data(tree_def, *args):
+def merge_data(tree_def: Any, *args: dict[int, Any]) -> Any:
     """
     Merges multiple dictionaries of data into a single structure based on a JAX tree definition.
 
@@ -181,7 +183,7 @@ def merge_data(tree_def, *args):
     return jax.tree.unflatten(tree_def, tuple(data[i] for i in range(len(data))))
 
 
-def get_single_step_data(*args):
+def get_single_step_data(*args: Any) -> Any:
     """
     Extracts and returns data corresponding to a single time step from the provided input data.
 
@@ -209,7 +211,7 @@ def get_single_step_data(*args):
     return args
 
 
-def has_multistep_data(*args):
+def has_multistep_data(*args: Any) -> bool:
     """
     Determines if any of the provided input data contains MultiStepData instances.
 

--- a/braintrace/_misc.py
+++ b/braintrace/_misc.py
@@ -14,6 +14,8 @@
 # ==============================================================================
 
 
+from __future__ import annotations
+
 import warnings
 from enum import Enum
 from typing import Sequence, Callable, Any
@@ -31,7 +33,7 @@ __all__ = [
 ]
 
 
-def _remove_quantity(tree):
+def _remove_quantity(tree: Any) -> Any:
     """
     Remove the quantity from the tree.
 
@@ -42,7 +44,7 @@ def _remove_quantity(tree):
       The tree without the quantity.
     """
 
-    def fn(x):
+    def fn(x: Any) -> Any:
         if isinstance(x, u.Quantity):
             return x.magnitude
         return x
@@ -53,7 +55,7 @@ def _remove_quantity(tree):
 def check_dict_keys(
     d1: dict,
     d2: dict,
-):
+) -> None:
     """
     Check the keys of two dictionaries.
 
@@ -150,14 +152,14 @@ def unknown_state_path(i: int) -> Path:
     return (f'_unknown_path_{i}',)
 
 
-def _dimensionless(x):
+def _dimensionless(x: Any) -> Any:
     if isinstance(x, u.Quantity):
         return x.mantissa
     else:
         return x
 
 
-def remove_units(xs):
+def remove_units(xs: Any) -> Any:
     """
     Remove units from a tree structure of quantities.
 
@@ -185,7 +187,7 @@ def remove_units(xs):
 git_issue_addr = 'https://github.com/chaobrain/braintrace/issues'
 
 
-def deprecation_getattr(module, deprecations):
+def deprecation_getattr(module: str, deprecations: dict) -> Callable[..., Any]:
     """
     Create a custom getattr function to handle deprecated attributes.
 
@@ -208,7 +210,7 @@ def deprecation_getattr(module, deprecations):
         A custom getattr function that handles deprecated attributes.
     """
 
-    def getattr(name):
+    def getattr(name: str) -> Any:
         if name in deprecations:
             message, fn = deprecations[name]
             if fn is None:  # Is the deprecation accelerated?
@@ -240,7 +242,7 @@ class CompilationError(Exception):
     __module__ = 'braintrace'
 
 
-def state_traceback(states: Sequence[brainstate.State]):
+def state_traceback(states: Sequence[brainstate.State]) -> str:
     """
     Generate a traceback string for a sequence of brain model states.
 
@@ -272,7 +274,7 @@ def state_traceback(states: Sequence[brainstate.State]):
     return '\n'.join(state_info)
 
 
-def set_module_as(module: str = 'braintrace'):
+def set_module_as(module: str = 'braintrace') -> Callable[..., Any]:
     """
     Decorator to set the module attribute of a function.
 
@@ -308,7 +310,7 @@ class BaseEnum(Enum):
     """
 
     @classmethod
-    def get_by_name(cls, name: str):
+    def get_by_name(cls, name: str) -> BaseEnum:
         """
         Retrieve an enumeration member by its name.
 
@@ -338,7 +340,7 @@ class BaseEnum(Enum):
         raise ValueError(f'Cannot find the {cls.__name__} type {name}. Only support {all_names}.')
 
     @classmethod
-    def get(cls, item: str | Enum):
+    def get(cls, item: str | Enum) -> BaseEnum:
         """
         Retrieve an enumeration member by its name or directly if it is an Enum.
 

--- a/braintrace/_op/__init__.py
+++ b/braintrace/_op/__init__.py
@@ -30,6 +30,8 @@ The public surface mirrors the legacy module: every name previously
 exported from ``braintrace._op`` is also available here.
 """
 
+from __future__ import annotations
+
 from ._primitive import ETPPrimitive, register_primitive
 from ._registries import (
     BATCHED_PRIMITIVES,

--- a/braintrace/_op/_primitive.py
+++ b/braintrace/_op/_primitive.py
@@ -22,8 +22,10 @@ MLIR lowering, JVP, transpose, batching — are auto-derived from a single
 implementation function via :func:`register_primitive`.
 """
 
+from __future__ import annotations
+
 from functools import partial
-from typing import Callable
+from typing import Any, Callable
 
 import jax
 import jax.numpy as jnp
@@ -78,7 +80,7 @@ class ETPPrimitive(Primitive):
         (2, 4)
     """
 
-    def register_yw_to_w(self, fn: Callable):
+    def register_yw_to_w(self, fn: Callable[..., Any]) -> None:
         """Install a D-RTRL trace propagation rule.
 
         Parameters
@@ -88,7 +90,7 @@ class ETPPrimitive(Primitive):
         """
         ETP_RULES_YW_TO_W[self] = fn
 
-    def register_xy_to_dw(self, fn: Callable):
+    def register_xy_to_dw(self, fn: Callable[..., Any]) -> None:
         """Install a weight-gradient rule.
 
         Parameters
@@ -98,7 +100,7 @@ class ETPPrimitive(Primitive):
         """
         ETP_RULES_XY_TO_DW[self] = fn
 
-    def register_init_drtrl(self, fn: Callable):
+    def register_init_drtrl(self, fn: Callable[..., Any]) -> None:
         """Install a D-RTRL trace initialiser.
 
         Parameters
@@ -109,7 +111,7 @@ class ETPPrimitive(Primitive):
         """
         ETP_RULES_INIT_DRTRL[self] = fn
 
-    def register_init_pp(self, fn: Callable):
+    def register_init_pp(self, fn: Callable[..., Any]) -> None:
         """Install a pp_prop (IO-dim) df trace initialiser.
 
         Parameters
@@ -123,11 +125,11 @@ class ETPPrimitive(Primitive):
     def register_etp_rules(
         self,
         *,
-        yw_to_w: Callable = None,
-        xy_to_dw: Callable = None,
-        init_drtrl: Callable = None,
-        init_pp: Callable = None,
-    ):
+        yw_to_w: Callable[..., Any] | None = None,
+        xy_to_dw: Callable[..., Any] | None = None,
+        init_drtrl: Callable[..., Any] | None = None,
+        init_pp: Callable[..., Any] | None = None,
+    ) -> None:
         """Install multiple ETP rules in one call.
 
         Any argument left as ``None`` is skipped.
@@ -154,15 +156,15 @@ class ETPPrimitive(Primitive):
 
 
 def register_primitive(
-    name,
-    impl_fn,
+    name: str,
+    impl_fn: Callable[..., Any],
     *,
-    batched=False,
-    gradient_enabled=False,
-    trainable_invars_fn=None,
-    x_invar_index=0,
-    y_outvar_index=0,
-):
+    batched: bool = False,
+    gradient_enabled: bool = False,
+    trainable_invars_fn: Callable[..., dict[str, int]] | None = None,
+    x_invar_index: int | None = 0,
+    y_outvar_index: int = 0,
+) -> ETPPrimitive:
     """Create an :class:`ETPPrimitive` with all JAX rules auto-derived.
 
     Only the four ETP-specific rules need hand-writing — call the returned
@@ -224,7 +226,7 @@ def register_primitive(
     p.def_impl(impl_fn)
 
     @p.def_abstract_eval
-    def _abstract(*args, **params):
+    def _abstract(*args: Any, **params: Any) -> Any:
         shapes = tuple(ShapedArray(a.shape, a.dtype) for a in args)
         out = jax.eval_shape(partial(impl_fn, **params), *shapes)
         return ShapedArray(out.shape, out.dtype)
@@ -233,7 +235,7 @@ def register_primitive(
         p, mlir.lower_fun(impl_fn, multiple_results=False),
     )
 
-    def _jvp(primals, tangents, **params):
+    def _jvp(primals: Any, tangents: Any, **params: Any) -> Any:
         tans = tuple(
             jnp.zeros(pr.shape, pr.dtype) if isinstance(t, ad.Zero) else t
             for pr, t in zip(primals, tangents)
@@ -242,7 +244,7 @@ def register_primitive(
 
     ad.primitive_jvps[p] = _jvp
 
-    def _batching(args, dims, **params):
+    def _batching(args: Any, dims: Any, **params: Any) -> Any:
         return jax.vmap(partial(impl_fn, **params), in_axes=dims)(*args), 0
 
     batching.primitive_batchers[p] = _batching

--- a/braintrace/_op/conv.py
+++ b/braintrace/_op/conv.py
@@ -69,6 +69,8 @@ output element). The conv primitive implements:
   batched input tensor held by the executor.
 """
 
+from __future__ import annotations
+
 from typing import Any, Optional, Sequence
 
 import jax
@@ -76,6 +78,7 @@ import jax.numpy as jnp
 import brainunit as u
 
 from ._primitive import register_primitive
+from braintrace._typing import ArrayLike, WeightFn
 
 __all__ = [
     'etp_conv_p',
@@ -84,18 +87,18 @@ __all__ = [
 
 
 def _etp_conv_impl(
-    *args,
-    has_bias=False,
-    strides=(1,),
-    padding='SAME',
-    lhs_dilation=None,
-    rhs_dilation=None,
-    feature_group_count=1,
-    batch_group_count=1,
-    dimension_numbers=None,
-    kernel_fn=None,
-    bias_fn=None,
-):
+    *args: Any,
+    has_bias: bool = False,
+    strides: Sequence[int] = (1,),
+    padding: str = 'SAME',
+    lhs_dilation: Optional[Sequence[int]] = None,
+    rhs_dilation: Optional[Sequence[int]] = None,
+    feature_group_count: int = 1,
+    batch_group_count: int = 1,
+    dimension_numbers: Any = None,
+    kernel_fn: WeightFn | None = None,
+    bias_fn: WeightFn | None = None,
+) -> Any:
     x, kernel = args[0], args[1]
     if kernel_fn is not None:
         kernel = kernel_fn(kernel)
@@ -118,7 +121,7 @@ def _etp_conv_impl(
     return y
 
 
-def _conv_trainable_invars(params):
+def _conv_trainable_invars(params: dict[str, Any]) -> dict[str, int]:
     """Return ``{key: invar_index}`` depending on ``has_bias``."""
     base = {'weight': 1}
     if params.get('has_bias', False):
@@ -126,7 +129,7 @@ def _conv_trainable_invars(params):
     return base
 
 
-def _conv_layout(params):
+def _conv_layout(params: dict[str, Any]) -> tuple[int, int, int, int]:
     """Return ``(n_spatial, channel_axis, batch_axis, kernel_out_axis)``.
 
     ``n_spatial``:       spatial rank (1, 2, or 3).
@@ -183,7 +186,7 @@ def _conv_layout(params):
     return n_spatial, channel_axis, batch_axis, kernel_out_axis
 
 
-def _conv_yw_to_w(hidden_dim, trace, **params):
+def _conv_yw_to_w(hidden_dim: Any, trace: dict[str, Any], **params: Any) -> dict[str, Any]:
     r"""Propagate :math:`\partial h / \partial y` through the conv trace.
 
     **Role in D-RTRL.** Implements the :math:`y \to (K, b)` chain factor
@@ -304,7 +307,7 @@ def _conv_yw_to_w(hidden_dim, trace, **params):
     return out
 
 
-def _conv_xy_to_dw(x, hidden_dim, weights, **params):
+def _conv_xy_to_dw(x: Any, hidden_dim: Any, weights: dict[str, Any], **params: Any) -> dict[str, Any]:
     r"""Instantaneous conv Jacobian :math:`\partial h / \partial (K, b)`.
 
     **Role in D-RTRL.** Produces the
@@ -375,7 +378,7 @@ def _conv_xy_to_dw(x, hidden_dim, weights, **params):
 
     # Kernel gradient via VJP (needs x); apply kernel_fn inside so jax.vjp
     # auto-composes f' for the kernel gradient.
-    def _fwd_w(w):
+    def _fwd_w(w: Any) -> Any:
         if kernel_fn is not None:
             w = kernel_fn(w)
         return u.get_mantissa(
@@ -406,7 +409,8 @@ def _conv_xy_to_dw(x, hidden_dim, weights, **params):
     return out
 
 
-def _conv_init_drtrl(x_var, y_var, weight_vars, num_hidden_state):
+def _conv_init_drtrl(x_var: Any, y_var: Any, weight_vars: dict[str, Any],
+                     num_hidden_state: int) -> dict[str, Any]:
     r"""Initialise conv D-RTRL weight-shaped trace.
 
     .. math::
@@ -438,7 +442,8 @@ def _conv_init_drtrl(x_var, y_var, weight_vars, num_hidden_state):
     return out
 
 
-def _conv_init_pp(x_var, y_var, weight_vars, num_hidden_state):
+def _conv_init_pp(x_var: Any, y_var: Any, weight_vars: dict[str, Any],
+                  num_hidden_state: int) -> Any:
     r"""Initialise conv pp-prop / ES-D-RTRL df trace.
 
     .. math::
@@ -469,9 +474,9 @@ etp_conv_p.register_etp_rules(
 
 
 def conv(
-    x,
-    kernel,
-    bias=None,
+    x: ArrayLike,
+    kernel: ArrayLike,
+    bias: ArrayLike | None = None,
     *,
     strides: Sequence[int] = (1,),
     padding: str = 'SAME',
@@ -480,9 +485,9 @@ def conv(
     feature_group_count: int = 1,
     batch_group_count: int = 1,
     dimension_numbers: Any = None,
-    kernel_fn=None,
-    bias_fn=None,
-):
+    kernel_fn: WeightFn | None = None,
+    bias_fn: WeightFn | None = None,
+) -> ArrayLike:
     r"""ETP-aware convolution.
 
     Computes :math:`y = \mathrm{conv}(x, kernel) \; (+ b)` by routing the

--- a/braintrace/_op/dense.py
+++ b/braintrace/_op/dense.py
@@ -75,11 +75,16 @@ When ``has_bias=False`` the ``'bias'`` key is simply absent from every
 dict, so the legacy (no-bias) code path is unchanged in behaviour.
 """
 
+from __future__ import annotations
+
+from typing import Any
+
 import jax
 import jax.numpy as jnp
 import brainunit as u
 
 from ._primitive import register_primitive
+from braintrace._typing import ArrayLike, WeightFn
 
 __all__ = [
     'etp_mm_p',
@@ -88,7 +93,9 @@ __all__ = [
 ]
 
 
-def _etp_matmul_impl(*args, has_bias=False, weight_fn=None, bias_fn=None):
+def _etp_matmul_impl(*args: Any, has_bias: bool = False,
+                     weight_fn: WeightFn | None = None,
+                     bias_fn: WeightFn | None = None) -> Any:
     x, w = args[0], args[1]
     if weight_fn is not None:
         w = weight_fn(w)
@@ -105,7 +112,7 @@ def _etp_matmul_impl(*args, has_bias=False, weight_fn=None, bias_fn=None):
 # etp_mm_p — batched
 # ---------------------------------------------------------------------------
 
-def _mm_trainable_invars(params):
+def _mm_trainable_invars(params: dict[str, Any]) -> dict[str, int]:
     """Return ``{key: invar_index}`` depending on ``has_bias``."""
     base = {'weight': 1}
     if params.get('has_bias', False):
@@ -113,7 +120,9 @@ def _mm_trainable_invars(params):
     return base
 
 
-def _mm_yw_to_w(hidden_dim, trace, *, has_bias=False, weight_fn=None, bias_fn=None):
+def _mm_yw_to_w(hidden_dim: Any, trace: dict[str, Any], *, has_bias: bool = False,
+                weight_fn: WeightFn | None = None,
+                bias_fn: WeightFn | None = None) -> dict[str, Any]:
     r"""Batched ``yw_to_w`` — propagate :math:`\partial h / \partial y`
     through a weight-shaped D-RTRL trace.
 
@@ -167,7 +176,9 @@ def _mm_yw_to_w(hidden_dim, trace, *, has_bias=False, weight_fn=None, bias_fn=No
     return out
 
 
-def _mm_xy_to_dw(x, hidden_dim, weights, *, has_bias=False, weight_fn=None, bias_fn=None):
+def _mm_xy_to_dw(x: Any, hidden_dim: Any, weights: dict[str, Any], *,
+                 has_bias: bool = False, weight_fn: WeightFn | None = None,
+                 bias_fn: WeightFn | None = None) -> dict[str, Any]:
     r"""Batched ``xy_to_dw`` — instantaneous hidden-to-weight Jacobian.
 
     **Role.** Computes :math:`\partial h / \partial W` (and
@@ -190,7 +201,7 @@ def _mm_xy_to_dw(x, hidden_dim, weights, *, has_bias=False, weight_fn=None, bias
     when ``has_bias=True``.
     """
 
-    def _fwd(w_dict):
+    def _fwd(w_dict: dict[str, Any]) -> Any:
         w = w_dict['weight']
         if weight_fn is not None:
             w = weight_fn(w)
@@ -206,7 +217,8 @@ def _mm_xy_to_dw(x, hidden_dim, weights, *, has_bias=False, weight_fn=None, bias
     return jax.tree.map(u.get_mantissa, vjp_fn(hidden_dim)[0])
 
 
-def _mm_init_drtrl(x_var, y_var, weight_vars, num_hidden_state):
+def _mm_init_drtrl(x_var: Any, y_var: Any, weight_vars: dict[str, Any],
+                   num_hidden_state: int) -> dict[str, Any]:
     r"""Initialise the batched D-RTRL weight-shaped trace.
 
     D-RTRL stores one trace per (weight-entry, hidden-state) pair:
@@ -237,7 +249,8 @@ def _mm_init_drtrl(x_var, y_var, weight_vars, num_hidden_state):
     return out
 
 
-def _mm_init_pp(x_var, y_var, weight_vars, num_hidden_state):
+def _mm_init_pp(x_var: Any, y_var: Any, weight_vars: dict[str, Any],
+                num_hidden_state: int) -> Any:
     r"""Initialise the batched pp-prop / ES-D-RTRL output-shaped df trace.
 
     pp-prop factorises the eligibility trace as
@@ -276,7 +289,7 @@ etp_mm_p.register_etp_rules(
 # etp_mv_p — unbatched
 # ---------------------------------------------------------------------------
 
-def _mv_trainable_invars(params):
+def _mv_trainable_invars(params: dict[str, Any]) -> dict[str, int]:
     """Return ``{key: invar_index}`` depending on ``has_bias``."""
     base = {'weight': 1}
     if params.get('has_bias', False):
@@ -284,7 +297,9 @@ def _mv_trainable_invars(params):
     return base
 
 
-def _mv_yw_to_w(hidden_dim, trace, *, has_bias=False, weight_fn=None, bias_fn=None):
+def _mv_yw_to_w(hidden_dim: Any, trace: dict[str, Any], *, has_bias: bool = False,
+                weight_fn: WeightFn | None = None,
+                bias_fn: WeightFn | None = None) -> dict[str, Any]:
     r"""Unbatched ``yw_to_w`` — same algebra as the batched case, no batch axis.
 
     **Role in D-RTRL.** Realises the :math:`y \to W` chain factor within
@@ -314,7 +329,9 @@ def _mv_yw_to_w(hidden_dim, trace, *, has_bias=False, weight_fn=None, bias_fn=No
     return out
 
 
-def _mv_xy_to_dw(x, hidden_dim, weights, *, has_bias=False, weight_fn=None, bias_fn=None):
+def _mv_xy_to_dw(x: Any, hidden_dim: Any, weights: dict[str, Any], *,
+                 has_bias: bool = False, weight_fn: WeightFn | None = None,
+                 bias_fn: WeightFn | None = None) -> dict[str, Any]:
     r"""Unbatched ``xy_to_dw`` — instantaneous :math:`\partial h / \partial W`.
 
     Same chain rule as the batched case with no batch axis. When ``weight_fn``
@@ -334,7 +351,7 @@ def _mv_xy_to_dw(x, hidden_dim, weights, *, has_bias=False, weight_fn=None, bias
     and bias gradients in one pass.
     """
 
-    def _fwd(w_dict):
+    def _fwd(w_dict: dict[str, Any]) -> Any:
         w = w_dict['weight']
         if weight_fn is not None:
             w = weight_fn(w)
@@ -350,7 +367,8 @@ def _mv_xy_to_dw(x, hidden_dim, weights, *, has_bias=False, weight_fn=None, bias
     return jax.tree.map(u.get_mantissa, vjp_fn(hidden_dim)[0])
 
 
-def _mv_init_drtrl(x_var, y_var, weight_vars, num_hidden_state):
+def _mv_init_drtrl(x_var: Any, y_var: Any, weight_vars: dict[str, Any],
+                   num_hidden_state: int) -> dict[str, Any]:
     r"""Initialise unbatched D-RTRL weight-shaped trace.
 
     .. math::
@@ -372,7 +390,8 @@ def _mv_init_drtrl(x_var, y_var, weight_vars, num_hidden_state):
     return out
 
 
-def _mv_init_pp(x_var, y_var, weight_vars, num_hidden_state):
+def _mv_init_pp(x_var: Any, y_var: Any, weight_vars: dict[str, Any],
+                num_hidden_state: int) -> Any:
     r"""Initialise unbatched pp-prop / ES-D-RTRL df trace.
 
     .. math::
@@ -404,7 +423,14 @@ etp_mv_p.register_etp_rules(
 # Public API
 # ---------------------------------------------------------------------------
 
-def matmul(x, weight, bias=None, *, weight_fn=None, bias_fn=None):
+def matmul(
+    x: ArrayLike,
+    weight: ArrayLike,
+    bias: ArrayLike | None = None,
+    *,
+    weight_fn: WeightFn | None = None,
+    bias_fn: WeightFn | None = None,
+) -> ArrayLike:
     r"""ETP-aware matrix multiplication.
 
     Computes :math:`y = x \mathbin{@} \text{weight\_fn}(w) \; (+ \text{bias\_fn}(b))`.
@@ -469,7 +495,7 @@ def matmul(x, weight, bias=None, *, weight_fn=None, bias_fn=None):
         >>> print(y2.shape)
         (16, 4)
     """
-    p = etp_mm_p if x.ndim >= 2 else etp_mv_p
+    p = etp_mm_p if x.ndim >= 2 else etp_mv_p  # type: ignore[union-attr]  # x is an array here; ArrayLike also admits scalars without .ndim
     x_v, x_u = u.split_mantissa_unit(x)
     weight_v, weight_u = u.split_mantissa_unit(weight)
     unit = x_u * weight_u

--- a/braintrace/_op/elemwise.py
+++ b/braintrace/_op/elemwise.py
@@ -62,11 +62,16 @@ primitive when composing Jacobians).
   an identity op the weight-shape coincides with the output-shape.
 """
 
+from __future__ import annotations
+
+from typing import Any
+
 import jax
 import jax.numpy as jnp
 import brainunit as u
 
 from ._primitive import register_primitive
+from braintrace._typing import ArrayLike, WeightFn
 
 __all__ = [
     'etp_elemwise_p',
@@ -74,15 +79,16 @@ __all__ = [
 ]
 
 
-def _etp_elemwise_impl(w, weight_fn=None):
+def _etp_elemwise_impl(w: Any, weight_fn: WeightFn | None = None) -> Any:
     return w if weight_fn is None else weight_fn(w)
 
 
-def _elem_trainable_invars(params):
+def _elem_trainable_invars(params: dict[str, Any]) -> dict[str, int]:
     return {'weight': 0}
 
 
-def _elemwise_yw_to_w(hidden_dim, trace, *, weight_fn=None):
+def _elemwise_yw_to_w(hidden_dim: Any, trace: dict[str, Any], *,
+                      weight_fn: WeightFn | None = None) -> dict[str, Any]:
     r"""Diagonal trace propagation for an identity-like op.
 
     **Role in D-RTRL.** Realises the :math:`y \to w` chain factor inside
@@ -107,7 +113,8 @@ def _elemwise_yw_to_w(hidden_dim, trace, *, weight_fn=None):
     return {'weight': trace['weight'] * hidden_dim}
 
 
-def _elemwise_xy_to_dw(x, hidden_dim, weights, *, weight_fn=None):
+def _elemwise_xy_to_dw(x: Any, hidden_dim: Any, weights: dict[str, Any], *,
+                       weight_fn: WeightFn | None = None) -> dict[str, Any]:
     r"""Instantaneous Jacobian for the identity marker.
 
     **Role in D-RTRL / ES-D-RTRL.** For :math:`y = \text{weight\_fn}(w)`,
@@ -138,7 +145,8 @@ def _elemwise_xy_to_dw(x, hidden_dim, weights, *, weight_fn=None):
     return {'weight': u.get_mantissa(vjp_fn(hidden_dim)[0])}
 
 
-def _elemwise_init_drtrl(x_var, y_var, weight_vars, num_hidden_state, group=None):
+def _elemwise_init_drtrl(x_var: Any, y_var: Any, weight_vars: dict[str, Any],
+                         num_hidden_state: int, group: Any = None) -> dict[str, Any]:
     r"""Initialise the D-RTRL weight-shaped trace for an identity op.
 
     Weight-shape and output-shape coincide for the identity, so
@@ -175,7 +183,8 @@ def _elemwise_init_drtrl(x_var, y_var, weight_vars, num_hidden_state, group=None
     return {'weight': jnp.zeros((*leading, num_hidden_state))}
 
 
-def _elemwise_init_pp(x_var, y_var, weight_vars, num_hidden_state, group=None):
+def _elemwise_init_pp(x_var: Any, y_var: Any, weight_vars: dict[str, Any],
+                      num_hidden_state: int, group: Any = None) -> Any:
     r"""Initialise the pp-prop df trace for an identity op.
 
     .. math::
@@ -212,7 +221,7 @@ etp_elemwise_p.register_etp_rules(
 )
 
 
-def element_wise(weight, *, weight_fn=None):
+def element_wise(weight: ArrayLike, *, weight_fn: WeightFn | None = None) -> ArrayLike:
     r"""ETP-aware element-wise operation.
 
     Applies ``weight_fn`` to ``weight`` *inside* the ETP primitive, so

--- a/braintrace/_op/lora.py
+++ b/braintrace/_op/lora.py
@@ -80,11 +80,16 @@ Keys ``'lora_b'`` / ``'lora_a'`` match the pytree leaf names in
 ``braintrace.nn.LoRALinear``'s merged ``ParamState``.
 """
 
+from __future__ import annotations
+
+from typing import Any
+
 import jax
 import jax.numpy as jnp
 import brainunit as u
 
 from ._primitive import register_primitive
+from braintrace._typing import ArrayLike, WeightFn
 
 __all__ = [
     'etp_lora_mm_p',
@@ -93,7 +98,9 @@ __all__ = [
 ]
 
 
-def _etp_lora_impl(*args, alpha=1.0, has_bias=False, b_fn=None, a_fn=None, bias_fn=None):
+def _etp_lora_impl(*args: Any, alpha: float = 1.0, has_bias: bool = False,
+                   b_fn: WeightFn | None = None, a_fn: WeightFn | None = None,
+                   bias_fn: WeightFn | None = None) -> Any:
     x, B, A = args[0], args[1], args[2]
     if b_fn is not None:
         B = b_fn(B)
@@ -108,7 +115,7 @@ def _etp_lora_impl(*args, alpha=1.0, has_bias=False, b_fn=None, a_fn=None, bias_
     return y
 
 
-def _lora_trainable_invars(params):
+def _lora_trainable_invars(params: dict[str, Any]) -> dict[str, int]:
     """Return ``{key: invar_index}`` for LoRA's trainable inputs."""
     base = {'lora_b': 1, 'lora_a': 2}
     if params.get('has_bias', False):
@@ -116,7 +123,9 @@ def _lora_trainable_invars(params):
     return base
 
 
-def _lora_mm_yw_to_w(hidden_dim, trace, *, alpha=1.0, has_bias=False, b_fn=None, a_fn=None, bias_fn=None):
+def _lora_mm_yw_to_w(hidden_dim: Any, trace: dict[str, Any], *, alpha: float = 1.0,
+                     has_bias: bool = False, b_fn: WeightFn | None = None,
+                     a_fn: WeightFn | None = None, bias_fn: WeightFn | None = None) -> dict[str, Any]:
     r"""Batched LoRA ``yw_to_w`` — propagate :math:`\partial h / \partial y`
     through the :math:`y \to A` link.
 
@@ -168,7 +177,9 @@ def _lora_mm_yw_to_w(hidden_dim, trace, *, alpha=1.0, has_bias=False, b_fn=None,
     return out
 
 
-def _lora_mv_yw_to_w(hidden_dim, trace, *, alpha=1.0, has_bias=False, b_fn=None, a_fn=None, bias_fn=None):
+def _lora_mv_yw_to_w(hidden_dim: Any, trace: dict[str, Any], *, alpha: float = 1.0,
+                     has_bias: bool = False, b_fn: WeightFn | None = None,
+                     a_fn: WeightFn | None = None, bias_fn: WeightFn | None = None) -> dict[str, Any]:
     r"""Unbatched LoRA ``yw_to_w`` — identical algebra with no batch axis.
 
     Trace shapes:
@@ -189,7 +200,9 @@ def _lora_mv_yw_to_w(hidden_dim, trace, *, alpha=1.0, has_bias=False, b_fn=None,
     return out
 
 
-def _lora_xy_to_dw(x, hidden_dim, weights, *, alpha=1.0, has_bias=False, b_fn=None, a_fn=None, bias_fn=None):
+def _lora_xy_to_dw(x: Any, hidden_dim: Any, weights: dict[str, Any], *, alpha: float = 1.0,
+                   has_bias: bool = False, b_fn: WeightFn | None = None,
+                   a_fn: WeightFn | None = None, bias_fn: WeightFn | None = None) -> dict[str, Any]:
     r"""Instantaneous LoRA Jacobian via fused VJP.
 
     **Role in D-RTRL / ES-D-RTRL.** Produces the full instantaneous
@@ -229,7 +242,7 @@ def _lora_xy_to_dw(x, hidden_dim, weights, *, alpha=1.0, has_bias=False, b_fn=No
     :math:`\boldsymbol{\epsilon}_x^t` into the weight gradient.
     """
 
-    def _fwd(w):
+    def _fwd(w: dict[str, Any]) -> Any:
         B = w['lora_b']
         A = w['lora_a']
         if b_fn is not None:
@@ -248,7 +261,8 @@ def _lora_xy_to_dw(x, hidden_dim, weights, *, alpha=1.0, has_bias=False, b_fn=No
     return jax.tree.map(u.get_mantissa, vjp_fn(hidden_dim)[0])
 
 
-def _lora_mm_init_drtrl(x_var, y_var, weight_vars, num_hidden_state):
+def _lora_mm_init_drtrl(x_var: Any, y_var: Any, weight_vars: dict[str, Any],
+                        num_hidden_state: int) -> dict[str, Any]:
     r"""Initialise batched LoRA D-RTRL trace.
 
     Each LoRA factor gets its own trace leaf:
@@ -277,7 +291,8 @@ def _lora_mm_init_drtrl(x_var, y_var, weight_vars, num_hidden_state):
     return out
 
 
-def _lora_mm_init_pp(x_var, y_var, weight_vars, num_hidden_state):
+def _lora_mm_init_pp(x_var: Any, y_var: Any, weight_vars: dict[str, Any],
+                     num_hidden_state: int) -> Any:
     r"""Initialise batched LoRA pp-prop / ES-D-RTRL df trace.
 
     .. math::
@@ -292,7 +307,8 @@ def _lora_mm_init_pp(x_var, y_var, weight_vars, num_hidden_state):
     return jnp.zeros((*y_var.aval.shape, num_hidden_state), dtype=y_var.aval.dtype)
 
 
-def _lora_mv_init_drtrl(x_var, y_var, weight_vars, num_hidden_state):
+def _lora_mv_init_drtrl(x_var: Any, y_var: Any, weight_vars: dict[str, Any],
+                        num_hidden_state: int) -> dict[str, Any]:
     r"""Initialise unbatched LoRA D-RTRL trace.
 
     .. math::
@@ -316,7 +332,8 @@ def _lora_mv_init_drtrl(x_var, y_var, weight_vars, num_hidden_state):
     return out
 
 
-def _lora_mv_init_pp(x_var, y_var, weight_vars, num_hidden_state):
+def _lora_mv_init_pp(x_var: Any, y_var: Any, weight_vars: dict[str, Any],
+                     num_hidden_state: int) -> Any:
     r"""Initialise unbatched LoRA pp-prop / ES-D-RTRL df trace.
 
     .. math::
@@ -355,7 +372,17 @@ etp_lora_mv_p.register_etp_rules(
 )
 
 
-def lora_matmul(x, B, A, *, alpha=1.0, bias=None, b_fn=None, a_fn=None, bias_fn=None):
+def lora_matmul(
+    x: ArrayLike,
+    B: ArrayLike,
+    A: ArrayLike,
+    *,
+    alpha: float = 1.0,
+    bias: ArrayLike | None = None,
+    b_fn: WeightFn | None = None,
+    a_fn: WeightFn | None = None,
+    bias_fn: WeightFn | None = None,
+) -> ArrayLike:
     r"""ETP-aware LoRA (Low-Rank Adaptation) matrix multiplication.
 
     Computes :math:`y = \alpha \cdot x \mathbin{@} b\_fn(B) \mathbin{@} a\_fn(A) \; (+ bias\_fn(b))`,
@@ -415,7 +442,7 @@ def lora_matmul(x, B, A, *, alpha=1.0, bias=None, b_fn=None, a_fn=None, bias_fn=
         >>> print(y.shape)
         (16, 4)
     """
-    p = etp_lora_mm_p if x.ndim >= 2 else etp_lora_mv_p
+    p = etp_lora_mm_p if x.ndim >= 2 else etp_lora_mv_p  # type: ignore[union-attr]  # x is an array here; ArrayLike also admits scalars without .ndim
     x_v, x_u = u.split_mantissa_unit(x)
     B_v, B_u = u.split_mantissa_unit(B)
     A_v, A_u = u.split_mantissa_unit(A)

--- a/braintrace/_op/sparse.py
+++ b/braintrace/_op/sparse.py
@@ -77,11 +77,16 @@ When ``has_bias=False`` the ``'bias'`` key is simply absent from every
 dict, so the legacy (no-bias) code path is unchanged in behaviour.
 """
 
+from __future__ import annotations
+
+from typing import Any
+
 import jax
 import jax.numpy as jnp
 import brainunit as u
 
 from ._primitive import register_primitive
+from braintrace._typing import ArrayLike, WeightFn
 
 __all__ = [
     'etp_sp_mm_p',
@@ -90,11 +95,13 @@ __all__ = [
 ]
 
 
-def _etp_sp_matmul_impl(*args, sparse_mat=None, has_bias=False, weight_fn=None, bias_fn=None):
+def _etp_sp_matmul_impl(*args: Any, sparse_mat: Any = None, has_bias: bool = False,
+                        weight_fn: WeightFn | None = None,
+                        bias_fn: WeightFn | None = None) -> Any:
     x, weight_data = args[0], args[1]
     if weight_fn is not None:
         weight_data = weight_fn(weight_data)
-    w = sparse_mat.with_data(weight_data)
+    w = sparse_mat.with_data(weight_data)  # type: ignore[union-attr]  # sparse_mat is always supplied at bind time
     y = x @ w
     if has_bias:
         b = args[2]
@@ -108,7 +115,7 @@ def _etp_sp_matmul_impl(*args, sparse_mat=None, has_bias=False, weight_fn=None, 
 # trainable_invars_fn — shared by both mm and mv
 # ---------------------------------------------------------------------------
 
-def _sp_trainable_invars(params):
+def _sp_trainable_invars(params: dict[str, Any]) -> dict[str, int]:
     """Return ``{key: invar_index}`` depending on ``has_bias``."""
     base = {'weight': 1}
     if params.get('has_bias', False):
@@ -120,7 +127,9 @@ def _sp_trainable_invars(params):
 # etp_sp_mm_p — batched
 # ---------------------------------------------------------------------------
 
-def _sp_mm_yw_to_w(hidden_dim, trace, *, sparse_mat=None, has_bias=False, weight_fn=None, bias_fn=None):
+def _sp_mm_yw_to_w(hidden_dim: Any, trace: dict[str, Any], *, sparse_mat: Any = None,
+                   has_bias: bool = False, weight_fn: WeightFn | None = None,
+                   bias_fn: WeightFn | None = None) -> dict[str, Any]:
     r"""Batched sparse ``yw_to_w`` — propagate :math:`\partial h / \partial y`
     through the nnz-shaped D-RTRL trace.
 
@@ -152,13 +161,15 @@ def _sp_mm_yw_to_w(hidden_dim, trace, *, sparse_mat=None, has_bias=False, weight
                       ``trace['bias']   : (batch, out)``.
         solve context: batch axis dropped by the outer vmap.
     """
-    out = {'weight': sparse_mat.yw_to_w_transposed(hidden_dim, trace['weight'])}
+    out = {'weight': sparse_mat.yw_to_w_transposed(hidden_dim, trace['weight'])}  # type: ignore[union-attr]  # sparse_mat is always supplied at bind time
     if has_bias:
         out['bias'] = trace['bias'] * hidden_dim
     return out
 
 
-def _sp_xy_to_dw(x, hidden_dim, weights, *, sparse_mat=None, has_bias=False, weight_fn=None, bias_fn=None):
+def _sp_xy_to_dw(x: Any, hidden_dim: Any, weights: dict[str, Any], *, sparse_mat: Any = None,
+                 has_bias: bool = False, weight_fn: WeightFn | None = None,
+                 bias_fn: WeightFn | None = None) -> dict[str, Any]:
     r"""Sparse instantaneous Jacobian :math:`\partial h / \partial w_{\text{data}}`,
     and :math:`\partial h / \partial b`.
 
@@ -189,11 +200,11 @@ def _sp_xy_to_dw(x, hidden_dim, weights, *, sparse_mat=None, has_bias=False, wei
     dict-valued forward function.
     """
 
-    def _fwd(w_dict):
+    def _fwd(w_dict: dict[str, Any]) -> Any:
         wd = w_dict['weight']
         if weight_fn is not None:
             wd = weight_fn(wd)
-        y = x @ sparse_mat.with_data(wd)
+        y = x @ sparse_mat.with_data(wd)  # type: ignore[union-attr]  # sparse_mat is always supplied at bind time
         if has_bias:
             b = w_dict['bias']
             if bias_fn is not None:
@@ -205,7 +216,8 @@ def _sp_xy_to_dw(x, hidden_dim, weights, *, sparse_mat=None, has_bias=False, wei
     return jax.tree.map(u.get_mantissa, vjp_fn(hidden_dim)[0])
 
 
-def _sp_mm_init_drtrl(x_var, y_var, weight_vars, num_hidden_state):
+def _sp_mm_init_drtrl(x_var: Any, y_var: Any, weight_vars: dict[str, Any],
+                      num_hidden_state: int) -> dict[str, Any]:
     r"""Initialise batched sparse D-RTRL trace.
 
     The memory advantage of sparse vs dense lives here:
@@ -228,7 +240,8 @@ def _sp_mm_init_drtrl(x_var, y_var, weight_vars, num_hidden_state):
     return out
 
 
-def _sp_mm_init_pp(x_var, y_var, weight_vars, num_hidden_state):
+def _sp_mm_init_pp(x_var: Any, y_var: Any, weight_vars: dict[str, Any],
+                   num_hidden_state: int) -> Any:
     r"""Initialise batched sparse pp-prop / ES-D-RTRL df trace.
 
     .. math::
@@ -245,7 +258,9 @@ def _sp_mm_init_pp(x_var, y_var, weight_vars, num_hidden_state):
 # etp_sp_mv_p — unbatched
 # ---------------------------------------------------------------------------
 
-def _sp_mv_yw_to_w(hidden_dim, trace, *, sparse_mat=None, has_bias=False, weight_fn=None, bias_fn=None):
+def _sp_mv_yw_to_w(hidden_dim: Any, trace: dict[str, Any], *, sparse_mat: Any = None,
+                   has_bias: bool = False, weight_fn: WeightFn | None = None,
+                   bias_fn: WeightFn | None = None) -> dict[str, Any]:
     r"""Unbatched sparse ``yw_to_w`` — identical algebra to the batched case
     with no batch axis.
 
@@ -263,13 +278,14 @@ def _sp_mv_yw_to_w(hidden_dim, trace, *, sparse_mat=None, has_bias=False, weight
              ``trace['weight'] : (nnz,)``,
              ``trace['bias']   : (out,)``.
     """
-    out = {'weight': sparse_mat.yw_to_w_transposed(hidden_dim, trace['weight'])}
+    out = {'weight': sparse_mat.yw_to_w_transposed(hidden_dim, trace['weight'])}  # type: ignore[union-attr]  # sparse_mat is always supplied at bind time
     if has_bias:
         out['bias'] = trace['bias'] * hidden_dim
     return out
 
 
-def _sp_mv_init_drtrl(x_var, y_var, weight_vars, num_hidden_state):
+def _sp_mv_init_drtrl(x_var: Any, y_var: Any, weight_vars: dict[str, Any],
+                      num_hidden_state: int) -> dict[str, Any]:
     r"""Initialise unbatched sparse D-RTRL trace.
 
     .. math::
@@ -288,7 +304,8 @@ def _sp_mv_init_drtrl(x_var, y_var, weight_vars, num_hidden_state):
     return out
 
 
-def _sp_mv_init_pp(x_var, y_var, weight_vars, num_hidden_state):
+def _sp_mv_init_pp(x_var: Any, y_var: Any, weight_vars: dict[str, Any],
+                   num_hidden_state: int) -> Any:
     r"""Initialise unbatched sparse pp-prop / ES-D-RTRL df trace.
 
     .. math::
@@ -331,7 +348,15 @@ etp_sp_mv_p.register_etp_rules(
 )
 
 
-def sparse_matmul(x, weight, *, sparse_mat, bias=None, weight_fn=None, bias_fn=None):
+def sparse_matmul(
+    x: ArrayLike,
+    weight: ArrayLike,
+    *,
+    sparse_mat: Any,
+    bias: ArrayLike | None = None,
+    weight_fn: WeightFn | None = None,
+    bias_fn: WeightFn | None = None,
+) -> ArrayLike:
     r"""ETP-aware sparse matrix multiplication.
 
     Computes :math:`y = x \mathbin{@} \mathrm{sparse}(f(w)) \; (+ g(b))`, where
@@ -372,7 +397,7 @@ def sparse_matmul(x, weight, *, sparse_mat, bias=None, weight_fn=None, bias_fn=N
     ArrayLike
         Output array.
     """
-    p = etp_sp_mm_p if x.ndim >= 2 else etp_sp_mv_p
+    p = etp_sp_mm_p if x.ndim >= 2 else etp_sp_mv_p  # type: ignore[union-attr]  # x is an array here; ArrayLike also admits scalars without .ndim
     x_v, x_u = u.split_mantissa_unit(x)
     w_v, w_u = u.split_mantissa_unit(weight)
     unit = x_u * w_u

--- a/braintrace/_typing.py
+++ b/braintrace/_typing.py
@@ -15,7 +15,9 @@
 
 # -*- coding: utf-8 -*-
 
-from typing import Dict, Sequence, Union, FrozenSet, List, Tuple, Any, TypeAlias
+from __future__ import annotations
+
+from typing import Callable, Dict, Sequence, Union, FrozenSet, List, Tuple, Any, TypeAlias
 
 import brainstate
 import jax
@@ -33,6 +35,10 @@ StateID: TypeAlias = int
 WeightID: TypeAlias = int
 Size: TypeAlias = brainstate.typing.Size
 Axis: TypeAlias = int
+
+# Elementwise, shape-preserving transform applied to a weight/bias/kernel
+# inside an ETP op (``weight_fn`` / ``bias_fn`` / ``kernel_fn`` / ``a_fn`` / ``b_fn``).
+WeightFn: TypeAlias = Callable[[ArrayLike], ArrayLike]
 
 
 def as_size_tuple(size: Size) -> Tuple[int, ...]:

--- a/braintrace/nn/__init__.py
+++ b/braintrace/nn/__init__.py
@@ -40,6 +40,10 @@ re-implemented here; accessing them through ``braintrace.nn`` emits a
 :mod:`brainstate.state`.
 """
 
+from __future__ import annotations
+
+from typing import Any
+
 from ._conv import Conv1d, Conv2d, Conv3d
 from ._linear import Linear, SignedWLinear, ScaledWSLinear, SparseLinear, LoRA
 from ._readout import LeakyRateReadout
@@ -58,7 +62,7 @@ __all__ = [
 ]
 
 
-def __getattr__(name):
+def __getattr__(name: str) -> Any:
     import warnings
     if name in ['IF', 'LIF', 'ALIF', 'Expon', 'Alpha', 'DualExpon', 'STP', 'STD']:
         warnings.warn(

--- a/braintrace/nn/_conv.py
+++ b/braintrace/nn/_conv.py
@@ -15,14 +15,19 @@
 
 # -*- coding: utf-8 -*-
 
+from __future__ import annotations
+
+from typing import Any
+
 import brainstate
 
 from braintrace._op import conv as etp_conv
+from braintrace._typing import ArrayLike
 
 __all__ = ['Conv1d', 'Conv2d', 'Conv3d']
 
 
-def _etp_conv_op(self, x, params):
+def _etp_conv_op(self: Any, x: ArrayLike, params: dict[str, Any]) -> ArrayLike:
     """Route a convolution through the ETP ``conv`` primitive.
 
     Shared ``_conv_op`` override installed on :class:`Conv1d`, :class:`Conv2d`

--- a/braintrace/nn/_linear.py
+++ b/braintrace/nn/_linear.py
@@ -15,6 +15,8 @@
 
 # -*- coding: utf-8 -*-
 
+from __future__ import annotations
+
 import brainstate
 import brainunit as u
 
@@ -34,7 +36,7 @@ class Linear(brainstate.nn.Linear):
     __module__ = 'braintrace.nn'
     __doc__ = (brainstate.nn.Linear.__doc__ or '').replace('brainstate', 'braintrace')
 
-    def update(self, x):
+    def update(self, x: ArrayLike) -> ArrayLike:
         """Apply the linear transform through the ETP ``matmul`` primitive.
 
         Routing the matrix multiplication through :func:`braintrace.matmul`
@@ -63,7 +65,7 @@ class SignedWLinear(brainstate.nn.SignedWLinear):
     __module__ = 'braintrace.nn'
     __doc__ = (brainstate.nn.SignedWLinear.__doc__ or '').replace('brainstate', 'braintrace')
 
-    def update(self, x):
+    def update(self, x: ArrayLike) -> ArrayLike:
         """Apply the sign-constrained linear transform through ETP ``matmul``.
 
         The stored weight magnitudes are made non-negative and then given a
@@ -91,7 +93,7 @@ class ScaledWSLinear(brainstate.nn.ScaledWSLinear):
     __module__ = 'braintrace.nn'
     __doc__ = (brainstate.nn.ScaledWSLinear.__doc__ or '').replace('brainstate', 'braintrace')
 
-    def update(self, x):
+    def update(self, x: ArrayLike) -> ArrayLike:
         """Apply the weight-standardized linear transform through ETP ``matmul``.
 
         Weight standardization (and the optional mask) are applied inside
@@ -135,7 +137,7 @@ class ScaledWSLinear(brainstate.nn.ScaledWSLinear):
         #   x @ (std(w) * gain) == (x @ std(w)) * gain
         # when gain has shape (1, out_size), and the ETP trace's hidden_dim
         # already carries the gain factor through the hidden-to-output Jacobian.
-        def _wfn(ww):
+        def _wfn(ww: ArrayLike) -> ArrayLike:
             w = brainstate.nn.weight_standardization(ww, eps, None)
             if mask is not None:
                 w = w * mask
@@ -156,7 +158,7 @@ class SparseLinear(brainstate.nn.SparseLinear):
     __module__ = 'braintrace.nn'
     __doc__ = (brainstate.nn.SparseLinear.__doc__ or '').replace('brainstate', 'braintrace')
 
-    def update(self, x):
+    def update(self, x: ArrayLike) -> ArrayLike:
         """Apply the sparse linear transform through the ETP ``sparse_matmul``.
 
         The dense data of the sparse weight is routed through
@@ -258,7 +260,7 @@ class LoRA(brainstate.nn.LoRA):
     """
     __module__ = 'braintrace.nn'
 
-    def update(self, x: ArrayLike):
+    def update(self, x: ArrayLike) -> ArrayLike:
         r"""Apply the low-rank adaptation through the ETP ``lora_matmul``.
 
         Computes :math:`y = \frac{1}{r}\, x\, \mathbf{A}\, \mathbf{B}` via
@@ -290,7 +292,7 @@ class LoRA(brainstate.nn.LoRA):
             out += self.base_module(x)
         return out
 
-    def __call__(self, x: ArrayLike):
+    def __call__(self, x: ArrayLike) -> ArrayLike:
         """Route the forward pass through the ETP-aware :meth:`update`.
 
         The upstream :class:`brainstate.nn.LoRA` defines its own ``__call__``

--- a/braintrace/nn/_readout.py
+++ b/braintrace/nn/_readout.py
@@ -15,7 +15,9 @@
 
 # -*- coding: utf-8 -*-
 
-from typing import Callable, Optional
+from __future__ import annotations
+
+from typing import Any, Callable, Optional
 
 import brainstate
 import braintools
@@ -107,7 +109,7 @@ class LeakyRateReadout(brainstate.nn.Module):
         w_init: Callable = braintools.init.KaimingNormal(),
         r_init: Callable = braintools.init.ZeroInit(),
         name: Optional[str] = None,
-    ):
+    ) -> None:
         super().__init__(name=name)  # type: ignore[call-arg]  # brainstate hides Module.__init__ from type checkers
 
         # parameters
@@ -124,13 +126,13 @@ class LeakyRateReadout(brainstate.nn.Module):
             braintools.init.param(w_init, (as_size_tuple(self.in_size)[0], as_size_tuple(self.out_size)[0]))
         )
 
-    def init_state(self, batch_size=None, **kwargs):
+    def init_state(self, batch_size: int | None = None, **kwargs: Any) -> None:
         self.r = brainstate.HiddenState(braintools.init.param(self.r_init, self.out_size, batch_size))
 
-    def reset_state(self, batch_size=None, **kwargs):
+    def reset_state(self, batch_size: int | None = None, **kwargs: Any) -> None:
         self.r.value = braintools.init.param(self.r_init, self.out_size, batch_size)
 
-    def update(self, x):
+    def update(self, x: ArrayLike) -> ArrayLike:
         r"""Advance the readout by one time step of leaky integration.
 
         Applies :math:`r_t = \mathrm{decay} \cdot r_{t-1} + W^\top x_t` and

--- a/braintrace/nn/_rnn.py
+++ b/braintrace/nn/_rnn.py
@@ -14,6 +14,8 @@
 # ==============================================================================
 # -*- coding: utf-8 -*-
 
+from __future__ import annotations
+
 from typing import Any, Callable, Union
 
 import brainstate
@@ -87,8 +89,8 @@ class ValinaRNNCell(brainstate.nn.RNNCell):
         w_init: Union[ArrayLike, Callable] = braintools.init.XavierNormal(),
         b_init: Union[ArrayLike, Callable] = braintools.init.ZeroInit(),
         activation: str | Callable = 'relu',
-        name: str = None,
-    ):
+        name: str | None = None,
+    ) -> None:
         super().__init__(name=name)  # type: ignore[call-arg]
 
         # parameters
@@ -110,14 +112,14 @@ class ValinaRNNCell(brainstate.nn.RNNCell):
             b_init=b_init,
         )
 
-    def init_state(self, batch_size: int = None, **kwargs):
+    def init_state(self, batch_size: int | None = None, **kwargs: Any) -> None:
         self.h = brainstate.HiddenState(
             braintools.init.param(self._state_initializer, self.out_size, batch_size))
 
-    def reset_state(self, batch_size: int = None, **kwargs):
+    def reset_state(self, batch_size: int | None = None, **kwargs: Any) -> None:
         self.h.value = braintools.init.param(self._state_initializer, self.out_size, batch_size)
 
-    def update(self, x):
+    def update(self, x: ArrayLike) -> ArrayLike:
         r"""Advance the cell by one time step.
 
         Parameters
@@ -186,8 +188,8 @@ class GRUCell(brainstate.nn.RNNCell):
         b_init: Union[ArrayLike, Callable] = braintools.init.ZeroInit(),
         state_init: Union[ArrayLike, Callable] = braintools.init.ZeroInit(),
         activation: str | Callable = 'tanh',
-        name: str = None,
-    ):
+        name: str | None = None,
+    ) -> None:
         super().__init__(name=name)  # type: ignore[call-arg]
 
         # parameters
@@ -208,13 +210,13 @@ class GRUCell(brainstate.nn.RNNCell):
         self.Wr = Linear(_as_size_tuple(self.in_size)[-1] + _as_size_tuple(self.out_size)[-1], _as_size_tuple(self.out_size)[-1], **params)
         self.Wh = Linear(_as_size_tuple(self.in_size)[-1] + _as_size_tuple(self.out_size)[-1], _as_size_tuple(self.out_size)[-1], **params)
 
-    def init_state(self, batch_size: int = None, **kwargs):
+    def init_state(self, batch_size: int | None = None, **kwargs: Any) -> None:
         self.h = brainstate.HiddenState(braintools.init.param(self._state_initializer, self.out_size, batch_size))
 
-    def reset_state(self, batch_size: int = None, **kwargs):
+    def reset_state(self, batch_size: int | None = None, **kwargs: Any) -> None:
         self.h.value = braintools.init.param(self._state_initializer, self.out_size, batch_size)
 
-    def update(self, x):
+    def update(self, x: ArrayLike) -> ArrayLike:
         r"""Advance the cell by one time step.
 
         Parameters
@@ -288,8 +290,8 @@ class CFNCell(brainstate.nn.RNNCell):
         b_init: Union[ArrayLike, Callable] = braintools.init.ZeroInit(),
         state_init: Union[ArrayLike, Callable] = braintools.init.ZeroInit(),
         activation: str | Callable = 'tanh',
-        name: str = None,
-    ):
+        name: str | None = None,
+    ) -> None:
         super().__init__(name=name)  # type: ignore[call-arg]
 
         # parameters
@@ -310,13 +312,13 @@ class CFNCell(brainstate.nn.RNNCell):
         self.Wi = Linear(_as_size_tuple(self.in_size)[-1] + _as_size_tuple(self.out_size)[-1], _as_size_tuple(self.out_size)[-1], **params)
         self.Wh = Linear(_as_size_tuple(self.out_size)[-1], _as_size_tuple(self.out_size)[-1], **params)
 
-    def init_state(self, batch_size: int = None, **kwargs):
+    def init_state(self, batch_size: int | None = None, **kwargs: Any) -> None:
         self.h = brainstate.HiddenState(braintools.init.param(self._state_initializer, self.out_size, batch_size))
 
-    def reset_state(self, batch_size: int = None, **kwargs):
+    def reset_state(self, batch_size: int | None = None, **kwargs: Any) -> None:
         self.h.value = braintools.init.param(self._state_initializer, self.out_size, batch_size)
 
-    def update(self, x):
+    def update(self, x: ArrayLike) -> ArrayLike:
         r"""Advance the cell by one time step.
 
         Parameters
@@ -404,8 +406,8 @@ class MGUCell(brainstate.nn.RNNCell):
         b_init: Union[ArrayLike, Callable] = braintools.init.ZeroInit(),
         state_init: Union[ArrayLike, Callable] = braintools.init.ZeroInit(),
         activation: str | Callable = 'tanh',
-        name: str = None,
-    ):
+        name: str | None = None,
+    ) -> None:
         super().__init__(name=name)  # type: ignore[call-arg]
 
         # parameters
@@ -425,13 +427,13 @@ class MGUCell(brainstate.nn.RNNCell):
         self.Wf = Linear(_as_size_tuple(self.in_size)[-1] + _as_size_tuple(self.out_size)[-1], _as_size_tuple(self.out_size)[-1], **params)
         self.Wh = Linear(_as_size_tuple(self.in_size)[-1] + _as_size_tuple(self.out_size)[-1], _as_size_tuple(self.out_size)[-1], **params)
 
-    def init_state(self, batch_size: int = None, **kwargs):
+    def init_state(self, batch_size: int | None = None, **kwargs: Any) -> None:
         self.h = brainstate.HiddenState(braintools.init.param(self._state_initializer, self.out_size, batch_size))
 
-    def reset_state(self, batch_size: int = None, **kwargs):
+    def reset_state(self, batch_size: int | None = None, **kwargs: Any) -> None:
         self.h.value = braintools.init.param(self._state_initializer, self.out_size, batch_size)
 
-    def update(self, x):
+    def update(self, x: ArrayLike) -> ArrayLike:
         r"""Advance the cell by one time step.
 
         Parameters
@@ -534,8 +536,8 @@ class LSTMCell(brainstate.nn.RNNCell):
         b_init: Union[ArrayLike, Callable] = braintools.init.ZeroInit(),
         state_init: Union[ArrayLike, Callable] = braintools.init.ZeroInit(),
         activation: str | Callable = 'tanh',
-        name: str = None,
-    ):
+        name: str | None = None,
+    ) -> None:
         super().__init__(name=name)  # type: ignore[call-arg]
 
         # parameters
@@ -559,15 +561,15 @@ class LSTMCell(brainstate.nn.RNNCell):
         self.Wf = Linear(_as_size_tuple(self.in_size)[-1] + _as_size_tuple(self.out_size)[-1], _as_size_tuple(self.out_size)[-1], **params)
         self.Wo = Linear(_as_size_tuple(self.in_size)[-1] + _as_size_tuple(self.out_size)[-1], _as_size_tuple(self.out_size)[-1], **params)
 
-    def init_state(self, batch_size: int = None, **kwargs):
+    def init_state(self, batch_size: int | None = None, **kwargs: Any) -> None:
         self.c = brainstate.HiddenState(braintools.init.param(self._state_initializer, self.out_size, batch_size))
         self.h = brainstate.HiddenState(braintools.init.param(self._state_initializer, self.out_size, batch_size))
 
-    def reset_state(self, batch_size: int = None, **kwargs):
+    def reset_state(self, batch_size: int | None = None, **kwargs: Any) -> None:
         self.c.value = braintools.init.param(self._state_initializer, self.out_size, batch_size)
         self.h.value = braintools.init.param(self._state_initializer, self.out_size, batch_size)
 
-    def update(self, x):
+    def update(self, x: ArrayLike) -> ArrayLike:
         r"""Advance the cell by one time step.
 
         Updates both the cell state ``c`` and the hidden state ``h`` in place.
@@ -642,8 +644,8 @@ class URLSTMCell(brainstate.nn.RNNCell):
         w_init: Union[ArrayLike, Callable] = braintools.init.XavierNormal(),
         state_init: Union[ArrayLike, Callable] = braintools.init.ZeroInit(),
         activation: str | Callable = 'tanh',
-        name: str = None,
-    ):
+        name: str | None = None,
+    ) -> None:
         super().__init__(name=name)  # type: ignore[call-arg]
 
         # parameters
@@ -668,17 +670,17 @@ class URLSTMCell(brainstate.nn.RNNCell):
         self.Wo = Linear(_as_size_tuple(self.in_size)[-1] + _as_size_tuple(self.out_size)[-1], _as_size_tuple(self.out_size)[-1], **params)
         self.bias = brainstate.ParamState(self._forget_bias())
 
-    def _forget_bias(self):
+    def _forget_bias(self) -> ArrayLike:
         rand_val = brainstate.random.uniform(1 / _as_size_tuple(self.out_size)[-1], 1 - 1 / _as_size_tuple(self.out_size)[-1], (_as_size_tuple(self.out_size)[-1],))
         return -u.math.log(1 / rand_val - 1)
 
-    def init_state(self, batch_size: int = None, **kwargs):
+    def init_state(self, batch_size: int | None = None, **kwargs: Any) -> None:
         self.c = brainstate.HiddenState(
             braintools.init.param(self._state_initializer, self.out_size, batch_size))
         self.h = brainstate.HiddenState(
             braintools.init.param(self._state_initializer, self.out_size, batch_size))
 
-    def reset_state(self, batch_size: int = None, **kwargs):
+    def reset_state(self, batch_size: int | None = None, **kwargs: Any) -> None:
         self.c.value = braintools.init.param(self._state_initializer, self.out_size, batch_size)
         self.h.value = braintools.init.param(self._state_initializer, self.out_size, batch_size)
 
@@ -778,8 +780,8 @@ class MinimalRNNCell(brainstate.nn.RNNCell):
         b_init: Union[ArrayLike, Callable] = braintools.init.ZeroInit(),
         state_init: Union[ArrayLike, Callable] = braintools.init.ZeroInit(),
         phi: Callable = None,
-        name: str = None,
-    ):
+        name: str | None = None,
+    ) -> None:
         super().__init__(name=name)  # type: ignore[call-arg]
 
         # parameters
@@ -797,13 +799,13 @@ class MinimalRNNCell(brainstate.nn.RNNCell):
         # weights
         self.W_u = Linear(_as_size_tuple(self.out_size)[-1] * 2, _as_size_tuple(self.out_size)[-1], **params)
 
-    def init_state(self, batch_size: int = None, **kwargs):
+    def init_state(self, batch_size: int | None = None, **kwargs: Any) -> None:
         self.h = brainstate.HiddenState(braintools.init.param(self._state_initializer, self.out_size, batch_size))
 
-    def reset_state(self, batch_size: int = None, **kwargs):
+    def reset_state(self, batch_size: int | None = None, **kwargs: Any) -> None:
         self.h.value = braintools.init.param(self._state_initializer, self.out_size, batch_size)
 
-    def update(self, x):
+    def update(self, x: ArrayLike) -> ArrayLike:
         r"""Advance the cell by one time step.
 
         Parameters
@@ -879,8 +881,8 @@ class MiniGRU(brainstate.nn.RNNCell):
         w_init: Union[ArrayLike, Callable] = braintools.init.Orthogonal(),
         b_init: Union[ArrayLike, Callable] = braintools.init.ZeroInit(),
         state_init: Union[ArrayLike, Callable] = braintools.init.ZeroInit(),
-        name: str = None,
-    ):
+        name: str | None = None,
+    ) -> None:
         super().__init__(name=name)  # type: ignore[call-arg]
 
         # parameters
@@ -895,13 +897,13 @@ class MiniGRU(brainstate.nn.RNNCell):
         # weights
         self.W_z = Linear(_as_size_tuple(self.in_size)[-1] + _as_size_tuple(self.out_size)[-1], _as_size_tuple(self.out_size)[-1], **params)
 
-    def init_state(self, batch_size: int = None, **kwargs):
+    def init_state(self, batch_size: int | None = None, **kwargs: Any) -> None:
         self.h = brainstate.HiddenState(braintools.init.param(self._state_initializer, self.out_size, batch_size))
 
-    def reset_state(self, batch_size: int = None, **kwargs):
+    def reset_state(self, batch_size: int | None = None, **kwargs: Any) -> None:
         self.h.value = braintools.init.param(self._state_initializer, self.out_size, batch_size)
 
-    def update(self, x):
+    def update(self, x: ArrayLike) -> ArrayLike:
         r"""Advance the cell by one time step.
 
         Parameters
@@ -976,8 +978,8 @@ class MiniLSTM(brainstate.nn.RNNCell):
         w_init: Union[ArrayLike, Callable] = braintools.init.Orthogonal(),
         b_init: Union[ArrayLike, Callable] = braintools.init.ZeroInit(),
         state_init: Union[ArrayLike, Callable] = braintools.init.ZeroInit(),
-        name: str = None,
-    ):
+        name: str | None = None,
+    ) -> None:
         super().__init__(name=name)  # type: ignore[call-arg]
 
         # parameters
@@ -993,13 +995,13 @@ class MiniLSTM(brainstate.nn.RNNCell):
         self.W_f = Linear(_as_size_tuple(self.in_size)[-1] + _as_size_tuple(self.out_size)[-1], _as_size_tuple(self.out_size)[-1], **params)
         self.W_i = Linear(_as_size_tuple(self.in_size)[-1] + _as_size_tuple(self.out_size)[-1], _as_size_tuple(self.out_size)[-1], **params)
 
-    def init_state(self, batch_size: int = None, **kwargs):
+    def init_state(self, batch_size: int | None = None, **kwargs: Any) -> None:
         self.h = brainstate.HiddenState(braintools.init.param(self._state_initializer, self.out_size, batch_size))
 
-    def reset_state(self, batch_size: int = None, **kwargs):
+    def reset_state(self, batch_size: int | None = None, **kwargs: Any) -> None:
         self.h.value = braintools.init.param(self._state_initializer, self.out_size, batch_size)
 
-    def update(self, x):
+    def update(self, x: ArrayLike) -> ArrayLike:
         r"""Advance the cell by one time step.
 
         Parameters
@@ -1019,7 +1021,7 @@ class MiniLSTM(brainstate.nn.RNNCell):
         return self.h.value
 
 
-def glorot_init(s):
+def glorot_init(s: Any) -> ArrayLike:
     return brainstate.random.randn(*s) / u.math.sqrt(s[0])
 
 
@@ -1073,7 +1075,7 @@ class LRUCell(brainstate.nn.Module):
         r_min: float = 0.0,  # smallest lambda norm
         r_max: float = 1.0,  # largest lambda norm
         max_phase: float = 6.28,  # max phase lambda
-    ):
+    ) -> None:
         super().__init__()
 
         self.in_size = d_model
@@ -1118,15 +1120,15 @@ class LRUCell(brainstate.nn.Module):
         # Parameter for skip connection
         self.D = brainstate.ParamState(brainstate.random.randn(d_model))
 
-    def init_state(self, batch_size: int = None, **kwargs):
+    def init_state(self, batch_size: int | None = None, **kwargs: Any) -> None:
         self.h_re = brainstate.HiddenState(braintools.init.param(braintools.init.ZeroInit(), self.d_hidden, batch_size))
         self.h_im = brainstate.HiddenState(braintools.init.param(braintools.init.ZeroInit(), self.d_hidden, batch_size))
 
-    def reset_state(self, batch_size: int = None, **kwargs):
+    def reset_state(self, batch_size: int | None = None, **kwargs: Any) -> None:
         self.h_re.value = braintools.init.param(braintools.init.ZeroInit(), self.d_hidden, batch_size)
         self.h_im.value = braintools.init.param(braintools.init.ZeroInit(), self.d_hidden, batch_size)
 
-    def update(self, inputs):
+    def update(self, inputs: ArrayLike) -> ArrayLike:
         r"""Advance the unit by one time step.
 
         Updates the real and imaginary parts of the complex hidden state

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -156,6 +156,8 @@ module = [
     "braintrace._op.lora",
     "braintrace._op._primitive",
     "braintrace._op",
+    "braintrace._compile",
+    "braintrace",
 ]
 disallow_untyped_defs = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -153,6 +153,7 @@ module = [
     "braintrace._op.elemwise",
     "braintrace._op.conv",
     "braintrace._op.sparse",
+    "braintrace._op.lora",
 ]
 disallow_untyped_defs = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -168,6 +168,10 @@ module = [
     "braintrace.nn",
     "braintrace._algorithm.base",
     "braintrace._algorithm.graph_executor",
+    "braintrace._algorithm.vjp_base",
+    "braintrace._algorithm.vjp_graph_executor",
+    "braintrace._algorithm.param_dim_vjp",
+    "braintrace._algorithm.io_dim_vjp",
 ]
 disallow_untyped_defs = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -162,6 +162,8 @@ module = [
     "braintrace._grad_exponential",
     "braintrace._misc",
     "braintrace.nn._linear",
+    "braintrace.nn._conv",
+    "braintrace.nn._readout",
 ]
 disallow_untyped_defs = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -165,6 +165,9 @@ module = [
     "braintrace.nn._conv",
     "braintrace.nn._readout",
     "braintrace.nn._rnn",
+    "braintrace.nn",
+    "braintrace._algorithm.base",
+    "braintrace._algorithm.graph_executor",
 ]
 disallow_untyped_defs = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -154,6 +154,8 @@ module = [
     "braintrace._op.conv",
     "braintrace._op.sparse",
     "braintrace._op.lora",
+    "braintrace._op._primitive",
+    "braintrace._op",
 ]
 disallow_untyped_defs = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,6 +152,7 @@ module = [
     "braintrace._op.dense",
     "braintrace._op.elemwise",
     "braintrace._op.conv",
+    "braintrace._op.sparse",
 ]
 disallow_untyped_defs = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,6 +158,9 @@ module = [
     "braintrace._op",
     "braintrace._compile",
     "braintrace",
+    "braintrace._input_data",
+    "braintrace._grad_exponential",
+    "braintrace._misc",
 ]
 disallow_untyped_defs = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -172,6 +172,15 @@ module = [
     "braintrace._algorithm.vjp_graph_executor",
     "braintrace._algorithm.param_dim_vjp",
     "braintrace._algorithm.io_dim_vjp",
+    "braintrace._algorithm.d_rtrl",
+    "braintrace._algorithm.pp_prop",
+    "braintrace._algorithm.e_prop",
+    "braintrace._algorithm.ostl",
+    "braintrace._algorithm.otpe",
+    "braintrace._algorithm.ottt",
+    "braintrace._algorithm.osttp",
+    "braintrace._algorithm._common",
+    "braintrace._algorithm",
 ]
 disallow_untyped_defs = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -151,6 +151,7 @@ module = [
     "braintrace._typing",
     "braintrace._op.dense",
     "braintrace._op.elemwise",
+    "braintrace._op.conv",
 ]
 disallow_untyped_defs = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,6 +164,7 @@ module = [
     "braintrace.nn._linear",
     "braintrace.nn._conv",
     "braintrace.nn._readout",
+    "braintrace.nn._rnn",
 ]
 disallow_untyped_defs = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -150,6 +150,7 @@ ignore_missing_imports = true
 module = [
     "braintrace._typing",
     "braintrace._op.dense",
+    "braintrace._op.elemwise",
 ]
 disallow_untyped_defs = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -142,6 +142,16 @@ module = [
 follow_imports = "skip"
 ignore_missing_imports = true
 
+# Public-API surface: every def in these modules must be fully annotated. This
+# is what makes "every public API is typed" a property mypy enforces, so it
+# cannot silently regress. Explicit module list (no wildcards) so internal /
+# test-helper modules are not dragged in. Later changes append to this list.
+[[tool.mypy.overrides]]
+module = [
+    "braintrace._typing",
+]
+disallow_untyped_defs = true
+
 
 # Coverage configuration (coverage.py / pytest-cov). The measured surface is the
 # shipped `braintrace` package only: co-located `*_test.py` files and the

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,6 +149,7 @@ ignore_missing_imports = true
 [[tool.mypy.overrides]]
 module = [
     "braintrace._typing",
+    "braintrace._op.dense",
 ]
 disallow_untyped_defs = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -161,6 +161,7 @@ module = [
     "braintrace._input_data",
     "braintrace._grad_exponential",
     "braintrace._misc",
+    "braintrace.nn._linear",
 ]
 disallow_untyped_defs = true
 


### PR DESCRIPTION
## Summary

Adds detailed inline type annotations to every public API symbol (those exported in `braintrace.__all__` and `braintrace.nn.__all__` — free functions plus the public constructors/methods/properties of exported classes), and makes "every public def is typed" a property mypy **enforces** so it cannot silently regress.

## Approach

- **Inline annotations** (no `.pyi` stubs), reusing/extending `braintrace/_typing.py` (new `WeightFn` alias).
- **Scoped enforcement gate:** a `[[tool.mypy.overrides]]` block with `disallow_untyped_defs = true` over an explicit list of the 32 public-API-bearing modules (plus the `braintrace` root). No wildcards, so internal/test-helper modules are not dragged in.
- All files use `from __future__ import annotations`; jax/jaxpr plumbing internals are typed pragmatically with `Any`; third-party scientific deps remain untyped via the existing per-module overrides.

## Surface covered

- Operators: `matmul`, `element_wise`, `conv`, `sparse_matmul`, `lora_matmul`, `ETPPrimitive`, `register_primitive`
- Entry point: `compile` (`-> ETraceAlgorithm | brainstate.nn.Vmap`)
- Containers/utilities: `SingleStepData`, `MultiStepData`, `GradExpon`, error classes
- `braintrace.nn`: `Linear`/`SignedWLinear`/`ScaledWSLinear`/`SparseLinear`/`LoRA`, `Conv1d/2d/3d`, `LeakyRateReadout`, all 9 recurrent cells
- Algorithms: `ETraceAlgorithm` + executors, the VJP base classes, and the concrete algorithms (`D_RTRL`, `pp_prop`/`ES_D_RTRL`, `EProp`, `OSTLRecurrent`/`OSTLFeedforward`, `OTPE`, `OTTT`, `OSTTP`) and common trace/feedback classes

Deprecated v0.1.x legacy shims are intentionally excluded.

## Verification

- `mypy braintrace` → Success (52 source files); negative-control check confirms the gate catches a removed return annotation.
- Behaviour-neutral: full `pytest` passes (annotations only; a small number of subprocess example-smoke tests are load-flaky and pass in isolation).
- Downstream typed-usage spot check type-checks against the package.