### PR TITLE
Compiler upgrade: deterministic ordering, jit inlining, fan-out & perturbation fixes

### DIFF
--- a/braintrace/_algorithm/io_dim_vjp.py
+++ b/braintrace/_algorithm/io_dim_vjp.py
@@ -627,7 +627,6 @@ class IODimVjpAlgorithm(ETraceVjpAlgorithm):
         name: Optional[str] = None,
         vjp_method: str = 'single-step',
         fast_solve: bool = True,
-        **kwargs: Any,
     ) -> None:
         super().__init__(model, name=name, vjp_method=vjp_method)
         self.decay, num_rank = _format_decay_and_rank(decay_or_rank)

--- a/braintrace/_algorithm/otpe.py
+++ b/braintrace/_algorithm/otpe.py
@@ -200,7 +200,6 @@ class OTPE(ETraceVjpAlgorithm):
         name: Optional[str] = None,
         vjp_method: str = 'single-step',
         trace_clip_abs: Optional[float] = None,
-        **kwargs: Any,
     ) -> None:
         if mode not in ('full', 'approx'):
             raise ValueError(f"mode must be 'full' or 'approx'; got {mode!r}")

--- a/braintrace/_algorithm/ottt.py
+++ b/braintrace/_algorithm/ottt.py
@@ -165,7 +165,6 @@ class OTTT(ETraceVjpAlgorithm):
         leak: float,
         name: Optional[str] = None,
         vjp_method: str = 'single-step',
-        **kwargs: Any,
     ) -> None:
         if mode not in ('A', 'O'):
             raise ValueError(f"mode must be 'A' or 'O'; got {mode!r}")

--- a/braintrace/_algorithm/param_dim_vjp.py
+++ b/braintrace/_algorithm/param_dim_vjp.py
@@ -621,7 +621,6 @@ class ParamDimVjpAlgorithm(ETraceVjpAlgorithm):
         vjp_method: str = 'single-step',
         fast_solve: bool = True,
         trace_dtype: Optional[DTypeLike] = None,
-        **kwargs: Any,
     ) -> None:
         super().__init__(model, name=name, vjp_method=vjp_method)
         # ``fast_solve=True`` enables closed-form einsum kernels for

