### PR TITLE
fix: weight_fn/bias_fn fast-path gradients + move D-RTRL fast-path kernels into the operator layer

### DIFF
--- a/braintrace/_algorithm/d_rtrl_test.py
+++ b/braintrace/_algorithm/d_rtrl_test.py
@@ -25,7 +25,6 @@ from braintrace._algorithm.d_rtrl import D_RTRL
 from braintrace._algorithm.param_dim_vjp import (
     ParamDimVjpAlgorithm,
     _remove_units,
-    _fast_solve_contract,
 )
 from braintrace._etrace_model_test import (
     IF_Delta_Dense_Layer,
@@ -39,7 +38,7 @@ from braintrace._etrace_model_test import (
     ALIF_STDExpCu_Dense_Layer,
     ALIF_STPExpCu_Dense_Layer,
 )
-from braintrace._op import etp_mm_p
+from braintrace._op import etp_mm_p, get_fast_path_rules
 
 
 # ---------------------------------------------------------------------------
@@ -931,7 +930,8 @@ class TestTraceDtypeKnob:
 
 def _alif(n_in=4, n_rec=5):
     """Adaptive-LIF dense layer -> coupled (V, adaptation) hidden group with
-    num_state==2, exercising the S>1 einsum branch of _fast_recurrent_term."""
+    num_state==2, exercising the S>1 einsum branch of the dense fast-path
+    recurrent rule (``FastPathRules.recurrent``)."""
     model = ALIF_Delta_Dense_Layer(n_in, n_rec)
     brainstate.nn.init_all_states(model)
     return model
@@ -984,11 +984,12 @@ class TestSolveBatchFold:
             'bias': brainstate.random.randn(B, O, S),
         }
         # reference: current per-batch contraction, then explicit batch sum
-        ref = _fast_solve_contract(etp_mm_p, diag_like, etrace)
+        solve = get_fast_path_rules(etp_mm_p).solve
+        ref = solve(diag_like, etrace, fold_batch=False)
         ref_w = ref['weight'].sum(axis=0)   # (I, O)
         ref_b = ref['bias'].sum(axis=0)     # (O,)
         # new: fold the batch axis inside the einsum
-        folded = _fast_solve_contract(etp_mm_p, diag_like, etrace, fold_batch=True)
+        folded = solve(diag_like, etrace, fold_batch=True)
         assert folded['weight'].shape == (I, O)
         assert folded['bias'].shape == (O,)
         npt.assert_allclose(folded['weight'], ref_w, atol=1e-6)

--- a/braintrace/_algorithm/d_rtrl_test.py
+++ b/braintrace/_algorithm/d_rtrl_test.py
@@ -657,7 +657,7 @@ class TestDRtrlDictTraceStorage:
 # Helpers for the trace-update specialization + dtype-knob tests
 # ---------------------------------------------------------------------------
 
-def _rnn_mm(seed=0, n=4, bias=False):
+def _rnn_mm(seed=0, n=4, bias=False, weight_fn=None, bias_fn=None):
     """Batched single-recurrent-weight tanh RNN -> etp_mm_p, num_state==1."""
 
     class Net(brainstate.nn.Module):
@@ -670,7 +670,10 @@ def _rnn_mm(seed=0, n=4, bias=False):
 
         def update(self, x):
             b = self.b.value if self.b is not None else None
-            self.h.value = jax.nn.tanh(braintrace.matmul(self.h.value + x, self.w.value, b))
+            self.h.value = jax.nn.tanh(braintrace.matmul(
+                self.h.value + x, self.w.value, b,
+                weight_fn=weight_fn, bias_fn=bias_fn,
+            ))
             return self.h.value
 
     net = Net()
@@ -678,7 +681,7 @@ def _rnn_mm(seed=0, n=4, bias=False):
     return net
 
 
-def _rnn_mv(seed=0, n=4):
+def _rnn_mv(seed=0, n=4, weight_fn=None):
     """Unbatched single-recurrent-weight tanh RNN -> etp_mv_p, num_state==1."""
 
     class Net(brainstate.nn.Module):
@@ -690,11 +693,34 @@ def _rnn_mv(seed=0, n=4):
             self.h = brainstate.HiddenState(jnp.zeros((n,)))
 
         def update(self, x):
-            self.h.value = jax.nn.tanh(braintrace.matmul(self.h.value + x, self.w.value))
+            self.h.value = jax.nn.tanh(braintrace.matmul(
+                self.h.value + x, self.w.value, weight_fn=weight_fn,
+            ))
             return self.h.value
 
     net = Net()
     brainstate.nn.init_all_states(net)
+    return net
+
+
+def _rnn_elemwise(seed=0, n=4, weight_fn=None):
+    """Single element-wise-weight tanh RNN -> etp_elemwise_p, num_state==1."""
+
+    class Net(brainstate.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.alpha = brainstate.ParamState(
+                0.5 * jax.random.normal(jax.random.PRNGKey(seed), (n,))
+            )
+            self.h = brainstate.HiddenState(jnp.zeros((1, n)))
+
+        def update(self, x):
+            a = braintrace.element_wise(self.alpha.value, weight_fn=weight_fn)
+            self.h.value = jax.nn.tanh(a * (self.h.value + x))
+            return self.h.value
+
+    net = Net()
+    brainstate.nn.init_all_states(net, batch_size=1)
     return net
 
 
@@ -770,6 +796,73 @@ class TestS1RecurrentBroadcastEqualsLegacy:
         xs = self._xs_mv()
         fast = _run_updates(ParamDimVjpAlgorithm(_rnn_mv(), fast_solve=True), xs)
         legacy = _run_updates(ParamDimVjpAlgorithm(_rnn_mv(), fast_solve=False), xs)
+        _assert_etrace_lists_equal(fast, legacy, exact=True)
+
+
+# ---------------------------------------------------------------------------
+# weight_fn/bias_fn — the fast closed-form trace must equal the rule (legacy)
+# path when a transform hook is present.
+#
+# The fast kernels compute the instant term as the outer product x ⊗ df, which
+# equals ∂h/∂V (the *transformed* weight). With a transform present the true
+# eligibility trace is ∂h/∂W_raw = (x ⊗ df) ⊙ f'(W); the f' factor is supplied
+# only by the rule path's ``xy_to_dw`` (via jax.vjp). So the fast path must fall
+# back to the rules whenever a ``*_fn`` hook is set, otherwise the trace is the
+# gradient w.r.t. the transformed weight and silently drops f'(W).
+# ---------------------------------------------------------------------------
+
+class TestTransformFastEqualsLegacy:
+    """With a weight_fn/bias_fn hook, the default (fast) trace must match the
+    rule path bit-for-bit — i.e. the fast path falls back to the rules so the
+    f'(W) factor from ``xy_to_dw`` is not dropped.
+
+    Run several steps so the recurrent term (non-zero from the 2nd update) is
+    exercised, not just the instant term."""
+
+    def _xs_mm(self, n=4, steps=4):
+        return brainstate.random.randn(steps, 1, n)
+
+    def _xs_mv(self, n=4, steps=4):
+        return brainstate.random.randn(steps, n)
+
+    def test_mm_weight_fn_fast_equals_legacy(self):
+        xs = self._xs_mm()
+        wfn = lambda w: w ** 2
+        fast = _run_updates(ParamDimVjpAlgorithm(_rnn_mm(weight_fn=wfn), fast_solve=True), xs)
+        legacy = _run_updates(ParamDimVjpAlgorithm(_rnn_mm(weight_fn=wfn), fast_solve=False), xs)
+        _assert_etrace_lists_equal(fast, legacy, exact=True)
+
+    def test_mm_weight_fn_and_bias_fn_fast_equals_legacy(self):
+        xs = self._xs_mm()
+        fast = _run_updates(
+            ParamDimVjpAlgorithm(
+                _rnn_mm(bias=True, weight_fn=jnp.tanh, bias_fn=lambda b: b * 2.0),
+                fast_solve=True), xs)
+        legacy = _run_updates(
+            ParamDimVjpAlgorithm(
+                _rnn_mm(bias=True, weight_fn=jnp.tanh, bias_fn=lambda b: b * 2.0),
+                fast_solve=False), xs)
+        _assert_etrace_lists_equal(fast, legacy, exact=True)
+
+    def test_mv_weight_fn_fast_equals_legacy(self):
+        xs = self._xs_mv()
+        fast = _run_updates(ParamDimVjpAlgorithm(_rnn_mv(weight_fn=jnp.tanh), fast_solve=True), xs)
+        legacy = _run_updates(ParamDimVjpAlgorithm(_rnn_mv(weight_fn=jnp.tanh), fast_solve=False), xs)
+        _assert_etrace_lists_equal(fast, legacy, exact=True)
+
+    def test_elemwise_weight_fn_fast_equals_legacy(self):
+        xs = self._xs_mm()
+        wfn = jnp.tanh
+        fast = _run_updates(ParamDimVjpAlgorithm(_rnn_elemwise(weight_fn=wfn), fast_solve=True), xs)
+        legacy = _run_updates(ParamDimVjpAlgorithm(_rnn_elemwise(weight_fn=wfn), fast_solve=False), xs)
+        _assert_etrace_lists_equal(fast, legacy, exact=True)
+
+    def test_no_transform_still_uses_fast_path(self):
+        """Guard: without a transform, fast and legacy remain bit-identical (the
+        gate must not disable the fast path when no ``*_fn`` hook is present)."""
+        xs = self._xs_mm()
+        fast = _run_updates(ParamDimVjpAlgorithm(_rnn_mm(), fast_solve=True), xs)
+        legacy = _run_updates(ParamDimVjpAlgorithm(_rnn_mm(), fast_solve=False), xs)
         _assert_etrace_lists_equal(fast, legacy, exact=True)
 
 

--- a/braintrace/_algorithm/param_dim_vjp.py
+++ b/braintrace/_algorithm/param_dim_vjp.py
@@ -66,6 +66,22 @@ __all__ = [
 _ELEMENTWISE_YW_PRIMITIVES = (etp_mm_p, etp_mv_p, etp_elemwise_p)
 
 
+def _has_param_transform(eqn_params):
+    """Whether an ETP equation uses any ``*_fn`` parameter-transform hook.
+
+    The fast closed-form kernels compute the instantaneous trace as the bare
+    outer product ``x ⊗ df`` (i.e. ``∂h/∂V`` w.r.t. the *transformed* weight
+    ``V = f(W)``). When a transform hook (``weight_fn`` / ``bias_fn`` /
+    ``kernel_fn`` / ``a_fn`` / ``b_fn`` / ...) is present, the true eligibility
+    trace is ``∂h/∂W_raw = (x ⊗ df) ⊙ f'(W)``; the ``f'(W)`` factor is supplied
+    only by the rule path's ``xy_to_dw`` (via ``jax.vjp``). So a transform-bearing
+    relation must fall back to the rule path. Detection is generic over the
+    ``*_fn`` naming convention so no per-primitive knowledge leaks into the
+    algorithm layer.
+    """
+    return any(k.endswith('_fn') and v is not None for k, v in eqn_params.items())
+
+
 def _cast_to_dtype(tree, dtype):
     """Cast every array leaf of ``tree`` to ``dtype`` (unit-safe; ``None`` -> no-op).
 
@@ -268,8 +284,14 @@ def _update_param_dim_etrace_scan_fn(
         is_elemwise = relation.primitive is etp_elemwise_p
         batched = is_batched_primitive(relation.primitive)
         has_bias = eqn_params.get('has_bias', False)
-        # Fast path only applies to primitives with elementwise yw_to_w.
-        use_fast = fast_solve and (relation.primitive in _ELEMENTWISE_YW_PRIMITIVES)
+        # Fast path only applies to primitives with elementwise yw_to_w, and
+        # only when no parameter-transform hook is present (the closed-form
+        # kernels drop the f'(W) factor — see ``_has_param_transform``).
+        use_fast = (
+            fast_solve
+            and (relation.primitive in _ELEMENTWISE_YW_PRIMITIVES)
+            and not _has_param_transform(eqn_params)
+        )
 
         if is_elemwise:
             x = None
@@ -452,7 +474,13 @@ def _solve_param_dim_weight_gradients(
         batched = is_batched_primitive(relation.primitive)
         if batched:
             batched_paths.update(relation.trainable_paths.values())
-        use_fast = fast_solve and (relation.primitive in _ELEMENTWISE_YW_PRIMITIVES)
+        # Fast path only for elementwise-yw primitives with no transform hook
+        # (the closed-form solve drops f'(W) — see ``_has_param_transform``).
+        use_fast = (
+            fast_solve
+            and (relation.primitive in _ELEMENTWISE_YW_PRIMITIVES)
+            and not _has_param_transform(eqn_params)
+        )
 
         def _call_yw_to_w_dict(d, trace_, _rule=yw_to_w_rule, _params=eqn_params):
             return _rule(d, trace_, **_params)

--- a/braintrace/_algorithm/param_dim_vjp.py
+++ b/braintrace/_algorithm/param_dim_vjp.py
@@ -24,12 +24,11 @@ import brainunit as u
 from braintrace._compiler import HiddenParamOpRelation, HiddenGroup
 from braintrace._op import (
     etp_elemwise_p,
-    etp_mm_p,
-    etp_mv_p,
     ETP_RULES_YW_TO_W,
     ETP_RULES_XY_TO_DW,
     ETP_RULES_INIT_DRTRL,
     is_batched_primitive,
+    get_fast_path_rules,
 )
 from braintrace._misc import etrace_df_key
 from braintrace._typing import (
@@ -57,30 +56,6 @@ from .vjp_base import ETraceVjpAlgorithm
 __all__ = [
     'ParamDimVjpAlgorithm',
 ]
-
-# Primitives with an elementwise ``yw_to_w`` rule, i.e. rules of the form
-# ``trace * hidden_dim_broadcast``. For these we can replace the nested
-# ``vmap(yw_to_w, -1, -1) + sum`` pattern with a single ``einsum`` contraction
-# over the hidden-state axis of ``diag`` and ``trace``. Conv / sparse / LoRA
-# primitives have non-elementwise rules and stay on the legacy path.
-_ELEMENTWISE_YW_PRIMITIVES = (etp_mm_p, etp_mv_p, etp_elemwise_p)
-
-
-def _has_param_transform(eqn_params):
-    """Whether an ETP equation uses any ``*_fn`` parameter-transform hook.
-
-    The fast closed-form kernels compute the instantaneous trace as the bare
-    outer product ``x ⊗ df`` (i.e. ``∂h/∂V`` w.r.t. the *transformed* weight
-    ``V = f(W)``). When a transform hook (``weight_fn`` / ``bias_fn`` /
-    ``kernel_fn`` / ``a_fn`` / ``b_fn`` / ...) is present, the true eligibility
-    trace is ``∂h/∂W_raw = (x ⊗ df) ⊙ f'(W)``; the ``f'(W)`` factor is supplied
-    only by the rule path's ``xy_to_dw`` (via ``jax.vjp``). So a transform-bearing
-    relation must fall back to the rule path. Detection is generic over the
-    ``*_fn`` naming convention so no per-primitive knowledge leaks into the
-    algorithm layer.
-    """
-    return any(k.endswith('_fn') and v is not None for k, v in eqn_params.items())
-
 
 def _cast_to_dtype(tree, dtype):
     """Cast every array leaf of ``tree`` to ``dtype`` (unit-safe; ``None`` -> no-op).
@@ -131,72 +106,9 @@ def _init_param_dim_state(
                 f'Primitive {relation.primitive.name} init_drtrl must return a dict; '
                 f'got {type(init_val).__name__}.'
             )
-        if relation.primitive in _ELEMENTWISE_YW_PRIMITIVES:
+        if get_fast_path_rules(relation.primitive) is not None:
             init_val = _cast_to_dtype(init_val, trace_dtype)
         etrace_bwg[bwg_key] = EligibilityTrace(init_val)
-
-
-def _fast_recurrent_term(primitive, diag, old_bwg, num_state):
-    """Closed-form ``D^t * eps^{t-1}`` for primitives with an elementwise
-    ``yw_to_w`` rule.
-
-    ``diag`` has shape ``(*varshape, num_state_alpha, num_state_beta)`` with
-    ``varshape == y_shape`` for mm/mv/elemwise. ``old_bwg`` is the per-key
-    trace dict. For mm/mv the weight trace has shape
-    ``(*y_shape, in_features, num_state)`` (batched mm has a leading batch
-    axis; mv/elemwise do not); the bias trace has shape
-    ``(*y_shape, num_state)`` when present.
-
-    The contraction is
-        new[b..., i, k, alpha] = sum_beta diag[b..., k, alpha, beta]
-                                       * trace[b..., i, k, beta]
-    which maps exactly to ``einsum('...kab,...ikb->...ika')``. For elemwise
-    the ``i`` axis disappears and it reduces to ``einsum('...ab,...b->...a')``.
-
-    When ``num_state == 1`` (the common single-state case) both state axes have
-    size 1, so the sum over ``beta`` collapses to a single term and the whole
-    contraction becomes a broadcast multiply — bit-identical to the einsum but
-    with no degenerate ``dot_general``. ``diag[..., 0, 0]`` indexes the hidden
-    (``k``) axis.
-    """
-    if num_state == 1:
-        if primitive is etp_elemwise_p:
-            # diag[..., 0, :] keeps the size-1 beta axis to align with trace.
-            return {'weight': diag[..., 0, :] * old_bwg['weight']}
-        d = diag[..., 0, 0]  # (*varshape) ending in the hidden ``k`` axis
-        out = {'weight': d[..., None, :, None] * old_bwg['weight']}
-        if 'bias' in old_bwg:
-            out['bias'] = d[..., None] * old_bwg['bias']
-        return out
-    if primitive is etp_elemwise_p:
-        return {
-            'weight': jnp.einsum('...ab,...b->...a', diag, old_bwg['weight']),
-        }
-    # mm / mv: trace['weight'] has an extra in-features axis before ``out``.
-    out = {
-        'weight': jnp.einsum('...kab,...ikb->...ika', diag, old_bwg['weight']),
-    }
-    if 'bias' in old_bwg:
-        out['bias'] = jnp.einsum('...kab,...kb->...ka', diag, old_bwg['bias'])
-    return out
-
-
-def _fast_instant_term(primitive, x, df, has_bias):
-    """Closed-form ``diag(D_f^t) ⊗ x^t`` for mm/mv/elemwise primitives.
-
-    For mm/mv the instantaneous gradient of ``y = x @ W + b`` w.r.t. ``W``
-    is the outer product ``x ⊗ df`` with a ``num_state`` axis tagged on.
-    For the elemwise identity op it is simply ``df`` (no ``x`` factor).
-    """
-    if primitive is etp_elemwise_p:
-        return {'weight': df}
-    if primitive is etp_mm_p:
-        out = {'weight': jnp.einsum('...i,...ka->...ika', x, df)}
-    else:  # etp_mv_p — no batch axis
-        out = {'weight': jnp.einsum('i,ka->ika', x, df)}
-    if has_bias:
-        out['bias'] = df
-    return out
 
 
 def _update_param_dim_etrace_scan_fn(
@@ -286,12 +198,9 @@ def _update_param_dim_etrace_scan_fn(
         has_bias = eqn_params.get('has_bias', False)
         # Fast path only applies to primitives with elementwise yw_to_w, and
         # only when no parameter-transform hook is present (the closed-form
-        # kernels drop the f'(W) factor — see ``_has_param_transform``).
-        use_fast = (
-            fast_solve
-            and (relation.primitive in _ELEMENTWISE_YW_PRIMITIVES)
-            and not _has_param_transform(eqn_params)
-        )
+        # kernels drop the f'(W) factor — gated by ``fp.applicable``).
+        fp = get_fast_path_rules(relation.primitive)
+        use_fast = fast_solve and fp is not None and fp.applicable(eqn_params)
 
         if is_elemwise:
             x = None
@@ -364,8 +273,7 @@ def _update_param_dim_etrace_scan_fn(
             # multiply-add runs in the trace precision and the new trace stays
             # there; Jacobians/learning-signal remain full precision elsewhere.
             if use_fast:
-                phg_to_pw = _fast_instant_term(
-                    relation.primitive,
+                phg_to_pw = fp.instant(
                     _cast_to_dtype(x, trace_dtype),
                     _cast_to_dtype(df, trace_dtype),
                     has_bias,
@@ -380,8 +288,7 @@ def _update_param_dim_etrace_scan_fn(
 
             # Recurrent term: D^t · ε^{t-1}.
             if use_fast:
-                new_bwg_pre = _fast_recurrent_term(
-                    relation.primitive,
+                new_bwg_pre = fp.recurrent(
                     _cast_to_dtype(diag, trace_dtype),
                     old_bwg,
                     group.num_state,
@@ -396,35 +303,6 @@ def _update_param_dim_etrace_scan_fn(
             new_etrace_bwg[w_key] = new_bwg
 
     return new_etrace_bwg, None
-
-
-def _fast_solve_contract(primitive, diag_like, etrace_data, fold_batch=False):
-    """Solve-time closed-form contraction for mm/mv/elemwise.
-
-    ``diag_like`` is the dl/dh group gradient with shape ``(*y_shape, num_state)``;
-    ``etrace_data`` is the weight-shaped trace dict. The solver computes
-    ``sum_alpha diag_like[..., alpha] * yw_to_w(etrace[..., alpha])``, which
-    for elementwise ``yw_to_w`` is an einsum along the ``num_state`` axis.
-
-    When ``fold_batch`` is True the leading batch axis ``b`` is contracted inside
-    the einsum, so the result is the already batch-summed gradient. This avoids
-    materializing a ``(B, I, O)`` intermediate and a follow-up ``sum(axis=0)``.
-    It assumes exactly one leading batch axis (the same assumption the trailing
-    ``sum(axis=0)`` already makes).
-    """
-    if primitive is etp_elemwise_p:
-        spec = 'b...a,b...a->...' if fold_batch else '...a,...a->...'
-        return {
-            'weight': jnp.einsum(spec, diag_like, etrace_data['weight']),
-        }
-    w_spec = 'bka,bika->ik' if fold_batch else '...ka,...ika->...ik'
-    out = {
-        'weight': jnp.einsum(w_spec, diag_like, etrace_data['weight']),
-    }
-    if 'bias' in etrace_data:
-        b_spec = 'bka,bka->k' if fold_batch else '...ka,...ka->...k'
-        out['bias'] = jnp.einsum(b_spec, diag_like, etrace_data['bias'])
-    return out
 
 
 def _solve_param_dim_weight_gradients(
@@ -475,12 +353,9 @@ def _solve_param_dim_weight_gradients(
         if batched:
             batched_paths.update(relation.trainable_paths.values())
         # Fast path only for elementwise-yw primitives with no transform hook
-        # (the closed-form solve drops f'(W) — see ``_has_param_transform``).
-        use_fast = (
-            fast_solve
-            and (relation.primitive in _ELEMENTWISE_YW_PRIMITIVES)
-            and not _has_param_transform(eqn_params)
-        )
+        # (the closed-form solve drops f'(W) — gated by ``fp.applicable``).
+        fp = get_fast_path_rules(relation.primitive)
+        use_fast = fast_solve and fp is not None and fp.applicable(eqn_params)
 
         def _call_yw_to_w_dict(d, trace_, _rule=yw_to_w_rule, _params=eqn_params):
             return _rule(d, trace_, **_params)
@@ -531,8 +406,8 @@ def _solve_param_dim_weight_gradients(
                 # batched primitive, fold the batch reduction into the einsum so
                 # no (B, I, O) intermediate is materialized; record the routed
                 # paths so the trailing batch-sum skips them (already reduced).
-                dg_weight_dict = _fast_solve_contract(
-                    relation.primitive, dg_hidden_unitless, etrace_for_solve,
+                dg_weight_dict = fp.solve(
+                    dg_hidden_unitless, etrace_for_solve,
                     fold_batch=batched,
                 )
                 if batched:

--- a/braintrace/_op/__init__.py
+++ b/braintrace/_op/__init__.py
@@ -33,6 +33,7 @@ exported from ``braintrace._op`` is also available here.
 from ._primitive import ETPPrimitive, register_primitive
 from ._registries import (
     BATCHED_PRIMITIVES,
+    ETP_FAST_PATH_RULES,
     ETP_PRIMITIVES,
     ETP_RULES_INIT_DRTRL,
     ETP_RULES_INIT_PP,
@@ -41,7 +42,9 @@ from ._registries import (
     ETP_TRAINABLE_INVARS_FNS,
     ETP_X_INVAR_INDICES,
     ETP_Y_OUTVAR_INDICES,
+    FastPathRules,
     GRADIENT_ENABLED_PRIMITIVES,
+    get_fast_path_rules,
     get_trainable_invars,
     get_x_invar_index,
     get_y_outvar_index,
@@ -78,6 +81,9 @@ __all__ = [
     'get_trainable_invars',
     'get_x_invar_index',
     'get_y_outvar_index',
+    'FastPathRules',
+    'ETP_FAST_PATH_RULES',
+    'get_fast_path_rules',
 
     # primitives
     'etp_mm_p',

--- a/braintrace/_op/_primitive.py
+++ b/braintrace/_op/_primitive.py
@@ -33,6 +33,7 @@ from jax.interpreters import ad, batching, mlir
 from braintrace._compatible_imports import Primitive
 from ._registries import (
     BATCHED_PRIMITIVES,
+    ETP_FAST_PATH_RULES,
     ETP_PRIMITIVES,
     ETP_RULES_INIT_DRTRL,
     ETP_RULES_INIT_PP,
@@ -127,6 +128,7 @@ class ETPPrimitive(Primitive):
         xy_to_dw: Callable = None,
         init_drtrl: Callable = None,
         init_pp: Callable = None,
+        fast_path=None,
     ):
         """Install multiple ETP rules in one call.
 
@@ -142,6 +144,12 @@ class ETPPrimitive(Primitive):
             D-RTRL trace initialiser. Default ``None``.
         init_pp : Callable, optional
             pp_prop (IO-dim) df trace initialiser. Default ``None``.
+        fast_path : FastPathRules, optional
+            Closed-form param-dim D-RTRL fast-path kernel bundle (instant /
+            recurrent / solve kernels plus the ``applicable`` gate). Registered
+            into :data:`ETP_FAST_PATH_RULES`. Supplied only by primitives with
+            an elementwise ``yw_to_w`` rule (mm / mv / elemwise); ``None``
+            leaves the primitive without a fast path. Default ``None``.
         """
         if yw_to_w is not None:
             ETP_RULES_YW_TO_W[self] = yw_to_w
@@ -151,6 +159,8 @@ class ETPPrimitive(Primitive):
             ETP_RULES_INIT_DRTRL[self] = init_drtrl
         if init_pp is not None:
             ETP_RULES_INIT_PP[self] = init_pp
+        if fast_path is not None:
+            ETP_FAST_PATH_RULES[self] = fast_path
 
 
 def register_primitive(

--- a/braintrace/_op/_registries.py
+++ b/braintrace/_op/_registries.py
@@ -34,9 +34,15 @@ weight / ``x`` / ``y`` variables on an equation. They are populated by
 :func:`register_primitive` and queried through the accessor helpers
 :func:`get_trainable_invars`, :func:`get_x_invar_index` and
 :func:`get_y_outvar_index`.
+
+One further metadata dictionary — :data:`ETP_FAST_PATH_RULES` — holds the
+optional per-primitive closed-form param-dim D-RTRL "fast-path" kernel
+bundle (:class:`FastPathRules`). Only primitives with an elementwise
+``yw_to_w`` rule register one; it is queried through
+:func:`get_fast_path_rules`.
 """
 
-from typing import Callable, Dict, Optional
+from typing import Callable, Dict, NamedTuple, Optional
 
 from braintrace._compatible_imports import Primitive
 
@@ -57,6 +63,9 @@ __all__ = [
     'get_trainable_invars',
     'get_x_invar_index',
     'get_y_outvar_index',
+    'FastPathRules',
+    'ETP_FAST_PATH_RULES',
+    'get_fast_path_rules',
 ]
 
 ETP_PRIMITIVES: set = set()
@@ -134,3 +143,64 @@ def get_x_invar_index(primitive) -> Optional[int]:
 def get_y_outvar_index(primitive) -> int:
     """Return the index of ``y`` in ``eqn.outvars``."""
     return ETP_Y_OUTVAR_INDICES.get(primitive, 0)
+
+
+class FastPathRules(NamedTuple):
+    """Per-primitive closed-form param-dim D-RTRL fast-path kernels + gate.
+
+    Bundles the three closed-form einsum kernels that replace the generic
+    nested-``vmap`` trace path for primitives with an *elementwise*
+    ``yw_to_w`` rule (currently ``etp_mm_p`` / ``etp_mv_p`` / ``etp_elemwise_p``),
+    together with a gate predicate that decides whether the fast path is
+    valid for a given equation.
+
+    Parameters
+    ----------
+    instant : Callable
+        Instantaneous term ``diag(D_f^t) ⊗ x^t``. Signature
+        ``(x, df, has_bias) -> {'weight': ..., ['bias': ...]}``.
+    recurrent : Callable
+        Recurrent term ``D^t · ε^{t-1}``. Signature
+        ``(diag, old_bwg, num_state) -> dict``.
+    solve : Callable
+        Solve-time contraction ``Σ_alpha diag_like[..., alpha] · yw_to_w(ε[..., alpha])``.
+        Signature ``(diag_like, etrace_data, *, fold_batch) -> dict``.
+    applicable : Callable
+        Gate predicate ``(eqn_params) -> bool`` — ``True`` iff the closed-form
+        kernels are valid for this equation. The kernels drop the ``f'(W)``
+        transform factor, so a primitive carrying an active transform hook
+        (``weight_fn`` / ``bias_fn``) must report ``False`` and fall back to
+        the rule path.
+    """
+
+    instant: Callable
+    recurrent: Callable
+    solve: Callable
+    applicable: Callable
+
+
+ETP_FAST_PATH_RULES: Dict[Primitive, FastPathRules] = {}
+r"""Closed-form param-dim D-RTRL fast-path bundle per primitive.
+
+Populated by :meth:`ETPPrimitive.register_etp_rules` (via its ``fast_path``
+keyword). Only primitives with an elementwise ``yw_to_w`` rule register one;
+conv / sparse / LoRA primitives are absent (they have no closed-form fast
+path). Queried through :func:`get_fast_path_rules`.
+"""
+
+
+def get_fast_path_rules(primitive) -> Optional[FastPathRules]:
+    """Return the :class:`FastPathRules` bundle for *primitive*, or ``None``.
+
+    Parameters
+    ----------
+    primitive : Primitive
+        The ETP primitive to look up.
+
+    Returns
+    -------
+    FastPathRules or None
+        The registered fast-path bundle, or ``None`` if *primitive* has no
+        fast path (e.g. conv / sparse / LoRA).
+    """
+    return ETP_FAST_PATH_RULES.get(primitive)

--- a/braintrace/_op/_registries_test.py
+++ b/braintrace/_op/_registries_test.py
@@ -40,6 +40,7 @@ from braintrace._op import (
     etp_mv_p,
     etp_sp_mm_p,
     etp_sp_mv_p,
+    get_fast_path_rules,
     is_batched_primitive,
     is_etp_enable_gradient_primitive,
     is_etp_primitive,
@@ -163,3 +164,14 @@ class TestRegistriesAreSharedAcrossImports:
         from braintrace import _op as legacy
         assert legacy.GRADIENT_ENABLED_PRIMITIVES is GRADIENT_ENABLED_PRIMITIVES
         assert legacy.BATCHED_PRIMITIVES is BATCHED_PRIMITIVES
+
+
+def test_get_fast_path_rules_none_for_sparse_conv_lora():
+    """Primitives without a closed-form fast path return ``None``.
+
+    Only the elementwise-``yw_to_w`` primitives (mm / mv / elemwise) register
+    a :class:`FastPathRules` bundle. Conv / sparse / LoRA primitives have
+    non-elementwise rules and so must not appear in the fast-path registry.
+    """
+    for prim in (etp_sp_mm_p, etp_sp_mv_p, etp_conv_p, etp_lora_mm_p, etp_lora_mv_p):
+        assert get_fast_path_rules(prim) is None, prim.name

--- a/braintrace/_op/conv.py
+++ b/braintrace/_op/conv.py
@@ -67,6 +67,22 @@ output element). The conv primitive implements:
 * ``init_pp`` — allocates the pp-prop output-shaped df trace; the
   :math:`\boldsymbol{\epsilon}_x` factor in ES-D-RTRL is the full
   batched input tensor held by the executor.
+
+**Transform hooks**
+
+The primitive accepts two optional transform hooks in its ``eqn.params``:
+``kernel_fn`` (computes ``y = conv(x, kernel_fn(kernel))`` — note the
+kernel-facing name, not ``weight_fn``) and ``bias_fn`` (adds
+``bias_fn(b)``). The forward impl and :func:`_conv_xy_to_dw` apply them; the
+eligibility trace and gradient are always taken w.r.t. the **raw** kernel /
+bias, so the transform Jacobian :math:`f'` enters *only* through
+``xy_to_dw`` via :func:`jax.vjp` (``kernel_fn`` through a full kernel VJP,
+``bias_fn`` as an elementwise per-channel diagonal factor). The ``yw_to_w``
+rule and the trace initialisers are transform-free and stay exact (they
+operate on :math:`\partial h / \partial K_{\text{raw}}`).
+
+This primitive has **no fast path** — it always uses the generic rule path,
+which threads :math:`f'` correctly when a transform hook is present.
 """
 
 from typing import Any, Optional, Sequence

--- a/braintrace/_op/dense.py
+++ b/braintrace/_op/dense.py
@@ -73,6 +73,25 @@ gradients to *both* weight and bias ``ParamState`` objects in one pass.
 
 When ``has_bias=False`` the ``'bias'`` key is simply absent from every
 dict, so the legacy (no-bias) code path is unchanged in behaviour.
+
+**Transform hooks**
+
+Both primitives accept two optional elementwise transform hooks in their
+``eqn.params``: ``weight_fn`` (computes ``y = x @ weight_fn(w)``) and
+``bias_fn`` (adds ``bias_fn(b)``). The forward and :func:`_mm_xy_to_dw` /
+:func:`_mv_xy_to_dw` rules apply them; the eligibility trace and gradient
+are always taken w.r.t. the **raw** weight/bias, so the transform Jacobian
+:math:`f'` enters *only* through ``xy_to_dw`` via :func:`jax.vjp`. The
+``yw_to_w`` rule does **not** apply :math:`f'`.
+
+**Fast path**
+
+A closed-form param-dim D-RTRL kernel bundle (:class:`FastPathRules`,
+defined as ``_DENSE_FAST_PATH`` and registered on *both* primitives) replaces
+the generic nested-``vmap`` trace path with direct einsums. Because those
+kernels emit the bare outer product ``x ⊗ df`` (i.e. the gradient w.r.t. the
+*transformed* weight, dropping :math:`f'`), the bundle's ``applicable`` gate
+disables the fast path whenever ``weight_fn`` *or* ``bias_fn`` is present.
 """
 
 import jax
@@ -80,6 +99,7 @@ import jax.numpy as jnp
 import brainunit as u
 
 from ._primitive import register_primitive
+from ._registries import FastPathRules
 
 __all__ = [
     'etp_mm_p',
@@ -257,6 +277,151 @@ def _mm_init_pp(x_var, y_var, weight_vars, num_hidden_state):
     return jnp.zeros((*y_var.aval.shape, num_hidden_state), dtype=y_var.aval.dtype)
 
 
+# ---------------------------------------------------------------------------
+# Closed-form param-dim D-RTRL fast-path kernels (shared by mm and mv)
+# ---------------------------------------------------------------------------
+
+def _dense_fast_instant(x, df, has_bias):
+    r"""Instantaneous term :math:`\operatorname{diag}(\mathbf{D}_f^t) \otimes \mathbf{x}^t`.
+
+    Parameters
+    ----------
+    x : ArrayLike
+        Presynaptic input. Shape ``(..., in)`` (``(B, in)`` for mm,
+        ``(in,)`` for mv).
+    df : ArrayLike
+        State-to-output Jacobian :math:`\mathbf{D}_f^t`, shape
+        ``(..., out, num_state)``.
+    has_bias : bool
+        Whether to emit a ``'bias'`` entry (equal to ``df``).
+
+    Returns
+    -------
+    dict
+        ``{'weight': x ⊗ df}`` (plus ``'bias': df`` when ``has_bias``).
+
+    Notes
+    -----
+    The single spec ``'...i,...ka->...ika'`` covers both mm and mv: the
+    ``...`` block absorbs mm's leading batch axis and matches the empty
+    leading block of mv, so the outer product ``x_i ⊗ df_{ka}`` is computed
+    identically in both ranks (verified numerically equal to mv's bespoke
+    ``'i,ka->ika'``).
+    """
+    out = {'weight': jnp.einsum('...i,...ka->...ika', x, df)}
+    if has_bias:
+        out['bias'] = df
+    return out
+
+
+def _dense_fast_recurrent(diag, old_bwg, num_state):
+    r"""Recurrent term :math:`\mathbf{D}^t \boldsymbol{\epsilon}^{t-1}`.
+
+    Parameters
+    ----------
+    diag : ArrayLike
+        Hidden-to-hidden Jacobian, shape ``(..., out, num_state, num_state)``.
+    old_bwg : dict
+        Previous weight-shaped trace dict; ``'weight'`` has shape
+        ``(..., in, out, num_state)`` and optional ``'bias'`` has shape
+        ``(..., out, num_state)``.
+    num_state : int
+        Number of hidden states per group.
+
+    Returns
+    -------
+    dict
+        The contracted trace dict for the current step.
+
+    Notes
+    -----
+    The contraction is ``new[...,i,k,a] = Σ_b diag[...,k,a,b] · trace[...,i,k,b]``,
+    i.e. ``einsum('...kab,...ikb->...ika')`` (bias: ``'...kab,...kb->...ka'``).
+    When ``num_state == 1`` both state axes are size 1, so the sum over
+    ``b`` collapses to a broadcast multiply by ``diag[..., 0, 0]`` —
+    bit-identical to the einsum but without a degenerate ``dot_general``.
+    """
+    if num_state == 1:
+        d = diag[..., 0, 0]  # (..., out) — the hidden ``k`` axis
+        out = {'weight': d[..., None, :, None] * old_bwg['weight']}
+        if 'bias' in old_bwg:
+            out['bias'] = d[..., None] * old_bwg['bias']
+        return out
+    out = {'weight': jnp.einsum('...kab,...ikb->...ika', diag, old_bwg['weight'])}
+    if 'bias' in old_bwg:
+        out['bias'] = jnp.einsum('...kab,...kb->...ka', diag, old_bwg['bias'])
+    return out
+
+
+def _dense_fast_solve(diag_like, etrace_data, *, fold_batch=False):
+    r"""Solve-time contraction of the learning signal with the trace.
+
+    Parameters
+    ----------
+    diag_like : ArrayLike
+        The :math:`\partial \mathcal{L}/\partial \mathbf{h}` group gradient,
+        shape ``(..., out, num_state)`` (``(B, out, num_state)`` when batched).
+    etrace_data : dict
+        Weight-shaped trace dict; ``'weight'`` shape
+        ``(..., in, out, num_state)`` and optional ``'bias'`` shape
+        ``(..., out, num_state)``.
+    fold_batch : bool, optional
+        When ``True``, contract a leading batch axis ``b`` inside the einsum
+        so the result is already batch-summed (avoids a ``(B, I, O)``
+        intermediate). Default ``False``.
+
+    Returns
+    -------
+    dict
+        ``{'weight': dW}`` (plus ``'bias': db`` when present).
+
+    Notes
+    -----
+    Contracts the ``num_state`` axis (``a``): ``'...ka,...ika->...ik'`` for
+    the weight and ``'...ka,...ka->...k'`` for the bias. With ``fold_batch``
+    the leading ``b`` axis is added to the contraction
+    (``'bka,bika->ik'`` / ``'bka,bka->k'``), assuming exactly one batch axis.
+    """
+    w_spec = 'bka,bika->ik' if fold_batch else '...ka,...ika->...ik'
+    out = {'weight': jnp.einsum(w_spec, diag_like, etrace_data['weight'])}
+    if 'bias' in etrace_data:
+        b_spec = 'bka,bka->k' if fold_batch else '...ka,...ka->...k'
+        out['bias'] = jnp.einsum(b_spec, diag_like, etrace_data['bias'])
+    return out
+
+
+def _dense_fast_applicable(eqn_params):
+    r"""Gate: is the dense fast path valid for this equation?
+
+    Parameters
+    ----------
+    eqn_params : dict
+        The ETP equation's ``params`` dict.
+
+    Returns
+    -------
+    bool
+        ``True`` iff neither ``weight_fn`` nor ``bias_fn`` is active.
+
+    Notes
+    -----
+    The closed-form kernels emit the bare outer product ``x ⊗ df`` — the
+    gradient w.r.t. the *transformed* weight, dropping the ``f'(W)`` factor.
+    Both keys are always present in ``eqn.params`` for mm / mv, so the
+    AND-both test also disables the fast path for a ``bias_fn``-only
+    transform (the kernels cannot supply ``f'``).
+    """
+    return eqn_params.get('weight_fn') is None and eqn_params.get('bias_fn') is None
+
+
+_DENSE_FAST_PATH = FastPathRules(
+    _dense_fast_instant,
+    _dense_fast_recurrent,
+    _dense_fast_solve,
+    _dense_fast_applicable,
+)
+
+
 etp_mm_p = register_primitive(
     'etp_mm',
     _etp_matmul_impl,
@@ -269,6 +434,7 @@ etp_mm_p.register_etp_rules(
     xy_to_dw=_mm_xy_to_dw,
     init_drtrl=_mm_init_drtrl,
     init_pp=_mm_init_pp,
+    fast_path=_DENSE_FAST_PATH,
 )
 
 
@@ -397,6 +563,7 @@ etp_mv_p.register_etp_rules(
     xy_to_dw=_mv_xy_to_dw,
     init_drtrl=_mv_init_drtrl,
     init_pp=_mv_init_pp,
+    fast_path=_DENSE_FAST_PATH,
 )
 
 

--- a/braintrace/_op/dense_test.py
+++ b/braintrace/_op/dense_test.py
@@ -44,6 +44,7 @@ from braintrace._op import (
     ETP_RULES_YW_TO_W,
     etp_mm_p,
     etp_mv_p,
+    get_fast_path_rules,
     matmul,
 )
 
@@ -664,3 +665,97 @@ class TestMatmulWeightFnExactness:
             factory, inputs, algo_factory=lambda m: braintrace.D_RTRL(m, vjp_method='multi-step')
         )
         assert_param_gradients_close(online, bptt, atol=1e-4)
+
+
+# ---------------------------------------------------------------------------
+# Closed-form param-dim D-RTRL fast-path kernels (operator-layer bundle)
+# ---------------------------------------------------------------------------
+
+class TestDenseFastPath:
+    """The dense closed-form fast-path bundle registered on ``etp_mm_p`` /
+    ``etp_mv_p``.
+
+    Both dense primitives share the *same* :class:`FastPathRules` object: the
+    instant/recurrent/solve einsums are rank-polymorphic (``...`` absorbs
+    mv's missing batch axis), and the ``applicable`` gate keys off the
+    transform hooks present in ``eqn.params``.
+    """
+
+    def test_fast_path_registered_on_mm_and_mv(self):
+        mm_rules = get_fast_path_rules(etp_mm_p)
+        mv_rules = get_fast_path_rules(etp_mv_p)
+        assert mm_rules is not None
+        assert mv_rules is not None
+        # Shared bundle — mm and mv register the *same* object.
+        assert mm_rules is mv_rules
+
+    def test_fast_applicable_true_without_transforms(self):
+        rules = get_fast_path_rules(etp_mm_p)
+        assert rules.applicable(
+            {'weight_fn': None, 'bias_fn': None, 'has_bias': False}
+        ) is True
+
+    def test_fast_applicable_false_with_weight_fn(self):
+        rules = get_fast_path_rules(etp_mm_p)
+        assert rules.applicable(
+            {'weight_fn': lambda w: w ** 2, 'bias_fn': None, 'has_bias': False}
+        ) is False
+
+    def test_fast_applicable_false_with_bias_fn(self):
+        # bias_fn set, weight_fn None -> still False (locks the AND-both rule:
+        # any transform hook disables the fast path, even a bias-only one).
+        rules = get_fast_path_rules(etp_mm_p)
+        assert rules.applicable(
+            {'weight_fn': None, 'bias_fn': u.math.abs, 'has_bias': True}
+        ) is False
+
+    def test_fast_instant_matches_outer_product(self):
+        rules = get_fast_path_rules(etp_mm_p)
+        # mm-shaped: x (B, in), df (B, out, S)
+        x_mm = brainstate.random.randn(2, 3)
+        df_mm = brainstate.random.randn(2, 4, 5)
+        out_mm = rules.instant(x_mm, df_mm, False)
+        np.testing.assert_allclose(
+            out_mm['weight'], jnp.einsum('...i,...ka->...ika', x_mm, df_mm)
+        )
+        assert 'bias' not in out_mm
+
+        # mv-shaped: x (in,), df (out, S)
+        x_mv = brainstate.random.randn(3)
+        df_mv = brainstate.random.randn(4, 5)
+        out_mv = rules.instant(x_mv, df_mv, False)
+        np.testing.assert_allclose(
+            out_mv['weight'], jnp.einsum('...i,...ka->...ika', x_mv, df_mv)
+        )
+
+        # has_bias=True -> 'bias' entry equals df.
+        out_bias = rules.instant(x_mm, df_mm, True)
+        np.testing.assert_allclose(out_bias['bias'], df_mm)
+
+    def test_fast_recurrent_num_state_1_equals_general_einsum(self):
+        rules = get_fast_path_rules(etp_mm_p)
+        # num_state == 1: diag (B, out, 1, 1); weight trace (B, in, out, 1).
+        batch, in_dim, out_dim = 2, 3, 4
+        diag = brainstate.random.randn(batch, out_dim, 1, 1)
+        trace = {'weight': brainstate.random.randn(batch, in_dim, out_dim, 1)}
+        fast = rules.recurrent(diag, trace, 1)
+        # General einsum for the same contraction.
+        general = jnp.einsum('...kab,...ikb->...ika', diag, trace['weight'])
+        np.testing.assert_allclose(fast['weight'], general, atol=1e-6)
+
+    def test_fast_solve_fold_batch_equals_sum_of_unfolded(self):
+        rules = get_fast_path_rules(etp_mm_p)
+        batch, in_dim, out_dim, n_state = 2, 3, 4, 5
+        diag_like = brainstate.random.randn(batch, out_dim, n_state)
+        etrace = {
+            'weight': brainstate.random.randn(batch, in_dim, out_dim, n_state),
+            'bias': brainstate.random.randn(batch, out_dim, n_state),
+        }
+        folded = rules.solve(diag_like, etrace, fold_batch=True)
+        unfolded = rules.solve(diag_like, etrace, fold_batch=False)
+        np.testing.assert_allclose(
+            folded['weight'], unfolded['weight'].sum(axis=0), atol=1e-5
+        )
+        np.testing.assert_allclose(
+            folded['bias'], unfolded['bias'].sum(axis=0), atol=1e-5
+        )

--- a/braintrace/_op/elemwise.py
+++ b/braintrace/_op/elemwise.py
@@ -119,23 +119,37 @@ def _elemwise_xy_to_dw(x, hidden_dim, weights, *, weight_fn=None):
     computed via VJP. When ``weight_fn`` is ``None`` (identity), the
     contribution is simply the hidden cotangent itself.
 
+    Because the op is diagonal, ``weight_fn`` is element-wise and its Jacobian is
+    ``diag(weight_fn'(w))``. We therefore extract the per-element derivative once
+    (cotangent of ones, shape ``(*w_shape,)``) and broadcast-multiply it against
+    ``hidden_dim``. This is identical to ``vjp_fn(hidden_dim)`` in the unbatched
+    case (``vjp_fn(c) = c ⊙ weight_fn'(w)`` for a diagonal Jacobian) but, unlike a
+    direct ``vjp_fn(hidden_dim)``, it accepts a ``hidden_dim`` carrying extra
+    leading axes (e.g. a batch axis under :class:`brainstate.mixin.Batching`),
+    which the unbatched VJP would reject as a shape mismatch.
+
     Args:
         x: Unused (``x_invar_index=None``).
-        hidden_dim: Cotangent :math:`\partial h / \partial y`, shape matches weight.
+        hidden_dim: Cotangent :math:`\partial h / \partial y`. Shape matches the
+            weight, optionally with extra leading axes (e.g. a batch axis).
         weights: Dict with key 'weight' (the raw weight mantissa).
         weight_fn: Element-wise function applied inside the primitive. When
             ``None``, behaves as identity.
 
     Returns:
-        ``{'weight': vjp(weight_fn, w)(hidden_dim)[0]}``, or
+        ``{'weight': hidden_dim ⊙ weight_fn'(w)}``, or
         ``{'weight': hidden_dim}`` when ``weight_fn is None``.
     """
     # ∂h/∂w = (∂h/∂y) · weight_fn'(w). For the identity (weight_fn None) this is
     # just the cotangent itself.
     if weight_fn is None:
         return {'weight': hidden_dim}
-    _, vjp_fn = jax.vjp(weight_fn, weights['weight'])
-    return {'weight': u.get_mantissa(vjp_fn(hidden_dim)[0])}
+    w = weights['weight']
+    out, vjp_fn = jax.vjp(weight_fn, w)
+    # Diagonal Jacobian: vjp(ones) yields the per-element derivative weight_fn'(w),
+    # shaped like w. Broadcast it against hidden_dim's (possibly batched) leading axes.
+    deriv = u.get_mantissa(vjp_fn(jnp.ones_like(out))[0])
+    return {'weight': hidden_dim * deriv}
 
 
 def _elemwise_init_drtrl(x_var, y_var, weight_vars, num_hidden_state, group=None):

--- a/braintrace/_op/elemwise.py
+++ b/braintrace/_op/elemwise.py
@@ -60,6 +60,23 @@ primitive when composing Jacobians).
 
 * ``init_pp`` — pp-prop df trace, same shape as ``init_drtrl`` since for
   an identity op the weight-shape coincides with the output-shape.
+
+**Transform hooks**
+
+The primitive accepts a single optional elementwise transform hook,
+``weight_fn``, in its ``eqn.params`` (computing ``y = weight_fn(w)``; there
+is no ``x`` input and no bias for this op). The eligibility trace and
+gradient are taken w.r.t. the **raw** weight, so the transform Jacobian
+:math:`f'` enters *only* through :func:`_elemwise_xy_to_dw` via
+:func:`jax.vjp`; the ``yw_to_w`` rule does **not** apply :math:`f'`.
+
+**Fast path**
+
+A closed-form param-dim D-RTRL kernel bundle (:class:`FastPathRules`,
+registered on ``etp_elemwise_p``) replaces the generic nested-``vmap`` trace
+path with diagonal einsums. Because those kernels return the bare ``df``
+(dropping :math:`f'`), the bundle's ``applicable`` gate disables the fast
+path whenever ``weight_fn`` is present.
 """
 
 import jax
@@ -67,6 +84,7 @@ import jax.numpy as jnp
 import brainunit as u
 
 from ._primitive import register_primitive
+from ._registries import FastPathRules
 
 __all__ = [
     'etp_elemwise_p',
@@ -210,6 +228,118 @@ def _elemwise_init_pp(x_var, y_var, weight_vars, num_hidden_state, group=None):
     return jnp.zeros((*leading, num_hidden_state), dtype=y_var.aval.dtype)
 
 
+# ---------------------------------------------------------------------------
+# Closed-form param-dim D-RTRL fast-path kernels (diagonal, no x, no bias)
+# ---------------------------------------------------------------------------
+
+def _elemwise_fast_instant(x, df, has_bias):
+    r"""Instantaneous term for the diagonal identity op.
+
+    Parameters
+    ----------
+    x : Any
+        Unused (the elemwise op has no ``x`` input). Accepted for a uniform
+        kernel signature.
+    df : ArrayLike
+        State-to-output Jacobian :math:`\mathbf{D}_f^t`, shape
+        ``(..., num_state)``.
+    has_bias : bool
+        Unused (the elemwise op has no bias).
+
+    Returns
+    -------
+    dict
+        ``{'weight': df}``.
+
+    Notes
+    -----
+    With no input factor and an identity ``y = w``, the instantaneous
+    Jacobian :math:`\operatorname{diag}(\mathbf{D}_f^t) \otimes 1` reduces
+    to ``df`` itself.
+    """
+    return {'weight': df}
+
+
+def _elemwise_fast_recurrent(diag, old_bwg, num_state):
+    r"""Recurrent term :math:`\mathbf{D}^t \boldsymbol{\epsilon}^{t-1}` (diagonal).
+
+    Parameters
+    ----------
+    diag : ArrayLike
+        Hidden-to-hidden Jacobian, shape ``(..., num_state, num_state)``.
+    old_bwg : dict
+        Previous trace dict; ``'weight'`` shape ``(..., num_state)``.
+    num_state : int
+        Number of hidden states per group.
+
+    Returns
+    -------
+    dict
+        ``{'weight': D^t · ε^{t-1}}``.
+
+    Notes
+    -----
+    The contraction is ``einsum('...ab,...b->...a')`` over the ``num_state``
+    axis. When ``num_state == 1`` the sum collapses to a broadcast multiply
+    by ``diag[..., 0, :]`` (the size-1 ``beta`` axis is kept to align with
+    the trace) — bit-identical to the einsum.
+    """
+    if num_state == 1:
+        return {'weight': diag[..., 0, :] * old_bwg['weight']}
+    return {'weight': jnp.einsum('...ab,...b->...a', diag, old_bwg['weight'])}
+
+
+def _elemwise_fast_solve(diag_like, etrace_data, *, fold_batch=False):
+    r"""Solve-time contraction of the learning signal with the trace (diagonal).
+
+    Parameters
+    ----------
+    diag_like : ArrayLike
+        The :math:`\partial \mathcal{L}/\partial \mathbf{h}` group gradient,
+        shape ``(..., num_state)`` (``(B, ..., num_state)`` when batched).
+    etrace_data : dict
+        Trace dict; ``'weight'`` shape matches ``diag_like``.
+    fold_batch : bool, optional
+        When ``True``, contract the leading batch axis ``b`` inside the
+        einsum so the result is already batch-summed. Default ``False``.
+
+    Returns
+    -------
+    dict
+        ``{'weight': dW}``.
+
+    Notes
+    -----
+    Contracts every shared axis to a scalar-per-weight via
+    ``'...a,...a->...'`` (and ``'b...a,b...a->...'`` under ``fold_batch``).
+    """
+    spec = 'b...a,b...a->...' if fold_batch else '...a,...a->...'
+    return {'weight': jnp.einsum(spec, diag_like, etrace_data['weight'])}
+
+
+def _elemwise_fast_applicable(eqn_params):
+    r"""Gate: is the elemwise fast path valid for this equation?
+
+    Parameters
+    ----------
+    eqn_params : dict
+        The ETP equation's ``params`` dict.
+
+    Returns
+    -------
+    bool
+        ``True`` iff ``weight_fn`` is absent / ``None``.
+
+    Notes
+    -----
+    The closed-form kernels return the bare ``df`` (dropping the ``f'(w)``
+    transform factor), so any active ``weight_fn`` must fall back to the rule
+    path (which applies ``f'`` via :func:`jax.vjp`). The op has no
+    ``bias_fn``.
+    """
+    return eqn_params.get('weight_fn') is None
+
+
 etp_elemwise_p = register_primitive(
     'etp_elemwise',
     _etp_elemwise_impl,
@@ -223,6 +353,12 @@ etp_elemwise_p.register_etp_rules(
     xy_to_dw=_elemwise_xy_to_dw,
     init_drtrl=_elemwise_init_drtrl,
     init_pp=_elemwise_init_pp,
+    fast_path=FastPathRules(
+        _elemwise_fast_instant,
+        _elemwise_fast_recurrent,
+        _elemwise_fast_solve,
+        _elemwise_fast_applicable,
+    ),
 )
 
 

--- a/braintrace/_op/elemwise_test.py
+++ b/braintrace/_op/elemwise_test.py
@@ -47,6 +47,7 @@ from braintrace._op import (
     GRADIENT_ENABLED_PRIMITIVES,
     element_wise,
     etp_elemwise_p,
+    get_fast_path_rules,
     is_etp_enable_gradient_primitive,
 )
 
@@ -338,3 +339,56 @@ class TestElemwiseWeightFnExactness:
             factory, inputs, algo_factory=lambda m: braintrace.D_RTRL(m, vjp_method='multi-step')
         )
         assert_param_gradients_close(online, bptt, atol=1e-4)
+
+
+# ---------------------------------------------------------------------------
+# Closed-form param-dim D-RTRL fast-path kernels (operator-layer bundle)
+# ---------------------------------------------------------------------------
+
+class TestElemwiseFastPath:
+    """The diagonal closed-form fast-path bundle registered on
+    ``etp_elemwise_p``.
+
+    The elemwise op is diagonal and carries no ``x`` input and no bias, so
+    its kernels operate on a single ``'weight'`` key only. The gate keys off
+    ``weight_fn`` alone (no ``bias_fn`` for this op).
+    """
+
+    def test_fast_path_registered_on_elemwise(self):
+        assert get_fast_path_rules(etp_elemwise_p) is not None
+
+    def test_fast_applicable_true_without_weight_fn(self):
+        rules = get_fast_path_rules(etp_elemwise_p)
+        assert rules.applicable({'weight_fn': None}) is True
+
+    def test_fast_applicable_false_with_weight_fn(self):
+        rules = get_fast_path_rules(etp_elemwise_p)
+        assert rules.applicable({'weight_fn': jnp.tanh}) is False
+
+    def test_fast_instant_returns_df(self):
+        rules = get_fast_path_rules(etp_elemwise_p)
+        df = brainstate.random.randn(4, 3)
+        out = rules.instant(None, df, False)
+        assert set(out.keys()) == {'weight'}
+        np.testing.assert_allclose(out['weight'], df)
+
+    def test_fast_recurrent_num_state_1_equals_general_einsum(self):
+        rules = get_fast_path_rules(etp_elemwise_p)
+        # diag (*var, 1, 1); trace (*var, 1).
+        var = 4
+        diag = brainstate.random.randn(var, 1, 1)
+        trace = {'weight': brainstate.random.randn(var, 1)}
+        fast = rules.recurrent(diag, trace, 1)
+        general = jnp.einsum('...ab,...b->...a', diag, trace['weight'])
+        np.testing.assert_allclose(fast['weight'], general, atol=1e-6)
+
+    def test_fast_solve_elemwise_fold_batch(self):
+        rules = get_fast_path_rules(etp_elemwise_p)
+        batch, var, n_state = 2, 4, 3
+        diag_like = brainstate.random.randn(batch, var, n_state)
+        etrace = {'weight': brainstate.random.randn(batch, var, n_state)}
+        folded = rules.solve(diag_like, etrace, fold_batch=True)
+        unfolded = rules.solve(diag_like, etrace, fold_batch=False)
+        np.testing.assert_allclose(
+            folded['weight'], unfolded['weight'].sum(axis=0), atol=1e-5
+        )

--- a/braintrace/_op/elemwise_test.py
+++ b/braintrace/_op/elemwise_test.py
@@ -271,6 +271,28 @@ class TestElemwiseWeightFnInside:
         out = rule(None, hidden, {'weight': brainstate.random.randn(5)}, weight_fn=None)
         np.testing.assert_allclose(out['weight'], hidden, atol=1e-6)
 
+    def test_xy_to_dw_handles_batched_cotangent(self):
+        """A ``hidden_dim`` with leading batch axis must broadcast against the
+        unbatched per-element weight derivative.
+
+        Under a batched hidden state the cotangent ``∂h/∂y`` acquires a leading
+        batch axis ``(batch, n)`` while the weight stays ``(n,)``. Because the
+        op is diagonal, ``∂h/∂w = hidden_dim ⊙ weight_fn'(w)`` broadcasts over
+        the leading axes. The naive ``vjp_fn(hidden_dim)`` rejects the batched
+        cotangent (output shape is ``(n,)``), so the rule must use the
+        per-element derivative.
+        """
+        import brainstate
+        from braintrace._op import ETP_RULES_XY_TO_DW, etp_elemwise_p
+        rule = ETP_RULES_XY_TO_DW[etp_elemwise_p]
+        w = brainstate.random.randn(4)
+        hidden = brainstate.random.randn(2, 4)  # (batch, n) cotangent
+        out = rule(None, hidden, {'weight': w}, weight_fn=lambda x: x ** 2)
+        # f'(w) = 2w, broadcast over the batch axis.
+        expected = hidden * (2.0 * w)
+        assert out['weight'].shape == (2, 4)
+        np.testing.assert_allclose(out['weight'], expected, atol=1e-5)
+
 
 # ---------------------------------------------------------------------------
 # Exactness gate: D_RTRL == BPTT when element_wise carries weight_fn=tanh

--- a/braintrace/_op/lora.py
+++ b/braintrace/_op/lora.py
@@ -78,6 +78,24 @@ Both primitives declare ``trainable_invars_fn``, which returns
 ``{'lora_b': 1, 'lora_a': 2, 'bias': 3}`` when ``has_bias=True``.
 Keys ``'lora_b'`` / ``'lora_a'`` match the pytree leaf names in
 ``braintrace.nn.LoRALinear``'s merged ``ParamState``.
+
+**Transform hooks**
+
+Both primitives accept three optional elementwise transform hooks in their
+``eqn.params``: ``b_fn`` and ``a_fn`` (per-factor, computing
+``y = alpha * x @ b_fn(B) @ a_fn(A)``) and ``bias_fn`` (adds ``bias_fn(b)``).
+Note the per-factor names ``b_fn`` / ``a_fn`` rather than a single
+``weight_fn``. The forward impl and :func:`_lora_xy_to_dw` apply them; the
+eligibility trace and gradient are always taken w.r.t. the **raw** factors /
+bias, so each transform Jacobian :math:`f'` enters *only* through
+``xy_to_dw`` via :func:`jax.vjp` (the single fused VJP threads ``b_fn'``,
+``a_fn'`` and ``bias_fn'`` simultaneously). The ``yw_to_w`` rule and the
+trace initialisers are transform-free and stay exact (they operate on the
+raw-factor Jacobians).
+
+These primitives have **no fast path** — they always use the generic rule
+path, which threads each :math:`f'` correctly when a transform hook is
+present.
 """
 
 import brainunit as u

--- a/braintrace/_op/sparse.py
+++ b/braintrace/_op/sparse.py
@@ -75,6 +75,20 @@ gradients to *both* weight and bias ``ParamState`` objects in one pass.
 
 When ``has_bias=False`` the ``'bias'`` key is simply absent from every
 dict, so the legacy (no-bias) code path is unchanged in behaviour.
+
+**Transform hooks**
+
+Both primitives accept two optional elementwise transform hooks in their
+``eqn.params``: ``weight_fn`` (computes ``y = x @ sparse(weight_fn(w_data))``)
+and ``bias_fn`` (adds ``bias_fn(b)``). The forward impl and
+:func:`_sp_xy_to_dw` apply them; the eligibility trace and gradient are
+always taken w.r.t. the **raw** weight data / bias, so the transform
+Jacobian :math:`f'` enters *only* through ``xy_to_dw`` via :func:`jax.vjp`.
+The ``yw_to_w`` rule and the trace initialisers are transform-free and stay
+exact (they operate on :math:`\partial h / \partial w_{\text{raw}}`).
+
+These primitives have **no fast path** — they always use the generic rule
+path, which threads :math:`f'` correctly when a transform hook is present.
 """
 
 import jax

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -92,6 +92,7 @@ See also the ecosystem
    :caption: Tutorial
 
    tutorials/etp_primitives.ipynb
+   tutorials/customizing_primitive_transforms.ipynb
    tutorials/hidden_states.ipynb
    tutorials/graph_visualization.ipynb
    tutorials/batching.ipynb

--- a/docs/tutorials/customizing_primitive_transforms.ipynb
+++ b/docs/tutorials/customizing_primitive_transforms.ipynb
@@ -1,0 +1,630 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "id": "ca38f518",
+   "metadata": {},
+   "source": [
+    "# Customizing Primitive Transforms\n",
+    "\n",
+    "This is the *next chapter* after **ETP Primitives Deep Dive**. There we saw how each ETP primitive marks a weight operation and how a custom primitive (`scaled_matmul`) is registered. Here we add **parameter transform hooks** — small elementwise functions applied to a weight *inside* the primitive — and explain the one design rule that keeps online learning exact in their presence. We close with the optional closed-form **fast path** and its transform-aware gate."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "c23d77d0",
+   "metadata": {},
+   "source": [
+    "## 1. Why parameter transforms, and the one rule\n",
+    "\n",
+    "Models often need a *reparametrized* weight rather than the raw stored parameter:\n",
+    "\n",
+    "- **masked / structured** weights: `weight_fn=lambda w: w * mask`\n",
+    "- **standardized** weights: subtract mean / divide by std before use\n",
+    "- **sign-constrained** weights: `weight_fn=lambda w: w ** 2` (non-negative), `jnp.abs`, `jax.nn.softplus`\n",
+    "- **squashed** weights: `weight_fn=jnp.tanh`\n",
+    "\n",
+    "Rather than rewriting the parameter and losing the raw value (which the optimizer updates), each built-in ETP op takes an optional, shape-preserving `*_fn` hook. The op computes the forward pass on the *transformed* weight $V = f(W)$ while the eligibility trace and gradient stay attached to the **raw** weight $W$.\n",
+    "\n",
+    "**The load-bearing rule.** Let $f$ be the transform and $V = f(W)$. The transform Jacobian $f'(W)$ is applied in **exactly one place** — the primitive's `xy_to_dw` rule, via `jax.vjp` through the impl. Everything else (`yw_to_w`, `init_drtrl`, `init_pp`) is transform-free: those rules operate on $\\partial h / \\partial W_{\\text{raw}}$ and are correct as written. Because `xy_to_dw` builds its VJP *through the same impl that applies $f$*, the chain rule threads $f'$ automatically — no per-transform code is needed.\n",
+    "\n",
+    "$$\n",
+    "\\frac{\\partial h}{\\partial W_{\\text{raw}}}\n",
+    "= \\underbrace{\\frac{\\partial h}{\\partial V}}_{\\text{closed-form rule}}\n",
+    "  \\cdot \\underbrace{f'(W_{\\text{raw}})}_{\\text{threaded by } \\texttt{jax.vjp} \\text{ in } \\texttt{xy\\_to\\_dw}}\n",
+    "$$\n",
+    "\n",
+    "Units note: every wrapper splits a `brainunit.Quantity` into mantissa + unit and applies the transform to the **unitless mantissa**, recombining the unit afterwards."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "6387391b",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-30T04:09:38.724504Z",
+     "iopub.status.busy": "2026-06-30T04:09:38.724361Z",
+     "iopub.status.idle": "2026-06-30T04:09:41.868101Z",
+     "shell.execute_reply": "2026-06-30T04:09:41.867212Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import jax\n",
+    "import jax.numpy as jnp\n",
+    "import brainunit as u\n",
+    "import brainstate\n",
+    "\n",
+    "import braintrace\n",
+    "\n",
+    "brainstate.environ.set(precision=64)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "40ccb969",
+   "metadata": {},
+   "source": [
+    "## 2. Transforms on the built-in ops\n",
+    "\n",
+    "Each ETP op exposes the hooks that make sense for it. The names differ where the op has more than one trainable factor:\n",
+    "\n",
+    "| Op | Transform hook(s) |\n",
+    "|---|---|\n",
+    "| `braintrace.matmul(x, weight, bias=None, *, weight_fn=None, bias_fn=None)` | `weight_fn`, `bias_fn` |\n",
+    "| `braintrace.element_wise(weight, *, weight_fn=None)` | `weight_fn` |\n",
+    "| `braintrace.conv(x, kernel, bias=None, *, ..., kernel_fn=None, bias_fn=None)` | `kernel_fn` (note: *not* `weight_fn`), `bias_fn` |\n",
+    "| `braintrace.sparse_matmul(x, weight, *, sparse_mat, bias=None, weight_fn=None, bias_fn=None)` | `weight_fn`, `bias_fn` |\n",
+    "| `braintrace.lora_matmul(x, B, A, *, alpha=1.0, bias=None, b_fn=None, a_fn=None, bias_fn=None)` | per-factor `b_fn`, `a_fn`, plus `bias_fn` |\n",
+    "\n",
+    "All hooks default to `None` (identity), so omitting them reproduces the untransformed op bit-for-bit. The forward pass applies the transform:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "fc2ffd41",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-30T04:09:41.870171Z",
+     "iopub.status.busy": "2026-06-30T04:09:41.869945Z",
+     "iopub.status.idle": "2026-06-30T04:10:04.109078Z",
+     "shell.execute_reply": "2026-06-30T04:10:04.107531Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "matmul forward matches x @ tanh(w) + |b| : True\n"
+     ]
+    }
+   ],
+   "source": [
+    "# matmul with weight_fn + bias_fn: forward uses the transformed weight/bias.\n",
+    "x = brainstate.random.randn(4, 3)\n",
+    "w = brainstate.random.randn(3, 5)\n",
+    "b = brainstate.random.randn(5)\n",
+    "\n",
+    "y = braintrace.matmul(x, w, bias=b, weight_fn=jnp.tanh, bias_fn=jnp.abs)\n",
+    "y_ref = x @ jnp.tanh(w) + jnp.abs(b)\n",
+    "print(\"matmul forward matches x @ tanh(w) + |b| :\", bool(jnp.allclose(y, y_ref)))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "04f46b2f",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-30T04:10:04.113648Z",
+     "iopub.status.busy": "2026-06-30T04:10:04.113360Z",
+     "iopub.status.idle": "2026-06-30T04:10:17.729431Z",
+     "shell.execute_reply": "2026-06-30T04:10:17.727833Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "element_wise matches tanh(w): True\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "conv forward matches conv(x, kernel**2): True\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "lora forward matches alpha * x @ B @ tanh(A): True\n"
+     ]
+    }
+   ],
+   "source": [
+    "# element_wise: the single weight_fn squashes the parameter in place.\n",
+    "wg = brainstate.random.randn(5)\n",
+    "print(\"element_wise matches tanh(w):\",\n",
+    "      bool(jnp.allclose(braintrace.element_wise(wg, weight_fn=jnp.tanh), jnp.tanh(wg))))\n",
+    "\n",
+    "# conv uses kernel_fn (not weight_fn) for the kernel.\n",
+    "xc = brainstate.random.randn(8, 3, 16)        # NCH (JAX default layout)\n",
+    "k = brainstate.random.randn(4, 3, 5)          # OIH\n",
+    "yc = braintrace.conv(xc, k, strides=(1,), padding='SAME', kernel_fn=lambda ww: ww ** 2)\n",
+    "yc_ref = jax.lax.conv_general_dilated(xc, k ** 2, window_strides=(1,), padding='SAME')\n",
+    "print(\"conv forward matches conv(x, kernel**2):\", bool(jnp.allclose(yc, yc_ref)))\n",
+    "\n",
+    "# lora has per-factor b_fn / a_fn.\n",
+    "xl = brainstate.random.randn(16, 8)\n",
+    "B = brainstate.random.randn(8, 2)\n",
+    "A = brainstate.random.randn(2, 4)\n",
+    "yl = braintrace.lora_matmul(xl, B, A, alpha=0.5, a_fn=jnp.tanh)\n",
+    "print(\"lora forward matches alpha * x @ B @ tanh(A):\",\n",
+    "      bool(jnp.allclose(yl, 0.5 * (xl @ B @ jnp.tanh(A)))))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "9c2d84de",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-30T04:10:17.732106Z",
+     "iopub.status.busy": "2026-06-30T04:10:17.731847Z",
+     "iopub.status.idle": "2026-06-30T04:10:17.868021Z",
+     "shell.execute_reply": "2026-06-30T04:10:17.865725Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "unit preserved (V * S = A): A\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Units act on the mantissa: the transform sees the unitless value, the unit is\n",
+    "# split off before and recombined after.\n",
+    "x_q = jnp.ones((4, 3)) * u.volt\n",
+    "w_q = jnp.ones((3, 5)) * u.siemens\n",
+    "y_q = braintrace.matmul(x_q, w_q, weight_fn=lambda ww: ww ** 2)\n",
+    "print(\"unit preserved (V * S = A):\", u.get_unit(y_q))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "582653e6",
+   "metadata": {},
+   "source": [
+    "## 3. Correctness check: a transformed weight is handled *exactly*\n",
+    "\n",
+    "A transform is not an approximation. Because `xy_to_dw` threads $f'$ via `jax.vjp`, an **exact** online algorithm such as `D_RTRL` must still reproduce the BPTT gradient element-wise. We verify this with the gradient oracle in `braintrace._algorithm.oracle`:\n",
+    "\n",
+    "- `bptt_param_gradients(factory, inputs)` — exact backprop-through-time over the sequence sum-of-squares loss.\n",
+    "- `online_param_gradients(factory, inputs, algo_factory=...)` — the same total gradient via the online algorithm's multi-step path.\n",
+    "- `assert_param_gradients_close(online, bptt, atol=...)` — element-wise comparison.\n",
+    "\n",
+    "We build a tiny RNN cell whose recurrent map routes through `braintrace.matmul(..., weight_fn=jnp.tanh)` and assert `D_RTRL == BPTT`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "1791e74c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-30T04:10:17.872301Z",
+     "iopub.status.busy": "2026-06-30T04:10:17.871984Z",
+     "iopub.status.idle": "2026-06-30T04:10:31.712950Z",
+     "shell.execute_reply": "2026-06-30T04:10:31.711941Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "D_RTRL == BPTT with weight_fn=tanh  ->  transform handled exactly\n"
+     ]
+    }
+   ],
+   "source": [
+    "from braintrace._algorithm.oracle import (\n",
+    "    bptt_param_gradients,\n",
+    "    online_param_gradients,\n",
+    "    assert_param_gradients_close,\n",
+    ")\n",
+    "\n",
+    "\n",
+    "class TanhWeightRNN(brainstate.nn.Module):\n",
+    "    \"\"\"A 1-state-group RNN whose weight is squashed by tanh inside the ETP op.\"\"\"\n",
+    "\n",
+    "    def __init__(self, in_dim=2, hid_dim=4):\n",
+    "        super().__init__()\n",
+    "        self.in_dim = in_dim\n",
+    "        self.hid_dim = hid_dim\n",
+    "        # One weight maps [x ; h] -> h, marked with braintrace.matmul.\n",
+    "        self.W = brainstate.ParamState(\n",
+    "            brainstate.random.randn(in_dim + hid_dim, hid_dim) * 0.2\n",
+    "        )\n",
+    "\n",
+    "    def init_state(self, batch_size=None, **kwargs):\n",
+    "        size = (self.hid_dim,) if batch_size is None else (batch_size, self.hid_dim)\n",
+    "        self.h = brainstate.HiddenState(jnp.zeros(size))\n",
+    "\n",
+    "    def update(self, x):\n",
+    "        xh = jnp.concatenate([x.reshape(1, -1), self.h.value], axis=-1)\n",
+    "        # weight_fn=tanh: forward uses tanh(W); the trace stays attached to raw W.\n",
+    "        self.h.value = jnp.tanh(braintrace.matmul(xh, self.W.value, weight_fn=jnp.tanh))\n",
+    "        return self.h.value\n",
+    "\n",
+    "\n",
+    "def factory():\n",
+    "    brainstate.random.seed(0)\n",
+    "    return TanhWeightRNN()\n",
+    "\n",
+    "\n",
+    "brainstate.random.seed(1)\n",
+    "inputs = brainstate.random.randn(6, 2)  # 6 time steps, in_dim=2\n",
+    "\n",
+    "bptt = bptt_param_gradients(factory, inputs)\n",
+    "online = online_param_gradients(\n",
+    "    factory, inputs,\n",
+    "    algo_factory=lambda m: braintrace.D_RTRL(m, vjp_method='multi-step'),\n",
+    ")\n",
+    "assert_param_gradients_close(online, bptt, atol=1e-4)\n",
+    "print(\"D_RTRL == BPTT with weight_fn=tanh  ->  transform handled exactly\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "85c73db3",
+   "metadata": {},
+   "source": [
+    "## 4. Adding transforms to a custom primitive\n",
+    "\n",
+    "We now extend the `scaled_matmul` example from the previous tutorial — $y = \\text{scale} \\cdot (x\\,@\\,W) \\;(+ b)$ — with transform hooks. **The four ETP rules are unchanged from the untransformed version.** Only the *impl* (and the `xy_to_dw` forward it differentiates) need to apply `weight_fn` / `bias_fn`; because `xy_to_dw` builds its VJP through that same forward, $f'$ is threaded for free and `D_RTRL` stays exact."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "30ae0189",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-30T04:10:31.715494Z",
+     "iopub.status.busy": "2026-06-30T04:10:31.715271Z",
+     "iopub.status.idle": "2026-06-30T04:10:31.719393Z",
+     "shell.execute_reply": "2026-06-30T04:10:31.718301Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from braintrace import register_primitive\n",
+    "\n",
+    "\n",
+    "# Step 1: impl applies the transforms (this is the ONLY place the forward changes).\n",
+    "def _scaled_matmul_impl(*args, scale=1.0, has_bias=False, weight_fn=None, bias_fn=None):\n",
+    "    x, w = args[0], args[1]\n",
+    "    if weight_fn is not None:\n",
+    "        w = weight_fn(w)\n",
+    "    y = scale * (x @ w)\n",
+    "    if has_bias:\n",
+    "        b = args[2]\n",
+    "        if bias_fn is not None:\n",
+    "            b = bias_fn(b)\n",
+    "        y = y + b\n",
+    "    return y\n",
+    "\n",
+    "\n",
+    "def _scaled_trainable_invars(params):\n",
+    "    base = {'weight': 1}\n",
+    "    if params.get('has_bias', False):\n",
+    "        base['bias'] = 2\n",
+    "    return base\n",
+    "\n",
+    "\n",
+    "scaled_mm_p = register_primitive(\n",
+    "    'etp_scaled_mm_transforms',\n",
+    "    _scaled_matmul_impl,\n",
+    "    batched=True,\n",
+    "    trainable_invars_fn=_scaled_trainable_invars,\n",
+    "    x_invar_index=0,\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "508ef4c6",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-30T04:10:31.721023Z",
+     "iopub.status.busy": "2026-06-30T04:10:31.720890Z",
+     "iopub.status.idle": "2026-06-30T04:10:31.726327Z",
+     "shell.execute_reply": "2026-06-30T04:10:31.725521Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "custom primitive registered with transform-aware xy_to_dw\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Step 2: the four ETP rules. Note: yw_to_w / init_* are TRANSFORM-FREE.\n",
+    "# Only xy_to_dw differentiates the impl (which applies f), so f' enters here alone.\n",
+    "\n",
+    "def _scaled_yw_to_w(hidden_dim, trace, *, scale=1.0, has_bias=False,\n",
+    "                    weight_fn=None, bias_fn=None):\n",
+    "    # y -> W chain link for y = scale * x @ W: scale on the matching out column.\n",
+    "    # No f' here by design.\n",
+    "    out = {'weight': trace['weight'] * jnp.expand_dims(hidden_dim, axis=-2) * scale}\n",
+    "    if has_bias:\n",
+    "        out['bias'] = trace['bias'] * hidden_dim\n",
+    "    return out\n",
+    "\n",
+    "\n",
+    "def _scaled_xy_to_dw(x, hidden_dim, weights, *, scale=1.0, has_bias=False,\n",
+    "                     weight_fn=None, bias_fn=None):\n",
+    "    # Single fused VJP THROUGH the transform -> gradient w.r.t. the RAW weight,\n",
+    "    # with f' threaded automatically by jax.vjp.\n",
+    "    def _fwd(w_dict):\n",
+    "        w = w_dict['weight']\n",
+    "        if weight_fn is not None:\n",
+    "            w = weight_fn(w)\n",
+    "        y = scale * (x @ w)\n",
+    "        if has_bias:\n",
+    "            b = w_dict['bias']\n",
+    "            if bias_fn is not None:\n",
+    "                b = bias_fn(b)\n",
+    "            y = y + b\n",
+    "        return u.get_mantissa(y)\n",
+    "\n",
+    "    _, vjp_fn = jax.vjp(_fwd, weights)\n",
+    "    return jax.tree.map(u.get_mantissa, vjp_fn(hidden_dim)[0])\n",
+    "\n",
+    "\n",
+    "def _scaled_init_drtrl(x_var, y_var, weight_vars, num_hidden_state):\n",
+    "    batch = x_var.aval.shape[0]\n",
+    "    out = {'weight': jnp.zeros((batch, *weight_vars['weight'].aval.shape, num_hidden_state))}\n",
+    "    if 'bias' in weight_vars:\n",
+    "        out['bias'] = jnp.zeros((batch, *weight_vars['bias'].aval.shape, num_hidden_state))\n",
+    "    return out\n",
+    "\n",
+    "\n",
+    "def _scaled_init_pp(x_var, y_var, weight_vars, num_hidden_state):\n",
+    "    return jnp.zeros((*y_var.aval.shape, num_hidden_state), dtype=y_var.aval.dtype)\n",
+    "\n",
+    "\n",
+    "scaled_mm_p.register_etp_rules(\n",
+    "    yw_to_w=_scaled_yw_to_w,\n",
+    "    xy_to_dw=_scaled_xy_to_dw,\n",
+    "    init_drtrl=_scaled_init_drtrl,\n",
+    "    init_pp=_scaled_init_pp,\n",
+    ")\n",
+    "print(\"custom primitive registered with transform-aware xy_to_dw\")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "id": "2dc77b4c",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-30T04:10:31.727866Z",
+     "iopub.status.busy": "2026-06-30T04:10:31.727727Z",
+     "iopub.status.idle": "2026-06-30T04:10:38.044842Z",
+     "shell.execute_reply": "2026-06-30T04:10:38.043871Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "forward matches 2 * (x @ tanh(w)): True\n"
+     ]
+    },
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "grad shape: (3, 5)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Forward + grad work immediately (auto-derived JAX rules thread the transform).\n",
+    "x = jnp.ones((4, 3))\n",
+    "w = jnp.ones((3, 5))\n",
+    "y = scaled_mm_p.bind(x, w, scale=2.0, has_bias=False, weight_fn=jnp.tanh, bias_fn=None)\n",
+    "print(\"forward matches 2 * (x @ tanh(w)):\", bool(jnp.allclose(y, 2.0 * (x @ jnp.tanh(w)))))\n",
+    "\n",
+    "dw = jax.grad(\n",
+    "    lambda w_: jnp.sum(\n",
+    "        scaled_mm_p.bind(x, w_, scale=2.0, has_bias=False, weight_fn=jnp.tanh, bias_fn=None)\n",
+    "    )\n",
+    ")(w)\n",
+    "print(\"grad shape:\", dw.shape)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "92a7a949",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-30T04:10:38.047374Z",
+     "iopub.status.busy": "2026-06-30T04:10:38.047106Z",
+     "iopub.status.idle": "2026-06-30T04:10:38.753482Z",
+     "shell.execute_reply": "2026-06-30T04:10:38.752496Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "custom scaled_mm: D_RTRL == BPTT with weight_fn=tanh  ->  rules need no change\n"
+     ]
+    }
+   ],
+   "source": [
+    "# And the four unchanged ETP rules give an EXACT D_RTRL gradient with the\n",
+    "# transform active, just like the built-in matmul did in Section 3.\n",
+    "class ScaledTanhRNN(brainstate.nn.Module):\n",
+    "    def __init__(self, in_dim=2, hid_dim=4):\n",
+    "        super().__init__()\n",
+    "        self.in_dim = in_dim\n",
+    "        self.hid_dim = hid_dim\n",
+    "        self.W = brainstate.ParamState(\n",
+    "            brainstate.random.randn(in_dim + hid_dim, hid_dim) * 0.2\n",
+    "        )\n",
+    "\n",
+    "    def init_state(self, batch_size=None, **kwargs):\n",
+    "        size = (self.hid_dim,) if batch_size is None else (batch_size, self.hid_dim)\n",
+    "        self.h = brainstate.HiddenState(jnp.zeros(size))\n",
+    "\n",
+    "    def update(self, x):\n",
+    "        xh = jnp.concatenate([x.reshape(1, -1), self.h.value], axis=-1)\n",
+    "        r = scaled_mm_p.bind(xh, self.W.value, scale=1.5, has_bias=False,\n",
+    "                             weight_fn=jnp.tanh, bias_fn=None)\n",
+    "        self.h.value = jnp.tanh(r)\n",
+    "        return self.h.value\n",
+    "\n",
+    "\n",
+    "def custom_factory():\n",
+    "    brainstate.random.seed(0)\n",
+    "    return ScaledTanhRNN()\n",
+    "\n",
+    "\n",
+    "brainstate.random.seed(1)\n",
+    "inp = brainstate.random.randn(6, 2)\n",
+    "bptt_c = bptt_param_gradients(custom_factory, inp)\n",
+    "online_c = online_param_gradients(\n",
+    "    custom_factory, inp,\n",
+    "    algo_factory=lambda m: braintrace.D_RTRL(m, vjp_method='multi-step'),\n",
+    ")\n",
+    "assert_param_gradients_close(online_c, bptt_c, atol=1e-4)\n",
+    "print(\"custom scaled_mm: D_RTRL == BPTT with weight_fn=tanh  ->  rules need no change\")"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "95f8f50a",
+   "metadata": {},
+   "source": [
+    "## 5. (Advanced) The fast path and its transform-aware gate\n",
+    "\n",
+    "For the elementwise-`yw_to_w` primitives (`etp_mm` / `etp_mv` / `etp_elemwise`), a closed-form param-dim D-RTRL kernel bundle replaces the generic nested-`vmap` trace path with direct einsums. The bundle is a `FastPathRules(instant, recurrent, solve, applicable)` namedtuple, registered alongside the four rules via `register_etp_rules(fast_path=...)`, and looked up with `get_fast_path_rules(primitive)`.\n",
+    "\n",
+    "- `instant` — the instantaneous $\\operatorname{diag}(\\mathbf{D}_f^t) \\otimes \\mathbf{x}^t$ term.\n",
+    "- `recurrent` — the $\\mathbf{D}^t \\boldsymbol{\\epsilon}^{t-1}$ contraction.\n",
+    "- `solve` — the solve-time contraction of the learning signal with the trace.\n",
+    "- `applicable(eqn_params)` — the **gate**.\n",
+    "\n",
+    "The closed-form kernels compute $\\partial h / \\partial V$ for the *transformed* weight $V = f(W)$ — they emit the bare outer product and **drop $f'$**. So whenever a transform hook is present, `applicable` returns `False`, and that relation falls back to the rule path (whose `xy_to_dw` applies $f'$ via `jax.vjp`, as in Sections 3-4). This is what keeps the fast path an optimization, never a correctness hazard.\n",
+    "\n",
+    "Note `sparse` / `conv` / `lora` have **no** fast path at all — they always use the rule path."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "id": "1bf1f341",
+   "metadata": {
+    "execution": {
+     "iopub.execute_input": "2026-06-30T04:10:38.755192Z",
+     "iopub.status.busy": "2026-06-30T04:10:38.755031Z",
+     "iopub.status.idle": "2026-06-30T04:10:38.759114Z",
+     "shell.execute_reply": "2026-06-30T04:10:38.758302Z"
+    }
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "etp_mm has a fast path: True\n",
+      "applicable (no transform)     : True\n",
+      "applicable (weight_fn=tanh)    : False\n",
+      "etp_elemwise fast path: True\n",
+      "etp_sp_mm fast path is None: True\n",
+      "etp_conv fast path is None: True\n",
+      "etp_lora_mm fast path is None: True\n"
+     ]
+    }
+   ],
+   "source": [
+    "from braintrace._op import (\n",
+    "    get_fast_path_rules,\n",
+    "    etp_mm_p, etp_elemwise_p,\n",
+    "    etp_sp_mm_p, etp_conv_p, etp_lora_mm_p,\n",
+    ")\n",
+    "\n",
+    "fp = get_fast_path_rules(etp_mm_p)\n",
+    "assert fp is not None\n",
+    "print(\"etp_mm has a fast path:\", fp is not None)\n",
+    "\n",
+    "# Gate ON when no transform; OFF the moment a transform hook is present.\n",
+    "print(\"applicable (no transform)     :\", fp.applicable({'weight_fn': None, 'bias_fn': None}))\n",
+    "print(\"applicable (weight_fn=tanh)    :\", fp.applicable({'weight_fn': jnp.tanh, 'bias_fn': None}))\n",
+    "assert fp.applicable({'weight_fn': None, 'bias_fn': None}) is True\n",
+    "assert fp.applicable({'weight_fn': jnp.tanh, 'bias_fn': None}) is False\n",
+    "\n",
+    "# elemwise also has one; sparse / conv / lora do not.\n",
+    "print(\"etp_elemwise fast path:\", get_fast_path_rules(etp_elemwise_p) is not None)\n",
+    "for p, name in [(etp_sp_mm_p, 'etp_sp_mm'), (etp_conv_p, 'etp_conv'), (etp_lora_mm_p, 'etp_lora_mm')]:\n",
+    "    print(f\"{name} fast path is None:\", get_fast_path_rules(p) is None)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "35baaa47",
+   "metadata": {},
+   "source": [
+    "## Summary\n",
+    "\n",
+    "- **Transform hooks** let a model use a reparametrized weight (`weight_fn` / `kernel_fn` / `b_fn` / `a_fn` / `bias_fn`) while the trace and gradient stay attached to the raw parameter.\n",
+    "- **One rule:** the transform Jacobian $f'$ enters *only* in `xy_to_dw` (via `jax.vjp` through the impl). `yw_to_w` and the trace initializers stay transform-free and exact.\n",
+    "- **Exactness:** `D_RTRL == BPTT` element-wise even with `weight_fn=tanh`, for both built-in and custom primitives — verified via `braintrace._algorithm.oracle`.\n",
+    "- **Custom primitives** need no rule changes for transforms: apply the hook in the impl, and `xy_to_dw`'s VJP threads $f'$ for free.\n",
+    "- **Fast path:** the closed-form `FastPathRules` bundle drops $f'$, so its `applicable` gate disables it under any transform; such relations fall back to the (correct) rule path. `sparse` / `conv` / `lora` have no fast path."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.13.11"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## Summary

Two related changes to the param-dim D-RTRL fast path, plus a per-primitive
gate mechanism, author docs, and tests.

### 1. Correctness fix (`36332b9`)
The closed-form fast-path kernels reconstruct `∂h/∂V` for the *transformed*
weight `V = f(W)` but dropped the `f'(W)` factor, so `weight_fn`/`bias_fn`
transforms produced wrong gradients on the fast path. `f'` is applied **only**
in `xy_to_dw` (via `jax.vjp`); `yw_to_w` stays transform-free. Also fixes the
elementwise slow-path batched-cotangent crash.

### 2. Refactor: fast-path kernels → operator layer (`69f7546`)
Per the project's "primitives are thin markers / identify by type, not name"
principle, the closed-form einsum kernels (`instant`/`recurrent`/`solve`) now
live next to each primitive's other ETP rules instead of being branched-on by
primitive identity inside the algorithm:

- New `FastPathRules` NamedTuple + `ETP_FAST_PATH_RULES` registry +
  `get_fast_path_rules()` accessor in `_op/_registries.py`.
- `register_etp_rules(..., fast_path=FastPathRules(...))` installs the bundle.
- Dense kernels registered on both `etp_mm_p` and `etp_mv_p`; elemwise on
  `etp_elemwise_p`. Sparse/conv/lora simply don't register and fall to the
  rule path.
- The fragile algorithm-layer `_has_param_transform` string-match gate is
  replaced by a per-primitive `applicable(eqn_params)` predicate — so the
  `weight_fn` name can change in future without touching the algorithm.

### Docs
- New runnable tutorial `docs/tutorials/customizing_primitive_transforms.ipynb`
  (registered in the toctree) covering the `*_fn` transform hooks, the
  `f'`-in-`xy_to_dw` rule, and how to register a `FastPathRules` bundle.
- "Transform hooks" / "Fast path" notes added to the dense, elemwise, sparse,
  conv, and lora module docstrings.

### Tests
- New `TestDenseFastPath`, `TestElemwiseFastPath`, and registry coverage.
- Regression net (`test_fast_solve_matches_legacy_path`,
  `TestTransformFastEqualsLegacy`, multistep-vs-BPTT) kept green — the move is
  numerically a no-op.

## Verification
- `mypy`: clean (public-API gate enforced).
- Full suite: **1652 passed, 3 skipped**.