### PR TITLE
cond support: if-conversion to select_n in etrace compilation (Phase 1)

### DIFF
--- a/braintrace/__init__.py
+++ b/braintrace/__init__.py
@@ -94,6 +94,7 @@ from ._algorithm import (
     PresynapticTrace,
 )
 from ._compiler import (
+    ControlFlowPolicy,
     ETraceGraph,
     compile_etrace_graph,
     HiddenParamOpRelation,
@@ -185,6 +186,7 @@ __all__ = [
     'ETraceGraphExecutor',
 
     # compiler
+    'ControlFlowPolicy',
     'ETraceGraph',
     'compile_etrace_graph',
     'HiddenGroup',

--- a/braintrace/_algorithm/oracle_models.py
+++ b/braintrace/_algorithm/oracle_models.py
@@ -193,3 +193,43 @@ def batched_tanh_rnn(n_in: int = 3, n_rec: int = 4, batch: int = 4, seed: int = 
         return Net()
 
     return ModelSpec(factory=factory, etp_param_keys=(('w',),), plain_param_keys=(('win',),))
+
+
+def cond_gate_rnn(n_in: int = 3, n_rec: int = 4, leak: float = 0.9, seed: int = 0) -> ModelSpec:
+    """Leaky integrator whose drive is a ``lax.cond`` between two ETP matmuls.
+
+    The ETP primitives live inside the ``cond`` branches; the compiler
+    if-converts the equation into both inlined branches + ``select_n`` at
+    extraction time (Phase 1 canonicalization), so ``w_a`` and ``w_b`` are
+    both genuine ETP relations. The hidden-to-hidden Jacobian stays
+    ``leak * I`` (the drive contains no ``h``), keeping D_RTRL exact.
+    """
+
+    def factory():
+        class Net(brainstate.nn.Module):
+            def __init__(self):
+                super().__init__()
+                with brainstate.random.seed_context(seed):
+                    self.w_a = brainstate.ParamState(
+                        0.1 * brainstate.random.randn(n_in, n_rec)
+                    )
+                    self.w_b = brainstate.ParamState(
+                        0.1 * brainstate.random.randn(n_in, n_rec)
+                    )
+                self.h = brainstate.HiddenState(jnp.zeros((1, n_rec)))
+
+            def update(self, x):
+                x_row = x.reshape(1, -1)
+                drive = jax.lax.cond(
+                    jnp.sum(x) > 0.,
+                    lambda: braintrace.matmul(x_row, self.w_a.value),
+                    lambda: braintrace.matmul(x_row, self.w_b.value),
+                )
+                self.h.value = leak * self.h.value + jnp.tanh(drive)
+                return self.h.value
+
+        return Net()
+
+    return ModelSpec(
+        factory=factory, etp_param_keys=(('w_a',), ('w_b',)), plain_param_keys=()
+    )

--- a/braintrace/_algorithm/tests/exact_correctness_test.py
+++ b/braintrace/_algorithm/tests/exact_correctness_test.py
@@ -31,6 +31,7 @@ from braintrace._algorithm.oracle import (
     online_param_gradients,
 )
 from braintrace._algorithm.oracle_models import (
+    cond_gate_rnn,
     leaky_linear,
     stacked_tanh_rnn,
     tanh_rnn,
@@ -89,10 +90,13 @@ _EXACT_MULTISTEP_ALGOS = {
 }
 
 # (model_name, algo_name) pairs verified exact by the P4 spikes.
+# cond_gate exercises the Phase 1 cond -> select_n canonicalization: ETP
+# matmuls inside `lax.cond` branches must stay BPTT-exact after conversion.
 _EXACT_CASES = (
     [('tanh_rnn', a) for a in _EXACT_MULTISTEP_ALGOS]
     + [('stacked_tanh_rnn', a) for a in _EXACT_MULTISTEP_ALGOS]
     + [('leaky_linear', 'D_RTRL')]
+    + [('cond_gate', 'D_RTRL')]
 )
 
 
@@ -103,6 +107,8 @@ def _model_spec(name):
         return stacked_tanh_rnn(n_in=3, n_rec=4, seed=0)
     if name == 'leaky_linear':
         return leaky_linear(n_in=3, n_rec=4, leak=0.9, seed=0)
+    if name == 'cond_gate':
+        return cond_gate_rnn(n_in=3, n_rec=4, leak=0.9, seed=0)
     raise KeyError(name)
 
 

--- a/braintrace/_compatible_imports.py
+++ b/braintrace/_compatible_imports.py
@@ -23,6 +23,7 @@ __all__ = [
     'ClosedJaxpr',
     'Literal',
     'new_var',
+    'new_jaxpr_eqn',
     'is_jit_primitive',
     'is_scan_primitive',
     'is_while_primitive',
@@ -30,6 +31,11 @@ __all__ = [
 ]
 
 from brainstate._compatible_import import Primitive, Var, JaxprEqn, Jaxpr, ClosedJaxpr, Literal
+
+try:
+    from jax.extend.core import new_jaxpr_eqn
+except ImportError:  # older JAX exposes it on jax.core only
+    from jax.core import new_jaxpr_eqn
 
 
 def new_var(suffix, aval):

--- a/braintrace/_compiler/__init__.py
+++ b/braintrace/_compiler/__init__.py
@@ -19,6 +19,11 @@ from braintrace._compiler.base import (
     find_element_exist_in_the_set,
     find_matched_vars,
 )
+from braintrace._compiler.canonicalize import (
+    ControlFlowPolicy,
+    DEFAULT_CONTROL_FLOW_POLICY,
+    if_convert_conds,
+)
 from braintrace._compiler.diagnostics import (
     CompilationRecord,
     DiagnosticKind,

--- a/braintrace/_compiler/canonicalize.py
+++ b/braintrace/_compiler/canonicalize.py
@@ -1,0 +1,378 @@
+# Copyright 2026 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Jaxpr canonicalization passes for the ETrace compiler.
+
+Control-flow constructs hide their bodies behind sub-jaxprs, but every ETrace
+analysis identifies weights, hidden states, and ETP primitives by ``Var``
+identity in one flat top-level jaxpr. The passes in this module rewrite
+ETP-relevant control flow into flat, semantically identical equation
+sequences before any analysis runs — the same role
+:func:`~braintrace._compiler.jaxpr_graph.inline_jit_calls` plays for ``jit``
+boundaries.
+
+Phase 1 implements ``cond`` if-conversion (:func:`if_convert_conds`):
+every ETP-relevant ``cond`` equation is replaced by the inlined bodies of
+*all* its branches followed by one ``select_n`` equation per output. The
+integer index semantics of ``cond`` and ``select_n`` match exactly, and the
+JVP of ``select_n`` selects tangents, so values *and* Jacobians of the
+canonicalized jaxpr are exact.
+
+Inner-``scan`` unrolling is Phase 2; the ``scan_unroll_limit`` knob on
+:class:`ControlFlowPolicy` is reserved for it.
+"""
+
+from dataclasses import dataclass
+from typing import Any, Callable, Container, Dict, Iterable, List, Optional
+
+import jax
+
+from braintrace._compatible_imports import (
+    ClosedJaxpr,
+    Jaxpr,
+    JaxprEqn,
+    Var,
+    is_cond_primitive,
+    is_jit_primitive,
+    is_scan_primitive,
+    is_while_primitive,
+    new_jaxpr_eqn,
+    new_var,
+)
+from braintrace._op import is_etp_primitive
+from .diagnostics import DiagnosticKind, DiagnosticLevel, emit
+from .jaxpr_graph import inline_jit_calls
+
+__all__ = [
+    'ControlFlowPolicy',
+    'DEFAULT_CONTROL_FLOW_POLICY',
+    'if_convert_conds',
+]
+
+
+@dataclass(frozen=True)
+class ControlFlowPolicy:
+    """Policy knobs governing control-flow canonicalization.
+
+    Parameters
+    ----------
+    cond : str, optional
+        How ETP-relevant ``cond`` equations are handled. ``'convert'``
+        (default) if-converts them into inlined branches + ``select_n``;
+        ``'opaque'`` leaves every ``cond`` untouched, so the existing
+        control-flow restrictions apply (weights used inside raise
+        ``NotImplementedError``; ETP primitives inside are excluded with a
+        warning).
+    scan_unroll_limit : int, optional
+        Reserved for the Phase 2 inner-``scan`` unrolling pass; currently
+        unused. Default ``16``.
+
+    Notes
+    -----
+    If-conversion changes execution semantics: **both** branches of a
+    converted ``cond`` execute every step, and ``select_n`` discards the
+    dead branch's value. Guarded partial operations (a ``cond`` used to
+    avoid ``sqrt`` of a negative number, for example) can produce NaN/Inf
+    in the dead branch — the value is discarded and, because whole outputs
+    are selected rather than multiplied, gradients are not contaminated.
+    Branches with effects, or containing ``while``/``scan``, are never
+    converted (see :func:`if_convert_conds`).
+
+    Examples
+    --------
+    .. code-block:: python
+
+        >>> import braintrace
+        >>> policy = braintrace.ControlFlowPolicy(cond='opaque')
+        >>> policy.cond
+        'opaque'
+    """
+
+    cond: str = 'convert'
+    scan_unroll_limit: int = 16
+
+
+DEFAULT_CONTROL_FLOW_POLICY = ControlFlowPolicy()
+
+ControlFlowPolicy.__module__ = 'braintrace'
+
+
+def _subjaxprs(eqn: JaxprEqn) -> Iterable[Jaxpr]:
+    """Yield every sub-jaxpr stored on an equation's params."""
+    for key in ('jaxpr', 'cond_jaxpr', 'body_jaxpr'):
+        sub = eqn.params.get(key)
+        if sub is not None:
+            yield getattr(sub, 'jaxpr', sub)
+    branches = eqn.params.get('branches')
+    if branches is not None:
+        for b in branches:
+            yield getattr(b, 'jaxpr', b)
+
+
+def _jaxpr_contains(jaxpr: Jaxpr, pred: Callable[[JaxprEqn], bool]) -> bool:
+    """Whether any equation in *jaxpr* (descending sub-jaxprs) satisfies *pred*."""
+    for eqn in jaxpr.eqns:
+        if pred(eqn):
+            return True
+        for sub in _subjaxprs(eqn):
+            if _jaxpr_contains(sub, pred):
+                return True
+    return False
+
+
+def _is_etp_eqn(eqn: JaxprEqn) -> bool:
+    return is_etp_primitive(eqn.primitive)
+
+
+def if_convert_conds(
+    closed_jaxpr: ClosedJaxpr,
+    *,
+    weight_invars: Container[Var],
+    hidden_invars: Container[Var],
+    hidden_outvars: Container[Var],
+    policy: ControlFlowPolicy = DEFAULT_CONTROL_FLOW_POLICY,
+) -> ClosedJaxpr:
+    """If-convert every ETP-relevant ``cond`` equation in *closed_jaxpr*.
+
+    Each converted ``cond`` is replaced by the inlined bodies of all its
+    branches (every internal variable freshened) followed by one
+    ``select_n(index, out_0[k], ..., out_{n-1}[k])`` equation per output
+    position ``k``, written to the *original* ``cond`` output variables.
+    Because the pass preserves the jaxpr's ``invars`` and ``outvars`` by
+    object identity, every Var-identity lookup table built from them stays
+    valid.
+
+    Parameters
+    ----------
+    closed_jaxpr : ClosedJaxpr
+        The closed jaxpr to canonicalize. ``jit`` equations should already
+        be inlined (the pass re-runs
+        :func:`~braintrace._compiler.jaxpr_graph.inline_jit_calls` afterwards
+        to flatten ``jit`` bodies surfaced from converted branches).
+    weight_invars : Container[Var]
+        Jaxpr input variables of the trainable weights.
+    hidden_invars : Container[Var]
+        Jaxpr input variables of the hidden states.
+    hidden_outvars : Container[Var]
+        Jaxpr output variables of the hidden states.
+    policy : ControlFlowPolicy, optional
+        Canonicalization policy. With ``policy.cond == 'opaque'`` the input
+        is returned unchanged.
+
+    Returns
+    -------
+    ClosedJaxpr
+        The canonicalized closed jaxpr. When nothing is converted, the input
+        object itself is returned unchanged.
+
+    Raises
+    ------
+    ValueError
+        If ``policy.cond`` is neither ``'convert'`` nor ``'opaque'``.
+
+    Notes
+    -----
+    A ``cond`` equation is converted only when it is *relevant* — any branch
+    transitively contains an ETP primitive, or the equation consumes a
+    weight/hidden input variable, or produces a hidden output variable — and
+    *safe*: no effects, and no branch transitively contains ``while`` or
+    ``scan`` (inner-``scan`` unrolling lands in Phase 2). A relevant-but-
+    unsafe ``cond`` stays opaque and a
+    :attr:`~braintrace.DiagnosticKind.COND_CONVERSION_SKIPPED` warning is
+    emitted; the existing control-flow restrictions then apply unchanged.
+    Irrelevant ``cond`` equations always stay opaque, at zero cost.
+
+    On the canonicalized jaxpr **both branches execute every step**; see
+    :class:`ControlFlowPolicy` for the semantics discussion.
+    """
+    if policy.cond == 'opaque':
+        return closed_jaxpr
+    if policy.cond != 'convert':
+        raise ValueError(
+            f"policy.cond must be 'convert' or 'opaque', got {policy.cond!r}."
+        )
+
+    jaxpr = closed_jaxpr.jaxpr
+    if not any(is_cond_primitive(eqn) for eqn in jaxpr.eqns):
+        return closed_jaxpr
+
+    extra_constvars: List[Var] = []
+    extra_consts: List[Any] = []
+    new_eqns: List[JaxprEqn] = []
+    n_converted = 0
+
+    def fresh_like(v: Var) -> Var:
+        return new_var('', v.aval)
+
+    def relevance_reason(resolved_invars, outvars, branches) -> Optional[str]:
+        for v in resolved_invars:
+            if isinstance(v, Var):
+                if v in weight_invars:
+                    return 'it consumes a weight invar'
+                if v in hidden_invars:
+                    return 'it consumes a hidden-state invar'
+        for v in outvars:
+            if v in hidden_outvars:
+                return 'it produces a hidden-state outvar'
+        for b in branches:
+            if _jaxpr_contains(getattr(b, 'jaxpr', b), _is_etp_eqn):
+                return 'a branch contains an ETP primitive'
+        return None
+
+    def unsafe_reason(eqn: JaxprEqn) -> Optional[str]:
+        if eqn.effects:
+            return 'the cond has effects'
+        for b in eqn.params['branches']:
+            sub = getattr(b, 'jaxpr', b)
+            if sub.effects:
+                return 'a branch has effects'
+            if _jaxpr_contains(sub, is_while_primitive):
+                return 'a branch contains a while loop'
+            if _jaxpr_contains(sub, is_scan_primitive):
+                return (
+                    'a branch contains an inner scan '
+                    '(scan unrolling is not implemented yet)'
+                )
+        return None
+
+    def inline_branch(branch_closed, operand_atoms) -> List[Any]:
+        """Splice one branch body into ``new_eqns`` with every internal var
+        freshened; return the branch's output atoms."""
+        br = getattr(branch_closed, 'jaxpr', branch_closed)
+        consts = getattr(branch_closed, 'consts', [])
+        # Freshen constvars (instead of adopting the branch's Var objects):
+        # the same branch ClosedJaxpr object may be inlined at several call
+        # sites, and adopting would define its vars more than once.
+        subst: Dict[Var, Any] = {}
+        for cv, cval in zip(br.constvars, consts):
+            fresh = fresh_like(cv)
+            subst[cv] = fresh
+            extra_constvars.append(fresh)
+            extra_consts.append(cval)
+        for iv, atom in zip(br.invars, operand_atoms):
+            subst[iv] = atom
+
+        def resolve(atom):
+            if isinstance(atom, Var):
+                return subst.get(atom, atom)
+            return atom
+
+        for sub_eqn in br.eqns:
+            handle_eqn(sub_eqn, resolve, subst)
+        return [resolve(v) for v in br.outvars]
+
+    def handle_eqn(eqn: JaxprEqn, resolve, subst: Optional[Dict[Var, Any]]) -> None:
+        """Process one equation. ``subst`` is ``None`` at the top level (the
+        equation's vars are kept); inside a branch, invars are resolved and
+        outvars freshened into ``subst``."""
+        nonlocal n_converted
+
+        if is_cond_primitive(eqn) and 'branches' in eqn.params:
+            index_atom = resolve(eqn.invars[0])
+            operand_atoms = [resolve(v) for v in eqn.invars[1:]]
+            if subst is None:
+                outvars = list(eqn.outvars)
+            else:
+                outvars = [fresh_like(v) for v in eqn.outvars]
+                for ov, fresh in zip(eqn.outvars, outvars):
+                    subst[ov] = fresh
+
+            branches = eqn.params['branches']
+            reason = relevance_reason(
+                [index_atom, *operand_atoms], outvars, branches
+            )
+            if reason is not None:
+                bad = unsafe_reason(eqn)
+                if bad is None:
+                    per_branch_outs = [
+                        inline_branch(b, operand_atoms) for b in branches
+                    ]
+                    for k, ov in enumerate(outvars):
+                        cases = [outs[k] for outs in per_branch_outs]
+                        new_eqns.append(new_jaxpr_eqn(
+                            [index_atom, *cases],
+                            [ov],
+                            jax.lax.select_n_p,
+                            {},
+                            set(),
+                            eqn.source_info.replace(),
+                        ))
+                    n_converted += 1
+                    emit(
+                        kind=DiagnosticKind.COND_IF_CONVERTED,
+                        level=DiagnosticLevel.INFO,
+                        message=(
+                            f'If-converted a cond with {len(branches)} '
+                            f'branches and {len(outvars)} outputs into '
+                            f'inlined branches + select_n because {reason}. '
+                            f'Both branches now execute every step.'
+                        ),
+                        context={
+                            'n_branches': len(branches),
+                            'n_outputs': len(outvars),
+                            'reason': reason,
+                        },
+                    )
+                    return
+                emit(
+                    kind=DiagnosticKind.COND_CONVERSION_SKIPPED,
+                    level=DiagnosticLevel.WARNING,
+                    message=(
+                        f'An ETP-relevant cond ({reason}) was NOT '
+                        f'if-converted because {bad}; it stays opaque and '
+                        f'the existing control-flow restrictions apply.'
+                    ),
+                    context={'reason': bad, 'relevance': reason},
+                )
+            # Not converted: keep the cond eqn (resolved when inside a branch).
+            if subst is None:
+                new_eqns.append(eqn)
+            else:
+                new_eqns.append(eqn.replace(
+                    invars=[index_atom, *operand_atoms],
+                    outvars=outvars,
+                ))
+            return
+
+        if subst is None:
+            new_eqns.append(eqn)
+        else:
+            fresh_outvars = [fresh_like(v) for v in eqn.outvars]
+            for ov, fresh in zip(eqn.outvars, fresh_outvars):
+                subst[ov] = fresh
+            new_eqns.append(eqn.replace(
+                invars=[resolve(v) for v in eqn.invars],
+                outvars=fresh_outvars,
+            ))
+
+    for eqn in jaxpr.eqns:
+        handle_eqn(eqn, lambda atom: atom, None)
+
+    if n_converted == 0:
+        return closed_jaxpr
+
+    new_jaxpr = Jaxpr(
+        constvars=list(jaxpr.constvars) + extra_constvars,
+        invars=list(jaxpr.invars),
+        outvars=list(jaxpr.outvars),
+        eqns=new_eqns,
+        effects=jaxpr.effects,
+        debug_info=jaxpr.debug_info,
+    )
+    result = ClosedJaxpr(new_jaxpr, list(closed_jaxpr.consts) + extra_consts)
+    # Branch bodies may contain user ``jit`` calls that are now top-level
+    # equations; flatten them exactly as extract_module_info does before
+    # this pass runs. No-op (same object) when no jit equation surfaced.
+    return inline_jit_calls(result)

--- a/braintrace/_compiler/canonicalize.py
+++ b/braintrace/_compiler/canonicalize.py
@@ -227,14 +227,18 @@ def if_convert_conds(
     # Fixpoint loop: converting a cond can surface user ``jit`` equations
     # from its branches, and their inlined bodies can expose further conds.
     # Each iteration converts what is visible, then flattens surfaced jits;
-    # nesting depth is finite, so this terminates.
+    # nesting depth is finite, so this terminates. ``skip_warned`` carries
+    # the equations already reported as skipped, so a relevant-but-unsafe
+    # cond warns once, not once per iteration.
     result = closed_jaxpr
+    skip_warned: set = set()
     while True:
         converted, n_converted = _convert_conds_once(
             result,
             weight_invars=weight_invars,
             hidden_invars=hidden_invars,
             hidden_outvars=hidden_outvars,
+            skip_warned=skip_warned,
         )
         if n_converted == 0:
             return result
@@ -247,6 +251,7 @@ def _convert_conds_once(
     weight_invars: Container[Var],
     hidden_invars: Container[Var],
     hidden_outvars: Container[Var],
+    skip_warned: set,
 ):
     """One conversion sweep over the top-level equations.
 
@@ -375,16 +380,18 @@ def _convert_conds_once(
                         },
                     )
                     return
-                emit(
-                    kind=DiagnosticKind.COND_CONVERSION_SKIPPED,
-                    level=DiagnosticLevel.WARNING,
-                    message=(
-                        f'An ETP-relevant cond ({reason}) was NOT '
-                        f'if-converted because {bad}; it stays opaque and '
-                        f'the existing control-flow restrictions apply.'
-                    ),
-                    context={'reason': bad, 'relevance': reason},
-                )
+                if id(eqn) not in skip_warned:
+                    skip_warned.add(id(eqn))
+                    emit(
+                        kind=DiagnosticKind.COND_CONVERSION_SKIPPED,
+                        level=DiagnosticLevel.WARNING,
+                        message=(
+                            f'An ETP-relevant cond ({reason}) was NOT '
+                            f'if-converted because {bad}; it stays opaque and '
+                            f'the existing control-flow restrictions apply.'
+                        ),
+                        context={'reason': bad, 'relevance': reason},
+                    )
             # Not converted: keep the cond eqn (resolved when inside a branch).
             if subst is None:
                 new_eqns.append(eqn)

--- a/braintrace/_compiler/canonicalize.py
+++ b/braintrace/_compiler/canonicalize.py
@@ -27,8 +27,10 @@ Phase 1 implements ``cond`` if-conversion (:func:`if_convert_conds`):
 every ETP-relevant ``cond`` equation is replaced by the inlined bodies of
 *all* its branches followed by one ``select_n`` equation per output. The
 integer index semantics of ``cond`` and ``select_n`` match exactly, and the
-JVP of ``select_n`` selects tangents, so values *and* Jacobians of the
-canonicalized jaxpr are exact.
+JVP of ``select_n`` selects tangents, so — for branches with finite values
+and Jacobians — the canonicalized jaxpr is exact in both value and
+derivative (see :class:`ControlFlowPolicy` for the dead-branch NaN/Inf
+caveat under reverse mode).
 
 Inner-``scan`` unrolling is Phase 2; the ``scan_unroll_limit`` knob on
 :class:`ControlFlowPolicy` is reserved for it.
@@ -83,12 +85,25 @@ class ControlFlowPolicy:
     -----
     If-conversion changes execution semantics: **both** branches of a
     converted ``cond`` execute every step, and ``select_n`` discards the
-    dead branch's value. Guarded partial operations (a ``cond`` used to
-    avoid ``sqrt`` of a negative number, for example) can produce NaN/Inf
-    in the dead branch — the value is discarded and, because whole outputs
-    are selected rather than multiplied, gradients are not contaminated.
-    Branches with effects, or containing ``while``/``scan``, are never
-    converted (see :func:`if_convert_conds`).
+    dead branch's *value*. Guarded partial operations (a ``cond`` used to
+    avoid ``sqrt`` of a negative number, for example) therefore need care:
+
+    - **Values and forward-mode (JVP) derivatives are safe** — ``select_n``
+      selects whole outputs and tangents, so a dead-branch NaN/Inf never
+      reaches the selected result.
+    - **Reverse-mode (VJP) gradients are NOT safe** when the dead branch's
+      local Jacobian is NaN/Inf: ``select_n``'s transpose hands the dead
+      branch an exact-zero cotangent, but the dead branch's VJP multiplies
+      that zero by its NaN/Inf Jacobian (``0 * nan = nan``), contaminating
+      gradients of inputs shared with the live branch — the classic
+      single-``where`` pitfall. If a ``cond`` guards a partial operation's
+      domain, keep it opaque (``cond='opaque'``) or guard the operand
+      itself (e.g. ``sqrt(where(ok, x, 1.))``) inside the branch.
+
+    For branches whose values and Jacobians are finite, the canonicalized
+    jaxpr is exact in both value and derivative. Branches with effects, or
+    containing ``while``/``scan``, are never converted (see
+    :func:`if_convert_conds`).
 
     Examples
     --------
@@ -110,8 +125,13 @@ ControlFlowPolicy.__module__ = 'braintrace'
 
 
 def _subjaxprs(eqn: JaxprEqn) -> Iterable[Jaxpr]:
-    """Yield every sub-jaxpr stored on an equation's params."""
-    for key in ('jaxpr', 'cond_jaxpr', 'body_jaxpr'):
+    """Yield every sub-jaxpr stored on an equation's params.
+
+    ``call_jaxpr`` (custom_jvp/custom_vjp bodies) is descended for
+    *detection* only — those equations are never rewritten, but the gates
+    must still see ETP or while/scan primitives inside them.
+    """
+    for key in ('jaxpr', 'cond_jaxpr', 'body_jaxpr', 'call_jaxpr'):
         sub = eqn.params.get(key)
         if sub is not None:
             yield getattr(sub, 'jaxpr', sub)
@@ -204,9 +224,38 @@ def if_convert_conds(
             f"policy.cond must be 'convert' or 'opaque', got {policy.cond!r}."
         )
 
+    # Fixpoint loop: converting a cond can surface user ``jit`` equations
+    # from its branches, and their inlined bodies can expose further conds.
+    # Each iteration converts what is visible, then flattens surfaced jits;
+    # nesting depth is finite, so this terminates.
+    result = closed_jaxpr
+    while True:
+        converted, n_converted = _convert_conds_once(
+            result,
+            weight_invars=weight_invars,
+            hidden_invars=hidden_invars,
+            hidden_outvars=hidden_outvars,
+        )
+        if n_converted == 0:
+            return result
+        result = inline_jit_calls(converted)
+
+
+def _convert_conds_once(
+    closed_jaxpr: ClosedJaxpr,
+    *,
+    weight_invars: Container[Var],
+    hidden_invars: Container[Var],
+    hidden_outvars: Container[Var],
+):
+    """One conversion sweep over the top-level equations.
+
+    Returns ``(closed_jaxpr, n_converted)``; the input object itself when
+    nothing is converted.
+    """
     jaxpr = closed_jaxpr.jaxpr
     if not any(is_cond_primitive(eqn) for eqn in jaxpr.eqns):
-        return closed_jaxpr
+        return closed_jaxpr, 0
 
     extra_constvars: List[Var] = []
     extra_consts: List[Any] = []
@@ -361,7 +410,7 @@ def if_convert_conds(
         handle_eqn(eqn, lambda atom: atom, None)
 
     if n_converted == 0:
-        return closed_jaxpr
+        return closed_jaxpr, 0
 
     new_jaxpr = Jaxpr(
         constvars=list(jaxpr.constvars) + extra_constvars,
@@ -372,7 +421,4 @@ def if_convert_conds(
         debug_info=jaxpr.debug_info,
     )
     result = ClosedJaxpr(new_jaxpr, list(closed_jaxpr.consts) + extra_consts)
-    # Branch bodies may contain user ``jit`` calls that are now top-level
-    # equations; flatten them exactly as extract_module_info does before
-    # this pass runs. No-op (same object) when no jit equation surfaced.
-    return inline_jit_calls(result)
+    return result, n_converted

--- a/braintrace/_compiler/canonicalize_test.py
+++ b/braintrace/_compiler/canonicalize_test.py
@@ -1,0 +1,422 @@
+# Copyright 2026 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+import brainstate
+import jax
+import jax.numpy as jnp
+import pytest
+
+import braintrace
+from braintrace._compiler.canonicalize import (
+    ControlFlowPolicy,
+    DEFAULT_CONTROL_FLOW_POLICY,
+    if_convert_conds,
+)
+from braintrace._compiler.diagnostics import (
+    DiagnosticKind,
+    diagnostic_context,
+)
+
+
+def _primitive_names(closed_jaxpr):
+    return [eqn.primitive.name for eqn in closed_jaxpr.jaxpr.eqns]
+
+
+def _convert(closed_jaxpr, weights=(), hiddens_in=(), hiddens_out=(), policy=None):
+    kwargs = dict(
+        weight_invars=set(weights),
+        hidden_invars=set(hiddens_in),
+        hidden_outvars=set(hiddens_out),
+    )
+    if policy is not None:
+        kwargs['policy'] = policy
+    return if_convert_conds(closed_jaxpr, **kwargs)
+
+
+def _eval(closed_jaxpr, *args):
+    return jax.core.eval_jaxpr(closed_jaxpr.jaxpr, closed_jaxpr.consts, *args)
+
+
+class TestControlFlowPolicy:
+    def test_defaults(self):
+        assert DEFAULT_CONTROL_FLOW_POLICY.cond == 'convert'
+        assert DEFAULT_CONTROL_FLOW_POLICY.scan_unroll_limit == 16
+
+    def test_opaque_returns_input_unchanged(self):
+        def f(x, w):
+            return jax.lax.cond(
+                jnp.sum(x) > 0.,
+                lambda: braintrace.matmul(x, w),
+                lambda: x * 2.,
+            )
+
+        closed = jax.make_jaxpr(f)(jnp.ones(3), jnp.ones((3, 3)))
+        out = _convert(closed, policy=ControlFlowPolicy(cond='opaque'))
+        assert out is closed
+
+    def test_invalid_cond_policy_raises(self):
+        closed = jax.make_jaxpr(lambda x: x * 2.)(jnp.ones(3))
+        with pytest.raises(ValueError, match='cond'):
+            _convert(closed, policy=ControlFlowPolicy(cond='bogus'))
+
+
+class TestIfConvertConds:
+    """Unit tests of the cond -> inlined branches + select_n rewrite."""
+
+    def _etp_cond_jaxpr(self):
+        def f(x, w):
+            return jax.lax.cond(
+                jnp.sum(x) > 0.,
+                lambda: braintrace.matmul(x, w),
+                lambda: x * 2.,
+            )
+
+        x = jnp.arange(3, dtype=jnp.float32) - 0.5
+        w = jnp.eye(3) * 0.5
+        closed = jax.make_jaxpr(f)(x, w)
+        return f, closed, x, w
+
+    def test_etp_cond_is_converted(self):
+        f, closed, x, w = self._etp_cond_jaxpr()
+        conv = _convert(closed)
+        names = _primitive_names(conv)
+        assert 'cond' not in names
+        assert 'select_n' in names
+        assert 'etp_mv' in names
+
+    def test_outvars_and_invars_preserved_by_identity(self):
+        f, closed, x, w = self._etp_cond_jaxpr()
+        conv = _convert(closed)
+        assert all(a is b for a, b in zip(conv.jaxpr.invars, closed.jaxpr.invars))
+        assert all(a is b for a, b in zip(conv.jaxpr.outvars, closed.jaxpr.outvars))
+
+    def test_value_equivalence_both_branches(self):
+        f, closed, x, w = self._etp_cond_jaxpr()
+        conv = _convert(closed)
+        for xi in (jnp.abs(x) + 1., -jnp.abs(x) - 1.):
+            expected = f(xi, w)
+            got = _eval(conv, xi, w)[0]
+            assert jnp.allclose(got, expected)
+
+    def test_gradient_equivalence_both_branches(self):
+        f, closed, x, w = self._etp_cond_jaxpr()
+        conv = _convert(closed)
+
+        def f_conv(xi, wi):
+            return _eval(conv, xi, wi)[0]
+
+        for xi in (jnp.abs(x) + 1., -jnp.abs(x) - 1.):
+            for argnum in (0, 1):
+                g_ref = jax.grad(lambda a, b: jnp.sum(f(a, b) ** 2), argnum)(xi, w)
+                g_conv = jax.grad(lambda a, b: jnp.sum(f_conv(a, b) ** 2), argnum)(xi, w)
+                assert jnp.allclose(g_ref, g_conv, atol=1e-6)
+
+    def test_three_branch_switch(self):
+        def f(i, x, w):
+            return jax.lax.switch(
+                i,
+                [
+                    lambda: x * 0.,
+                    lambda: braintrace.matmul(x, w),
+                    lambda: x + 1.,
+                ],
+            )
+
+        x = jnp.arange(3, dtype=jnp.float32)
+        w = jnp.eye(3) * 2.
+        closed = jax.make_jaxpr(f)(jnp.int32(0), x, w)
+        conv = _convert(closed)
+        names = _primitive_names(conv)
+        assert 'cond' not in names
+        assert 'etp_mv' in names
+        for i in range(3):
+            expected = f(jnp.int32(i), x, w)
+            got = _eval(conv, jnp.int32(i), x, w)[0]
+            assert jnp.allclose(got, expected)
+
+    def test_multi_output_cond(self):
+        def f(x, w):
+            return jax.lax.cond(
+                jnp.sum(x) > 0.,
+                lambda: (braintrace.matmul(x, w), x + 1.),
+                lambda: (x * 2., x - 1.),
+            )
+
+        x = jnp.arange(3, dtype=jnp.float32) + 1.
+        w = jnp.eye(3)
+        closed = jax.make_jaxpr(f)(x, w)
+        conv = _convert(closed)
+        names = _primitive_names(conv)
+        assert 'cond' not in names
+        assert names.count('select_n') == 2
+        assert all(a is b for a, b in zip(conv.jaxpr.outvars, closed.jaxpr.outvars))
+        for xi in (x, -x):
+            for got, expected in zip(_eval(conv, xi, w), f(xi, w)):
+                assert jnp.allclose(got, expected)
+
+    def test_passthrough_branch_output(self):
+        def f(x):
+            return jax.lax.cond(jnp.sum(x) > 0., lambda: x, lambda: -x)
+
+        x = jnp.arange(3, dtype=jnp.float32) + 1.
+        closed = jax.make_jaxpr(f)(x)
+        # Force relevance by marking x as a hidden invar.
+        conv = _convert(closed, hiddens_in=[closed.jaxpr.invars[0]])
+        assert 'cond' not in _primitive_names(conv)
+        for xi in (x, -x):
+            assert jnp.allclose(_eval(conv, xi)[0], f(xi))
+
+    def test_irrelevant_cond_stays_opaque(self):
+        def f(x):
+            return jax.lax.cond(jnp.sum(x) > 0., lambda: x * 2., lambda: x * 3.)
+
+        closed = jax.make_jaxpr(f)(jnp.ones(3))
+        conv = _convert(closed)
+        assert conv is closed
+
+    def test_relevant_by_weight_invar(self):
+        def f(x, w):
+            # Plain (non-ETP) matmul: relevance comes from consuming w.
+            return jax.lax.cond(jnp.sum(x) > 0., lambda: x @ w, lambda: x * 2.)
+
+        x = jnp.ones(3)
+        w = jnp.eye(3)
+        closed = jax.make_jaxpr(f)(x, w)
+        conv = _convert(closed, weights=[closed.jaxpr.invars[1]])
+        assert 'cond' not in _primitive_names(conv)
+        for xi in (x, -x):
+            assert jnp.allclose(_eval(conv, xi, w)[0], f(xi, w))
+
+    def test_relevant_by_hidden_outvar(self):
+        def f(h):
+            return jax.lax.cond(jnp.sum(h) > 0., lambda: h * 2., lambda: h * 3.)
+
+        closed = jax.make_jaxpr(f)(jnp.ones(3))
+        conv = _convert(closed, hiddens_out=[closed.jaxpr.outvars[0]])
+        assert 'cond' not in _primitive_names(conv)
+
+    def test_nested_cond_converted(self):
+        def f(x, w):
+            def outer_true():
+                return jax.lax.cond(
+                    jnp.max(x) > 2.,
+                    lambda: braintrace.matmul(x, w),
+                    lambda: x * 5.,
+                )
+
+            return jax.lax.cond(jnp.sum(x) > 0., outer_true, lambda: x * 2.)
+
+        x = jnp.arange(3, dtype=jnp.float32)
+        w = jnp.eye(3)
+        closed = jax.make_jaxpr(f)(x, w)
+        conv = _convert(closed)
+        names = _primitive_names(conv)
+        assert 'cond' not in names
+        assert 'etp_mv' in names
+        for xi in (x + 10., x + 0.1, x - 10.):
+            assert jnp.allclose(_eval(conv, xi, w)[0], f(xi, w))
+
+    def test_jit_inside_branch_is_inlined(self):
+        @jax.jit
+        def jitted(a, b):
+            return braintrace.matmul(a, b)
+
+        def f(x, w):
+            return jax.lax.cond(
+                jnp.sum(x) > 0.,
+                lambda: jitted(x, w),
+                lambda: x * 2.,
+            )
+
+        x = jnp.ones(3)
+        w = jnp.eye(3)
+        closed = jax.make_jaxpr(f)(x, w)
+        conv = _convert(closed)
+        names = _primitive_names(conv)
+        assert 'cond' not in names
+        assert 'jit' not in names and 'pjit' not in names
+        assert 'etp_mv' in names
+        for xi in (x, -x):
+            assert jnp.allclose(_eval(conv, xi, w)[0], f(xi, w))
+
+    def test_safety_gate_while_in_branch(self):
+        def f(x, w):
+            def true_fn():
+                return jax.lax.while_loop(
+                    lambda v: jnp.sum(v) < 10., lambda v: v + 1., x
+                )
+
+            return jax.lax.cond(
+                jnp.sum(x) > 0., true_fn, lambda: braintrace.matmul(x, w)
+            )
+
+        closed = jax.make_jaxpr(f)(jnp.ones(3), jnp.eye(3))
+        with diagnostic_context() as reporter:
+            with pytest.warns(UserWarning, match='NOT if-converted'):
+                conv = _convert(closed)
+        assert 'cond' in _primitive_names(conv)
+        kinds = [r.kind for r in reporter.records()]
+        assert DiagnosticKind.COND_CONVERSION_SKIPPED in kinds
+
+    def test_safety_gate_scan_in_branch(self):
+        def f(x, w):
+            def true_fn():
+                return jax.lax.scan(lambda c, _: (c * 1.1, None), x, length=3)[0]
+
+            return jax.lax.cond(
+                jnp.sum(x) > 0., true_fn, lambda: braintrace.matmul(x, w)
+            )
+
+        closed = jax.make_jaxpr(f)(jnp.ones(3), jnp.eye(3))
+        with diagnostic_context() as reporter:
+            with pytest.warns(UserWarning, match='NOT if-converted'):
+                conv = _convert(closed)
+        assert 'cond' in _primitive_names(conv)
+        kinds = [r.kind for r in reporter.records()]
+        assert DiagnosticKind.COND_CONVERSION_SKIPPED in kinds
+
+    def test_conversion_emits_info_diagnostic(self):
+        _, closed, x, w = self._etp_cond_jaxpr()
+        with diagnostic_context() as reporter:
+            _convert(closed)
+        kinds = [r.kind for r in reporter.records()]
+        assert DiagnosticKind.COND_IF_CONVERTED in kinds
+
+    def test_deterministic_output(self):
+        _, closed, x, w = self._etp_cond_jaxpr()
+        names_a = _primitive_names(_convert(closed))
+        names_b = _primitive_names(_convert(closed))
+        assert names_a == names_b
+
+
+class _CondGateCell(brainstate.nn.Module):
+    """h' = tanh(cond(sum(x) > 0, etp_mv(x, w_a), etp_mv(x, w_b)) + 0.9 h)."""
+
+    def __init__(self, n_in, n_rec):
+        super().__init__()
+        self.w_a = brainstate.ParamState(brainstate.random.randn(n_in, n_rec) * 0.1)
+        self.w_b = brainstate.ParamState(brainstate.random.randn(n_in, n_rec) * 0.1)
+        self.n_rec = n_rec
+
+    def init_state(self, batch_size=None, **kw):
+        shape = (self.n_rec,) if batch_size is None else (batch_size, self.n_rec)
+        self.h = brainstate.HiddenState(jnp.zeros(shape))
+
+    def update(self, x):
+        u_val = jax.lax.cond(
+            jnp.sum(x) > 0.,
+            lambda: braintrace.matmul(x, self.w_a.value),
+            lambda: braintrace.matmul(x, self.w_b.value),
+        )
+        self.h.value = jnp.tanh(u_val + 0.9 * self.h.value)
+        return self.h.value
+
+
+class _SelectGateCell(brainstate.nn.Module):
+    """Hand-flattened equivalent of :class:`_CondGateCell`."""
+
+    def __init__(self, n_in, n_rec):
+        super().__init__()
+        self.w_a = brainstate.ParamState(brainstate.random.randn(n_in, n_rec) * 0.1)
+        self.w_b = brainstate.ParamState(brainstate.random.randn(n_in, n_rec) * 0.1)
+        self.n_rec = n_rec
+
+    def init_state(self, batch_size=None, **kw):
+        shape = (self.n_rec,) if batch_size is None else (batch_size, self.n_rec)
+        self.h = brainstate.HiddenState(jnp.zeros(shape))
+
+    def update(self, x):
+        idx = (jnp.sum(x) > 0.).astype(jnp.int32)
+        y_a = braintrace.matmul(x, self.w_a.value)
+        y_b = braintrace.matmul(x, self.w_b.value)
+        # cond(pred, true_fn, false_fn): branches[0] is false_fn -> w_b.
+        u_val = jax.lax.select_n(idx, y_b, y_a)
+        self.h.value = jnp.tanh(u_val + 0.9 * self.h.value)
+        return self.h.value
+
+
+class TestCondModelCompilation:
+    """A model with ETP ops inside `lax.cond` must compile identically to the
+    hand-flattened select model (spec Phase 1)."""
+
+    N_IN, N_REC = 3, 4
+
+    def _graph_for(self, cell_cls, **compile_kwargs):
+        with brainstate.random.seed_context(42):
+            cell = cell_cls(self.N_IN, self.N_REC)
+        brainstate.nn.init_all_states(cell)
+        x = jnp.ones(self.N_IN)
+        return braintrace.compile_etrace_graph(cell, x, **compile_kwargs)
+
+    def test_cond_model_compiles_without_cond_eqn(self):
+        graph = self._graph_for(_CondGateCell)
+        names = [eqn.primitive.name for eqn in graph.module_info.jaxpr.eqns]
+        assert 'cond' not in names
+        assert 'select_n' in names
+
+    def test_relation_parity_with_select_model(self):
+        g_cond = self._graph_for(_CondGateCell)
+        g_select = self._graph_for(_SelectGateCell)
+        assert len(g_cond.hidden_param_op_relations) == 2
+        assert len(g_select.hidden_param_op_relations) == 2
+        cond_prims = {r.primitive for r in g_cond.hidden_param_op_relations}
+        select_prims = {r.primitive for r in g_select.hidden_param_op_relations}
+        assert cond_prims == select_prims
+
+    def test_conversion_diagnostic_recorded(self):
+        graph = self._graph_for(_CondGateCell)
+        records = graph.explain(kind=DiagnosticKind.COND_IF_CONVERTED)
+        assert len(records) == 1
+
+    def test_opaque_policy_keeps_existing_error(self):
+        with pytest.raises(NotImplementedError, match='cond'):
+            with pytest.warns(UserWarning):
+                self._graph_for(
+                    _CondGateCell,
+                    control_flow=ControlFlowPolicy(cond='opaque'),
+                )
+
+    def test_drtrl_gradient_parity_with_select_model(self):
+        def build_and_grads(cell_cls):
+            with brainstate.random.seed_context(42):
+                model = cell_cls(self.N_IN, self.N_REC)
+            learner = braintrace.compile(model, braintrace.D_RTRL, jnp.zeros(self.N_IN))
+            weights = model.states(brainstate.ParamState)
+            with brainstate.random.seed_context(7):
+                xs = brainstate.random.randn(6, self.N_IN)
+
+            def total_loss(xs):
+                def step(carry, x):
+                    out = learner(x)
+                    return carry, jnp.mean(jnp.asarray(out) ** 2)
+
+                _, ls = brainstate.transform.scan(step, None, xs)
+                return jnp.sum(ls)
+
+            return brainstate.transform.grad(total_loss, weights)(xs)
+
+        g_cond = build_and_grads(_CondGateCell)
+        g_select = build_and_grads(_SelectGateCell)
+        leaves_cond = jax.tree.leaves(g_cond)
+        leaves_select = jax.tree.leaves(g_select)
+        assert leaves_cond and len(leaves_cond) == len(leaves_select)
+        for a, b in zip(leaves_cond, leaves_select):
+            assert jnp.allclose(a, b, atol=1e-6), (a - b)
+        # Gradients must be nonzero: both branches are exercised by the inputs.
+        assert any(jnp.any(jnp.abs(leaf) > 0) for leaf in leaves_cond)
+
+
+if __name__ == '__main__':
+    pytest.main([__file__, '-v'])

--- a/braintrace/_compiler/canonicalize_test.py
+++ b/braintrace/_compiler/canonicalize_test.py
@@ -367,6 +367,42 @@ class TestIfConvertConds:
         kinds = [r.kind for r in reporter.records()]
         assert DiagnosticKind.COND_CONVERSION_SKIPPED in kinds
 
+    def test_skipped_cond_warns_once_across_fixpoint_iterations(self):
+        # A convertible cond hiding another cond inside a jit forces >= 2
+        # fixpoint iterations; the unsafe cond must be reported once, not
+        # once per iteration.
+        @jax.jit
+        def jitted(a, w):
+            return jax.lax.cond(
+                jnp.max(a) > 2.,
+                lambda: braintrace.matmul(a, w),
+                lambda: a * 5.,
+            )
+
+        def f(x, w):
+            unsafe = jax.lax.cond(
+                jnp.sum(x) > 1.,
+                lambda: jax.lax.while_loop(
+                    lambda v: jnp.sum(v) < 10., lambda v: v + 1., x),
+                lambda: braintrace.matmul(x, w),
+            )
+            safe = jax.lax.cond(
+                jnp.sum(x) > 0.,
+                lambda: jitted(x, w),
+                lambda: x * 2.,
+            )
+            return unsafe + safe
+
+        closed = jax.make_jaxpr(f)(jnp.ones(3), jnp.eye(3))
+        with diagnostic_context() as reporter:
+            with pytest.warns(UserWarning, match='NOT if-converted'):
+                _convert(closed)
+        n_skip = sum(
+            r.kind is DiagnosticKind.COND_CONVERSION_SKIPPED
+            for r in reporter.records()
+        )
+        assert n_skip == 1
+
     def test_conversion_emits_info_diagnostic(self):
         _, closed, x, w = self._etp_cond_jaxpr()
         with diagnostic_context() as reporter:

--- a/braintrace/_compiler/canonicalize_test.py
+++ b/braintrace/_compiler/canonicalize_test.py
@@ -251,6 +251,86 @@ class TestIfConvertConds:
         for xi in (x, -x):
             assert jnp.allclose(_eval(conv, xi, w)[0], f(xi, w))
 
+    def test_shared_jitted_helper_in_both_branches(self):
+        # JAX's trace cache hands both branches' calls the SAME inner jaxpr
+        # object; conversion + jit inlining must freshen per call site or the
+        # two calls silently alias (values from the wrong branch).
+        @jax.jit
+        def helper(a, b):
+            return braintrace.matmul(a, b)
+
+        def f(x, wa, wb):
+            return jax.lax.cond(
+                jnp.sum(x) > 0.,
+                lambda: helper(x, wa),
+                lambda: helper(x, wb),
+            )
+
+        x = jnp.arange(1., 4.)
+        wa = jnp.eye(3) * 2.
+        wb = jnp.eye(3) * 3.
+        closed = jax.make_jaxpr(f)(x, wa, wb)
+        conv = _convert(closed)
+        names = _primitive_names(conv)
+        assert 'cond' not in names
+        assert 'jit' not in names and 'pjit' not in names
+        for xi in (x, -x):
+            assert jnp.allclose(_eval(conv, xi, wa, wb)[0], f(xi, wa, wb))
+            for argnum in (1, 2):
+                g_ref = jax.grad(
+                    lambda a, b, c: jnp.sum(f(a, b, c) ** 2), argnum)(xi, wa, wb)
+                g_conv = jax.grad(
+                    lambda a, b, c: jnp.sum(_eval(conv, a, b, c)[0] ** 2),
+                    argnum)(xi, wa, wb)
+                assert jnp.allclose(g_ref, g_conv, atol=1e-6)
+
+    def test_cond_inside_jit_inside_branch_converted(self):
+        # A cond hidden inside a jitted function inside a branch surfaces
+        # only after the surfaced jit is inlined; the fixpoint loop must
+        # gate/convert it too.
+        @jax.jit
+        def jitted(a, w):
+            return jax.lax.cond(
+                jnp.max(a) > 2.,
+                lambda: braintrace.matmul(a, w),
+                lambda: a * 5.,
+            )
+
+        def f(x, w):
+            return jax.lax.cond(
+                jnp.sum(x) > 0.,
+                lambda: jitted(x, w),
+                lambda: braintrace.matmul(x, w) * 2.,
+            )
+
+        x = jnp.arange(3, dtype=jnp.float32)
+        w = jnp.eye(3)
+        closed = jax.make_jaxpr(f)(x, w)
+        conv = _convert(closed)
+        names = _primitive_names(conv)
+        assert 'cond' not in names
+        assert 'jit' not in names and 'pjit' not in names
+        for xi in (x + 10., x + 0.1, x - 10.):
+            assert jnp.allclose(_eval(conv, xi, w)[0], f(xi, w))
+
+    def test_safety_gate_effects_in_branch(self):
+        def f(x, w):
+            def true_fn():
+                jax.debug.print('branch taken: {}', x[0])
+                return x * 2.
+
+            return jax.lax.cond(
+                jnp.sum(x) > 0., true_fn, lambda: braintrace.matmul(x, w)
+            )
+
+        closed = jax.make_jaxpr(f)(jnp.ones(3), jnp.eye(3))
+        with diagnostic_context() as reporter:
+            with pytest.warns(UserWarning, match='NOT if-converted'):
+                conv = _convert(closed)
+        assert 'cond' in _primitive_names(conv)
+        kinds = [r.kind for r in reporter.records()]
+        assert DiagnosticKind.COND_CONVERSION_SKIPPED in kinds
+
     def test_safety_gate_while_in_branch(self):
         def f(x, w):
             def true_fn():
@@ -296,9 +376,9 @@ class TestIfConvertConds:
 
     def test_deterministic_output(self):
         _, closed, x, w = self._etp_cond_jaxpr()
-        names_a = _primitive_names(_convert(closed))
-        names_b = _primitive_names(_convert(closed))
-        assert names_a == names_b
+        # String form normalizes var names positionally, so equality pins
+        # the full equation *and wiring* order, not just the primitives.
+        assert str(_convert(closed).jaxpr) == str(_convert(closed).jaxpr)
 
 
 class _CondGateCell(brainstate.nn.Module):

--- a/braintrace/_compiler/diagnostics.py
+++ b/braintrace/_compiler/diagnostics.py
@@ -97,6 +97,10 @@ class DiagnosticKind(str, Enum):
     # Trainable invar did not trace back to any ParamState (e.g. a constant bias)
     TRAINABLE_INVAR_NOT_PARAMSTATE = 'trainable_invar_not_paramstate'
 
+    # Control-flow canonicalization (see _compiler/canonicalize.py)
+    COND_IF_CONVERTED = 'cond_if_converted'
+    COND_CONVERSION_SKIPPED = 'cond_conversion_skipped'
+
     # Structural observations (informational / partial)
     PRIMITIVE_INSIDE_NESTED_JIT = 'primitive_inside_nested_jit'
     PRIMITIVE_INSIDE_CONTROL_FLOW = 'primitive_inside_control_flow'

--- a/braintrace/_compiler/graph.py
+++ b/braintrace/_compiler/graph.py
@@ -25,6 +25,7 @@ from braintrace._typing import (
     Inputs,
     Path,
 )
+from .canonicalize import ControlFlowPolicy
 from .diagnostics import (
     CompilationRecord,
     DiagnosticKind,
@@ -282,6 +283,7 @@ def compile_etrace_graph(
     *model_args: Tuple,
     include_hidden_perturb: bool = True,
     include_recurrent_mixing: bool = False,
+    control_flow: Optional[ControlFlowPolicy] = None,
 ) -> ETraceGraph:
     """Construct the eligibility-trace graph for a given model and inputs.
 
@@ -311,6 +313,14 @@ def compile_etrace_graph(
         recurrence becomes coupled, and the true per-position block-diagonal
         Jacobian is extracted (RTRL-exact temporal credit, e.g. for
         :class:`~braintrace.OSTLRecurrent` / :class:`~braintrace.OSTTP`).
+    control_flow : ControlFlowPolicy or None, optional
+        Policy governing control-flow canonicalization, forwarded to
+        :func:`~braintrace.extract_module_info`. ``None`` (default) uses the
+        default policy, which if-converts every ETP-relevant ``cond`` into
+        inlined branches + ``select_n`` (both branches then execute every
+        step). Pass ``ControlFlowPolicy(cond='opaque')`` to restore the
+        previous behavior (weights inside ``cond`` raise
+        ``NotImplementedError``).
 
     Returns
     -------
@@ -345,7 +355,7 @@ def compile_etrace_graph(
     with compiler_context('compile_graph'), diagnostic_context() as reporter:
 
         assert isinstance(model_args, tuple)
-        minfo = extract_module_info(model, *model_args)
+        minfo = extract_module_info(model, *model_args, control_flow=control_flow)
 
         # ---       evaluating the relationship for hidden-to-hidden        --- #
         hidden_groups, hid_path_to_group = find_hidden_groups_from_minfo(

--- a/braintrace/_compiler/hidden_pertubation.py
+++ b/braintrace/_compiler/hidden_pertubation.py
@@ -25,7 +25,8 @@ from braintrace._compatible_imports import (
     JaxprEqn,
     Jaxpr,
     ClosedJaxpr,
-    new_var
+    new_var,
+    new_jaxpr_eqn,
 )
 from braintrace._misc import (
     git_issue_addr,
@@ -290,7 +291,7 @@ class JaxprEvalForHiddenPerturbation(JaxprEvaluation):
             perturb_var = self.perturb_invars[hidden_var]
             fresh = self._new_var_like(hidden_var)
             self.revised_eqns.append(
-                jax.core.new_jaxpr_eqn(
+                new_jaxpr_eqn(
                     [hidden_var, perturb_var],
                     [fresh],
                     jax.lax.add_p,
@@ -388,7 +389,7 @@ class JaxprEvalForHiddenPerturbation(JaxprEvaluation):
         for i in hidden_positions:
             hidden_var = eqn.outvars[i]
             self.revised_eqns.append(
-                jax.core.new_jaxpr_eqn(
+                new_jaxpr_eqn(
                     [new_outvars[i], self.perturb_invars[hidden_var]],
                     [hidden_var],
                     jax.lax.add_p,

--- a/braintrace/_compiler/jaxpr_graph.py
+++ b/braintrace/_compiler/jaxpr_graph.py
@@ -37,6 +37,7 @@ from braintrace._compatible_imports import (
     JaxprEqn,
     Var,
     is_jit_primitive,
+    new_var,
 )
 
 __all__ = [
@@ -138,7 +139,12 @@ def inline_jit_calls(closed_jaxpr: ClosedJaxpr) -> ClosedJaxpr:
 
     The pass is recursive (``jit`` inside ``jit`` is flattened), lifts inner
     closure constants into the outer ``constvars``/``consts``, and rewires
-    pass-through outputs by substitution. Control-flow bodies
+    pass-through outputs by substitution. Every spliced body has its internal
+    variables freshened *per call site*: JAX's trace cache hands every call
+    of the same jitted function the same inner jaxpr object, so splicing it
+    verbatim more than once would define its variables twice and silently
+    alias the calls' results. Top-level equations that are not jit calls keep
+    their original ``Var`` objects. Control-flow bodies
     (``scan``/``while``/``cond``) and custom-derivative call primitives are
     left untouched: control flow is diagnosed separately, and
     ``custom_jvp_call``/``custom_vjp_call`` carry derivative semantics that
@@ -160,51 +166,77 @@ def inline_jit_calls(closed_jaxpr: ClosedJaxpr) -> ClosedJaxpr:
     if not _contains_jit_eqn(jaxpr):
         return closed_jaxpr
 
-    subst: Dict[Var, Any] = {}  # Var -> Var | Literal
+    # Substitution at the top level only maps a jit call's outer outvars to
+    # their replacement atoms; every other top-level equation keeps its
+    # original Var objects, so downstream Var-identity tables built from the
+    # result see the same vars for untouched equations.
+    top_subst: Dict[Var, Any] = {}  # Var -> Var | Literal
 
-    def resolve(atom):
-        while isinstance(atom, Var) and atom in subst:
-            atom = subst[atom]
+    def resolve_top(atom):
+        if isinstance(atom, Var):
+            return top_subst.get(atom, atom)
         return atom
 
     extra_constvars: List[Var] = []
     extra_consts: List[Any] = []
     new_eqns: List[JaxprEqn] = []
 
-    def process(eqns) -> None:
-        for eqn in eqns:
+    def splice(inner_closed, call_arg_atoms) -> List[Any]:
+        """Inline one jit body with every internal var freshened; return the
+        body's (resolved) output atoms.
+
+        Freshening is per call site: JAX's trace cache hands every call of
+        the same jitted function the SAME inner ``ClosedJaxpr`` object, so
+        splicing it verbatim twice would define its vars twice (an SSA
+        violation that silently aliases the two calls' results).
+        """
+        inner = getattr(inner_closed, 'jaxpr', inner_closed)
+        inner_consts = getattr(inner_closed, 'consts', [])
+        local: Dict[Var, Any] = {}
+        for cv, cval in zip(inner.constvars, inner_consts):
+            fresh = new_var('', cv.aval)
+            local[cv] = fresh
+            extra_constvars.append(fresh)
+            extra_consts.append(cval)
+        for iv, arg in zip(inner.invars, call_arg_atoms):
+            local[iv] = arg
+
+        def res(atom):
+            if isinstance(atom, Var):
+                return local.get(atom, atom)
+            return atom
+
+        for eqn in inner.eqns:
             if is_jit_primitive(eqn) and 'jaxpr' in eqn.params:
-                inner_closed = eqn.params['jaxpr']
-                inner = getattr(inner_closed, 'jaxpr', inner_closed)
-                inner_consts = getattr(inner_closed, 'consts', [])
-                # Inner constvars are fresh Var objects: adopt them directly
-                # as outer constvars, carrying their values.
-                extra_constvars.extend(inner.constvars)
-                extra_consts.extend(inner_consts)
-                # Wire the inner parameters to the (resolved) call arguments.
-                for iv, arg in zip(inner.invars, eqn.invars):
-                    subst[iv] = resolve(arg)
-                # Splice the body (recursively inlining nested jit).
-                process(inner.eqns)
-                # Wire the call results to the inner outputs.
-                for outer_ov, inner_ov in zip(eqn.outvars, inner.outvars):
-                    subst[outer_ov] = resolve(inner_ov)
+                outs = splice(eqn.params['jaxpr'], [res(v) for v in eqn.invars])
+                for ov, out_atom in zip(eqn.outvars, outs):
+                    local[ov] = out_atom
             else:
-                new_invars = [
-                    resolve(v) if isinstance(v, Var) else v
-                    for v in eqn.invars
-                ]
-                if all(a is b for a, b in zip(new_invars, eqn.invars)):
-                    new_eqns.append(eqn)
-                else:
-                    new_eqns.append(eqn.replace(invars=new_invars))
+                fresh_outvars = [new_var('', v.aval) for v in eqn.outvars]
+                for ov, fresh in zip(eqn.outvars, fresh_outvars):
+                    local[ov] = fresh
+                new_eqns.append(eqn.replace(
+                    invars=[res(v) for v in eqn.invars],
+                    outvars=fresh_outvars,
+                ))
+        return [res(v) for v in inner.outvars]
 
-    process(jaxpr.eqns)
+    for eqn in jaxpr.eqns:
+        if is_jit_primitive(eqn) and 'jaxpr' in eqn.params:
+            outs = splice(
+                eqn.params['jaxpr'],
+                [resolve_top(v) for v in eqn.invars],
+            )
+            for outer_ov, out_atom in zip(eqn.outvars, outs):
+                top_subst[outer_ov] = out_atom
+        else:
+            new_invars = [resolve_top(v) for v in eqn.invars]
+            if all(a is b for a, b in zip(new_invars, eqn.invars)):
+                new_eqns.append(eqn)
+            else:
+                new_eqns.append(eqn.replace(invars=new_invars))
 
-    new_outvars = [
-        resolve(v) if isinstance(v, Var) else v
-        for v in jaxpr.outvars
-    ]
+    new_outvars = [resolve_top(v) for v in jaxpr.outvars]
     new_jaxpr = Jaxpr(
         constvars=list(jaxpr.constvars) + extra_constvars,
         invars=list(jaxpr.invars),

--- a/braintrace/_compiler/jaxpr_graph_test.py
+++ b/braintrace/_compiler/jaxpr_graph_test.py
@@ -192,3 +192,43 @@ class TestInlineJitCalls:
         closed = jax.make_jaxpr(f)(x)
         inlined = inline_jit_calls(closed)
         np.testing.assert_allclose(_eval_closed(inlined, x)[0], f(x))
+
+    def test_same_jit_called_twice_is_freshened_per_site(self):
+        # JAX's trace cache gives both call eqns the SAME inner ClosedJaxpr
+        # object; splicing it twice without freshening defines the same Vars
+        # twice and silently aliases the two call results.
+        @jax.jit
+        def g(a, b):
+            return a * b
+
+        def f(x):
+            return g(x, 2.0) + g(x, 3.0)  # = 5 x
+
+        x = jnp.arange(1.0, 4.0)
+        closed = jax.make_jaxpr(f)(x)
+        inlined = inline_jit_calls(closed)
+        assert not _has_jit_eqn(inlined.jaxpr)
+        # SSA: every var is defined at most once.
+        seen = set()
+        for eqn in inlined.jaxpr.eqns:
+            for ov in eqn.outvars:
+                assert id(ov) not in seen, 'duplicate var definition'
+                seen.add(id(ov))
+        np.testing.assert_allclose(_eval_closed(inlined, x)[0], f(x))
+
+    def test_same_jit_called_twice_gradients(self):
+        @jax.jit
+        def g(a, w):
+            return (a * w).sum()
+
+        def f(x):
+            return g(x, jnp.full(3, 2.0)) + g(x, jnp.full(3, 3.0))
+
+        x = jnp.arange(1.0, 4.0)
+        closed = jax.make_jaxpr(f)(x)
+        inlined = inline_jit_calls(closed)
+
+        def f_inlined(xi):
+            return _eval_closed(inlined, xi)[0]
+
+        np.testing.assert_allclose(jax.grad(f_inlined)(x), jax.grad(f)(x))

--- a/braintrace/_compiler/module_info.py
+++ b/braintrace/_compiler/module_info.py
@@ -41,6 +41,7 @@ from braintrace._typing import (
     StateVals,
     TempData,
 )
+from .canonicalize import ControlFlowPolicy, DEFAULT_CONTROL_FLOW_POLICY, if_convert_conds
 from .diagnostics import DiagnosticKind, DiagnosticLevel, emit
 from .jaxpr_graph import inline_jit_calls
 
@@ -482,6 +483,7 @@ ModuleInfo.__module__ = 'braintrace'
 def extract_module_info(
     model: brainstate.nn.Module,
     *model_args,
+    control_flow: Optional[ControlFlowPolicy] = None,
     **model_kwargs
 ) -> ModuleInfo:
     """Extract the model information for the ETrace compiler.
@@ -492,6 +494,12 @@ def extract_module_info(
         The model from which to extract the information.
     *model_args
         The positional arguments of the model.
+    control_flow : ControlFlowPolicy or None, optional
+        Policy governing control-flow canonicalization (currently ``cond``
+        if-conversion; see
+        :func:`~braintrace._compiler.canonicalize.if_convert_conds`).
+        ``None`` (default) uses the default policy, which converts every
+        ETP-relevant ``cond``.
     **model_kwargs
         The keyword arguments of the model.
 
@@ -632,6 +640,18 @@ def extract_module_info(
     hidden_outvar_to_invar = brainstate.util.PrettyDict(hidden_outvar_to_invar)
 
     weight_invars = brainstate.util.PrettyList(dict.fromkeys(v for vs in weight_path_to_invars.values() for v in vs))
+
+    # Canonicalize ETP-relevant control flow (Phase 1: cond -> select_n).
+    # The pass reuses each converted equation's original outvars and never
+    # touches the jaxpr's invars/outvars, so every Var-identity table built
+    # above stays valid; only the equation list (and consts) change.
+    closed_jaxpr = if_convert_conds(
+        closed_jaxpr,
+        weight_invars=set(weight_invars),
+        hidden_invars=set(hidden_path_to_invar.values()),
+        hidden_outvars=set(hidden_path_to_outvar.values()),
+        policy=control_flow if control_flow is not None else DEFAULT_CONTROL_FLOW_POLICY,
+    )
 
     return ModuleInfo(
         # stateful model

--- a/braintrace/_compiler/scenario_catalog.py
+++ b/braintrace/_compiler/scenario_catalog.py
@@ -321,6 +321,34 @@ def make_scan_body_etp_jaxpr(n_in: int, n_out: int, length: int = 4):
     return jax.make_jaxpr(f)(w, xs).jaxpr
 
 
+class CondBranchRNN(brainstate.nn.Module):
+    """``h = tanh(cond(sum(x) > 0, mv(x, Wa), mv(x, Wb)) + 0.9 h_prev)``.
+
+    ETP primitives inside ``lax.cond`` branches: the full pipeline
+    if-converts the cond into inlined branches + ``select_n`` at extraction
+    time (see ``_compiler/canonicalize.py``), so both weights participate
+    as relations exactly as in the hand-flattened select model.
+    """
+
+    def __init__(self, n_in: int, n_out: int):
+        super().__init__()
+        self.w_a = brainstate.ParamState(brainstate.random.randn(n_in, n_out))
+        self.w_b = brainstate.ParamState(brainstate.random.randn(n_in, n_out))
+        self.h = brainstate.HiddenState(jnp.zeros(n_out))
+
+    def init_state(self, *args, **kwargs):
+        self.h.value = jnp.zeros_like(self.h.value)
+
+    def update(self, x):
+        u = jax.lax.cond(
+            jnp.sum(x) > 0.,
+            lambda: braintrace.matmul(x, self.w_a.value),
+            lambda: braintrace.matmul(x, self.w_b.value),
+        )
+        self.h.value = jnp.tanh(u + 0.9 * self.h.value)
+        return self.h.value
+
+
 def make_cond_branches_etp_jaxpr(n_in: int, n_out: int):
     """Return a jaxpr containing ``braintrace.matmul`` in *both* cond branches."""
     w_true = jnp.zeros((n_in, n_out))

--- a/braintrace/_compiler/scenario_catalog_test.py
+++ b/braintrace/_compiler/scenario_catalog_test.py
@@ -710,6 +710,7 @@ from braintrace._compiler.scenario_catalog import (
     MixedBatchedRNN,
     PartialPathRNN,
     NestedJitRNN,
+    CondBranchRNN,
     make_scan_body_etp_jaxpr,
     make_cond_branches_etp_jaxpr,
     make_while_body_etp_jaxpr,
@@ -938,7 +939,24 @@ class TestCategoryN_ControlFlow:
     ``PRIMITIVE_INSIDE_CONTROL_FLOW``. They are *not* lifted into the
     top-level relation set (carry-variable lineage is not yet supported);
     skipping them is the safe behavior, and the structured diagnostic
-    surfaces the location for the user."""
+    surfaces the location for the user.
+
+    These tests exercise the *raw scanner* on unprocessed jaxprs. In the
+    full pipeline, ``cond`` never reaches the scanner: ETP-relevant conds
+    are if-converted into inlined branches + ``select_n`` at extraction
+    time (``_compiler/canonicalize.py``), so their weights DO participate
+    as relations — see ``test_cond_branches_full_pipeline_converts``."""
+
+    def test_cond_branches_full_pipeline_converts(self):
+        model = CondBranchRNN(3, 4)
+        brainstate.nn.init_all_states(model)
+        graph = compile_etrace_graph(model, jnp.ones(3))
+        names = [eqn.primitive.name for eqn in graph.module_info.jaxpr.eqns]
+        assert 'cond' not in names
+        assert 'select_n' in names
+        assert len(graph.hidden_param_op_relations) == 2
+        kinds = [r.kind for r in graph.diagnostics]
+        assert DiagnosticKind.COND_IF_CONVERTED in kinds
 
     def test_scan_body_etp_emits_diagnostic(self):
         jaxpr = make_scan_body_etp_jaxpr(3, 4)

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,32 @@
 
 ### Highlights
 
+#### New: `cond` if-conversion (compiler canonicalization, Phase 1)
+
+- **ETP operations inside `lax.cond` branches now participate in online
+  learning.** A new canonicalization pass (`_compiler/canonicalize.py`)
+  runs at extraction time (after user-`jit` inlining) and rewrites every
+  ETP-relevant `cond` equation into the inlined bodies of *all* branches
+  followed by one `select_n` per output. `select_n`'s index semantics and
+  JVP match `cond` exactly, so values and Jacobians — and therefore exact
+  algorithms such as D-RTRL — are unchanged. Weights used inside `cond`
+  branches previously raised `NotImplementedError` (or were silently
+  excluded when only ETP primitives appeared inside).
+- **Semantics note**: on the canonicalized graph **both branches execute
+  every step** and the dead branch's value is discarded by `select_n`.
+  Guarded partial operations (e.g. a `cond` protecting a `sqrt` domain) can
+  produce NaN/Inf in the dead branch; the value is discarded and gradients
+  are not contaminated (whole outputs are selected, not multiplied).
+- **Gates**: conds that touch no ETP primitive, weight, or hidden state
+  stay opaque at zero cost. Conds with effects or containing `while`/`scan`
+  in a branch are never converted; an ETP-relevant one that is skipped this
+  way emits a `COND_CONVERSION_SKIPPED` warning and keeps today's behavior.
+  Conversions are recorded as `COND_IF_CONVERTED` INFO diagnostics on
+  `ETraceGraph.diagnostics`.
+- **Opt-out**: `braintrace.ControlFlowPolicy(cond='opaque')` via the new
+  `control_flow` keyword on `compile_etrace_graph` / `extract_module_info`
+  restores the previous behavior.
+
 #### New: vmap identity preservation (operator layer)
 
 - **vmap identity preservation (operator layer)**: `jax.vmap` over an

--- a/changelog.md
+++ b/changelog.md
@@ -18,9 +18,14 @@
   excluded when only ETP primitives appeared inside).
 - **Semantics note**: on the canonicalized graph **both branches execute
   every step** and the dead branch's value is discarded by `select_n`.
-  Guarded partial operations (e.g. a `cond` protecting a `sqrt` domain) can
-  produce NaN/Inf in the dead branch; the value is discarded and gradients
-  are not contaminated (whole outputs are selected, not multiplied).
+  Values and forward-mode derivatives are unaffected by dead-branch
+  NaN/Inf. **Reverse-mode gradients are not**: if the dead branch's local
+  Jacobian is NaN/Inf (e.g. a `cond` protecting a `sqrt` domain), its VJP
+  multiplies the exact-zero cotangent by that Jacobian (`0 * nan = nan`)
+  and contaminates gradients of shared inputs — the classic single-`where`
+  pitfall. Keep such domain-guard conds opaque
+  (`ControlFlowPolicy(cond='opaque')`) or guard the operand inside the
+  branch.
 - **Gates**: conds that touch no ETP primitive, weight, or hidden state
   stay opaque at zero cost. Conds with effects or containing `while`/`scan`
   in a branch are never converted; an ETP-relevant one that is skipped this

--- a/changelog.md
+++ b/changelog.md
@@ -12,8 +12,8 @@
   runs at extraction time (after user-`jit` inlining) and rewrites every
   ETP-relevant `cond` equation into the inlined bodies of *all* branches
   followed by one `select_n` per output. `select_n`'s index semantics and
-  JVP match `cond` exactly, so values and Jacobians — and therefore exact
-  algorithms such as D-RTRL — are unchanged. Weights used inside `cond`
+  JVP match `cond` exactly, so for finite branches values and Jacobians —
+  and therefore exact algorithms such as D-RTRL — are unchanged. Weights used inside `cond`
   branches previously raised `NotImplementedError` (or were silently
   excluded when only ETP primitives appeared inside).
 - **Semantics note**: on the canonicalized graph **both branches execute


### PR DESCRIPTION
## Summary

Phase 1 of the control-flow support plan (vmap → **cond** → scan → while): ETP operations inside `lax.cond` branches now participate in online learning. Previously a weight used inside a `cond` raised `NotImplementedError`, and ETP primitives inside branches were silently excluded from relations.

A new canonicalization pass (`_compiler/canonicalize.py`) runs at extraction time, right after user-`jit` inlining, and rewrites every ETP-relevant `cond` equation into the inlined bodies of **all** branches followed by one `select_n` per output. `select_n`'s integer-index semantics and JVP match `cond` exactly, so for finite branches values and Jacobians — and therefore exact algorithms such as D-RTRL — are unchanged (verified element-wise against BPTT).

## Design

- **Identity preservation**: converted equations reuse the original `cond` outvars and the pass never touches the jaxpr's invars/outvars, so every Var-identity table built by `extract_module_info` stays valid.
- **Relevance gate**: convert only when a branch transitively contains an ETP primitive, or the equation consumes a weight/hidden invar, or produces a hidden outvar. Irrelevant conds stay opaque at zero cost.
- **Safety gate**: conds with effects, or branches containing `while`/`scan`, are never converted; ETP-relevant skips emit a `COND_CONVERSION_SKIPPED` warning (once) and keep today's behavior.
- **Fixpoint**: conds surfaced from `jit` bodies inside branches are converted too (convert → inline → repeat).
- **Policy**: `braintrace.ControlFlowPolicy(cond='opaque')` via the new `control_flow` keyword on `compile_etrace_graph` / `extract_module_info` restores the previous behavior. `scan_unroll_limit` is reserved for Phase 2.
- **Diagnostics**: `COND_IF_CONVERTED` (INFO) / `COND_CONVERSION_SKIPPED` (WARNING) on `ETraceGraph.diagnostics`.

## Semantics note

Both branches execute every step on the canonicalized graph. Values and forward-mode derivatives are protected from dead-branch NaN/Inf by `select_n`; **reverse-mode gradients are not** when the dead branch's local Jacobian is NaN/Inf (`0 * nan = nan`, the single-`where` pitfall). Domain-guard conds should stay opaque or guard the operand — documented in the policy Notes and changelog.

## Bug fix with impact beyond this feature

Review of this branch empirically confirmed a latent `inline_jit_calls` bug: calling the same jitted function twice (e.g. a shared helper in both cond branches, or two top-level calls) spliced the trace-cached shared body without freshening — duplicate var definitions and **silently wrong values/gradients**. The pass now freshens all body-internal vars per call site while keeping top-level equations' Var identity; regression tests cover both repros.

## Test plan

- 28 pass-level unit tests (`canonicalize_test.py`): value/gradient equivalence on every branch of 2- and 3-way conds, multi-output, passthrough, nested cond, jit-in-branch, shared-jit-in-both-branches, all gate arms, policy escape hatch, once-only skip warning, full-wiring determinism.
- Full-pipeline: relation + D-RTRL gradient parity between a cond model and its hand-flattened `select_n` model; scenario-catalog `CondBranchRNN`; `cond_gate_rnn` oracle case asserting D-RTRL multi-step ≡ BPTT element-wise.
- Whole-branch review by an independent reviewer: verdict "Ready to merge — Yes" after one fix round (1 Critical, 2 Important, 3 Minor, all fixed and re-verified against the reviewer's own repros).
- Full suite on CPU: **1735 passed, 0 failed, 3 skipped**.

## Follow-ups (not in this PR)

- Phase 2: inner-`scan` unrolling (needs relation-instance trace keying; also fixes latent tied-weights bug). Phase 3: `while` policy.