### PR TITLE
feat: require brainevent.DataRepresentation for sparse_matmul sparse_mat

### DIFF
--- a/braintrace/_legacy/_ops_test.py
+++ b/braintrace/_legacy/_ops_test.py
@@ -107,9 +107,9 @@ class TestOpsForward:
         assert y.shape == (1, 4, 4, 2)
 
     def test_sparse_op(self):
-        from brainunit import sparse as ss
+        import brainevent
         dense = jnp.eye(3) * 2.0
-        csr = ss.CSR.fromdense(dense)
+        csr = brainevent.CSR.fromdense(dense)
         op = SpMatMulOp(sparse_mat=csr)
         x = jnp.arange(3.0)
         w = {'weight': csr.data}

--- a/braintrace/_op/sparse.py
+++ b/braintrace/_op/sparse.py
@@ -18,9 +18,10 @@ r"""Sparse-matmul ETP primitives.
 ``etp_sp_mm_p`` (batched) and ``etp_sp_mv_p`` (unbatched). The sparse
 structure is supplied as a static parameter (``sparse_mat``); only the
 non-zero values flow through the primitive as the ``weight_data`` invar.
-The structure object must implement ``with_data`` (substitute new data
-into the structure) and ``yw_to_w_transposed`` (apply the transposed
-sparse pattern to a trace).
+The structure object must be a :class:`brainevent.DataRepresentation`,
+which provides the ETP online-learning protocol: ``with_data`` (substitute
+new data into the structure), ``yw_to_w_transposed`` (apply the transposed
+sparse pattern to a trace) and ``yw_to_w`` (the non-transposed counterpart).
 
 **Forward operation**
 
@@ -98,6 +99,7 @@ from typing import Any
 import jax
 import jax.numpy as jnp
 import brainunit as u
+import brainevent
 
 from ._primitive import register_primitive
 from braintrace._typing import ArrayLike, WeightFn
@@ -109,7 +111,8 @@ __all__ = [
 ]
 
 
-def _etp_sp_matmul_impl(*args: Any, sparse_mat: Any = None, has_bias: bool = False,
+def _etp_sp_matmul_impl(*args: Any, sparse_mat: brainevent.DataRepresentation | None = None,
+                        has_bias: bool = False,
                         weight_fn: WeightFn | None = None,
                         bias_fn: WeightFn | None = None) -> Any:
     x, weight_data = args[0], args[1]
@@ -141,7 +144,8 @@ def _sp_trainable_invars(params: dict[str, Any]) -> dict[str, int]:
 # etp_sp_mm_p — batched
 # ---------------------------------------------------------------------------
 
-def _sp_mm_yw_to_w(hidden_dim: Any, trace: dict[str, Any], *, sparse_mat: Any = None,
+def _sp_mm_yw_to_w(hidden_dim: Any, trace: dict[str, Any], *,
+                   sparse_mat: brainevent.DataRepresentation | None = None,
                    has_bias: bool = False, weight_fn: WeightFn | None = None,
                    bias_fn: WeightFn | None = None) -> dict[str, Any]:
     r"""Batched sparse ``yw_to_w`` — propagate :math:`\partial h / \partial y`
