### PR TITLE
vmap support: identity-preserving batching for ETP primitives (Phase 0)

### DIFF
--- a/braintrace/_algorithm/param_dim_vjp_test.py
+++ b/braintrace/_algorithm/param_dim_vjp_test.py
@@ -367,7 +367,7 @@ def _accumulate_online_grads(model, algo_ctor, inputs, targets, batched):
     @brainstate.transform.jit
     def run(inputs, targets):
         if batched:
-            online = algo_ctor(model, mode=brainstate.mixin.Batching())
+            online = algo_ctor(model)
             brainstate.nn.init_all_states(model, batch_size=inputs.shape[1])
         else:
             online = algo_ctor(model)

--- a/braintrace/_algorithm/tests/conv_vmap_correctness_test.py
+++ b/braintrace/_algorithm/tests/conv_vmap_correctness_test.py
@@ -59,6 +59,17 @@ import braintrace
 import braintools
 import brainpy.state
 
+# `etp_conv` has no registered batched counterpart, so every model here that
+# routes a sample through `braintrace.nn.Conv2d` under `brainstate.nn.Vmap`
+# hits the identity-preserving batching rule's decomposition fallback in
+# `braintrace/_op/_primitive.py`, which emits a `UserWarning`. That warning is
+# expected-but-not-under-test in this module (the module tests gradient
+# correctness, not the vmap-decomposition warning itself — that is covered by
+# `braintrace/_op/_primitive_test.py`), so it is filtered narrowly by message.
+pytestmark = pytest.mark.filterwarnings(
+    "ignore:ETP primitive 'etp_conv' was decomposed:UserWarning"
+)
+
 H = W = 6
 C_IN = 2
 C_OUT = 3