--- a/braintrace/_compiler/base.py
+++ b/braintrace/_compiler/base.py
@@ -114,16 +114,17 @@ def check_unsupported_op(
         in an unsupported manner.
     """
     # checking whether the weight variables are used in the equation
-    # Note: with the primitive-based system, weight vars inside JIT are
-    # handled by backward tracing in the compiler, so we only warn.
+    # Note: user ``jax.jit`` boundaries are inlined at extraction time
+    # (see ``jaxpr_graph.inline_jit_calls``), so reaching this check means
+    # a weight is used inside a genuinely opaque region (scan/while/cond).
     invar = find_element_exist_in_the_set(eqn.invars, self.weight_invars)
     if invar is not None:
         emit(
             kind=DiagnosticKind.WEIGHT_IN_CONTROL_FLOW,
-            level=DiagnosticLevel.WARNING,
+            level=DiagnosticLevel.ERROR,
             message=(
-                f'Weight state found inside a {op_name} function. '
-                f'The primitive-based compiler handles this via backward tracing.'
+                f'Weight state used inside a {op_name} region; the ETrace '
+                f'compiler cannot trace through it and compilation fails.'
             ),
             context={'op_name': op_name, 'invar': invar},
         )

--- a/braintrace/_compiler/base.py
+++ b/braintrace/_compiler/base.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 # ==============================================================================
 
-from typing import Dict, Sequence, Set, List
+from typing import Container, Dict, Sequence, Set, List
 
 from braintrace._compatible_imports import (
     Var,
@@ -37,7 +37,7 @@ __all__ = [
 
 def find_matched_vars(
     invars: Sequence[Var],
-    invar_needed_in_oth_eqns: Set[Var]
+    invar_needed_in_oth_eqns: Container[Var]
 ) -> List[Var]:
     """
     Checking whether the invars are matched with the invar_needed_in_oth_eqns.
@@ -46,8 +46,9 @@ def find_matched_vars(
     ----------
     invars : Sequence[Var]
         The input variables of the equation.
-    invar_needed_in_oth_eqns : Set[Var]
-        The variables needed in the other equations.
+    invar_needed_in_oth_eqns : Container[Var]
+        The variables needed in the other equations (a set, or an
+        insertion-ordered dict used as an ordered set).
 
     Returns
     -------
@@ -239,6 +240,10 @@ class JaxprEvaluation(object):
         eqn : JaxprEqn
             The JAX equation to evaluate.
         """
+        # Defensive branch: in the dispatch flow a jit equation's primitive is
+        # never an ETP primitive (those are custom Primitive instances), so
+        # this is reachable only when ``_eval_pjit`` is called directly — as
+        # unit tests do. Kept for that reason.
         if is_etp_primitive(eqn.primitive):
             if is_etp_enable_gradient_primitive(eqn.primitive):
                 self._eval_eqn(eqn)

--- a/braintrace/_compiler/hid_param_op.py
+++ b/braintrace/_compiler/hid_param_op.py
@@ -169,6 +169,14 @@ class HiddenParamOpRelation(NamedTuple):
         Per-key dict mapping each key to the backward-trace processing chain
         (primitives traversed from the trainable invar back to the originating
         ``ParamState`` invar).
+
+    Notes
+    -----
+    The dict-typed fields default to class-level empty dicts that are SHARED
+    across instances (the usual ``NamedTuple`` default semantics). The
+    compiler always passes freshly-built dicts and no consumer mutates a
+    relation, so this never bites in the pipeline — but when hand-constructing
+    relations in tests, pass explicit dicts instead of mutating the defaults.
     """
     primitive: Primitive
     x_var: Optional[Var]
@@ -305,6 +313,13 @@ def _trace_var_to_param(
     deduplicated, insertion-ordered tuple of intermediate primitive types
     traversed (mask multiplication, weight_fn, etc.). When the var is the
     raw ParamState invar, the chain is empty.
+
+    Known limitation: the backward BFS stops at the FIRST ParamState invar it
+    reaches. A trainable invar computed from *two* ParamStates (e.g.
+    ``w1 + w2``) is attributed to whichever the search reaches first; the
+    other's gradient is silently dropped. No library op produces such a
+    joint-parametric trainable input today — route each ParamState through
+    its own ETP op if you need both trained online.
     """
     if cache is not None and var in cache:
         cached = cache[var]
@@ -420,11 +435,12 @@ def _bfs_forward(
     of them are directly fed) while still excluding downstream layers that
     are reachable only *through* another hidden state.
     """
+    direct_groups: Optional[Set[int]] = None
     if outvar_to_group_index is not None:
         # --- Phase 1: directly-fed group discovery ------------------------
         # Do not expand through hidden outvars: a group reachable only via
         # another hidden state is a downstream layer, not a direct target.
-        direct_groups: Set[int] = set()
+        direct_groups = set()
         frontier: deque = deque([start_var])
         visited: Set[Var] = set()
         while frontier:
@@ -453,8 +469,6 @@ def _bfs_forward(
                 for ov in eqn.outvars:
                     if ov not in visited:
                         frontier.append(ov)
-    else:
-        direct_groups = None  # type: ignore[assignment]
 
     # --- Phase 2: full collection, filtered to the directly-fed groups ----
     reachable: Dict[Var, None] = {}
@@ -468,7 +482,7 @@ def _bfs_forward(
             continue
         visited.add(v)
         if v in hidden_outvar_set:
-            if direct_groups is not None:
+            if direct_groups is not None and outvar_to_group_index is not None:
                 g = outvar_to_group_index.get(v)
                 if g is None:
                     raise ValueError(

--- a/braintrace/_compiler/hid_param_op.py
+++ b/braintrace/_compiler/hid_param_op.py
@@ -651,11 +651,15 @@ def _scan_jaxpr_for_etp_eqns(
                     kind=DiagnosticKind.PRIMITIVE_INSIDE_NESTED_JIT,
                     level=DiagnosticLevel.WARNING,
                     message=(
-                        'Found ETP primitives inside a nested jit/pjit. '
-                        'This is currently handled by tracing through the '
-                        'outer jaxpr. If you see incorrect results, please '
-                        'avoid wrapping individual ETP calls in jax.jit. '
-                        f'Report issues at {git_issue_addr}.'
+                        'Found ETP primitives inside a jit/pjit call that was '
+                        'not inlined before relation analysis. These '
+                        'primitives are NOT registered as relations. The '
+                        'standard pipeline (extract_module_info / '
+                        'compile_etrace_graph) inlines user jit bodies before '
+                        'analysis; when running the relation pass on a raw '
+                        'jaxpr, apply '
+                        'braintrace._compiler.jaxpr_graph.inline_jit_calls '
+                        f'first. Report issues at {git_issue_addr}.'
                     ),
                     context={'inner_primitives': tuple(
                         e.primitive for e in inner_etp

--- a/braintrace/_compiler/hid_param_op.py
+++ b/braintrace/_compiler/hid_param_op.py
@@ -412,14 +412,54 @@ def _bfs_forward(
     returns the full reachability set (used by path classification).
 
     When ``outvar_to_group_index`` is provided, the search restricts itself
-    to hidden outvars in the *closest* hidden group — outvars from different
-    groups are pruned so the relation only tracks the recurrence of the
-    layer this primitive actually feeds.
+    to the *directly fed* hidden groups: phase 1 walks forward from
+    ``start_var`` WITHOUT expanding through hidden outvars, so it collects
+    exactly the groups whose hidden state the primitive output reaches on a
+    hidden-free path. Phase 2 is the ordinary traversal filtered to those
+    groups. This keeps a fan-out to several independent groups intact (all
+    of them are directly fed) while still excluding downstream layers that
+    are reachable only *through* another hidden state.
     """
+    if outvar_to_group_index is not None:
+        # --- Phase 1: directly-fed group discovery ------------------------
+        # Do not expand through hidden outvars: a group reachable only via
+        # another hidden state is a downstream layer, not a direct target.
+        direct_groups: Set[int] = set()
+        frontier: deque = deque([start_var])
+        visited: Set[Var] = set()
+        while frontier:
+            v = frontier.popleft()
+            if v in visited:
+                continue
+            visited.add(v)
+            if v in hidden_outvar_set:
+                g = outvar_to_group_index.get(v)
+                if g is None:
+                    raise ValueError(
+                        f'Hidden outvar {v} carries no hidden-group index. '
+                        f'The hidden-group table and the jaxpr disagree — '
+                        f'both must come from the same extract_module_info '
+                        f'result.'
+                    )
+                direct_groups.add(g)
+                continue
+            for eqn in consumer_map.get(v, []):
+                if (
+                    stop_at_non_grad_etp
+                    and is_etp_primitive(eqn.primitive)
+                    and not is_etp_enable_gradient_primitive(eqn.primitive)
+                ):
+                    continue
+                for ov in eqn.outvars:
+                    if ov not in visited:
+                        frontier.append(ov)
+    else:
+        direct_groups = None  # type: ignore[assignment]
+
+    # --- Phase 2: full collection, filtered to the directly-fed groups ----
     reachable: Dict[Var, None] = {}
-    home_group_indices: Set[int] = set()
-    frontier: deque = deque([start_var])
-    visited: Set[Var] = set()
+    frontier = deque([start_var])
+    visited = set()
     blocking_eqns: List[JaxprEqn] = []
     blocking_seen: Set[int] = set()
     while frontier:
@@ -428,12 +468,16 @@ def _bfs_forward(
             continue
         visited.add(v)
         if v in hidden_outvar_set:
-            if outvar_to_group_index is not None:
+            if direct_groups is not None:
                 g = outvar_to_group_index.get(v)
-                assert g is not None  # hidden outvars always carry a group index
-                if not home_group_indices:
-                    home_group_indices.add(g)
-                if g in home_group_indices:
+                if g is None:
+                    raise ValueError(
+                        f'Hidden outvar {v} carries no hidden-group index. '
+                        f'The hidden-group table and the jaxpr disagree — '
+                        f'both must come from the same extract_module_info '
+                        f'result.'
+                    )
+                if g in direct_groups:
                     reachable[v] = None
                 else:
                     continue
@@ -462,13 +506,17 @@ def _classify_path(
     consumer_map: Dict[Var, List[JaxprEqn]],
     producer_map: Dict[Var, JaxprEqn],
     self_eqn: JaxprEqn,
+    forward: Dict[Var, None],
 ) -> str:
     """Classify the set of paths from ``y_var`` to ``hidden_outvar``.
 
     Returns one of :class:`PathClassification` constants.
 
     Algorithm:
-      * ``forward`` = vars reachable from y_var without restriction.
+      * ``forward`` = vars reachable from y_var without restriction —
+        precomputed once per primitive equation by the caller (it depends
+        only on ``y_var``, not on ``hidden_outvar``) via
+        :func:`jaxpr_graph.forward_closure`.
       * ``backward`` = vars that can reach hidden_outvar by following
         consumers in reverse (i.e. equations that produce hidden_outvar).
       * ``mid`` = forward & backward = vars on at least one path y -> h.
@@ -478,19 +526,6 @@ def _classify_path(
         check if hidden_outvar is still reachable. Yes -> ``MIXED``;
         No -> ``ALL_THROUGH_OTHER_ETP``.
     """
-    # Forward reachability (unrestricted).
-    forward: Set[Var] = set()
-    frontier: deque = deque([y_var])
-    while frontier:
-        v = frontier.popleft()
-        if v in forward:
-            continue
-        forward.add(v)
-        for eqn in consumer_map.get(v, []):
-            for ov in eqn.outvars:
-                if ov not in forward:
-                    frontier.append(ov)
-
     if hidden_outvar not in forward:
         # Should not happen — caller already established reachability.
         return PathClassification.ALL_THROUGH_OTHER_ETP
@@ -710,10 +745,31 @@ def find_hidden_param_op_relations_from_jaxpr(
     hidden_outvar_set: Set[Var] = set(outvar_to_hidden_path.keys())
     weight_trace_cache: Dict[Var, Optional[Tuple[Path, Tuple[Primitive, ...]]]] = {}
 
+    # --- Seam validation: the hidden-group table and the jaxpr's hidden
+    # tables must describe the SAME compile. A missing group for a hidden
+    # path, or a group referring to outvars this jaxpr does not produce,
+    # means the two came from different extract_module_info results and
+    # every downstream Var-identity lookup would silently misbehave.
+    missing = [p for p in outvar_to_hidden_path.values() if p not in hid_path_to_group]
+    if missing:
+        raise ValueError(
+            f'Hidden state path(s) {missing} have no hidden group. The '
+            f'hidden-group table and the jaxpr must come from the same '
+            f'extract_module_info result.'
+        )
+    for group in hid_path_to_group.values():
+        for ov in group.hidden_outvars:
+            if ov not in hidden_outvar_set:
+                raise ValueError(
+                    f'Hidden group {group.index} refers to hidden outvar '
+                    f'{ov} which this jaxpr does not produce. The '
+                    f'hidden-group table and the jaxpr must come from the '
+                    f'same extract_module_info result.'
+                )
+
     outvar_to_group_index: Dict[Var, int] = {
         ov: hid_path_to_group[p].index
         for ov, p in outvar_to_hidden_path.items()
-        if p in hid_path_to_group
     }
 
     etp_eqns = _scan_jaxpr_for_etp_eqns(jaxpr)
@@ -732,31 +788,10 @@ def find_hidden_param_op_relations_from_jaxpr(
         trainable_param_states: Dict[str, brainstate.ParamState] = {}
         trainable_processing_chains: Dict[str, Tuple[Primitive, ...]] = {}
 
-        # Use the first trainable key for the primary weight trace (needed for
-        # diagnostics and shape-mismatch error messages below).
-        first_key = next(iter(trainable_invars_map)) if trainable_invars_map else None
-        weight_path: Optional[Path] = None
-        if first_key is not None:
-            primary_invar = trainable_invars_map[first_key]
-            weight_path, _ = _trace_var_to_param(
-                primary_invar, producers, invar_to_weight_path,
-                cache=weight_trace_cache,
-            )
-
-        if weight_path is None:
-            first_invar_repr = trainable_invars_map[first_key] if first_key is not None else None
-            emit(
-                kind=DiagnosticKind.RELATION_EXCLUDED_NO_PARAMSTATE,
-                level=DiagnosticLevel.WARNING,
-                message=(
-                    f'ETP primitive {primitive.name} at {eqn} has a trainable input '
-                    f'({first_key}) that could not be traced back to any ParamState. Skipping.'
-                ),
-                primitive=primitive,
-                context={'trainable_var': first_invar_repr, 'key': first_key},
-            )
-            continue
-
+        # Resolve every trainable key first; the relation is skipped only if
+        # NONE of them traces to a ParamState. A primitive whose first key
+        # (e.g. a constant weight) is unresolvable but whose bias IS a
+        # ParamState still participates through the resolved keys.
         for key, invar in trainable_invars_map.items():
             t_path, t_chain = _trace_var_to_param(
                 invar, producers, invar_to_weight_path,
@@ -791,6 +826,24 @@ def find_hidden_param_op_relations_from_jaxpr(
             trainable_param_states[key] = t_state
             trainable_processing_chains[key] = t_chain
 
+        if not trainable_paths:
+            first_key = next(iter(trainable_invars_map)) if trainable_invars_map else None
+            first_invar_repr = trainable_invars_map[first_key] if first_key is not None else None
+            emit(
+                kind=DiagnosticKind.RELATION_EXCLUDED_NO_PARAMSTATE,
+                level=DiagnosticLevel.WARNING,
+                message=(
+                    f'ETP primitive {primitive.name} at {eqn} has no trainable input '
+                    f'({tuple(trainable_invars_map)}) that traces back to any ParamState. Skipping.'
+                ),
+                primitive=primitive,
+                context={'trainable_var': first_invar_repr, 'key': first_key},
+            )
+            continue
+
+        # The first *resolved* key names the relation in diagnostics.
+        weight_path: Path = next(iter(trainable_paths.values()))
+
         # --- Restricted reachability for relation registration ---
         reachable_hvars, blocking_eqns = _bfs_forward(
             y_var, consumers, hidden_outvar_set,
@@ -799,6 +852,9 @@ def find_hidden_param_op_relations_from_jaxpr(
         )
 
         # --- Filter by shape compatibility ---
+        # The unrestricted forward closure depends only on ``y_var``:
+        # compute it once per primitive equation, not once per hidden var.
+        y_forward = forward_closure(y_var, consumers)
         connected_paths: List[Path] = []
         path_class: Dict[Path, str] = {}
         for hvar in list(reachable_hvars):
@@ -828,6 +884,7 @@ def find_hidden_param_op_relations_from_jaxpr(
             connected_paths.append(hpath)
             cls = _classify_path(
                 y_var, hvar, consumers, producers, self_eqn=eqn,
+                forward=y_forward,
             )
             path_class[hpath] = cls
 

--- a/braintrace/_compiler/hid_param_op.py
+++ b/braintrace/_compiler/hid_param_op.py
@@ -80,6 +80,7 @@ from .diagnostics import (
     emit,
 )
 from .hidden_group import HiddenGroup, find_hidden_groups_from_minfo
+from .jaxpr_graph import build_consumer_map, build_producer_map, forward_closure
 from .module_info import ModuleInfo, extract_module_info
 
 __all__ = [
@@ -245,29 +246,6 @@ class HiddenParamOpRelation(NamedTuple):
 
 
 HiddenParamOpRelation.__module__ = 'braintrace'
-
-
-# ---------------------------------------------------------------------------
-# Internal helpers — producer / consumer maps
-# ---------------------------------------------------------------------------
-
-def _build_producer_map(jaxpr: Jaxpr) -> Dict[Var, JaxprEqn]:
-    """Map each variable to the equation that produces it."""
-    producers: Dict[Var, JaxprEqn] = {}
-    for eqn in jaxpr.eqns:
-        for v in eqn.outvars:
-            producers[v] = eqn
-    return producers
-
-
-def _build_consumer_map(jaxpr: Jaxpr) -> Dict[Var, List[JaxprEqn]]:
-    """Map each variable to the equations that consume it."""
-    consumers: Dict[Var, List[JaxprEqn]] = {}
-    for eqn in jaxpr.eqns:
-        for v in eqn.invars:
-            if isinstance(v, Var):
-                consumers.setdefault(v, []).append(eqn)
-    return consumers
 
 
 # ---------------------------------------------------------------------------
@@ -723,8 +701,8 @@ def find_hidden_param_op_relations_from_jaxpr(
     **_ignored,
 ) -> Sequence[HiddenParamOpRelation]:
     """Find all ETP-primitive-to-hidden-state relations in *jaxpr*."""
-    producers = _build_producer_map(jaxpr)
-    consumers = _build_consumer_map(jaxpr)
+    producers = build_producer_map(jaxpr)
+    consumers = build_consumer_map(jaxpr)
     hidden_outvar_set: Set[Var] = set(outvar_to_hidden_path.keys())
     weight_trace_cache: Dict[Var, Optional[Tuple[Path, Tuple[Primitive, ...]]]] = {}
 

--- a/braintrace/_compiler/hidden_group.py
+++ b/braintrace/_compiler/hidden_group.py
@@ -63,6 +63,7 @@ from braintrace._typing import (
     Path,
 )
 from .base import JaxprEvaluation, find_matched_vars
+from .diagnostics import DiagnosticKind, DiagnosticLevel, emit
 from .module_info import extract_module_info, ModuleInfo
 
 __all__ = [
@@ -442,17 +443,23 @@ class HiddenToHiddenGroupTracer(NamedTuple):
     """
     The data structure for the tracing of the hidden-to-hidden states.
 
+    The variable collections are insertion-ordered ``dict`` objects used as
+    ordered sets (values are always ``None``), so every downstream ordering
+    (group members, transition constvars) is deterministic across processes;
+    plain ``set`` iteration follows memory-address hashes for jaxpr ``Var``
+    objects.
+
     Attributes:
         hidden_invar (Var): The input variable representing the hidden state.
-        connected_hidden_outvars (set[Var]): A set of output variables representing the connected hidden states.
-        other_invars (set[Var]): A set of other input variables involved in the tracing.
-        invar_needed_in_oth_eqns (set[Var]): A set of variables needed in other equations for trace analysis.
+        connected_hidden_outvars (Dict[Var, None]): Ordered set of output variables representing the connected hidden states.
+        other_invars (Dict[Var, None]): Ordered set of other input variables involved in the tracing.
+        invar_needed_in_oth_eqns (Dict[Var, None]): Ordered set of variables needed in other equations for trace analysis.
         trace (List[JaxprEqn]): A list of JAX equations representing the trace of operations.
     """
     hidden_invar: Var
-    connected_hidden_outvars: set[Var]
-    other_invars: set[Var]
-    invar_needed_in_oth_eqns: set[Var]
+    connected_hidden_outvars: Dict[Var, None]
+    other_invars: Dict[Var, None]
+    invar_needed_in_oth_eqns: Dict[Var, None]
     trace: List[JaxprEqn]
 
     def dict(self) -> Dict[str, Any]:
@@ -593,11 +600,13 @@ def _simplify_hid2hid_tracer(
     #      different sequential layers and are excluded.
     invar_path = hidden_invar_to_path[tracer.hidden_invar]
     invar_state = path_to_state[invar_path]
-    compatible_outvars = {
+    # Ordered dict-as-set: preserves the tracer's encounter order so the
+    # resulting transition outvars/constvars are deterministic.
+    compatible_outvars = dict.fromkeys(
         hv for hv in tracer.connected_hidden_outvars
         if (path_to_state[hidden_outvar_to_path[hv]].varshape == invar_state.varshape
             and _same_recurrence_layer(invar_path, hidden_outvar_to_path[hv]))
-    }
+    )
     if not compatible_outvars:
         return None
 
@@ -609,17 +618,19 @@ def _simplify_hid2hid_tracer(
     # that do not contain the hidden states.
     tracer.invar_needed_in_oth_eqns.clear()
     new_trace = []
-    whole_trace_needed_vars = set(compatible_outvars)
-    visited_needed_vars = set()  # needed_vars has been satisfied
+    whole_trace_needed_vars = dict.fromkeys(compatible_outvars)
+    visited_needed_vars: Dict[Var, None] = {}  # needed_vars has been satisfied
     for eqn in reversed(tracer.trace):
         need_outvars = []
         for outvar in eqn.outvars:
             if outvar in whole_trace_needed_vars:
                 need_outvars.append(outvar)
         if len(need_outvars):
-            visited_needed_vars.update(need_outvars)
+            visited_needed_vars.update(dict.fromkeys(need_outvars))
             new_trace.append(eqn)
-            whole_trace_needed_vars.update([invar for invar in eqn.invars if isinstance(invar, Var)])
+            whole_trace_needed_vars.update(
+                dict.fromkeys(invar for invar in eqn.invars if isinstance(invar, Var))
+            )
 
     # [second step]
     #
@@ -629,8 +640,8 @@ def _simplify_hid2hid_tracer(
     # [third step]
     #
     # Simplify the trace
-    visited_needed_vars.add(tracer.hidden_invar)
-    constvars = list(whole_trace_needed_vars.difference(visited_needed_vars))
+    visited_needed_vars[tracer.hidden_invar] = None
+    constvars = [v for v in whole_trace_needed_vars if v not in visited_needed_vars]
     jaxpr_opt = Jaxpr(
         # the const vars are not the hidden states, they are
         # intermediate data that are not used in the hidden states
@@ -798,18 +809,18 @@ class JaxprEvalForHiddenGroup(JaxprEvaluation):
                     f'{hidden_paths}'
                 )
             hidden_var = hidden_invars[0]
-            hidden_outvars = set([outvar for outvar in eqn.outvars if outvar in self.hidden_outvars])
-            needed_invars = set([outvar for outvar in eqn.outvars if outvar not in self.hidden_outvars])
+            hidden_outvars = dict.fromkeys(outvar for outvar in eqn.outvars if outvar in self.hidden_outvars)
+            needed_invars = dict.fromkeys(outvar for outvar in eqn.outvars if outvar not in self.hidden_outvars)
             if hidden_var in self.active_tracers:
                 self.active_tracers[hidden_var].trace.append(eqn.replace())
-                self.active_tracers[hidden_var].other_invars.update(other_invars)
+                self.active_tracers[hidden_var].other_invars.update(dict.fromkeys(other_invars))
                 self.active_tracers[hidden_var].invar_needed_in_oth_eqns.update(needed_invars)
                 self.active_tracers[hidden_var].connected_hidden_outvars.update(hidden_outvars)
             else:
                 tracer = HiddenToHiddenGroupTracer(
                     hidden_invar=hidden_var,
                     connected_hidden_outvars=hidden_outvars,
-                    other_invars=set(other_invars),
+                    other_invars=dict.fromkeys(other_invars),
                     invar_needed_in_oth_eqns=needed_invars,
                     trace=[eqn.replace()]
                 )
@@ -831,12 +842,12 @@ class JaxprEvalForHiddenGroup(JaxprEvaluation):
     ) -> None:
 
         tracer.trace.append(eqn.replace())
-        tracer.invar_needed_in_oth_eqns.update(eqn.outvars)
+        tracer.invar_needed_in_oth_eqns.update(dict.fromkeys(eqn.outvars))
 
         # check whether the hidden states are needed in the other equations
         for outvar in eqn.outvars:
             if outvar in self.hidden_outvars:
-                tracer.connected_hidden_outvars.add(outvar)
+                tracer.connected_hidden_outvars[outvar] = None
 
     def _eqn_consumes_hidden(self, eqn: JaxprEqn) -> bool:
         """Whether ``eqn`` reads a hidden-derived value.
@@ -884,16 +895,25 @@ class JaxprEvalForHiddenGroup(JaxprEvaluation):
         # [ second step ]
         #
         # Find out the hidden group,
-        # i.e., the hidden states that are connected to each other, the union of all hidden-to-group
+        # i.e., the hidden states that are connected to each other, the union of all hidden-to-group.
+        #
+        # The merge is deterministic and the result is canonicalized against
+        # the compiled state order (``hidden_outvar_to_invar`` insertion
+        # order): members within a group and the groups themselves follow the
+        # order the hidden states appear in the compiled model, never the
+        # address-hash order of an intermediate set.
         outvar_groups: list = [
-            set(
-                [self.hidden_invar_to_outvar[transition.hidden_invar]] +
-                list(transition.connected_hidden_outvars)
-            )
+            [self.hidden_invar_to_outvar[transition.hidden_invar]]
+            + list(transition.connected_hidden_outvars)
             for transition in hidden_to_group_transition
         ]
-        outvar_groups = group_merging(outvar_groups, version=0)
-        outvar_groups = [list(group) for group in outvar_groups]
+        outvar_groups = _merge_groups_ordered(outvar_groups)
+        outvar_order = {ov: i for i, ov in enumerate(self.hidden_outvar_to_invar)}
+        outvar_groups = [
+            sorted(group, key=outvar_order.__getitem__)
+            for group in outvar_groups
+        ]
+        outvar_groups.sort(key=lambda group: outvar_order[group[0]])
         invar_groups = [
             [self.hidden_outvar_to_invar[outvar] for outvar in group]
             for group in outvar_groups
@@ -954,6 +974,20 @@ class JaxprEvalForHiddenGroup(JaxprEvaluation):
                 transition_jaxpr_constvars=list(jaxpr.constvars),
                 is_diagonal_recurrence=not self.include_recurrent_mixing,
             )
+            # Belt-and-braces: the per-transition shape filter in
+            # ``_simplify_hid2hid_tracer`` should already guarantee this, but
+            # a merged group violating it would corrupt concat/split downstream.
+            group.check_consistent_varshape()
+            if len(group.hidden_paths) > 1:
+                emit(
+                    kind=DiagnosticKind.HIDDEN_GROUP_MERGED,
+                    level=DiagnosticLevel.INFO,
+                    message=(
+                        f'Hidden states {group.hidden_paths} are mutually '
+                        f'recurrent and were merged into one hidden group.'
+                    ),
+                    hidden_paths=tuple(group.hidden_paths),
+                )
             hidden_groups.append(group)
 
         # [ fourth-b step ]
@@ -976,7 +1010,10 @@ class JaxprEvalForHiddenGroup(JaxprEvaluation):
         covered_outvars: Set[Var] = set()
         for group in hidden_groups:
             covered_outvars.update(group.hidden_outvars)
-        for outvar in self.hidden_outvars:
+        # Iterate the insertion-ordered outvar->invar mapping (compiled state
+        # order), NOT the base-class ``hidden_outvars`` set, so the fallback
+        # groups are appended in deterministic order.
+        for outvar in self.hidden_outvar_to_invar:
             if outvar in covered_outvars:
                 continue
             invar = self.hidden_outvar_to_invar[outvar]
@@ -1044,23 +1081,25 @@ def write_jaxpr_of_hidden_group_transition(
     # 3. all outvars
     #
     eqns = []
-    all_invars = set()
-    all_outvars = set()
+    # Ordered dict-as-set bookkeeping keeps the derived ``constvars`` order
+    # deterministic across processes (Var hashing is address-based).
+    all_invars: Dict[Var, None] = {}
+    all_outvars: Dict[Var, None] = {}
     for invar in hidden_invars:
         if invar in hidden_invar_to_transition:
             transition = hidden_invar_to_transition[invar]
             for eq in transition.transition_jaxpr.eqns:
                 this_eq_exist = [outvar in all_outvars for outvar in eq.outvars]
-                # this_eq_exist = False
-                # for outvar in eq.outvars:
-                #     if outvar in all_outvars:
-                #         this_eq_exist = True
-                #         break
                 if not all(this_eq_exist):
                     eqns.append(eq.replace())
-                    all_invars.update([invar for invar in eq.invars if not isinstance(invar, Literal)])
-                    all_outvars.update(eq.outvars)
-    other_invars = list(all_invars.difference(all_outvars).difference(hidden_invars))
+                    all_invars.update(
+                        dict.fromkeys(invar for invar in eq.invars if not isinstance(invar, Literal))
+                    )
+                    all_outvars.update(dict.fromkeys(eq.outvars))
+    other_invars = [
+        v for v in all_invars
+        if v not in all_outvars and v not in hidden_invars
+    ]
 
     #
     # step 2:
@@ -1106,6 +1145,41 @@ def write_jaxpr_of_hidden_group_transition(
         eqns=new_eqns,
         debug_info=debug_info,
     )
+
+
+def _merge_groups_ordered(groups: Sequence[Sequence[HiddenOutVar]]) -> List[List[HiddenOutVar]]:
+    """Union intersecting groups, deterministically.
+
+    Semantically identical to :func:`group_merging` (transitive union of any
+    groups sharing a member) but order-preserving: the result lists groups by
+    first appearance in ``groups``, and each group's members by first
+    appearance, so the output never depends on ``Var`` hash (memory-address)
+    order. Used by the compiler; :func:`group_merging` is kept for its direct
+    importers.
+
+    Parameters
+    ----------
+    groups : sequence of sequence of Var
+        The groups to merge.
+
+    Returns
+    -------
+    list of list of Var
+        Disjoint merged groups, in deterministic order.
+    """
+    merged: List[Dict[HiddenOutVar, None]] = []
+    for g in groups:
+        new = dict.fromkeys(g)
+        hits = [m for m in merged if any(v in m for v in new)]
+        if hits:
+            base = hits[0]
+            for other in hits[1:]:
+                base.update(other)
+                merged.remove(other)
+            base.update(new)
+        else:
+            merged.append(new)
+    return [list(m) for m in merged]
 
 
 def group_merging(groups, version: int = 1) -> List[frozenset[HiddenOutVar]]:

--- a/braintrace/_compiler/hidden_group.py
+++ b/braintrace/_compiler/hidden_group.py
@@ -557,6 +557,14 @@ def _same_recurrence_layer(path1: Path, path2: Path) -> bool:
     ('layers', 1, ...)) indicate different sequential layers and should
     be in separate groups. Paths that diverge at string keys (e.g.,
     ('neu', 'V') vs ('neu', 'a')) are within the same layer.
+
+    This is a *path heuristic*, not a graph-structural test: sibling layers
+    keyed by strings (``self.cell0`` / ``self.cell1``, dicts of modules) are
+    NOT separated by it. Their separation instead relies on the recurrent-
+    mixing boundary skips in ``_eval_eqn`` — any matmul/conv between layers
+    cuts the trace — which holds for every realistic layered model. Two
+    purely-elementwise-coupled sibling string-keyed layers would merge into
+    one group; a graph-structural replacement is future work.
     """
     min_len = min(len(path1), len(path2))
     for i in range(min_len):
@@ -806,7 +814,12 @@ class JaxprEvalForHiddenGroup(JaxprEvaluation):
                 raise ValueError(
                     f'Currently, we only support one hidden state in a single equation. \n'
                     f'{eqn}\n'
-                    f'{hidden_paths}'
+                    f'The hidden states consumed by this equation are: \n'
+                    f'{hidden_paths}\n'
+                    f'If these states form one multi-component neuron, stack '
+                    f'them into a single array held by a '
+                    f'brainstate.HiddenGroupState (or HiddenTreeState) so the '
+                    f'equation consumes one hidden variable.'
                 )
             hidden_var = hidden_invars[0]
             hidden_outvars = dict.fromkeys(outvar for outvar in eqn.outvars if outvar in self.hidden_outvars)

--- a/braintrace/_compiler/hidden_group_test.py
+++ b/braintrace/_compiler/hidden_group_test.py
@@ -1105,3 +1105,100 @@ class TestHiddenGroup_diagonal_jacobian:
             print(jax_jac)
 
             assert (u.math.allclose(diag_jac, jax_jac, atol=1e-5))
+
+
+class TestGroupOrderingAndDiagnostics:
+    """Task-4 contracts: canonical member ordering, merge diagnostics, and
+    varshape validation at group construction time."""
+
+    def _lstm_minfo(self):
+        lstm = braintrace.nn.LSTMCell(3, 4)
+        brainstate.nn.init_all_states(lstm)
+        inp = brainstate.random.rand(3)
+        minfo = braintrace.extract_module_info(lstm, inp)
+        return lstm, inp, minfo
+
+    def test_lstm_group_paths_follow_compiled_state_order(self):
+        # Member order inside a merged group is canonical: it follows the
+        # compiled state order (hidden_path_to_outvar insertion order), not
+        # the hash order of an intermediate set.
+        _, inp, minfo = self._lstm_minfo()
+        state_order = list(minfo.hidden_path_to_outvar.keys())
+
+        from braintrace._compiler.hidden_group import find_hidden_groups_from_minfo
+        groups, _ = find_hidden_groups_from_minfo(minfo)
+
+        assert len(groups) == 1
+        assert groups[0].hidden_paths == state_order
+        # invars/outvars follow the same canonical order.
+        expected_outvars = [minfo.hidden_path_to_outvar[p] for p in state_order]
+        assert groups[0].hidden_outvars == expected_outvars
+
+    def test_group_ordering_identical_across_two_compiles(self):
+        def build():
+            lstm = braintrace.nn.LSTMCell(3, 4)
+            brainstate.nn.init_all_states(lstm)
+            inp = brainstate.random.rand(3)
+            groups, _ = find_hidden_groups_from_module(lstm, inp)
+            return [g.hidden_paths for g in groups]
+
+        assert build() == build()
+
+    def test_merged_group_emits_info_record(self):
+        from braintrace._compiler.diagnostics import (
+            DiagnosticKind,
+            DiagnosticLevel,
+            diagnostic_context,
+        )
+        lstm, inp, _ = self._lstm_minfo()
+
+        with diagnostic_context() as reporter:
+            find_hidden_groups_from_module(lstm, inp)
+
+        recs = [
+            r for r in reporter.records()
+            if r.kind is DiagnosticKind.HIDDEN_GROUP_MERGED
+        ]
+        assert len(recs) == 1, (
+            f'LSTM h/c must yield exactly one HIDDEN_GROUP_MERGED record; '
+            f'got {recs}'
+        )
+        assert recs[0].level is DiagnosticLevel.INFO
+        assert set(recs[0].hidden_paths) == {('h',), ('c',)}
+
+    def test_singleton_group_emits_no_merge_record(self):
+        from braintrace._compiler.diagnostics import (
+            DiagnosticKind,
+            diagnostic_context,
+        )
+        gru = braintrace.nn.GRUCell(3, 4)
+        brainstate.nn.init_all_states(gru)
+        inp = brainstate.random.rand(3)
+
+        with diagnostic_context() as reporter:
+            find_hidden_groups_from_module(gru, inp)
+
+        assert not any(
+            r.kind is DiagnosticKind.HIDDEN_GROUP_MERGED
+            for r in reporter.records()
+        )
+
+    def test_check_consistent_varshape_raises_on_mismatch(self):
+        from braintrace._misc import NotSupportedError
+
+        class _FakeState:
+            def __init__(self, varshape):
+                self.varshape = varshape
+                self.num_state = 1
+
+        group = braintrace.HiddenGroup(
+            index=0,
+            hidden_paths=[('a',), ('b',)],
+            hidden_states=[_FakeState((3,)), _FakeState((4,))],
+            hidden_invars=[],
+            hidden_outvars=[],
+            transition_jaxpr=None,
+            transition_jaxpr_constvars=[],
+        )
+        with pytest.raises(NotSupportedError):
+            group.check_consistent_varshape()

--- a/braintrace/_compiler/hidden_pertubation.py
+++ b/braintrace/_compiler/hidden_pertubation.py
@@ -272,6 +272,34 @@ class JaxprEvalForHiddenPerturbation(JaxprEvaluation):
         # revising equations
         self._eval_jaxpr(self.closed_jaxpr.jaxpr)
 
+        # [read-only hidden states]
+        # A hidden state that is read but never written has no producing
+        # equation: its jaxpr outvar IS its invar (or a constvar). Synthesize
+        # the perturbed passthrough  ``h^t = h^{t-1} + p``  and substitute the
+        # fresh var into the jaxpr outvar slots that referenced the old one.
+        # The equation invars are NOT substituted: reads inside the step see
+        # ``h^{t-1}``, which is unperturbed by definition.
+        outvar_subst: Dict[Var, Var] = {}
+        source_vars = set(self.closed_jaxpr.jaxpr.invars) | set(self.closed_jaxpr.jaxpr.constvars)
+        for hidden_var in tuple(self._hidden_outvars_ordered):
+            if hidden_var not in self.hidden_jaxvars_to_remove:
+                continue
+            if hidden_var not in source_vars:
+                continue  # truly unexplained; reported below
+            self.hidden_jaxvars_to_remove.remove(hidden_var)
+            perturb_var = self.perturb_invars[hidden_var]
+            fresh = self._new_var_like(hidden_var)
+            self.revised_eqns.append(
+                jax.core.new_jaxpr_eqn(
+                    [hidden_var, perturb_var],
+                    [fresh],
+                    jax.lax.add_p,
+                    {},
+                    set(),
+                )
+            )
+            outvar_subst[hidden_var] = fresh
+
         # [final checking]
         # If there are hidden states that are not found in the code, we raise an error.
         if len(self.hidden_jaxvars_to_remove) > 0:
@@ -286,11 +314,16 @@ class JaxprEvalForHiddenPerturbation(JaxprEvaluation):
             )
 
         # new jaxpr
+        new_outvars = [
+            outvar_subst.get(v, v) if isinstance(v, Var) else v
+            for v in self.closed_jaxpr.jaxpr.outvars
+        ]
         jaxpr = Jaxpr(
             constvars=list(self.closed_jaxpr.jaxpr.constvars),
             invars=list(self.closed_jaxpr.jaxpr.invars) + list(self.perturb_invars.values()),
-            outvars=list(self.closed_jaxpr.jaxpr.outvars),
+            outvars=new_outvars,
             eqns=self.revised_eqns,
+            effects=self.closed_jaxpr.jaxpr.effects,
             debug_info=self.closed_jaxpr.jaxpr.debug_info,
         )
         revised_closed_jaxpr = ClosedJaxpr(jaxpr, self.closed_jaxpr.literals)
@@ -322,50 +355,48 @@ class JaxprEvalForHiddenPerturbation(JaxprEvaluation):
         """
         self._eval_eqn(eqn)
 
-    def _add_perturb_eqn(
-        self,
-        eqn: JaxprEqn,
-        perturb_var: Var
-    ):
+    def _eval_eqn(self, eqn: JaxprEqn):
         # ------------------------------------------------
         #
-        # For the hidden var eqn, we want to add a perturbation:
+        # For every hidden outvar the equation produces (any number, at any
+        # position), we add a perturbation:
         #    y = f(x)  =>  y = f(x) + perturb_var
         #
-        # Particularly, we first define a new variable
+        # Particularly, each hidden outvar slot is first redirected to a
+        # fresh variable
         #    new_outvar = f(x)
         #
-        # Then, we add a new equation for the perturbation
+        # then a perturbation equation re-defines the hidden var
         #    y = new_outvar + perturb_var
         #
         # ------------------------------------------------
+        hidden_positions = [
+            i for i, ov in enumerate(eqn.outvars)
+            if ov in self.hidden_jaxvars_to_remove
+        ]
+        if not hidden_positions:
+            self.revised_eqns.append(eqn.replace())
+            return
 
-        hidden_var = eqn.outvars[0]
+        new_outvars = list(eqn.outvars)
+        for i in hidden_positions:
+            hidden_var = eqn.outvars[i]
+            self.hidden_jaxvars_to_remove.remove(hidden_var)
+            new_outvars[i] = self._new_var_like(hidden_var)
+        self.revised_eqns.append(eqn.replace(outvars=new_outvars))
 
-        # Frist step, define the hidden var as a new variable
-        new_outvar = self._new_var_like(perturb_var)
-        old_eqn = eqn.replace(outvars=[new_outvar])
-        self.revised_eqns.append(old_eqn)
-
-        # Second step, add the perturbation equation
-        new_eqn = jax.core.new_jaxpr_eqn(
-            [new_outvar, perturb_var],
-            [hidden_var],
-            jax.lax.add_p,
-            {},
-            set(),
-            eqn.source_info.replace()
-        )
-        self.revised_eqns.append(new_eqn)
-
-    def _eval_eqn(self, eqn: JaxprEqn):
-        if len(eqn.outvars) == 1:
-            if eqn.outvars[0] in self.hidden_jaxvars_to_remove:
-                hidden_var = eqn.outvars[0]
-                self.hidden_jaxvars_to_remove.remove(hidden_var)
-                self._add_perturb_eqn(eqn, self.perturb_invars[hidden_var])
-                return
-        self.revised_eqns.append(eqn.replace())
+        for i in hidden_positions:
+            hidden_var = eqn.outvars[i]
+            self.revised_eqns.append(
+                jax.core.new_jaxpr_eqn(
+                    [new_outvars[i], self.perturb_invars[hidden_var]],
+                    [hidden_var],
+                    jax.lax.add_p,
+                    {},
+                    set(),
+                    eqn.source_info.replace(),
+                )
+            )
 
     def _new_var_like(self, v):
         return new_var('', jax.core.ShapedArray(v.aval.shape, v.aval.dtype))

--- a/braintrace/_compiler/hidden_pertubation_test.py
+++ b/braintrace/_compiler/hidden_pertubation_test.py
@@ -124,3 +124,128 @@ class TestFindHiddenGroupsFromModule:
 
         perturb = hidden_perturb.init_perturb_data()
         assert len(states) == len(perturb)
+
+
+class TestPerturbationRobustness:
+    """Task-6 contracts: multi-output equations, read-only hidden states,
+    and jaxpr-effects preservation."""
+
+    def test_multi_output_eqn_both_hidden_perturbed(self):
+        # One `sort` equation with TWO outvars, both of which are hidden
+        # outvars. Both must receive their perturbation, regardless of the
+        # position of the hidden var in the equation's outvar list.
+        import jax
+        import jax.numpy as jnp
+        import numpy as np
+        from braintrace._compiler.hidden_pertubation import (
+            JaxprEvalForHiddenPerturbation,
+        )
+
+        def f(a, b):
+            return jax.lax.sort((a, b), num_keys=1)
+
+        a = jnp.asarray([3.0, 1.0, 2.0])
+        b = jnp.asarray([10.0, 20.0, 30.0])
+        closed = jax.make_jaxpr(f)(a, b)
+        (eqn,) = closed.jaxpr.eqns
+        assert len(eqn.outvars) == 2, 'expected a single multi-output eqn'
+        h1, h2 = closed.jaxpr.outvars
+        a_in, b_in = closed.jaxpr.invars
+
+        perturb = JaxprEvalForHiddenPerturbation(
+            closed_jaxpr=closed,
+            hidden_outvar_to_invar={h1: a_in, h2: b_in},
+            weight_invars=set(),
+            invar_to_hidden_path={a_in: ('h1',), b_in: ('h2',)},
+            outvar_to_hidden_path={h1: ('h1',), h2: ('h2',)},
+            path_to_state={('h1',): None, ('h2',): None},
+        ).compile()
+
+        assert len(perturb.perturb_vars) == 2
+        p1 = jnp.full(3, 0.5)
+        p2 = jnp.full(3, -2.0)
+        base1, base2 = f(a, b)
+        out1, out2 = perturb.eval_jaxpr([a, b], [p1, p2])
+        np.testing.assert_allclose(out1, base1 + p1)
+        np.testing.assert_allclose(out2, base2 + p2)
+
+    def test_read_only_hidden_state_compiles_and_shifts(self):
+        # ``h_ro`` is read but never written: its jaxpr outvar is its invar
+        # and no equation produces it. The perturbation pass must synthesize
+        # the passthrough ``h_ro^t = h_ro^{t-1} + p`` instead of raising.
+        import jax
+        import jax.numpy as jnp
+        import numpy as np
+        from braintrace._compiler.hidden_pertubation import (
+            add_hidden_perturbation_from_minfo,
+        )
+
+        class _ReadOnlyHiddenRNN(brainstate.nn.Module):
+            def __init__(self, n):
+                super().__init__()
+                self.h_ro = brainstate.HiddenState(jnp.ones(n))
+                self.h = brainstate.HiddenState(jnp.zeros(n))
+
+            def init_state(self, *args, **kwargs):
+                pass
+
+            def update(self, x):
+                self.h.value = jnp.tanh(x + 0.5 * self.h.value + self.h_ro.value)
+                return self.h.value
+
+        model = _ReadOnlyHiddenRNN(4)
+        brainstate.nn.init_all_states(model)
+        inp = brainstate.random.rand(4)
+        minfo = braintrace.extract_module_info(model, inp)
+
+        perturb = add_hidden_perturbation_from_minfo(minfo)
+
+        assert set(perturb.perturb_hidden_paths) == {('h_ro',), ('h',)}
+        idx_ro = list(perturb.perturb_hidden_paths).index(('h_ro',))
+        flat_inputs = jax.tree.leaves(
+            ((inp,), [st.value for st in minfo.compiled_model_states])
+        )
+        zeros = perturb.init_perturb_data()
+        base = perturb.eval_jaxpr(flat_inputs, zeros)
+        pdata = list(zeros)
+        pdata[idx_ro] = jnp.full(4, 0.3)
+        shifted = perturb.eval_jaxpr(flat_inputs, pdata)
+
+        ro_outvar = minfo.hidden_path_to_outvar[('h_ro',)]
+        slot = list(minfo.jaxpr.outvars).index(ro_outvar)
+        np.testing.assert_allclose(
+            np.asarray(shifted[slot]), np.asarray(base[slot]) + 0.3, rtol=1e-6,
+        )
+        for i, (s, b) in enumerate(zip(shifted, base)):
+            if i != slot:
+                np.testing.assert_allclose(np.asarray(s), np.asarray(b))
+
+    def test_effects_preserved(self):
+        from braintrace._compiler.hidden_pertubation import (
+            add_hidden_perturbation_from_minfo,
+            JaxprEvalForHiddenPerturbation,
+        )
+        import jax
+        import jax.numpy as jnp
+
+        # Effectful jaxpr built directly (debug print inside): the perturbed
+        # jaxpr must carry the source jaxpr's effect set.
+        def f(a):
+            jax.debug.print('x={x}', x=a.sum())
+            return a * 2.0
+
+        closed = jax.make_jaxpr(f)(jnp.ones(3))
+        assert closed.jaxpr.effects, 'fixture must carry at least one effect'
+        h = closed.jaxpr.outvars[0]
+        a_in = closed.jaxpr.invars[0]
+
+        perturb = JaxprEvalForHiddenPerturbation(
+            closed_jaxpr=closed,
+            hidden_outvar_to_invar={h: a_in},
+            weight_invars=set(),
+            invar_to_hidden_path={a_in: ('h',)},
+            outvar_to_hidden_path={h: ('h',)},
+            path_to_state={('h',): None},
+        ).compile()
+
+        assert perturb.perturb_jaxpr.jaxpr.effects == closed.jaxpr.effects

--- a/braintrace/_compiler/jaxpr_graph.py
+++ b/braintrace/_compiler/jaxpr_graph.py
@@ -1,0 +1,216 @@
+# Copyright 2026 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Shared jaxpr-graph utilities for the ETrace compiler.
+
+Every compiler pass needs the same handful of graph primitives over a
+``Jaxpr``: a producer map (var -> defining equation), a consumer map
+(var -> reading equations), ordered forward reachability, and — since the
+analyses cannot see through ``jit`` call boundaries — a pass that splices
+``jit``/``pjit`` bodies into the surrounding jaxpr. They live here so the
+passes in :mod:`hid_param_op`, :mod:`hidden_group`, and
+:mod:`hidden_pertubation` share one implementation.
+
+All traversals use insertion-ordered ``dict`` objects as ordered sets, so
+results are deterministic across processes (plain ``set`` iteration follows
+memory-address hashes for jaxpr ``Var`` objects).
+"""
+
+from collections import deque
+from typing import Any, Dict, List
+
+from braintrace._compatible_imports import (
+    ClosedJaxpr,
+    Jaxpr,
+    JaxprEqn,
+    Var,
+    is_jit_primitive,
+)
+
+__all__ = [
+    'build_producer_map',
+    'build_consumer_map',
+    'forward_closure',
+    'inline_jit_calls',
+]
+
+
+def build_producer_map(jaxpr: Jaxpr) -> Dict[Var, JaxprEqn]:
+    """Map each variable to the equation that produces it.
+
+    Parameters
+    ----------
+    jaxpr : Jaxpr
+        The jaxpr to index.
+
+    Returns
+    -------
+    dict
+        Mapping from each output ``Var`` to its producing equation. Jaxpr
+        invars and constvars have no producer and are absent.
+    """
+    producers: Dict[Var, JaxprEqn] = {}
+    for eqn in jaxpr.eqns:
+        for v in eqn.outvars:
+            producers[v] = eqn
+    return producers
+
+
+def build_consumer_map(jaxpr: Jaxpr) -> Dict[Var, List[JaxprEqn]]:
+    """Map each variable to the equations that consume it.
+
+    Parameters
+    ----------
+    jaxpr : Jaxpr
+        The jaxpr to index.
+
+    Returns
+    -------
+    dict
+        Mapping from each ``Var`` to the list of equations reading it, in
+        equation order.
+    """
+    consumers: Dict[Var, List[JaxprEqn]] = {}
+    for eqn in jaxpr.eqns:
+        for v in eqn.invars:
+            if isinstance(v, Var):
+                consumers.setdefault(v, []).append(eqn)
+    return consumers
+
+
+def forward_closure(
+    start_var: Var,
+    consumer_map: Dict[Var, List[JaxprEqn]],
+) -> Dict[Var, None]:
+    """Collect every variable reachable forward from *start_var*.
+
+    Parameters
+    ----------
+    start_var : Var
+        The variable to start from (included in the result).
+    consumer_map : dict
+        Consumer map built by :func:`build_consumer_map`.
+
+    Returns
+    -------
+    dict
+        Insertion-ordered dict used as an ordered set; iteration follows BFS
+        encounter order, so the result is deterministic.
+    """
+    closure: Dict[Var, None] = {}
+    frontier: deque = deque([start_var])
+    while frontier:
+        v = frontier.popleft()
+        if v in closure:
+            continue
+        closure[v] = None
+        for eqn in consumer_map.get(v, []):
+            for ov in eqn.outvars:
+                if ov not in closure:
+                    frontier.append(ov)
+    return closure
+
+
+def _contains_jit_eqn(jaxpr: Jaxpr) -> bool:
+    return any(is_jit_primitive(eqn) for eqn in jaxpr.eqns)
+
+
+def inline_jit_calls(closed_jaxpr: ClosedJaxpr) -> ClosedJaxpr:
+    """Splice every top-level ``jit``/``pjit`` body into the enclosing jaxpr.
+
+    The ETrace analyses identify weights, hidden states, and ETP primitives by
+    ``Var`` identity in one flat jaxpr; a ``jit`` call boundary hides its body
+    behind fresh inner variables, so weights or hidden states used inside a
+    user's ``jax.jit``-wrapped function were previously either rejected or
+    silently excluded. Inlining removes the boundary before any analysis runs.
+
+    The pass is recursive (``jit`` inside ``jit`` is flattened), lifts inner
+    closure constants into the outer ``constvars``/``consts``, and rewires
+    pass-through outputs by substitution. Control-flow bodies
+    (``scan``/``while``/``cond``) and custom-derivative call primitives are
+    left untouched: control flow is diagnosed separately, and
+    ``custom_jvp_call``/``custom_vjp_call`` carry derivative semantics that
+    must not be flattened away.
+
+    Parameters
+    ----------
+    closed_jaxpr : ClosedJaxpr
+        The closed jaxpr to inline.
+
+    Returns
+    -------
+    ClosedJaxpr
+        A new closed jaxpr with no top-level ``jit`` equations, evaluating to
+        the same outputs. When the input contains no ``jit`` equation, the
+        input object itself is returned unchanged.
+    """
+    jaxpr = closed_jaxpr.jaxpr
+    if not _contains_jit_eqn(jaxpr):
+        return closed_jaxpr
+
+    subst: Dict[Var, Any] = {}  # Var -> Var | Literal
+
+    def resolve(atom):
+        while isinstance(atom, Var) and atom in subst:
+            atom = subst[atom]
+        return atom
+
+    extra_constvars: List[Var] = []
+    extra_consts: List[Any] = []
+    new_eqns: List[JaxprEqn] = []
+
+    def process(eqns) -> None:
+        for eqn in eqns:
+            if is_jit_primitive(eqn) and 'jaxpr' in eqn.params:
+                inner_closed = eqn.params['jaxpr']
+                inner = getattr(inner_closed, 'jaxpr', inner_closed)
+                inner_consts = getattr(inner_closed, 'consts', [])
+                # Inner constvars are fresh Var objects: adopt them directly
+                # as outer constvars, carrying their values.
+                extra_constvars.extend(inner.constvars)
+                extra_consts.extend(inner_consts)
+                # Wire the inner parameters to the (resolved) call arguments.
+                for iv, arg in zip(inner.invars, eqn.invars):
+                    subst[iv] = resolve(arg)
+                # Splice the body (recursively inlining nested jit).
+                process(inner.eqns)
+                # Wire the call results to the inner outputs.
+                for outer_ov, inner_ov in zip(eqn.outvars, inner.outvars):
+                    subst[outer_ov] = resolve(inner_ov)
+            else:
+                new_invars = [
+                    resolve(v) if isinstance(v, Var) else v
+                    for v in eqn.invars
+                ]
+                if all(a is b for a, b in zip(new_invars, eqn.invars)):
+                    new_eqns.append(eqn)
+                else:
+                    new_eqns.append(eqn.replace(invars=new_invars))
+
+    process(jaxpr.eqns)
+
+    new_outvars = [
+        resolve(v) if isinstance(v, Var) else v
+        for v in jaxpr.outvars
+    ]
+    new_jaxpr = Jaxpr(
+        constvars=list(jaxpr.constvars) + extra_constvars,
+        invars=list(jaxpr.invars),
+        outvars=new_outvars,
+        eqns=new_eqns,
+        effects=jaxpr.effects,
+        debug_info=jaxpr.debug_info,
+    )
+    return ClosedJaxpr(new_jaxpr, list(closed_jaxpr.consts) + extra_consts)

--- a/braintrace/_compiler/jaxpr_graph_test.py
+++ b/braintrace/_compiler/jaxpr_graph_test.py
@@ -1,0 +1,194 @@
+# Copyright 2026 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from braintrace._compatible_imports import Var, is_jit_primitive
+from braintrace._compiler.jaxpr_graph import (
+    build_consumer_map,
+    build_producer_map,
+    forward_closure,
+    inline_jit_calls,
+)
+
+
+def _has_jit_eqn(jaxpr) -> bool:
+    return any(is_jit_primitive(eqn) for eqn in jaxpr.eqns)
+
+
+def _eval_closed(closed_jaxpr, *args):
+    return jax.core.eval_jaxpr(closed_jaxpr.jaxpr, closed_jaxpr.consts, *args)
+
+
+class TestProducerConsumerMaps:
+
+    def test_producer_and_consumer_maps(self):
+        def f(a, b):
+            c = a + b
+            d = c * a
+            return d
+
+        jaxpr = jax.make_jaxpr(f)(1.0, 2.0).jaxpr
+        producers = build_producer_map(jaxpr)
+        consumers = build_consumer_map(jaxpr)
+
+        add_eqn, mul_eqn = jaxpr.eqns
+        c_var = add_eqn.outvars[0]
+        assert producers[c_var] is add_eqn
+        assert mul_eqn in consumers[c_var]
+        # the first invar `a` feeds both equations
+        a_var = jaxpr.invars[0]
+        assert consumers[a_var] == [add_eqn, mul_eqn]
+
+    def test_forward_closure_is_ordered_and_complete(self):
+        def f(a):
+            b = a + 1.0
+            c = b * 2.0
+            d = a - 1.0  # not downstream of b
+            return c, d
+
+        jaxpr = jax.make_jaxpr(f)(1.0).jaxpr
+        consumers = build_consumer_map(jaxpr)
+        b_var = jaxpr.eqns[0].outvars[0]
+        closure = forward_closure(b_var, consumers)
+        c_var = jaxpr.eqns[1].outvars[0]
+        d_var = jaxpr.eqns[2].outvars[0]
+        assert b_var in closure
+        assert c_var in closure
+        assert d_var not in closure
+        # insertion order: start var first
+        assert next(iter(closure)) is b_var
+
+
+class TestInlineJitCalls:
+
+    def test_no_jit_returns_same_object(self):
+        closed = jax.make_jaxpr(lambda x: x * 2.0 + 1.0)(1.0)
+        assert inline_jit_calls(closed) is closed
+
+    def test_single_jit_is_inlined_and_equivalent(self):
+        c = np.arange(3.0)
+
+        @jax.jit
+        def g(x):
+            return x * 2.0 + c
+
+        def f(x):
+            return g(x) + 1.0
+
+        x = jnp.ones(3)
+        closed = jax.make_jaxpr(f)(x)
+        assert _has_jit_eqn(closed.jaxpr)
+
+        inlined = inline_jit_calls(closed)
+        assert not _has_jit_eqn(inlined.jaxpr)
+        # invars are preserved as the same Var objects
+        assert list(inlined.jaxpr.invars) == list(closed.jaxpr.invars)
+        np.testing.assert_allclose(_eval_closed(inlined, x)[0], f(x))
+
+    def test_nested_jit_two_deep(self):
+        @jax.jit
+        def inner(x):
+            return x + 1.0
+
+        @jax.jit
+        def outer(x):
+            return inner(x) * 3.0
+
+        def f(x):
+            return outer(x) - 2.0
+
+        x = jnp.arange(4.0)
+        closed = jax.make_jaxpr(f)(x)
+        inlined = inline_jit_calls(closed)
+        assert not _has_jit_eqn(inlined.jaxpr)
+        np.testing.assert_allclose(_eval_closed(inlined, x)[0], f(x))
+
+    def test_passthrough_output(self):
+        @jax.jit
+        def g(x):
+            return x  # identity: inner outvar == inner invar
+
+        def f(x):
+            return g(x) + g(x)
+
+        x = jnp.float32(3.0)
+        closed = jax.make_jaxpr(f)(x)
+        inlined = inline_jit_calls(closed)
+        assert not _has_jit_eqn(inlined.jaxpr)
+        np.testing.assert_allclose(_eval_closed(inlined, x)[0], f(x))
+
+    def test_multi_output_jit(self):
+        @jax.jit
+        def g(x):
+            return x * 2.0, x + 1.0
+
+        def f(x):
+            a, b = g(x)
+            return a - b
+
+        x = jnp.arange(3.0)
+        closed = jax.make_jaxpr(f)(x)
+        inlined = inline_jit_calls(closed)
+        assert not _has_jit_eqn(inlined.jaxpr)
+        np.testing.assert_allclose(_eval_closed(inlined, x)[0], f(x))
+
+    def test_jit_output_is_final_output(self):
+        @jax.jit
+        def g(x):
+            return x * 2.0
+
+        def f(x):
+            return g(x)  # jit result is directly the jaxpr output
+
+        x = jnp.arange(3.0)
+        closed = jax.make_jaxpr(f)(x)
+        inlined = inline_jit_calls(closed)
+        assert not _has_jit_eqn(inlined.jaxpr)
+        np.testing.assert_allclose(_eval_closed(inlined, x)[0], f(x))
+
+    def test_consts_are_lifted(self):
+        c = np.full((2,), 7.0)
+
+        @jax.jit
+        def g(x):
+            return x + c
+
+        x = jnp.ones(2)
+        closed = jax.make_jaxpr(lambda x: g(x) * 1.0)(x)
+        inlined = inline_jit_calls(closed)
+        assert not _has_jit_eqn(inlined.jaxpr)
+        assert len(inlined.jaxpr.constvars) == len(inlined.consts)
+        np.testing.assert_allclose(_eval_closed(inlined, x)[0], x + c)
+
+    def test_scan_body_jit_left_untouched(self):
+        # jit inside a scan body is NOT inlined (control flow is opaque here).
+        @jax.jit
+        def g(x):
+            return x * 2.0
+
+        def f(x):
+            def body(carry, _):
+                return g(carry), None
+
+            out, _ = jax.lax.scan(body, x, None, length=3)
+            return out
+
+        x = jnp.float32(1.0)
+        closed = jax.make_jaxpr(f)(x)
+        inlined = inline_jit_calls(closed)
+        np.testing.assert_allclose(_eval_closed(inlined, x)[0], f(x))

--- a/braintrace/_compiler/module_info.py
+++ b/braintrace/_compiler/module_info.py
@@ -504,6 +504,14 @@ def extract_module_info(
     --------
     ModuleInfo : The returned data structure.
 
+    Notes
+    -----
+    Prefer positional arguments. ``**model_kwargs`` is accepted here for
+    tracing, but ``ModuleInfo.jaxpr_call`` and the downstream
+    ``compile_etrace_graph`` pipeline rebuild inputs from positional
+    arguments only — bind static keyword arguments with
+    ``functools.partial`` before compiling.
+
     Examples
     --------
     .. code-block:: python

--- a/braintrace/_compiler/module_info.py
+++ b/braintrace/_compiler/module_info.py
@@ -42,6 +42,7 @@ from braintrace._typing import (
     TempData,
 )
 from .diagnostics import DiagnosticKind, DiagnosticLevel, emit
+from .jaxpr_graph import inline_jit_calls
 
 __all__ = [
     'ModuleInfo',
@@ -539,6 +540,12 @@ def extract_module_info(
     state_id_to_path = brainstate.util.PrettyDict(state_id_to_path)
 
     closed_jaxpr = stateful_model.get_jaxpr_by_cache(cache_key)
+    # Splice user ``jax.jit`` bodies into the top-level jaxpr before any
+    # lookup table is built: every downstream analysis (weight/hidden var
+    # tables, hidden-group discovery, relation finding) identifies states
+    # and ETP primitives by ``Var`` identity in this one flat jaxpr, and a
+    # jit call boundary hides its body behind fresh inner variables.
+    closed_jaxpr = inline_jit_calls(closed_jaxpr)
     jaxpr = closed_jaxpr.jaxpr
 
     # out information

--- a/braintrace/_compiler/scenario_catalog.py
+++ b/braintrace/_compiler/scenario_catalog.py
@@ -43,6 +43,11 @@ exclude with a specific structured diagnostic).
 * Partial path (``PartialPathRNN``).
 * Control flow (``ScanBodyEtpRNN``, ``CondBranchEtpRNN``,
   ``WhileBodyEtpRNN``).
+* Nested jit (``NestedJitRNN``).
+* Branching fan-out (``BranchingFanOutRNN``).
+* Shared submodule, two call sites (``SharedSubmoduleTwiceRNN``).
+* Residual connection (``ResidualSkipRNN``).
+* Deep module nesting (``DeepNestedModuleRNN``).
 """
 
 
@@ -353,3 +358,146 @@ def make_while_body_etp_jaxpr(n_in: int, n_out: int, n_iter: int = 3):
         return jnp.tanh(h_final)
 
     return jax.make_jaxpr(f)(w, x).jaxpr
+
+
+# ---------------------------------------------------------------------------
+# Nested jit — ETP primitive inside a user ``jax.jit`` boundary
+# ---------------------------------------------------------------------------
+
+class NestedJitRNN(brainstate.nn.Module):
+    """The ETP matmul is wrapped in a user ``jax.jit`` function. The compiler
+    inlines the jit body at extraction time, so the relation must be found
+    exactly as in :class:`UnbatchedMvRNN`.
+    """
+
+    def __init__(self, n_in: int, n_out: int):
+        super().__init__()
+        self.w = brainstate.ParamState(brainstate.random.randn(n_in + n_out, n_out))
+        self.h = brainstate.HiddenState(jnp.zeros(n_out))
+
+    def init_state(self, *args, **kwargs):
+        self.h.value = jnp.zeros_like(self.h.value)
+
+    def update(self, x):
+        @jax.jit
+        def proj(xh, w):
+            return braintrace.matmul(xh, w)
+
+        xh = jnp.concatenate([x, self.h.value])
+        self.h.value = jnp.tanh(proj(xh, self.w.value))
+        return self.h.value
+
+
+# ---------------------------------------------------------------------------
+# Branching fan-out — one ETP output directly feeds two uncoupled hiddens
+# ---------------------------------------------------------------------------
+
+class BranchingFanOutRNN(brainstate.nn.Module):
+    """``y = matmul(x, w)`` feeds two *independent* recurrent hidden states.
+
+    ``h1`` and ``h2`` never read each other, so they land in two different
+    hidden groups; both are fed *directly* by ``y`` (no other hidden outvar
+    on the path), so the single relation must record **both** groups.
+    """
+
+    def __init__(self, n_in: int, n_out: int):
+        super().__init__()
+        self.w = brainstate.ParamState(brainstate.random.randn(n_in, n_out))
+        self.h1 = brainstate.HiddenState(jnp.zeros(n_out))
+        self.h2 = brainstate.HiddenState(jnp.zeros(n_out))
+
+    def init_state(self, *args, **kwargs):
+        self.h1.value = jnp.zeros_like(self.h1.value)
+        self.h2.value = jnp.zeros_like(self.h2.value)
+
+    def update(self, x):
+        y = braintrace.matmul(x, self.w.value)
+        self.h1.value = jnp.tanh(0.9 * self.h1.value + y)
+        self.h2.value = jnp.tanh(0.5 * self.h2.value - y)
+        return self.h1.value + self.h2.value
+
+
+# ---------------------------------------------------------------------------
+# Shared submodule — one module instance called at two sites per step
+# ---------------------------------------------------------------------------
+
+class SharedSubmoduleTwiceRNN(brainstate.nn.Module):
+    """One ``UnbatchedMvRNN``-style projection module applied twice per step.
+
+    The single ``ParamState`` appears in two ETP equations (two call sites),
+    so the compiler must register two relations sharing one weight path —
+    the module-sharing analogue of :class:`SharedTiedWeightRNN`.
+    """
+
+    def __init__(self, n: int):
+        super().__init__()
+        self.proj = braintrace.nn.Linear(n, n, b_init=None)
+        self.h = brainstate.HiddenState(jnp.zeros(n))
+
+    def init_state(self, *args, **kwargs):
+        self.h.value = jnp.zeros_like(self.h.value)
+
+    def update(self, x):
+        a = self.proj(x)
+        b = self.proj(self.h.value)
+        self.h.value = jnp.tanh(a + b)
+        return self.h.value
+
+
+# ---------------------------------------------------------------------------
+# Residual connection — skip path around the recurrent projection
+# ---------------------------------------------------------------------------
+
+class ResidualSkipRNN(brainstate.nn.Module):
+    """``h = tanh(matmul(xh, w) + x_proj_skip)`` with an elementwise residual.
+
+    The residual add is on the non-parametric tail, so the relation for
+    ``w`` is unaffected by the skip path; the skip input reaches the hidden
+    state without any ETP op and must not create extra relations.
+    """
+
+    def __init__(self, n: int):
+        super().__init__()
+        self.w = brainstate.ParamState(brainstate.random.randn(2 * n, n))
+        self.h = brainstate.HiddenState(jnp.zeros(n))
+
+    def init_state(self, *args, **kwargs):
+        self.h.value = jnp.zeros_like(self.h.value)
+
+    def update(self, x):
+        xh = jnp.concatenate([x, self.h.value])
+        self.h.value = jnp.tanh(braintrace.matmul(xh, self.w.value) + x)
+        return self.h.value
+
+
+# ---------------------------------------------------------------------------
+# Deep module nesting — the recurrent cell sits four levels deep
+# ---------------------------------------------------------------------------
+
+class _NestingLevel(brainstate.nn.Module):
+    def __init__(self, inner):
+        super().__init__()
+        self.inner = inner
+
+    def init_state(self, *args, **kwargs):
+        self.inner.init_state()
+
+    def update(self, x):
+        return self.inner.update(x)
+
+
+class DeepNestedModuleRNN(brainstate.nn.Module):
+    """An :class:`UnbatchedMvRNN` wrapped in three pass-through modules.
+
+    Relation and group paths must reflect the full nested module path.
+    """
+
+    def __init__(self, n_in: int, n_out: int):
+        super().__init__()
+        self.l1 = _NestingLevel(_NestingLevel(_NestingLevel(UnbatchedMvRNN(n_in, n_out))))
+
+    def init_state(self, *args, **kwargs):
+        self.l1.init_state()
+
+    def update(self, x):
+        return self.l1.update(x)

--- a/braintrace/_compiler/scenario_catalog.py
+++ b/braintrace/_compiler/scenario_catalog.py
@@ -501,3 +501,29 @@ class DeepNestedModuleRNN(brainstate.nn.Module):
 
     def update(self, x):
         return self.l1.update(x)
+
+
+# ---------------------------------------------------------------------------
+# Constant weight, trainable bias — any-trainable-key gating
+# ---------------------------------------------------------------------------
+
+class ConstWeightParamBiasRNN(brainstate.nn.Module):
+    """The matmul weight is a fixed constant; only the bias is a ParamState.
+
+    The relation must register with ``bias`` as its only resolved trainable
+    key — the unresolvable ``weight`` key must not veto the whole relation.
+    """
+
+    def __init__(self, n_in: int, n_out: int):
+        super().__init__()
+        self.w_const = jnp.asarray(brainstate.random.randn(n_in + n_out, n_out))
+        self.b = brainstate.ParamState(brainstate.random.randn(n_out))
+        self.h = brainstate.HiddenState(jnp.zeros(n_out))
+
+    def init_state(self, *args, **kwargs):
+        self.h.value = jnp.zeros_like(self.h.value)
+
+    def update(self, x):
+        xh = jnp.concatenate([x, self.h.value])
+        self.h.value = jnp.tanh(braintrace.matmul(xh, self.w_const, self.b.value))
+        return self.h.value

--- a/braintrace/_compiler/scenario_catalog_test.py
+++ b/braintrace/_compiler/scenario_catalog_test.py
@@ -1063,3 +1063,113 @@ class TestCategoryO_NestedJit:
             return _relation_set(_compile(model, brainstate.random.rand(3)))
 
         assert build() == build()
+
+
+# ---------------------------------------------------------------------------
+# Category P — Branching fan-out (one y directly feeds two groups)
+# ---------------------------------------------------------------------------
+
+from braintrace._compiler.scenario_catalog import (
+    BranchingFanOutRNN,
+    ConstWeightParamBiasRNN,
+)
+
+
+class TestCategoryP_BranchingFanOut:
+    """``y = matmul(x, w)`` directly feeds two *independent* recurrent hidden
+    states (two hidden groups). The single relation must record BOTH groups —
+    not just the group of whichever hidden outvar the BFS happened to reach
+    first."""
+
+    def test_one_relation_records_both_groups(self):
+        model = BranchingFanOutRNN(3, 4)
+        brainstate.nn.init_all_states(model)
+        inp = brainstate.random.rand(3)
+
+        graph = _compile(model, inp)
+
+        rels = graph.hidden_param_op_relations
+        assert len(rels) == 1
+        r = rels[0]
+        assert r.connected_hidden_paths == [('h1',), ('h2',)]
+        assert len(r.hidden_groups) == 2
+        assert len(r.y_to_hidden_group_jaxprs) == 2
+        assert r.primitive is etp_mv_p
+
+    def test_stacked_layers_stay_scoped(self):
+        # The directly-fed-groups fix must NOT leak downstream layers back
+        # in: cell0's weight still reaches only cell0's hidden state.
+        model = StackedDeepRNN(3, 4, depth=2)
+        brainstate.nn.init_all_states(model)
+        inp = brainstate.random.rand(3)
+
+        graph = _compile(model, inp)
+
+        assert _relation_set(graph) == {
+            (('cell0', 'w'), ('cell0', 'h')),
+            (('cell1', 'w'), ('cell1', 'h')),
+        }
+
+    def test_fan_out_stable_across_recompiles(self):
+        def build():
+            model = BranchingFanOutRNN(3, 4)
+            brainstate.nn.init_all_states(model)
+            g = _compile(model, brainstate.random.rand(3))
+            return [
+                (r.path, tuple(r.connected_hidden_paths),
+                 tuple(grp.index for grp in r.hidden_groups))
+                for r in g.hidden_param_op_relations
+            ]
+
+        assert build() == build()
+
+
+# ---------------------------------------------------------------------------
+# Category Q — Any-trainable-key gating (const weight, ParamState bias)
+# ---------------------------------------------------------------------------
+
+class TestCategoryQ_AnyTrainableKeyGating:
+    """The primitive's first trainable key ('weight') is a constant array,
+    but the 'bias' key IS a ParamState. The relation must be registered with
+    ``bias`` as its only resolved trainable key instead of being vetoed by
+    the unresolvable first key."""
+
+    def test_bias_only_relation_registers(self):
+        model = ConstWeightParamBiasRNN(3, 4)
+        brainstate.nn.init_all_states(model)
+        inp = brainstate.random.rand(3)
+
+        graph = _compile(model, inp)
+
+        rels = graph.hidden_param_op_relations
+        assert len(rels) == 1
+        r = rels[0]
+        assert set(r.trainable_paths) == {'bias'}
+        assert r.trainable_paths['bias'] == ('b',)
+        assert r.connected_hidden_paths == [('h',)]
+
+    def test_no_paramstate_at_all_still_excluded(self):
+        # Both weight and bias constant: the exclusion diagnostic must
+        # be preserved.
+        class _AllConstRNN(brainstate.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.w_const = jnp.asarray(brainstate.random.randn(7, 4))
+                self.h = brainstate.HiddenState(jnp.zeros(4))
+
+            def init_state(self, *args, **kwargs):
+                self.h.value = jnp.zeros_like(self.h.value)
+
+            def update(self, x):
+                xh = jnp.concatenate([x, self.h.value])
+                self.h.value = jnp.tanh(braintrace.matmul(xh, self.w_const))
+                return self.h.value
+
+        model = _AllConstRNN()
+        brainstate.nn.init_all_states(model)
+        inp = brainstate.random.rand(3)
+
+        graph = _compile(model, inp)
+
+        assert len(graph.hidden_param_op_relations) == 0
+        assert len(graph.explain(kind=DiagnosticKind.RELATION_EXCLUDED_NO_PARAMSTATE)) == 1

--- a/braintrace/_compiler/scenario_catalog_test.py
+++ b/braintrace/_compiler/scenario_catalog_test.py
@@ -1173,3 +1173,98 @@ class TestCategoryQ_AnyTrainableKeyGating:
 
         assert len(graph.hidden_param_op_relations) == 0
         assert len(graph.explain(kind=DiagnosticKind.RELATION_EXCLUDED_NO_PARAMSTATE)) == 1
+
+
+# ---------------------------------------------------------------------------
+# Category R — Complex module graphs (shared submodule, residual, deep nesting)
+# ---------------------------------------------------------------------------
+
+from braintrace._compiler.scenario_catalog import (
+    SharedSubmoduleTwiceRNN,
+    ResidualSkipRNN,
+    DeepNestedModuleRNN,
+)
+
+
+class TestCategoryR_ComplexModuleGraphs:
+
+    def test_shared_submodule_two_call_sites(self):
+        # One Linear module (one ParamState) applied at two call sites per
+        # step: two distinct relations, both pointing at the shared weight
+        # path — the module-sharing analogue of the tied-weight scenario.
+        model = SharedSubmoduleTwiceRNN(4)
+        brainstate.nn.init_all_states(model)
+        inp = brainstate.random.rand(4)
+
+        graph = _compile(model, inp)
+
+        rels = graph.hidden_param_op_relations
+        assert len(rels) == 2
+        for r in rels:
+            assert r.path == ('proj', 'weight')
+            assert r.connected_hidden_paths == [('h',)]
+        assert rels[0].y_var is not rels[1].y_var
+
+    def test_residual_skip_does_not_change_relation(self):
+        # The elementwise residual add sits on the non-parametric tail: the
+        # relation for ``w`` is unchanged and the skip path creates nothing.
+        model = ResidualSkipRNN(4)
+        brainstate.nn.init_all_states(model)
+        inp = brainstate.random.rand(4)
+
+        graph = _compile(model, inp)
+
+        assert _relation_set(graph) == {(('w',), ('h',))}
+        rel = graph.hidden_param_op_relations[0]
+        assert rel.primitive is etp_mv_p
+        assert rel.path_classification == {('h',): PathClassification.ALL_DIRECT}
+
+    def test_residual_transition_includes_skip_add(self):
+        # dh/dy must run through the residual add: perturbing y shifts h by
+        # tanh'(y + x) — structurally, the transition jaxpr executes and
+        # produces the group-shaped output.
+        model = ResidualSkipRNN(4)
+        brainstate.nn.init_all_states(model)
+        inp = brainstate.random.rand(4)
+
+        graph = _compile(model, inp)
+        _, _, _, temps = graph.module_info.jaxpr_call(inp)
+        rel = graph.hidden_param_op_relations[0]
+        vals = rel.y_to_hidden_groups(temps[rel.y_var], temps, concat_hidden_vals=True)
+        assert len(vals) == 1
+        assert vals[0].shape[:len(rel.hidden_groups[0].varshape)] == tuple(
+            rel.hidden_groups[0].varshape
+        )
+
+    def test_deep_nested_module_paths(self):
+        # Four levels of module nesting: relation and hidden paths carry the
+        # full nested module path.
+        model = DeepNestedModuleRNN(3, 4)
+        brainstate.nn.init_all_states(model)
+        inp = brainstate.random.rand(3)
+
+        graph = _compile(model, inp)
+
+        deep = ('l1', 'inner', 'inner', 'inner')
+        assert _relation_set(graph) == {(deep + ('w',), deep + ('h',))}
+        rel = graph.hidden_param_op_relations[0]
+        assert rel.primitive is etp_mv_p
+        assert len(rel.hidden_groups) == 1
+        assert rel.hidden_groups[0].hidden_paths == [deep + ('h',)]
+
+    def test_complex_graphs_deterministic(self):
+        for factory, n_inp in [
+            (lambda: SharedSubmoduleTwiceRNN(4), 4),
+            (lambda: ResidualSkipRNN(4), 4),
+            (lambda: DeepNestedModuleRNN(3, 4), 3),
+        ]:
+            def build():
+                m = factory()
+                brainstate.nn.init_all_states(m)
+                g = _compile(m, brainstate.random.rand(n_inp))
+                return [
+                    (r.path, tuple(r.connected_hidden_paths))
+                    for r in g.hidden_param_op_relations
+                ]
+
+            assert build() == build()

--- a/braintrace/_compiler/scenario_catalog_test.py
+++ b/braintrace/_compiler/scenario_catalog_test.py
@@ -709,6 +709,7 @@ from braintrace._compiler.scenario_catalog import (
     SharedTiedWeightRNN,
     MixedBatchedRNN,
     PartialPathRNN,
+    NestedJitRNN,
     make_scan_body_etp_jaxpr,
     make_cond_branches_etp_jaxpr,
     make_while_body_etp_jaxpr,
@@ -1017,3 +1018,48 @@ class TestCategoryG_StructuralSmoke:
             'No relation had its y_var available as a temp — '
             'the compiler is not emitting the y values it registered.'
         )
+
+
+# ---------------------------------------------------------------------------
+# Category O — Nested jit boundary
+# ---------------------------------------------------------------------------
+
+class TestCategoryO_NestedJit:
+    """The ETP matmul lives inside a user ``jax.jit`` function. The
+    compiler inlines the jit body at extraction time, so the relation
+    must be found exactly as for the plain :class:`UnbatchedMvRNN` —
+    same relation set, same primitive identity, executable transition."""
+
+    def test_jit_wrapped_matmul_registers_relation(self):
+        model = NestedJitRNN(3, 4)
+        brainstate.nn.init_all_states(model)
+        inp = brainstate.random.rand(3)
+
+        graph = _compile(model, inp)
+
+        assert _relation_set(graph) == {(('w',), ('h',))}
+        rel = graph.hidden_param_op_relations[0]
+        assert rel.primitive is etp_mv_p
+
+    def test_jit_wrapped_matmul_transition_executes(self):
+        model = NestedJitRNN(3, 4)
+        brainstate.nn.init_all_states(model)
+        inp = brainstate.random.rand(3)
+
+        graph = _compile(model, inp)
+
+        _, _, _, temps = graph.module_info.jaxpr_call(inp)
+        rel = graph.hidden_param_op_relations[0]
+        y_val = temps[rel.y_var]
+        vals = rel.y_to_hidden_groups(y_val, temps, concat_hidden_vals=True)
+        assert len(vals) == len(rel.hidden_groups)
+        for v, group in zip(vals, rel.hidden_groups):
+            assert v.shape[:len(group.varshape)] == tuple(group.varshape)
+
+    def test_jit_compile_twice_same_order(self):
+        def build():
+            model = NestedJitRNN(3, 4)
+            brainstate.nn.init_all_states(model)
+            return _relation_set(_compile(model, brainstate.random.rand(3)))
+
+        assert build() == build()

--- a/braintrace/_op/sparse.py
+++ b/braintrace/_op/sparse.py
@@ -111,7 +111,8 @@ __all__ = [
 ]
 
 
-def _etp_sp_matmul_impl(*args: Any, sparse_mat: brainevent.DataRepresentation | None = None,
+def _etp_sp_matmul_impl(*args: Any,
+                        sparse_mat: brainevent.DataRepresentation | None = None,
                         has_bias: bool = False,
                         weight_fn: WeightFn | None = None,
                         bias_fn: WeightFn | None = None) -> Any:


### PR DESCRIPTION
## Summary

Audit and upgrade of `braintrace/_compiler` covering `HiddenParamOpRelation`, `HiddenGroup`, `HiddenPerturbation`, `ModuleInfo`, `JaxprEvaluation`, and `ETraceGraph`. Full findings, architecture notes, and verification evidence are in `dev/2026-07-01-compiler-upgrade.md`.

- **F3 (nested jit):** user `jax.jit`-wrapped functions containing ETP primitives are now inlined at extraction time instead of raising `NotImplementedError` or silently losing the relation.
- **F1 (branching fan-out):** `_bfs_forward` now records *all* hidden groups a primitive output directly feeds, not just the first one the BFS happens to reach.
- **F2 (determinism):** hidden-group discovery previously depended on hash-ordered Python sets keyed by jaxpr `Var` objects — group index, member order, and constvar order were memory-address dependent across processes. Now fully insertion-ordered and canonicalized to compiled state order.
- **F4 (any-key gating):** a relation with an unresolvable first trainable key (e.g. a constant weight) but a resolvable second key (e.g. a `ParamState` bias) now registers instead of being dropped entirely.
- **F5 / F17 (perturbation robustness):** hidden outvars in multi-output equations and read-only hidden states now perturb correctly; jaxpr effects are preserved through the rewrite.
- F6/F7a/F7b/F8/F9 and documented limitations F10–F15: see the doc for details.

## Test plan

- [x] `python -m pytest braintrace/_compiler -q` (CPU): 410 passed (379 baseline + 31 new)
- [x] `python -m pytest braintrace -q` (CPU): 1685 passed, 2 failed — both pre-existing on `main` (unrelated `ParamDimVjpAlgorithm.__init__()` kwarg regression from `eee522b`), verified by reproducing on the main tree
- [x] `mypy braintrace`: no issues found