@@ -181,7 +185,8 @@ def _sp_mm_yw_to_w(hidden_dim: Any, trace: dict[str, Any], *, sparse_mat: Any = 
     return out
 
 
-def _sp_xy_to_dw(x: Any, hidden_dim: Any, weights: dict[str, Any], *, sparse_mat: Any = None,
+def _sp_xy_to_dw(x: Any, hidden_dim: Any, weights: dict[str, Any], *,
+                 sparse_mat: brainevent.DataRepresentation | None = None,
                  has_bias: bool = False, weight_fn: WeightFn | None = None,
                  bias_fn: WeightFn | None = None) -> dict[str, Any]:
     r"""Sparse instantaneous Jacobian :math:`\partial h / \partial w_{\text{data}}`,
@@ -272,7 +277,8 @@ def _sp_mm_init_pp(x_var: Any, y_var: Any, weight_vars: dict[str, Any],
 # etp_sp_mv_p — unbatched
 # ---------------------------------------------------------------------------
 
-def _sp_mv_yw_to_w(hidden_dim: Any, trace: dict[str, Any], *, sparse_mat: Any = None,
+def _sp_mv_yw_to_w(hidden_dim: Any, trace: dict[str, Any], *,
+                   sparse_mat: brainevent.DataRepresentation | None = None,
                    has_bias: bool = False, weight_fn: WeightFn | None = None,
                    bias_fn: WeightFn | None = None) -> dict[str, Any]:
     r"""Unbatched sparse ``yw_to_w`` — identical algebra to the batched case
@@ -366,7 +372,7 @@ def sparse_matmul(
     x: ArrayLike,
     weight: ArrayLike,
     *,
-    sparse_mat: Any,
+    sparse_mat: brainevent.DataRepresentation,
     bias: ArrayLike | None = None,
     weight_fn: WeightFn | None = None,
     bias_fn: WeightFn | None = None,
@@ -384,11 +390,13 @@ def sparse_matmul(
         Input array.
     weight : ArrayLike
         Sparse-matrix data, i.e. the non-zero values, shape ``(nnz,)``.
-    sparse_mat : object
-        Sparse-matrix structure (e.g. a ``brainunit.sparse`` matrix object).
-        Must expose ``with_data`` (substitute new data into the structure)
-        and ``yw_to_w_transposed`` (apply the transposed sparse pattern to
-        a trace).
+    sparse_mat : brainevent.DataRepresentation
+        Sparse-matrix structure (e.g. a :class:`brainevent.CSR`). Must be a
+        :class:`brainevent.DataRepresentation`, which implements the ETP
+        online-learning protocol: ``with_data`` (substitute new data into the
+        structure), ``yw_to_w_transposed`` (apply the transposed sparse
+        pattern to a trace) and ``yw_to_w`` (its non-transposed counterpart).
+        Passing any other object raises :class:`TypeError`.
     bias : ArrayLike or None, optional
         Bias vector. Default ``None``.
     weight_fn : callable or None, optional
@@ -410,7 +418,18 @@ def sparse_matmul(
     -------
     ArrayLike
         Output array.
+
+    Raises
+    ------
+    TypeError
+        If ``sparse_mat`` is not a :class:`brainevent.DataRepresentation`.
     """
+    if not isinstance(sparse_mat, brainevent.DataRepresentation):
+        raise TypeError(
+            'sparse_mat must be a brainevent.DataRepresentation providing the '
+            'with_data, yw_to_w_transposed and yw_to_w online-learning protocol '
+            f'methods, got {type(sparse_mat).__name__!r}.'
+        )
     p = etp_sp_mm_p if x.ndim >= 2 else etp_sp_mv_p  # type: ignore[union-attr]  # x is an array here; ArrayLike also admits scalars without .ndim
     x_v, x_u = u.split_mantissa_unit(x)
     w_v, w_u = u.split_mantissa_unit(weight)

--- a/braintrace/_op/sparse_test.py
+++ b/braintrace/_op/sparse_test.py
@@ -16,16 +16,20 @@
 """Tests for the sparse-matmul ETP primitives and the :func:`sparse_matmul` API.
 
 The sparse structure is supplied by the user as a static parameter
-(``sparse_mat``) and must implement two methods used by the ETP rules:
+(``sparse_mat``), which must be a :class:`brainevent.DataRepresentation`
+implementing the methods used by the ETP rules:
 
 * ``with_data(weight_data)`` — substitute new non-zero values into the
   structure, returning a sparse-matmul-able object.
 * ``yw_to_w_transposed(hidden_dim, trace)`` — apply the transposed
   pattern when propagating the trace.
+* ``yw_to_w(hidden_dim, trace)`` — the non-transposed counterpart.
 
-For end-to-end forward correctness a real ``brainunit.sparse.CSR`` works.
-For rule-level tests a tiny stub class fits the contract exactly so the
-test does not depend on the upstream sparse-matrix surface area.
+For end-to-end forward correctness a real :class:`brainevent.CSR` works.
+For rule-level and compile/gradient tests a tiny stub *subclassing*
+:class:`brainevent.DataRepresentation` fits the contract exactly (and is
+hashable, so it can be a static primitive parameter under ``jit``) without
+depending on the upstream sparse-matrix surface area.
 """
 
 
@@ -36,8 +40,9 @@ import brainstate
 import jax
 import jax.numpy as jnp
 import numpy as np
+import pytest
 import brainunit as u
-from brainunit import sparse as ss
+import brainevent
 
 import braintrace
 from braintrace._op import (
@@ -58,8 +63,12 @@ def _fake_var(shape, dtype=jnp.float32):
     return _FakeVar(aval=_FakeAval(shape=shape, dtype=dtype))
 
 
-class _StubSparseMat:
-    """Minimal sparse-matrix stub satisfying the rule contract.
+class _StubSparseMat(brainevent.DataRepresentation):
+    """Minimal :class:`brainevent.DataRepresentation` stub for the rule contract.
+
+    Subclasses :class:`brainevent.DataRepresentation` so it passes the
+    ``sparse_matmul`` runtime type check, while staying tiny and independent of
+    the upstream sparse-matrix surface area.
 
     Backed by a dense matrix internally; ``with_data`` rebuilds the dense
     form by reshaping the flat data vector into the original shape.
@@ -79,15 +88,11 @@ class _StubSparseMat:
     """
 
     def __init__(self, dense_template: jnp.ndarray):
-        self._shape = dense_template.shape
         self._template = dense_template
-
-    @property
-    def shape(self):
-        return self._shape
+        super().__init__((dense_template,), shape=dense_template.shape)
 
     def with_data(self, data: jnp.ndarray) -> jnp.ndarray:
-        return data.reshape(self._shape)
+        return data.reshape(self._template.shape)
 
     def yw_to_w_transposed(self, hidden_dim, trace):
         if trace.ndim == 1:
@@ -103,9 +108,14 @@ class _StubSparseMat:
         # pass trace in the old full-matrix form.
         return trace * jnp.expand_dims(hidden_dim, axis=0)
 
+    def yw_to_w(self, hidden_dim, trace):
+        # Non-transposed counterpart; the diagonal stub is symmetric so it
+        # delegates. Present to complete the DataRepresentation protocol.
+        return self.yw_to_w_transposed(hidden_dim, trace)
+
 
 def _csr_from_dense(dense: jnp.ndarray):
-    return ss.CSR.fromdense(dense)
+    return brainevent.CSR.fromdense(dense)
 
 
 # ---------------------------------------------------------------------------
@@ -355,8 +365,11 @@ class TestSparseMMBiasGradient:
         cols = jnp.array([0, 1, 2, 3])
         dense_template = jnp.eye(dim)  # shape (dim, dim)
 
-        class _HashableStub:
-            """Minimal stub satisfying the ETP sparse-mat contract."""
+        class _HashableStub(brainevent.DataRepresentation):
+            """Minimal hashable DataRepresentation satisfying the ETP contract."""
+
+            def __init__(self):
+                super().__init__((dense_template,), shape=dense_template.shape)
 
             def __hash__(self):
                 return id(self)
@@ -376,6 +389,9 @@ class TestSparseMMBiasGradient:
                     return trace * hidden_dim
                 n = trace.shape[0]
                 return trace * hidden_dim[:n]
+
+            def yw_to_w(self, hidden_dim, trace):
+                return self.yw_to_w_transposed(hidden_dim, trace)
 
         sparse_mat = _HashableStub()
         nnz = dim
@@ -452,6 +468,46 @@ class TestPublicAPIRoundTrip:
 
     def test_public_alias(self):
         assert braintrace.sparse_matmul is sparse_matmul
+
+
+# ---------------------------------------------------------------------------
+# Runtime type check — sparse_mat must be a brainevent.DataRepresentation
+# ---------------------------------------------------------------------------
+
+class TestRuntimeTypeCheck:
+    """``sparse_matmul`` rejects anything that is not a brainevent.DataRepresentation."""
+
+    def test_accepts_brainevent_csr(self):
+        csr = _csr_from_dense(jnp.eye(3) * 2.0)
+        out = sparse_matmul(jnp.ones(3), csr.data, sparse_mat=csr)
+        np.testing.assert_allclose(out, jnp.ones(3) @ (jnp.eye(3) * 2.0))
+
+    def test_rejects_brainunit_sparse(self):
+        """A brainunit (saiunit) sparse matrix lacks ``yw_to_w_transposed`` and is rejected."""
+        bu_csr = u.sparse.CSR.fromdense(jnp.eye(3))
+        assert not isinstance(bu_csr, brainevent.DataRepresentation)
+        with pytest.raises(TypeError, match='brainevent.DataRepresentation'):
+            sparse_matmul(jnp.ones(3), bu_csr.data, sparse_mat=bu_csr)
+
+    def test_rejects_plain_array(self):
+        with pytest.raises(TypeError, match='yw_to_w_transposed'):
+            sparse_matmul(jnp.ones(3), jnp.ones(3), sparse_mat=jnp.eye(3))
+
+    def test_rejects_duck_typed_non_subclass(self):
+        """An object with the right methods but not a DataRepresentation is still rejected."""
+
+        class _DuckMat:
+            def with_data(self, data):
+                return data
+
+            def yw_to_w_transposed(self, hidden_dim, trace):
+                return trace
+
+            def yw_to_w(self, hidden_dim, trace):
+                return trace
+
+        with pytest.raises(TypeError, match='brainevent.DataRepresentation'):
+            sparse_matmul(jnp.ones(3), jnp.ones(3), sparse_mat=_DuckMat())
 
 
 # ---------------------------------------------------------------------------

--- a/braintrace/nn/_linear_test.py
+++ b/braintrace/nn/_linear_test.py
@@ -28,9 +28,23 @@ import jax
 import jax.numpy as jnp
 import pytest
 import brainunit as u
+import brainevent
 from braintools import init
 
 import braintrace
+
+
+def _be_csr_from_coo(values, rows, cols, shape):
+    """Build a :class:`brainevent.CSR` from COO-style ``(values, rows, cols)``.
+
+    ``SparseLinear`` requires a :class:`brainevent.DataRepresentation` (the type
+    that provides the ``yw_to_w_transposed`` online-learning protocol). brainunit
+    ``COO`` does not qualify, so the connectivity is densified and re-encoded as a
+    brainevent CSR. These tests assert output shapes only, so duplicate-index
+    summation during densification is irrelevant.
+    """
+    dense = u.sparse.COO((values, rows, cols), shape=shape).todense()
+    return brainevent.CSR.fromdense(dense)
 
 
 def _flatten_grads(grads):
@@ -287,12 +301,12 @@ class TestSignedWLinear:
 class TestSparseLinear:
     """Test SparseLinear layer."""
 
-    def test_sparse_linear_basic_creation_coo(self):
-        """Test basic SparseLinear layer creation with COO sparse matrix."""
+    def test_sparse_linear_basic_creation_csr(self):
+        """Test basic SparseLinear layer creation with a brainevent CSR sparse matrix."""
         brainstate.random.seed(42)
         rows, cols = brainstate.random.randint(0, 512, size=(2, 1000))
         values = brainstate.random.randn(1000)
-        sparse_mat = u.sparse.COO((values, rows, cols), shape=(512, 256))
+        sparse_mat = _be_csr_from_coo(values, rows, cols, (512, 256))
 
         linear = braintrace.nn.SparseLinear(sparse_mat)
         assert hasattr(linear, 'out_size')
@@ -303,7 +317,7 @@ class TestSparseLinear:
         brainstate.random.seed(42)
         rows, cols = brainstate.random.randint(0, 512, size=(2, 1000))
         values = brainstate.random.randn(1000)
-        sparse_mat = u.sparse.COO((values, rows, cols), shape=(512, 256))
+        sparse_mat = _be_csr_from_coo(values, rows, cols, (512, 256))
 
         linear = braintrace.nn.SparseLinear(sparse_mat)
         x = brainstate.random.randn(8, 512)
@@ -315,7 +329,7 @@ class TestSparseLinear:
         brainstate.random.seed(42)
         rows, cols = brainstate.random.randint(0, 512, size=(2, 1000))
         values = brainstate.random.randn(1000)
-        sparse_mat = u.sparse.COO((values, rows, cols), shape=(512, 256))
+        sparse_mat = _be_csr_from_coo(values, rows, cols, (512, 256))
 
         linear = braintrace.nn.SparseLinear(sparse_mat)
         x = brainstate.random.randn(512)
@@ -327,7 +341,7 @@ class TestSparseLinear:
         brainstate.random.seed(42)
         rows, cols = brainstate.random.randint(0, 512, size=(2, 1000))
         values = brainstate.random.randn(1000)
-        sparse_mat = u.sparse.COO((values, rows, cols), shape=(512, 256))
+        sparse_mat = _be_csr_from_coo(values, rows, cols, (512, 256))
 
         linear = braintrace.nn.SparseLinear(sparse_mat, b_init=init.Constant(0.1))
         x = brainstate.random.randn(8, 512)
@@ -339,7 +353,7 @@ class TestSparseLinear:
         brainstate.random.seed(42)
         rows, cols = brainstate.random.randint(0, 512, size=(2, 1000))
         values = brainstate.random.randn(1000)
-        sparse_mat = u.sparse.COO((values, rows, cols), shape=(512, 256))
+        sparse_mat = _be_csr_from_coo(values, rows, cols, (512, 256))
 
         linear = braintrace.nn.SparseLinear(sparse_mat, b_init=None)
         x = brainstate.random.randn(8, 512)
@@ -351,7 +365,7 @@ class TestSparseLinear:
         brainstate.random.seed(42)
         rows, cols = brainstate.random.randint(0, 512, size=(2, 1000))
         values = brainstate.random.randn(1000)
-        sparse_mat = u.sparse.COO((values, rows, cols), shape=(512, 256))
+        sparse_mat = _be_csr_from_coo(values, rows, cols, (512, 256))
 
         linear = braintrace.nn.SparseLinear(sparse_mat, in_size=512)
         assert hasattr(linear, 'in_size')
@@ -362,7 +376,7 @@ class TestSparseLinear:
         brainstate.random.seed(42)
         rows, cols = brainstate.random.randint(0, 512, size=(2, 100))  # Only 100 connections
         values = brainstate.random.randn(100)
-        sparse_mat = u.sparse.COO((values, rows, cols), shape=(512, 256))
+        sparse_mat = _be_csr_from_coo(values, rows, cols, (512, 256))
 
         linear = braintrace.nn.SparseLinear(sparse_mat)
         x = brainstate.random.randn(8, 512)
@@ -374,7 +388,7 @@ class TestSparseLinear:
         brainstate.random.seed(42)
         rows, cols = brainstate.random.randint(0, 512, size=(2, 50000))  # Many connections
         values = brainstate.random.randn(50000)
-        sparse_mat = u.sparse.COO((values, rows, cols), shape=(512, 256))
+        sparse_mat = _be_csr_from_coo(values, rows, cols, (512, 256))
 
         linear = braintrace.nn.SparseLinear(sparse_mat)
         x = brainstate.random.randn(8, 512)
@@ -386,7 +400,7 @@ class TestSparseLinear:
         brainstate.random.seed(42)
         rows, cols = brainstate.random.randint(0, 512, size=(2, 1000))
         values = brainstate.random.randn(1000)
-        sparse_mat = u.sparse.COO((values, rows, cols), shape=(512, 256))
+        sparse_mat = _be_csr_from_coo(values, rows, cols, (512, 256))
 
         linear = braintrace.nn.SparseLinear(sparse_mat, name="test_sparse")
         assert linear.name == "test_sparse"
@@ -396,7 +410,7 @@ class TestSparseLinear:
         brainstate.random.seed(42)
         rows, cols = brainstate.random.randint(0, 512, size=(2, 1000))
         values = brainstate.random.randn(1000)
-        sparse_mat = u.sparse.COO((values, rows, cols), shape=(512, 256))
+        sparse_mat = _be_csr_from_coo(values, rows, cols, (512, 256))
 
         linear = braintrace.nn.SparseLinear(sparse_mat)
         x = brainstate.random.randn(32, 512)
@@ -731,7 +745,7 @@ class TestLinearIntegration:
         row_indices = jnp.repeat(jnp.arange(64), 32)
         col_indices = jnp.tile(jnp.arange(32), 64)
         values = brainstate.random.randn(64 * 32)
-        sparse_mat = u.sparse.COO((values, row_indices, col_indices), shape=(64, 32))
+        sparse_mat = _be_csr_from_coo(values, row_indices, col_indices, (64, 32))
 
         sparse_linear = braintrace.nn.SparseLinear(sparse_mat, b_init=None)
 

--- a/docs/tutorials/etp_primitives.ipynb
+++ b/docs/tutorials/etp_primitives.ipynb
@@ -325,7 +325,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": null,
    "id": "b4c5d6e7",
    "metadata": {
     "execution": {
@@ -335,34 +335,8 @@
      "shell.execute_reply": "2026-04-18T06:22:57.898623Z"
     }
    },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "Sparse matmul output shape: (4, 50)\n"
-     ]
-    }
-   ],
-   "source": [
-    "import brainunit as u\n",
-    "from brainunit import sparse as ss\n",
-    "\n",
-    "# Create a sparse connectivity matrix\n",
-    "dense_w = jnp.where(\n",
-    "    jax.random.uniform(jax.random.PRNGKey(0), (50, 50)) < 0.1,\n",
-    "    jax.random.normal(jax.random.PRNGKey(1), (50, 50)),\n",
-    "    0.0\n",
-    ")\n",
-    "sparse_mat = ss.CSR.fromdense(dense_w)\n",
-    "\n",
-    "# The learnable parameter is just the non-zero data\n",
-    "weight_data = sparse_mat.data\n",
-    "\n",
-    "x_sp = jnp.ones((4, 50))  # batch=4, features=50\n",
-    "y_sp = braintrace.sparse_matmul(x_sp, weight_data, sparse_mat=sparse_mat)\n",
-    "print(\"Sparse matmul output shape:\", y_sp.shape)  # (4, 50)"
-   ]
+   "outputs": [],
+   "source": "import brainunit as u\nimport brainevent\n\n# Create a sparse connectivity matrix\ndense_w = jnp.where(\n    jax.random.uniform(jax.random.PRNGKey(0), (50, 50)) < 0.1,\n    jax.random.normal(jax.random.PRNGKey(1), (50, 50)),\n    0.0\n)\n# sparse_mat must be a brainevent.DataRepresentation (e.g. brainevent.CSR),\n# which implements the with_data / yw_to_w_transposed / yw_to_w protocol.\nsparse_mat = brainevent.CSR.fromdense(dense_w)\n\n# The learnable parameter is just the non-zero data\nweight_data = sparse_mat.data\n\nx_sp = jnp.ones((4, 50))  # batch=4, features=50\ny_sp = braintrace.sparse_matmul(x_sp, weight_data, sparse_mat=sparse_mat)\nprint(\"Sparse matmul output shape:\", y_sp.shape)  # (4, 50)"
   },
   {
    "cell_type": "markdown",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ classifiers = [
 dependencies = [
     "brainstate>=0.5.2",
     "brainunit",
+    "brainevent",
     "brainpy.state",
     "braintools",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,6 +2,7 @@ jax
 numpy
 brainstate>=0.5.2
 brainunit
+brainevent
 brainpy-state
 braintools
 


### PR DESCRIPTION
## Summary

`braintrace.sparse_matmul`'s `sparse_mat` parameter is now typed as
`brainevent.DataRepresentation` and enforced with a strict runtime `isinstance`
check. `DataRepresentation` implements the protocol the ETP online-learning
compiler/executor needs: `with_data`, `yw_to_w_transposed`, and `yw_to_w`.

`brainevent` becomes a first-class runtime dependency.

## Why

The sparse ETP rules call `with_data` and `yw_to_w_transposed`. brainunit
(`saiunit`) `COO`/`CSR` provide `with_data`/`yw_to_w` but **not**
`yw_to_w_transposed`, so they can do a forward pass but could never do ETP
online learning. Requiring `brainevent.DataRepresentation` makes the contract
explicit and fails fast with a clear `TypeError` instead of breaking later
during trace propagation.

## Changes

- **Dependency:** add `brainevent` to `pyproject.toml` and `requirements.txt`.
- **`braintrace/_op/sparse.py`:** import `brainevent`; annotate the public
  `sparse_mat` as `brainevent.DataRepresentation` and the internal ETP rules as
  `brainevent.DataRepresentation | None`; add a runtime `isinstance` guard that
  raises `TypeError` naming the required protocol methods; refresh
  module/function docstrings.
- **Tests:** stubs now subclass `brainevent.DataRepresentation` (hashable, so
  they work as static primitive params under `jit`); forward tests use a real
  `brainevent.CSR`; new `TestRuntimeTypeCheck` covers rejection of brainunit
  sparse / plain array / duck-typed objects.
- **Migration:** `SparseLinear` tests, legacy `SpMatMulOp` test, and the
  `etp_primitives` tutorial move from brainunit `u.sparse` to `brainevent.CSR`.

## Verification

- 529 tests pass across `_op`, `nn`, `_legacy`, `_compile`.
- `mypy` clean (`brainevent` py.typed; the `| None` rules use the existing
  `# type: ignore[union-attr]`).

## Notes

- `brainevent.CSR` is unhashable, so it cannot be a static primitive param under
  `jit`/D-RTRL compile (forward/eager is fine). Compile/gradient tests therefore
  use a hashable `DataRepresentation` subclass stub. Pre-existing limitation,
  out of scope here.

## Summary by Sourcery

Require brainevent.DataRepresentation for sparse_matmul and migrate sparse-related tests and examples to use brainevent CSR-based representations.

New Features:
- Enforce sparse_matmul.sparse_mat to be a brainevent.DataRepresentation, defining a clear runtime protocol for sparse structures.

Bug Fixes:
- Add a strict runtime type check for sparse_matmul.sparse_mat to fail fast on incompatible sparse or duck-typed objects.

Enhancements:
- Annotate internal ETP sparse operations to accept optional brainevent.DataRepresentation and refresh related docstrings to describe the full protocol.
- Update sparse and linear layer tests to use brainevent CSR or DataRepresentation subclasses, including hashable stubs for JIT and gradient/compile coverage.
- Adjust the ETP primitives tutorial and legacy sparse op tests to use brainevent.CSR instead of brainunit sparse types.

Build:
- Add brainevent as an explicit runtime dependency in pyproject.toml and requirements.txt.

Documentation:
- Revise tutorial and API docstrings to document brainevent.DataRepresentation as the required sparse structure type and its protocol methods.

Tests:
- Add dedicated runtime type-check tests confirming acceptance of brainevent CSR and rejection of brainunit sparse matrices, plain arrays, and non-subclass duck types.