--- a/braintrace/_compile_test.py
+++ b/braintrace/_compile_test.py
@@ -385,6 +385,17 @@ _BOTH_MODE_CASES = [
 @pytest.mark.parametrize('name,builder,algo,kw,feat', _BOTH_MODE_CASES,
                          ids=[c[0] for c in _BOTH_MODE_CASES])
 @pytest.mark.parametrize('vmap', [False, True], ids=['no_vmap', 'vmap'])
+# `conv1d_minigru_d_rtrl` (etp_conv) and `lora_d_rtrl` (etp_lora_mv) have no
+# registered batched counterpart, so under `vmap=True` compilation they hit
+# the identity-preserving batching rule's decomposition fallback and warn
+# (see `braintrace/_op/_primitive.py`). This test asserts gradient
+# finiteness/non-zero-ness, not the vmap-decomposition warning (covered by
+# `braintrace/_op/_primitive_test.py`), so the expected warning is filtered
+# narrowly by message rather than left uncaptured.
+@pytest.mark.filterwarnings(
+    "ignore:ETP primitive 'etp_conv' was decomposed:UserWarning")
+@pytest.mark.filterwarnings(
+    "ignore:ETP primitive 'etp_lora_mv' was decomposed:UserWarning")
 def test_compile_both_modes_finite_nonzero_grad(name, builder, algo, kw, feat, vmap):
     B, T = 4, 5
     xs = brainstate.random.randn(T, B, *feat)

--- a/braintrace/_compile_test.py
+++ b/braintrace/_compile_test.py
@@ -385,17 +385,17 @@ _BOTH_MODE_CASES = [
 @pytest.mark.parametrize('name,builder,algo,kw,feat', _BOTH_MODE_CASES,
                          ids=[c[0] for c in _BOTH_MODE_CASES])
 @pytest.mark.parametrize('vmap', [False, True], ids=['no_vmap', 'vmap'])
-# `conv1d_minigru_d_rtrl` (etp_conv) and `lora_d_rtrl` (etp_lora_mv) have no
-# registered batched counterpart, so under `vmap=True` compilation they hit
-# the identity-preserving batching rule's decomposition fallback and warn
-# (see `braintrace/_op/_primitive.py`). This test asserts gradient
-# finiteness/non-zero-ness, not the vmap-decomposition warning (covered by
+# `conv1d_minigru_d_rtrl` (etp_conv) has no registered batched counterpart,
+# so under `vmap=True` compilation it hits the identity-preserving batching
+# rule's decomposition fallback and warns (see `braintrace/_op/_primitive.py`).
+# This test asserts gradient finiteness/non-zero-ness, not the
+# vmap-decomposition warning (covered by
 # `braintrace/_op/_primitive_test.py`), so the expected warning is filtered
-# narrowly by message rather than left uncaptured.
+# narrowly by message rather than left uncaptured. `lora_d_rtrl` (etp_lora_mv)
+# now has a registered batched counterpart (`etp_lora_mm`) and is promoted
+# instead of decomposed, so no filter is needed for it.
 @pytest.mark.filterwarnings(
     "ignore:ETP primitive 'etp_conv' was decomposed:UserWarning")
-@pytest.mark.filterwarnings(
-    "ignore:ETP primitive 'etp_lora_mv' was decomposed:UserWarning")
 def test_compile_both_modes_finite_nonzero_grad(name, builder, algo, kw, feat, vmap):
     B, T = 4, 5
     xs = brainstate.random.randn(T, B, *feat)

--- a/braintrace/_compiler/graph_test.py
+++ b/braintrace/_compiler/graph_test.py
@@ -19,6 +19,8 @@ from pprint import pprint
 
 import brainstate
 import brainunit as u
+import jax
+import jax.numpy as jnp
 
 import braintrace
 from braintrace._etrace_model_test import (
@@ -335,3 +337,82 @@ class TestCompileGraphSNN(unittest.TestCase):
 
 class TestStateConsistency(unittest.TestCase):
     pass
+
+
+class TestVmappedModelCompilation:
+    """A model applying `jax.vmap` over a per-sample ETP op inside update()
+    must compile identically to the natively batched model (spec Phase 0)."""
+
+    B, N_IN, N_REC = 4, 3, 8
+
+    class _NativeCell(brainstate.nn.Module):
+        def __init__(self, n_in, n_rec):
+            super().__init__()
+            self.w = brainstate.ParamState(
+                brainstate.random.randn(n_in + n_rec, n_rec) * 0.1)
+
+        def init_state(self, batch_size=None, **kw):
+            n_rec = self.w.value.shape[1]
+            self.h = brainstate.HiddenState(jnp.zeros((batch_size, n_rec)))
+
+        def update(self, x):
+            xh = jnp.concatenate([x, self.h.value], axis=-1)
+            self.h.value = jnp.tanh(braintrace.matmul(xh, self.w.value))
+            return self.h.value
+
+    class _VmappedCell(brainstate.nn.Module):
+        def __init__(self, n_in, n_rec):
+            super().__init__()
+            self.w = brainstate.ParamState(
+                brainstate.random.randn(n_in + n_rec, n_rec) * 0.1)
+
+        def init_state(self, batch_size=None, **kw):
+            n_rec = self.w.value.shape[1]
+            self.h = brainstate.HiddenState(jnp.zeros((batch_size, n_rec)))
+
+        def update(self, x):
+            xh = jnp.concatenate([x, self.h.value], axis=-1)
+            y = jax.vmap(lambda row: braintrace.matmul(row, self.w.value))(xh)
+            self.h.value = jnp.tanh(y)
+            return self.h.value
+
+    def _graph_for(self, cell_cls):
+        cell = cell_cls(self.N_IN, self.N_REC)
+        brainstate.nn.init_all_states(cell, batch_size=self.B)
+        x = brainstate.random.randn(self.B, self.N_IN)
+        return braintrace.compile_etrace_graph(cell, x)
+
+    def test_vmapped_cell_relation_parity_with_native(self):
+        from braintrace._op.dense import etp_mm_p
+        g_native = self._graph_for(self._NativeCell)
+        g_vmapped = self._graph_for(self._VmappedCell)
+        assert len(g_native.hidden_param_op_relations) == 1
+        assert len(g_vmapped.hidden_param_op_relations) == 1
+        assert g_vmapped.hidden_param_op_relations[0].primitive is etp_mm_p
+        assert (g_vmapped.hidden_param_op_relations[0].primitive
+                is g_native.hidden_param_op_relations[0].primitive)
+
+    def test_vmapped_cell_drtrl_gradient_parity_with_native(self):
+        def build_and_grads(cell_cls):
+            with brainstate.random.seed_context(42):
+                model = cell_cls(self.N_IN, self.N_REC)
+            learner = braintrace.compile(
+                model, braintrace.D_RTRL,
+                jnp.zeros((self.B, self.N_IN)), batch_size=self.B)
+            weights = model.states(brainstate.ParamState)
+            with brainstate.random.seed_context(7):
+                xs = brainstate.random.randn(5, self.B, self.N_IN)
+
+            def total_loss(xs):
+                def step(carry, x):
+                    out = learner(x)
+                    return carry, jnp.mean(jnp.asarray(out) ** 2)
+                _, ls = brainstate.transform.scan(step, None, xs)
+                return jnp.sum(ls)
+
+            return brainstate.transform.grad(total_loss, weights)(xs)
+
+        g_native = build_and_grads(self._NativeCell)
+        g_vmapped = build_and_grads(self._VmappedCell)
+        for a, b in zip(jax.tree.leaves(g_native), jax.tree.leaves(g_vmapped)):
+            assert jnp.allclose(a, b, atol=1e-5), (a - b)

--- a/braintrace/_op/_primitive.py
+++ b/braintrace/_op/_primitive.py
@@ -24,6 +24,7 @@ implementation function via :func:`register_primitive`.
 
 from __future__ import annotations
 
+import warnings
 from functools import partial
 from typing import Any, Callable
 
@@ -46,6 +47,7 @@ from ._registries import (
     ETP_Y_OUTVAR_INDICES,
     FastPathRules,
     GRADIENT_ENABLED_PRIMITIVES,
+    get_batched_counterpart,
 )
 
 __all__ = [
@@ -221,7 +223,12 @@ def register_primitive(
     - **lowering** — via ``mlir.lower_fun(impl)``.
     - **JVP** — via ``jax.jvp(impl)``.
     - **transpose** — derived by JAX from the JVP.
-    - **batching** — via ``jax.vmap(impl)``.
+    - **batching** — identity-preserving: when only ``x`` is mapped and a
+      batched counterpart is registered
+      (:func:`~braintrace._op._registries.register_batched_counterpart`),
+      the counterpart primitive is bound with the batch axis leading;
+      otherwise falls back to ``jax.vmap(impl)`` with a ``UserWarning``
+      (the decomposed weight drops out of eligibility-trace compilation).
     """
     p = ETPPrimitive(name)
     ETP_PRIMITIVES.add(p)
@@ -256,6 +263,36 @@ def register_primitive(
     ad.primitive_jvps[p] = _jvp
 
     def _batching(args: Any, dims: Any, **params: Any) -> Any:
+        # Identity-preserving promotion: when only ``x`` carries the batch
+        # dim and a batched counterpart is registered, re-bind that
+        # counterpart so the ETP primitive stays visible to the etrace
+        # compiler. Otherwise decompose (value-correct) and warn: the
+        # decomposed weight cannot participate in eligibility traces.
+        counterpart = get_batched_counterpart(p)
+        x_idx = ETP_X_INVAR_INDICES.get(p)
+        if (
+            counterpart is not None
+            and x_idx is not None
+            and dims[x_idx] is not None
+            and all(d is None for i, d in enumerate(dims) if i != x_idx)
+        ):
+            x = args[x_idx]
+            if dims[x_idx] != 0:
+                x = jnp.moveaxis(x, dims[x_idx], 0)
+            new_args = tuple(
+                x if i == x_idx else a for i, a in enumerate(args)
+            )
+            return counterpart.bind(*new_args, **params), 0
+        warnings.warn(
+            f'ETP primitive {name!r} was decomposed into standard JAX ops '
+            f'under vmap (batch dims {tuple(dims)}). Its trainable '
+            f'parameters will NOT be recognized by the eligibility-trace '
+            f'compiler if this trace is compiled for online learning. '
+            f'Map over the data input only (weights unbatched), or call '
+            f'the batched op directly.',
+            UserWarning,
+            stacklevel=2,
+        )
         return jax.vmap(partial(impl_fn, **params), in_axes=dims)(*args), 0
 
     batching.primitive_batchers[p] = _batching

--- a/braintrace/_op/_primitive_test.py
+++ b/braintrace/_op/_primitive_test.py
@@ -183,14 +183,19 @@ class TestVmap:
             _fresh_name('vmap'), lambda x: x * 2.0, batched=True,
         )
 
-        out = jax.vmap(lambda x: p.bind(x))(jnp.arange(5.0))
+        # No batched counterpart is registered for `p` itself, so the
+        # identity-preserving batching rule falls back to decomposition
+        # and warns (see `register_primitive`'s batching rule).
+        with pytest.warns(UserWarning, match='decomposed'):
+            out = jax.vmap(lambda x: p.bind(x))(jnp.arange(5.0))
         np.testing.assert_allclose(out, jnp.arange(5.0) * 2.0)
 
     def test_vmap_two_args(self):
         p = register_primitive(_fresh_name('vmap2'), lambda x, y: x + y)
         x = jnp.arange(4.0)
         y = jnp.arange(4.0) * 10
-        out = jax.vmap(lambda a, b: p.bind(a, b))(x, y)
+        with pytest.warns(UserWarning, match='decomposed'):
+            out = jax.vmap(lambda a, b: p.bind(a, b))(x, y)
         np.testing.assert_allclose(out, x + y)
 
 

--- a/braintrace/_op/_primitive_test.py
+++ b/braintrace/_op/_primitive_test.py
@@ -29,11 +29,13 @@ APIs.
 
 
 
+import brainstate
 import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
 
+import braintrace
 from braintrace._compatible_imports import Primitive
 from braintrace._op import (
     BATCHED_PRIMITIVES,
@@ -283,3 +285,66 @@ class TestUnknownKwargRejected:
             register_primitive(
                 _fresh_name('bad'), lambda x: x, unknown=True,
             )
+
+
+def _prim_names(fn, *args):
+    return [e.primitive.name for e in jax.make_jaxpr(fn)(*args).jaxpr.eqns]
+
+
+class TestVmapIdentityPreservation:
+    """vmap over an unbatched ETP op must promote to the batched primitive."""
+
+    def test_vmap_matmul_promotes_to_etp_mm(self):
+        x = jnp.ones((4, 3))
+        w = jnp.ones((3, 5))
+        fn = jax.vmap(lambda xi: braintrace.matmul(xi, w))
+        names = _prim_names(fn, x)
+        assert 'etp_mm' in names
+        assert 'dot_general' not in names
+
+    def test_promoted_values_match_reference(self):
+        x = jnp.asarray(brainstate.random.randn(4, 3))
+        w = jnp.asarray(brainstate.random.randn(3, 5))
+        out = jax.vmap(lambda xi: braintrace.matmul(xi, w))(x)
+        assert jnp.allclose(out, x @ w, atol=1e-6)
+
+    def test_promoted_with_bias(self):
+        x = jnp.asarray(brainstate.random.randn(4, 3))
+        w = jnp.asarray(brainstate.random.randn(3, 5))
+        b = jnp.asarray(brainstate.random.randn(5))
+        fn = jax.vmap(lambda xi: braintrace.matmul(xi, w, bias=b))
+        assert 'etp_mm' in _prim_names(fn, x)
+        assert jnp.allclose(fn(x), x @ w + b, atol=1e-6)
+
+    def test_promoted_params_pass_through_weight_fn(self):
+        x = jnp.asarray(brainstate.random.randn(4, 3))
+        w = jnp.asarray(brainstate.random.randn(3, 5))
+        wfn = lambda ww: ww ** 2
+        fn = jax.vmap(lambda xi: braintrace.matmul(xi, w, weight_fn=wfn))
+        jaxpr = jax.make_jaxpr(fn)(x)
+        mm_eqns = [e for e in jaxpr.jaxpr.eqns if e.primitive.name == 'etp_mm']
+        assert len(mm_eqns) == 1
+        assert mm_eqns[0].params['weight_fn'] is wfn
+        assert jnp.allclose(fn(x), x @ (w ** 2), atol=1e-6)
+
+    def test_promotion_from_nonzero_batch_axis(self):
+        xt = jnp.asarray(brainstate.random.randn(3, 4))  # batch on axis 1
+        w = jnp.asarray(brainstate.random.randn(3, 5))
+        fn = jax.vmap(lambda xi: braintrace.matmul(xi, w), in_axes=1)
+        assert 'etp_mm' in _prim_names(fn, xt)
+        assert jnp.allclose(fn(xt), xt.T @ w, atol=1e-6)
+
+    def test_gradient_through_promoted_path(self):
+        x = jnp.asarray(brainstate.random.randn(4, 3))
+        w = jnp.asarray(brainstate.random.randn(3, 5))
+        g = jax.grad(lambda ww: jax.vmap(lambda xi: braintrace.matmul(xi, ww))(x).sum())(w)
+        g_ref = jax.grad(lambda ww: (x @ ww).sum())(w)
+        assert jnp.allclose(g, g_ref, atol=1e-6)
+
+    def test_batched_weight_falls_back_with_warning(self):
+        x = jnp.asarray(brainstate.random.randn(3))
+        ws = jnp.asarray(brainstate.random.randn(4, 3, 5))  # per-lane weights
+        fn = jax.vmap(lambda wi: braintrace.matmul(x, wi))
+        with pytest.warns(UserWarning, match='decomposed'):
+            out = fn(ws)
+        assert jnp.allclose(out, jnp.einsum('i,bij->bj', x, ws), atol=1e-6)

--- a/braintrace/_op/_registries.py
+++ b/braintrace/_op/_registries.py
@@ -54,12 +54,15 @@ __all__ = [
     'ETP_RULES_INIT_PP',
     'GRADIENT_ENABLED_PRIMITIVES',
     'BATCHED_PRIMITIVES',
+    'BATCHED_COUNTERPARTS',
     'ETP_TRAINABLE_INVARS_FNS',
     'ETP_X_INVAR_INDICES',
     'ETP_Y_OUTVAR_INDICES',
     'is_etp_primitive',
     'is_etp_enable_gradient_primitive',
     'is_batched_primitive',
+    'register_batched_counterpart',
+    'get_batched_counterpart',
     'get_trainable_invars',
     'get_x_invar_index',
     'get_y_outvar_index',
@@ -84,6 +87,17 @@ r"""pp_prop df trace init: ``(x_var, y_var, weight_var, num_hidden_state) -> zer
 
 GRADIENT_ENABLED_PRIMITIVES: set = set()
 BATCHED_PRIMITIVES: set = set()
+
+BATCHED_COUNTERPARTS: Dict[Primitive, Primitive] = {}
+r"""Batched counterpart per unbatched ETP primitive.
+
+Maps an unbatched primitive (e.g. ``etp_mv_p``) to the batched primitive
+implementing the same operation with a leading batch axis on ``x``
+(e.g. ``etp_mm_p``). Consulted by the auto-derived batching rule in
+:func:`~braintrace._op._primitive.register_primitive` to keep ETP
+primitive identity intact under ``jax.vmap`` (identity-preserving
+promotion). Populated via :func:`register_batched_counterpart`.
+"""
 
 ETP_TRAINABLE_INVARS_FNS: Dict[Primitive, Callable] = {}
 r"""Trainable-input layout: ``eqn.params -> {key: invar_index}``.
@@ -121,6 +135,58 @@ def is_etp_enable_gradient_primitive(primitive) -> bool:
 def is_batched_primitive(primitive) -> bool:
     """Return True iff *primitive* was registered with ``batched=True``."""
     return primitive in BATCHED_PRIMITIVES
+
+
+def register_batched_counterpart(unbatched_p, batched_p) -> None:
+    """Declare *batched_p* as the batched form of *unbatched_p* under vmap.
+
+    Parameters
+    ----------
+    unbatched_p : Primitive
+        An ETP primitive registered with ``batched=False``.
+    batched_p : Primitive
+        The ETP primitive registered with ``batched=True`` that computes the
+        same operation with the batch axis leading on ``x``.
+
+    Raises
+    ------
+    ValueError
+        If either primitive is not an ETP primitive, if *unbatched_p* is
+        registered as batched, or if *batched_p* is not registered as batched.
+    """
+    if unbatched_p not in ETP_PRIMITIVES or batched_p not in ETP_PRIMITIVES:
+        raise ValueError(
+            f'Both primitives must be ETP primitives; got '
+            f'{unbatched_p} and {batched_p}.'
+        )
+    if unbatched_p in BATCHED_PRIMITIVES:
+        raise ValueError(
+            f'{unbatched_p} must be an unbatched primitive to receive a '
+            f'batched counterpart.'
+        )
+    if batched_p not in BATCHED_PRIMITIVES:
+        raise ValueError(
+            f'{batched_p} must be registered with batched=True to serve as '
+            f'a batched counterpart.'
+        )
+    BATCHED_COUNTERPARTS[unbatched_p] = batched_p
+
+
+def get_batched_counterpart(primitive):
+    """Return the batched counterpart of *primitive*, or ``None``.
+
+    Parameters
+    ----------
+    primitive : Primitive
+        The (unbatched) ETP primitive to look up.
+
+    Returns
+    -------
+    Primitive or None
+        The batched counterpart registered via
+        :func:`register_batched_counterpart`, or ``None``.
+    """
+    return BATCHED_COUNTERPARTS.get(primitive)
 
 
 def get_trainable_invars(primitive, eqn_params: dict) -> Dict[str, int]:

--- a/braintrace/_op/_registries_test.py
+++ b/braintrace/_op/_registries_test.py
@@ -21,7 +21,7 @@ flag-sets, and the True/False semantics of the three predicates that
 the compiler relies on.
 """
 
-
+import pytest
 
 from braintrace._compatible_imports import Primitive
 from braintrace._op import (
@@ -44,6 +44,12 @@ from braintrace._op import (
     is_batched_primitive,
     is_etp_enable_gradient_primitive,
     is_etp_primitive,
+)
+from braintrace._op._primitive import register_primitive
+from braintrace._op._registries import (
+    BATCHED_COUNTERPARTS,
+    get_batched_counterpart,
+    register_batched_counterpart,
 )
 
 _ALL_SHIPPED = (
@@ -175,3 +181,35 @@ def test_get_fast_path_rules_none_for_sparse_conv_lora():
     """
     for prim in (etp_sp_mm_p, etp_sp_mv_p, etp_conv_p, etp_lora_mm_p, etp_lora_mv_p):
         assert get_fast_path_rules(prim) is None, prim.name
+
+
+class TestBatchedCounterparts:
+    def test_lookup_unregistered_returns_none(self):
+        p = register_primitive('etp_test_ctr_unreg', lambda x, w: x @ w, batched=False)
+        assert get_batched_counterpart(p) is None
+
+    def test_register_and_lookup(self):
+        pu = register_primitive('etp_test_ctr_u', lambda x, w: x @ w, batched=False)
+        pb = register_primitive('etp_test_ctr_b', lambda x, w: x @ w, batched=True)
+        register_batched_counterpart(pu, pb)
+        assert get_batched_counterpart(pu) is pb
+        assert BATCHED_COUNTERPARTS[pu] is pb
+
+    def test_rejects_non_etp_primitive(self):
+        from braintrace._compatible_imports import Primitive
+        plain = Primitive('not_etp_test_ctr')
+        pb = register_primitive('etp_test_ctr_b2', lambda x, w: x @ w, batched=True)
+        with pytest.raises(ValueError, match='ETP'):
+            register_batched_counterpart(plain, pb)
+
+    def test_rejects_batched_source(self):
+        pb1 = register_primitive('etp_test_ctr_b3', lambda x, w: x @ w, batched=True)
+        pb2 = register_primitive('etp_test_ctr_b4', lambda x, w: x @ w, batched=True)
+        with pytest.raises(ValueError, match='unbatched'):
+            register_batched_counterpart(pb1, pb2)
+
+    def test_rejects_unbatched_target(self):
+        pu1 = register_primitive('etp_test_ctr_u2', lambda x, w: x @ w, batched=False)
+        pu2 = register_primitive('etp_test_ctr_u3', lambda x, w: x @ w, batched=False)
+        with pytest.raises(ValueError, match='batched'):
+            register_batched_counterpart(pu1, pu2)

--- a/braintrace/_op/dense.py
+++ b/braintrace/_op/dense.py
@@ -103,7 +103,7 @@ import jax.numpy as jnp
 import brainunit as u
 
 from ._primitive import register_primitive
-from ._registries import FastPathRules
+from ._registries import FastPathRules, register_batched_counterpart
 from braintrace._typing import ArrayLike, WeightFn
 
 __all__ = [
@@ -584,6 +584,7 @@ etp_mv_p.register_etp_rules(
     init_pp=_mv_init_pp,
     fast_path=_DENSE_FAST_PATH,
 )
+register_batched_counterpart(etp_mv_p, etp_mm_p)
 
 
 # ---------------------------------------------------------------------------

--- a/braintrace/_op/elemwise_test.py
+++ b/braintrace/_op/elemwise_test.py
@@ -35,6 +35,7 @@ from collections import namedtuple
 import jax
 import jax.numpy as jnp
 import numpy as np
+import pytest
 import brainunit as u
 
 import brainstate
@@ -153,7 +154,12 @@ class TestJAXRules:
 
     def test_vmap(self):
         w = jnp.arange(12.0).reshape(4, 3)
-        out = jax.vmap(element_wise)(w)
+        # `etp_elemwise` has no registered batched counterpart, so this
+        # falls back to the identity-preserving batching rule's
+        # decomposition path and warns (see `register_primitive`'s
+        # batching rule in `braintrace/_op/_primitive.py`).
+        with pytest.warns(UserWarning, match='decomposed'):
+            out = jax.vmap(element_wise)(w)
         np.testing.assert_allclose(out, w)
 
     def test_grad_default_fn(self):

--- a/braintrace/_op/lora.py
+++ b/braintrace/_op/lora.py
@@ -107,6 +107,7 @@ import jax.numpy as jnp
 import brainunit as u
 
 from ._primitive import register_primitive
+from ._registries import register_batched_counterpart
 from braintrace._typing import ArrayLike, WeightFn
 
 __all__ = [
@@ -388,6 +389,7 @@ etp_lora_mv_p.register_etp_rules(
     init_drtrl=_lora_mv_init_drtrl,
     init_pp=_lora_mv_init_pp,
 )
+register_batched_counterpart(etp_lora_mv_p, etp_lora_mm_p)
 
 
 def lora_matmul(

--- a/braintrace/_op/lora_test.py
+++ b/braintrace/_op/lora_test.py
@@ -440,3 +440,20 @@ class TestLoraFactorFns:
 
         assert_xy_to_dw_matches_vjp(rule=rule, impl=impl, x=x, hidden_dim=hidden,
                                     weights=weights, params=params, atol=1e-4)
+
+
+# ---------------------------------------------------------------------------
+# vmap identity-preserving promotion (etp_lora_mv -> etp_lora_mm)
+# ---------------------------------------------------------------------------
+
+class TestLoraVmapPromotion:
+    def test_vmap_lora_matmul_promotes_to_etp_lora_mm(self):
+        import brainstate
+        x = brainstate.random.randn(4, 3)
+        B = brainstate.random.randn(3, 2)
+        A = brainstate.random.randn(2, 5)
+        fn = jax.vmap(lambda xi: braintrace.lora_matmul(xi, B, A))
+        names = [e.primitive.name for e in jax.make_jaxpr(fn)(x).jaxpr.eqns]
+        assert 'etp_lora_mm' in names
+        assert 'dot_general' not in names
+        assert jnp.allclose(fn(x), x @ B @ A, atol=1e-6)

--- a/braintrace/_op/sparse.py
+++ b/braintrace/_op/sparse.py
@@ -102,6 +102,7 @@ import brainunit as u
 import brainevent
 
 from ._primitive import register_primitive
+from ._registries import register_batched_counterpart
 from braintrace._typing import ArrayLike, WeightFn
 
 __all__ = [
@@ -367,6 +368,7 @@ etp_sp_mv_p.register_etp_rules(
     init_drtrl=_sp_mv_init_drtrl,
     init_pp=_sp_mv_init_pp,
 )
+register_batched_counterpart(etp_sp_mv_p, etp_sp_mm_p)
 
 
 def sparse_matmul(

--- a/braintrace/_op/sparse_test.py
+++ b/braintrace/_op/sparse_test.py
@@ -616,3 +616,29 @@ class TestSparseWeightFnBiasFn:
             rule=rule, impl=impl, x=x, hidden_dim=hidden,
             weights=weights, params=params, atol=1e-4,
         )
+
+
+# ---------------------------------------------------------------------------
+# vmap identity-preserving promotion (etp_sp_mv -> etp_sp_mm)
+# ---------------------------------------------------------------------------
+
+class TestSparseVmapPromotion:
+    def test_vmap_sparse_matmul_promotes_to_etp_sp_mm(self):
+        # NOTE: real `brainevent.CSR` is not hashable under JAX 0.7+, so it
+        # cannot be a static primitive param under `jax.make_jaxpr`/`jit` —
+        # this is a pre-existing, unrelated limitation (reproduces even for
+        # the already-registered *unbatched* `etp_sp_mv` path with no vmap
+        # involved at all; see `TestAutoDispatch` above, which already works
+        # around it with `_HashableStubMat` for the same reason). Use the
+        # same hashable stub here so this test exercises vmap promotion
+        # rather than tripping the unrelated hashability bug.
+        dense = jnp.where(brainstate.random.rand(3, 5) < 0.5,
+                          brainstate.random.randn(3, 5), 0.0)
+        stub = _HashableStubMat(dense)
+        data = dense.reshape(-1)
+        x = brainstate.random.randn(4, 3)
+        fn = jax.vmap(lambda xi: braintrace.sparse_matmul(xi, data, sparse_mat=stub))
+        names = [e.primitive.name for e in jax.make_jaxpr(fn)(x).jaxpr.eqns]
+        assert 'etp_sp_mm' in names
+        ref = braintrace.sparse_matmul(x, data, sparse_mat=stub)
+        assert jnp.allclose(fn(x), ref, atol=1e-6)

--- a/changelog.md
+++ b/changelog.md
@@ -15,7 +15,10 @@
   eligibility-trace relations. When promotion is impossible (batched
   weights, `etp_conv`, nested vmap), the op decomposes as before but emits
   a `UserWarning` instead of silently dropping the parameter from online
-  learning.
+  learning. Note: when this warning appears from a `compile(..., vmap=True)`
+  learner's execution trace (e.g. conv models), it is expected and benign —
+  the eligibility-trace graph was already compiled per-sample before the
+  learner was vmapped, so no parameter is dropped.
 
 
 ## Version 0.2.3

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,23 @@
 # Release Notes
 
 
+## UNRELEASED
+
+### Highlights
+
+#### New: vmap identity preservation (operator layer)
+
+- **vmap identity preservation (operator layer)**: `jax.vmap` over an
+  unbatched ETP op (`matmul`, `lora_matmul`, `sparse_matmul` with vector
+  input) now re-binds the batched ETP primitive (`etp_mm` / `etp_lora_mm` /
+  `etp_sp_mm`) instead of decomposing into standard JAX ops. Models that
+  vmap per-sample ETP operations inside `update()` now compile with full
+  eligibility-trace relations. When promotion is impossible (batched
+  weights, `etp_conv`, nested vmap), the op decomposes as before but emits
+  a `UserWarning` instead of silently dropping the parameter from online
+  learning.
+
+
 ## Version 0.2.3
 
 This release adds optional, shape-preserving parameter-transform hooks to the


### PR DESCRIPTION
## Summary

Fixes the vmap identity-dissolution bug: the auto-derived batching rule (`jax.vmap(impl_fn)`) decomposed ETP primitives into plain JAX ops, so parameters used inside a `jax.vmap`-wrapped step were **silently dropped from online learning**. This PR makes vmap over the batch dimension preserve primitive identity by promoting unbatched primitives to their registered batched counterparts.

This is Phase 0 of the control-flow support plan (spec: vmap → cond → scan → while).

## Changes

- **`_op/_registries.py`** — new `BATCHED_COUNTERPARTS` registry with `register_batched_counterpart(unbatched_p, batched_p)` (validated: both ETP, source unbatched, target batched) and `get_batched_counterpart(...)`.
- **`_op/_primitive.py`** — identity-preserving batching rule: when only the `x` operand carries the batch dimension and a counterpart is registered, rebind to the batched primitive (batch axis moved to 0); otherwise fall back to decomposition **with an explicit `UserWarning`** so silent parameter drops can no longer happen.
- **Counterpart registrations** — `etp_mv → etp_mm` (dense), `etp_lora_mv → etp_lora_mm` (LoRA), `etp_sp_mv → etp_sp_mm` (sparse).
- **Tests** — promotion/identity/value/gradient-parity tests per op family; compiler-level parity test proving a `jax.vmap`-per-sample cell yields the same ETP relation (`etp_mm`) and element-wise-equal D-RTRL gradients as the natively batched cell; existing tests updated to assert or filter the new decomposition warning.
- **Pre-existing CI fix** — dropped a dead `mode` kwarg in `param_dim_vjp_test.py` broken by eee522b.
- **changelog.md** — UNRELEASED entry, including a note that the decomposition warning emitted from a `compile(..., vmap=True)` learner trace (e.g. conv models) is expected and benign.

## Test plan

- Full suite on CPU: **1703 passed, 0 failed, 3 skipped**.
- Every task went through TDD (red → green) plus a per-task review gate; a final whole-branch review returned "Ready to merge."

## Follow-ups (not in this PR)

- Phase 1: `cond` → `select_n` if-conversion; Phase 2: inner-`scan` unrolling; Phase 3: `while` policy.
- Conv counterpart or self-rebind (spec §8.6); duplicate-registration guard; shipped-pairs registry assertion.