### PR TITLE
Fix ETP audit findings: 4 Critical, 6 High, 6 Medium, 8 Minor

### DIFF
--- a/braintrace/_algorithm/_common.py
+++ b/braintrace/_algorithm/_common.py
@@ -131,9 +131,14 @@ class PresynapticTrace(_ZeroResetState):
 
 
 class KappaFilter(_ZeroResetState):
-    r"""Low-pass output-side filter used by EProp.
+    r"""Low-pass filter helper state.
 
-    The filter smooths the output-side signal following
+    :class:`~braintrace.EProp` no longer uses this class directly — it filters
+    the eligibility trace internally instead. ``KappaFilter`` remains public
+    and available for user-side filtering of an output-side (or any other)
+    signal outside the algorithm's own hooks.
+
+    The filter smooths the signal following
     :math:`x_{\mathrm{filt}} \leftarrow (1-\kappa) \cdot x + \kappa \cdot x_{\mathrm{filt}}`.
 
     Parameters

--- a/braintrace/_algorithm/_common.py
+++ b/braintrace/_algorithm/_common.py
@@ -234,7 +234,7 @@ class FixedRandomFeedback:
 
     def __init__(self, n_target: int, n_layer: int, key: Any, init_scale: float = 0.1) -> None:
         self.B = jax.lax.stop_gradient(
-            init_scale * jax.random.normal(key, (n_target, n_layer))
+            init_scale * brainstate.random.normal(size=(n_target, n_layer), key=key)
         )
         self.n_target = int(n_target)
         self.n_layer = int(n_layer)

--- a/braintrace/_algorithm/base.py
+++ b/braintrace/_algorithm/base.py
@@ -81,8 +81,13 @@ class ETraceAlgorithm(brainstate.nn.Module):
         The other states.
     is_compiled : bool
         Whether the etrace algorithm has been compiled.
-    running_index : brainstate.ParamState[int]
-        The running index.
+    running_index : brainstate.LongTermState[int]
+        Zero-based count of previously-completed ``update()`` calls: it reads
+        ``0`` during the first call, ``1`` during the second, and so on --
+        i.e. the value used *inside* a given ``update()`` is the
+        pre-increment count, not the 1-based call number. It is incremented
+        by one immediately after each ``update()`` completes, and reset back
+        to ``0`` by ``reset_state()``.
     """
     __module__ = 'braintrace'
 

--- a/braintrace/_algorithm/e_prop.py
+++ b/braintrace/_algorithm/e_prop.py
@@ -72,8 +72,8 @@ class EProp(ParamDimVjpAlgorithm):
     Here :math:`h_j^t` is the hidden state of neuron :math:`j` at time
     :math:`t`, :math:`x_i^t` the presynaptic input, :math:`D_j^t` the
     hidden-to-hidden (recurrent) Jacobian diagonal, :math:`D_{f,j}^t` the
-    state-to-output Jacobian, and :math:`\kappa \in [0, 1)` the readout-side
-    low-pass factor. The learning signal is
+    state-to-output Jacobian, and :math:`\kappa \in [0, 1)` the
+    eligibility-trace low-pass factor. The learning signal is
 
     .. math::
 
@@ -100,8 +100,11 @@ class EProp(ParamDimVjpAlgorithm):
     reverse-AD only ever exposes :math:`\ell^t = W_\mathrm{out}^\top \delta^t`,
     never the pre-readout error :math:`\delta^t` itself) and then projected
     through a frozen random matrix :math:`B`, removing the biologically
-    implausible weight-transport requirement up to that residual scale
-    dependence.
+    implausible weight-transport requirement. Normalization removes the
+    *scale* dependence on :math:`W_\mathrm{out}`; a residual *directional*
+    dependence on the readout weights remains, since full direction-
+    independence would require the pre-readout error :math:`\delta^t`
+    explicitly, which the current hook contract does not provide.
 
     Parameters
     ----------

--- a/braintrace/_algorithm/e_prop.py
+++ b/braintrace/_algorithm/e_prop.py
@@ -20,8 +20,10 @@ eligibility trace and a *learning signal* broadcast from the readout. This
 module builds on ``D_RTRL``'s per-parameter trace and adds the two ingredients
 that make the rule biologically plausible:
 
-- An optional κ-filter on each HiddenGroup's learning signal
-  (:math:`\\bar L = F_\\kappa(L)`), matching the paper's readout-side low-pass.
+- An optional κ-filter on each weight's *eligibility trace*
+  (:math:`\\bar e = F_\\kappa(e)`), matching the paper's low-pass eligibility
+  filter. The trailing per-hidden-state axis is filtered elementwise, so
+  multi-state HiddenGroups (``num_state > 1``) never mix across states.
 - An optional random-feedback variant (``feedback='random'``) that replaces the
   readout's symmetric gradient with a fixed random projection, removing the
   weight-transport requirement.
@@ -31,13 +33,14 @@ See :class:`EProp` for the mathematical formulation, references, and an example.
 
 from __future__ import annotations
 
-from typing import Any, Dict, Optional
+from typing import Any, Dict, Optional, Sequence
 
 import brainstate
 import jax
 import jax.numpy as jnp
 
-from ._common import FixedRandomFeedback, KappaFilter
+from braintrace._typing import ETraceWG_Key, Path, PyTree
+from ._common import FixedRandomFeedback, _reset_state_in_a_dict
 from .param_dim_vjp import ParamDimVjpAlgorithm
 
 __all__ = ['EProp']
@@ -76,9 +79,10 @@ class EProp(ParamDimVjpAlgorithm):
 
         L_j^t =
         \begin{cases}
-          \dfrac{\partial \mathcal{L}}{\partial h_j^t}
+          \ell_j^t = \dfrac{\partial \mathcal{L}}{\partial h_j^t}
             & \text{(symmetric feedback, standard backprop through readout)} \\[2ex]
-          \big(B\,e^t\big)_j
+          \big(B\,\hat\ell^t\big)_j,
+          \quad \hat\ell^t = \dfrac{\ell^t}{\lVert \ell^t \rVert + \varepsilon}
             & \text{(random feedback: a fixed random projection } B\text{)} .
         \end{cases}
 
@@ -87,10 +91,17 @@ class EProp(ParamDimVjpAlgorithm):
     only on quantities local to the synapse and is updated forward in time. The
     learning signal :math:`L_j^t` is broadcast from the readout. E-prop is
     therefore *online* (no backward pass through time) and uses memory linear in
-    the number of parameters. With ``kappa_filter_decay > 0`` the learning
-    signal is additionally low-pass filtered; with ``feedback='random'`` the
-    symmetric readout gradient is replaced by a frozen random matrix, removing
-    the biologically implausible weight-transport requirement.
+    the number of parameters. With ``kappa_filter_decay > 0`` each weight's
+    *eligibility trace* is additionally low-pass filtered (elementwise over the
+    trailing per-hidden-state axis, so multi-state HiddenGroups are filtered
+    per state with no cross-state mixing); with ``feedback='random'`` the
+    symmetric readout gradient :math:`\ell^t` is L2-normalized (removing its
+    dependence on the *magnitude* of the real readout weights, since
+    reverse-AD only ever exposes :math:`\ell^t = W_\mathrm{out}^\top \delta^t`,
+    never the pre-readout error :math:`\delta^t` itself) and then projected
+    through a frozen random matrix :math:`B`, removing the biologically
+    implausible weight-transport requirement up to that residual scale
+    dependence.
 
     Parameters
     ----------
@@ -99,13 +110,19 @@ class EProp(ParamDimVjpAlgorithm):
     feedback : {'symmetric', 'random'}, default 'symmetric'
         ``'symmetric'`` uses reverse-AD's :math:`\partial \mathcal{L}/\partial h`
         (standard backprop through the readout). ``'random'`` replaces the
-        readout gradient with a frozen random projection (requires
-        ``random_feedback_key``).
+        readout gradient with a frozen random projection of its L2-normalized
+        direction (requires ``random_feedback_key``). The projection matrix is
+        square (hidden-dim × hidden-dim): E-prop's hooks only see
+        :math:`\partial\mathcal L/\partial h`, which has no visibility into a
+        separate readout layer's width, so ``feedback='random'`` assumes a
+        single, direct readout whose output dimensionality equals the
+        HiddenGroup's own width.
     kappa_filter_decay : float in [0, 1), default 0.0
-        Readout-side low-pass factor :math:`\kappa`. If ``> 0``, each
-        HiddenGroup's learning signal is filtered each step
-        (:math:`\bar L^t = (1-\kappa)L^t + \kappa\bar L^{t-1}`). ``0`` disables
-        filtering.
+        Eligibility-trace low-pass factor :math:`\kappa` (see
+        :math:`\bar{e}_{ji}^t` above). If ``> 0``, each trainable weight's raw
+        eligibility trace is filtered every step, per hidden-state channel.
+        ``0`` disables filtering (the algorithm then reduces exactly to
+        :class:`~braintrace.D_RTRL`).
     random_feedback_key : jax.random.PRNGKey, optional
         Seed for the random-feedback matrices. Required when
         ``feedback='random'``; ignored otherwise.
@@ -180,69 +197,111 @@ class EProp(ParamDimVjpAlgorithm):
         self.feedback = feedback
         self.kappa_filter_decay = float(kappa_filter_decay)
         self._random_feedback_key = random_feedback_key
-        self._kappa_filters: Dict[int, KappaFilter] = {}
+        # Keyed exactly like ``self.etrace_bwg`` (ETraceWG_Key == (id(y_var),
+        # group.index)): one filter state per trainable weight / HiddenGroup
+        # relation, holding a PyTree that mirrors the raw trace's own
+        # structure and shape (including the trailing num_state axis).
+        self._trace_filters: Dict[ETraceWG_Key, brainstate.State] = {}
         self._random_feedback: Dict[int, FixedRandomFeedback] = {}
 
     def init_etrace_state(self, *args: Any, **kwargs: Any) -> None:
         super().init_etrace_state(*args, **kwargs)
-        self._kappa_filters = {}
+        self._trace_filters = {}
         self._random_feedback = {}
         if self.kappa_filter_decay > 0.0:
-            for rel in self.graph.hidden_param_op_relations:
-                for group in rel.hidden_groups:
-                    gid = group.index
-                    if gid in self._kappa_filters:
-                        continue
-                    zeros = jnp.zeros(group.varshape, dtype=jnp.float32)
-                    self._kappa_filters[gid] = KappaFilter(
-                        zeros, self.kappa_filter_decay
-                    )
+            # One filter per raw-trace key, initialised to zeros with the
+            # exact PyTree structure/shape of that trace (batch axis, weight
+            # shape, and the trailing num_state axis all included) -- no
+            # reduction, so per-state channels never mix.
+            for trace_key, trace_state in self.etrace_bwg.items():
+                self._trace_filters[trace_key] = brainstate.ShortTermState(
+                    jax.tree.map(jnp.zeros_like, trace_state.value)
+                )
         if self.feedback == 'random':
-            key = self._random_feedback_key
-            assert key is not None  # constructor enforces a key when feedback='random'
+            rf_key = self._random_feedback_key
+            assert rf_key is not None  # constructor enforces a key when feedback='random'
+            # Collect the (group id -> width) pairs needed first so the
+            # random draws below are made under a single seeded scope, using
+            # only `brainstate.random` (never `jax.random` directly).
+            groups_needed: Dict[int, int] = {}
             for rel in self.graph.hidden_param_op_relations:
                 for group in rel.hidden_groups:
-                    gid = group.index
-                    if gid in self._random_feedback:
-                        continue
-                    key, sub = jax.random.split(key)
-                    n_layer = int(group.varshape[-1])
-                    # n_target == n_layer — square projection over reverse-AD signal.
+                    groups_needed.setdefault(group.index, int(group.varshape[-1]))
+            with brainstate.random.seed_context(rf_key):
+                for gid, n_layer in groups_needed.items():
+                    # n_target == n_layer — square projection over reverse-AD
+                    # signal (see the class docstring's single-readout note).
                     self._random_feedback[gid] = FixedRandomFeedback(
-                        n_target=n_layer, n_layer=n_layer, key=sub, init_scale=0.1
+                        n_target=n_layer,
+                        n_layer=n_layer,
+                        key=brainstate.random.split_key(),
+                        init_scale=0.1,
                     )
 
     def reset_state(self, batch_size: Optional[int] = None, **kwargs: Any) -> None:
         super().reset_state(batch_size=batch_size, **kwargs)
-        for flt in self._kappa_filters.values():
-            flt.reset_state(batch_size=batch_size)
+        _reset_state_in_a_dict(self._trace_filters, batch_size)
 
     def _compute_learning_signal(self, dl_autodiff: Any, args: Any) -> Any:
         signals = list(dl_autodiff)
         if self.feedback == 'random' and self._random_feedback:
-            # dl_autodiff[g].shape == (*varshape, num_state). Project over the
-            # trailing n_layer axis (-2), preserving num_state on the tail.
+            # dl_autodiff[g].shape == (*varshape, num_state); varshape[-1] is
+            # the n_layer (hidden-width) axis, i.e. axis -2 of the full array.
+            # `s` is proportional to the *real* readout weights (reverse-AD
+            # only ever exposes W_out^T @ delta, never delta itself), so a
+            # linear projection through any fixed B cannot remove that
+            # dependency. L2-normalizing `s` per num_state channel over the
+            # n_layer axis strips the magnitude dependence on W_out (while
+            # keeping direction and the per-state axis untouched) before
+            # projecting through the frozen random matrix.
             def _project(B: Any, s: Any) -> Any:
-                return jnp.einsum('...lj,lk->...kj', s, B)
+                norm = jnp.sqrt(jnp.sum(jnp.square(s), axis=-2, keepdims=True))
+                s_normalized = s / (norm + 1e-8)
+                return jnp.einsum('...lj,lk->...kj', s_normalized, B)
 
             signals = [
                 _project(self._random_feedback[gid].B, s)
                 if gid in self._random_feedback else s
                 for gid, s in enumerate(signals)
             ]
-        if self._kappa_filters:
-            # KappaFilter state carries varshape, but signal has an extra
-            # trailing num_state axis. Collapse num_state for filter purposes;
-            # broadcast the filtered value back.
-            def _filter(flt: Any, s: Any) -> Any:
-                # collapse num_state tail: sum over last axis produces shape (*varshape,)
-                collapsed = s.sum(axis=-1)
-                filtered = flt.update(collapsed)
-                return jnp.expand_dims(filtered, axis=-1).astype(s.dtype)
-
-            signals = [
-                _filter(self._kappa_filters[gid], s)
-                if gid in self._kappa_filters else s
-                for gid, s in enumerate(signals)
-            ]
         return signals
+
+    def _solve_weight_gradients(
+        self,
+        running_index: int,
+        etrace_h2w_at_t: Dict[ETraceWG_Key, PyTree],
+        dl_to_hidden_groups: Sequence[jax.Array],
+        weight_vals: Dict[Path, PyTree],
+        dl_to_nonetws_at_t: Dict[Path, PyTree],
+        dl_to_etws_at_t: Optional[Dict[Path, PyTree]],
+    ) -> Any:
+        """Low-pass filter the raw eligibility trace, then delegate to D-RTRL.
+
+        Implements :math:`\\bar e_{ji}^t = \\kappa\\,\\bar e_{ji}^{t-1} + e_{ji}^t`
+        per weight-key, applied elementwise (``jax.tree.map`` over the trace's
+        own PyTree, including its trailing num_state axis) so multi-state
+        HiddenGroups are filtered independently per state -- never summed
+        across states and broadcast back.
+        """
+        if self._trace_filters:
+            kappa = self.kappa_filter_decay
+            filtered: Dict[ETraceWG_Key, PyTree] = {}
+            for key, trace in etrace_h2w_at_t.items():
+                flt = self._trace_filters.get(key)
+                if flt is None:
+                    filtered[key] = trace
+                    continue
+                new_val = jax.tree.map(
+                    lambda prev, e: kappa * prev + e, flt.value, trace
+                )
+                flt.value = new_val
+                filtered[key] = new_val
+            etrace_h2w_at_t = filtered
+        return super()._solve_weight_gradients(
+            running_index,
+            etrace_h2w_at_t,
+            dl_to_hidden_groups,
+            weight_vals,
+            dl_to_nonetws_at_t,
+            dl_to_etws_at_t,
+        )

--- a/braintrace/_algorithm/e_prop_test.py
+++ b/braintrace/_algorithm/e_prop_test.py
@@ -308,15 +308,15 @@ class TestEPropRandomFeedbackInvariance(unittest.TestCase):
         class Net(brainstate.nn.Module):
             def __init__(self):
                 super().__init__()
+                brainstate.random.seed(0)
                 self.w = brainstate.ParamState(
-                    0.1 * jax.random.normal(jax.random.PRNGKey(0), (3, 3))
+                    0.1 * brainstate.random.normal(size=(3, 3))
                 )
                 self.h = brainstate.HiddenState(jnp.zeros((1, 3)))
                 # Plain (non-ETP) readout matrix -- only its *scale* matters
                 # for this test, so it is not wrapped in a ParamState.
-                self.w_out = readout_scale * jax.random.normal(
-                    jax.random.PRNGKey(1), (3, 3)
-                )
+                brainstate.random.seed(1)
+                self.w_out = readout_scale * brainstate.random.normal(size=(3, 3))
 
             def update(self, x):
                 self.h.value = jax.nn.tanh(

--- a/braintrace/_algorithm/e_prop_test.py
+++ b/braintrace/_algorithm/e_prop_test.py
@@ -21,6 +21,7 @@ import jax.numpy as jnp
 
 import braintrace
 from braintrace._algorithm.e_prop import EProp
+from braintrace._algorithm.oracle_models import two_state_rnn
 
 
 def _lsnn_like():
@@ -58,14 +59,18 @@ class TestEPropConstruction(unittest.TestCase):
         x = jnp.ones((1, 3))
         algo.compile_graph(x)
         algo.init_etrace_state()
-        assert len(algo._kappa_filters) == len(algo.graph.hidden_param_op_relations)
+        # One trace-filter state per raw-trace key (matching etrace_bwg's own
+        # key space), not per hidden_param_op_relation -- those only happen
+        # to coincide (1-to-1) on this trivial single-weight, single-group model.
+        assert len(algo._trace_filters) == len(algo.etrace_bwg)
+        assert len(algo._trace_filters) > 0
 
     def test_kappa_filter_skipped_when_zero(self):
         algo = EProp(_lsnn_like(), kappa_filter_decay=0.0)
         x = jnp.ones((1, 3))
         algo.compile_graph(x)
         algo.init_etrace_state()
-        assert len(algo._kappa_filters) == 0
+        assert len(algo._trace_filters) == 0
 
 
 class TestEPropKappaApplied(unittest.TestCase):
@@ -94,18 +99,27 @@ class TestEPropKappaApplied(unittest.TestCase):
         assert jnp.allclose(g_drtrl, g_eprop, atol=1e-6)
 
     def test_kappa_nonzero_differs_from_zero(self):
+        """κ only accumulates history (``bar_e^t = kappa*bar_e^{t-1} + e^t``),
+        so its effect is invisible on the very first backward-invoking step
+        (bar_e^{t-1} starts at zero) and only shows up once a *second*
+        backward step carries forward non-trivial filter history.
+        """
+
         def compute(kappa):
             net = _lsnn_like()
             algo = EProp(net, kappa_filter_decay=kappa)
             x = jnp.ones((1, 3))
             algo.compile_graph(x)
             algo.init_etrace_state()
-            algo.update(x)
 
             def loss(x_):
                 out = algo.update(x_)
                 return (out ** 2).sum()
 
+            # First backward-invoking step primes the trace-filter history.
+            brainstate.transform.grad(
+                loss, algo.param_states, return_value=True
+            )(x)
             grads, _ = brainstate.transform.grad(
                 loss, algo.param_states, return_value=True
             )(x)
@@ -137,6 +151,219 @@ class TestEPropRandomFeedback(unittest.TestCase):
         g_sym = compute('symmetric')
         g_rnd = compute('random', random_feedback_key=jax.random.PRNGKey(123))
         assert not jnp.allclose(g_sym, g_rnd, atol=1e-4)
+
+
+class TestEPropNumStateIsolation(unittest.TestCase):
+    """H4: the kappa filter must not sum across the trailing ``num_state``
+    axis and broadcast the sum back -- each hidden-state channel of a
+    multi-state HiddenGroup must be filtered independently.
+    """
+
+    def _run(self, fast_solve):
+        spec = two_state_rnn(n_in=3, n_rec=3, seed=0)
+        net = spec.factory()
+        brainstate.nn.init_all_states(net, batch_size=1)
+        algo = EProp(net, kappa_filter_decay=0.9, fast_solve=fast_solve)
+        x = jnp.ones((1, 3))
+        algo.compile_graph(x)
+        algo.init_etrace_state()
+
+        def loss(x_):
+            # `update` only returns `v` (state 0); `a` (state 1) only
+            # influences the loss indirectly through the *next* step's `v`,
+            # so the two channels are state-asymmetric.
+            out = algo.update(x_)
+            return (out ** 2).sum()
+
+        # Two backward-invoking steps so the (kappa > 0) filter history is
+        # non-trivial in both channels.
+        brainstate.transform.grad(loss, algo.param_states, return_value=True)(x)
+        brainstate.transform.grad(loss, algo.param_states, return_value=True)(x)
+        return algo
+
+    def test_runs_without_shape_error_both_paths(self):
+        # Legacy path (fast_solve=False) shape-errors today (H4); fast path
+        # silently contaminates state 1 with state 0's sum. Both must simply
+        # run to completion post-fix.
+        self._run(fast_solve=False)
+        self._run(fast_solve=True)
+
+    def test_per_state_channels_are_not_contaminated(self):
+        for fast_solve in (False, True):
+            algo = self._run(fast_solve=fast_solve)
+            assert len(algo._trace_filters) == 1
+            flt = next(iter(algo._trace_filters.values()))
+            w = flt.value['weight']
+            assert w.shape[-1] == 2  # num_state == 2 (v, a)
+            channel_0, channel_1 = w[..., 0], w[..., 1]
+            assert not jnp.allclose(channel_0, channel_1, atol=1e-4), (
+                f'fast_solve={fast_solve}: per-state channels are identical -- '
+                'looks like a summed-then-broadcast contamination.'
+            )
+
+
+class TestEPropFilterSemantics(unittest.TestCase):
+    """M1: kappa must filter the *eligibility trace*
+    (``bar_e^t = kappa*bar_e^{t-1} + e^t``), not the learning signal. The two
+    orderings give different gradients whenever the learning signal varies in
+    time, which this hand-computed 2-step reference exercises via a
+    sign-flipping loss coefficient over a constant trace.
+    """
+
+    def test_kappa_zero_matches_unfiltered(self):
+        """Regression anchor: kappa=0 must reduce to the unfiltered algorithm."""
+        with brainstate.environ.context(precision=64):
+            def make():
+                class Net(brainstate.nn.Module):
+                    def __init__(self):
+                        super().__init__()
+                        self.w = brainstate.ParamState(jnp.array([[1.0]]))
+                        self.h = brainstate.HiddenState(jnp.zeros((1, 1)))
+
+                    def update(self, x):
+                        self.h.value = braintrace.matmul(x, self.w.value)
+                        return self.h.value
+
+                net = Net()
+                brainstate.nn.init_all_states(net, batch_size=1)
+                return net
+
+            def compute(kappa):
+                net = make()
+                algo = EProp(net, kappa_filter_decay=kappa)
+                x = jnp.array([[2.0]])
+                algo.compile_graph(x)
+                algo.init_etrace_state()
+
+                def loss(x_):
+                    out = algo.update(x_)
+                    return (out ** 2).sum()
+
+                grads, _ = brainstate.transform.grad(
+                    loss, algo.param_states, return_value=True
+                )(x)
+                return grads[next(iter(grads))]
+
+            g_unfiltered = compute(0.0)
+            # kappa=0.0 takes the `kappa_filter_decay > 0.0` branch's *else*
+            # path (no filters allocated at all), so this is a genuine
+            # code-path regression anchor, not just a numerically-tiny kappa.
+            assert jnp.allclose(g_unfiltered, jnp.array([[8.0]]), atol=1e-10)
+
+    def test_hand_computed_two_step_filtered_trace_reference(self):
+        """No-recurrence toy model: ``h_t = matmul(x, w)`` with constant
+        ``x = [[2.0]]``, so the raw eligibility trace ``e^t = 2.0`` every
+        step. With ``kappa=0.5`` and loss coefficients ``+1`` then ``-1``:
+
+            bar_e^1 = 0.5*0 + 2.0 = 2.0;  g1 = (+1)*bar_e^1 =  2.0
+            bar_e^2 = 0.5*2.0 + 2.0 = 3.0; g2 = (-1)*bar_e^2 = -3.0
+            total = g1 + g2 = -1.0
+
+        (The old signal-filtering ordering would instead filter the
+        already-scaled learning signal and produce a different total.)
+        """
+        with brainstate.environ.context(precision=64):
+            class Net(brainstate.nn.Module):
+                def __init__(self):
+                    super().__init__()
+                    self.w = brainstate.ParamState(jnp.array([[1.0]]))
+                    self.h = brainstate.HiddenState(jnp.zeros((1, 1)))
+
+                def update(self, x):
+                    self.h.value = braintrace.matmul(x, self.w.value)
+                    return self.h.value
+
+            net = Net()
+            brainstate.nn.init_all_states(net, batch_size=1)
+            algo = EProp(net, kappa_filter_decay=0.5)
+            x = jnp.array([[2.0]])
+            algo.compile_graph(x)
+            algo.init_etrace_state()
+
+            def grad_with_coeff(coeff):
+                def loss(x_):
+                    out = algo.update(x_)
+                    return (coeff * out).sum()
+
+                grads, _ = brainstate.transform.grad(
+                    loss, algo.param_states, return_value=True
+                )(x)
+                return grads[next(iter(grads))]
+
+            g1 = grad_with_coeff(1.0)
+            g2 = grad_with_coeff(-1.0)
+            assert jnp.allclose(g1, jnp.array([[2.0]]), atol=1e-10)
+            assert jnp.allclose(g2, jnp.array([[-3.0]]), atol=1e-10)
+            assert jnp.allclose(g1 + g2, jnp.array([[-1.0]]), atol=1e-10)
+
+
+class TestEPropRandomFeedbackInvariance(unittest.TestCase):
+    """M2: 'random feedback' must remove weight-transport (independence from
+    the readout weights' *magnitude*), while still depending on the
+    ``brainstate.random`` seed used to draw the fixed projection matrix.
+    """
+
+    @staticmethod
+    def _readout_net(readout_scale):
+        class Net(brainstate.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.w = brainstate.ParamState(
+                    0.1 * jax.random.normal(jax.random.PRNGKey(0), (3, 3))
+                )
+                self.h = brainstate.HiddenState(jnp.zeros((1, 3)))
+                # Plain (non-ETP) readout matrix -- only its *scale* matters
+                # for this test, so it is not wrapped in a ParamState.
+                self.w_out = readout_scale * jax.random.normal(
+                    jax.random.PRNGKey(1), (3, 3)
+                )
+
+            def update(self, x):
+                self.h.value = jax.nn.tanh(
+                    braintrace.matmul(self.h.value + x, self.w.value)
+                )
+                return self.h.value @ self.w_out
+
+        net = Net()
+        brainstate.nn.init_all_states(net, batch_size=1)
+        return net
+
+    def _compute(self, feedback, readout_scale, seed=None):
+        net = self._readout_net(readout_scale)
+        if feedback == 'random':
+            brainstate.random.seed(seed)
+            key = brainstate.random.split_key()
+            algo = EProp(net, feedback='random', random_feedback_key=key)
+        else:
+            algo = EProp(net, feedback='symmetric')
+        x = jnp.ones((1, 3))
+        algo.compile_graph(x)
+        algo.init_etrace_state()
+
+        def loss(x_):
+            out = algo.update(x_)
+            return (out ** 2).sum()
+
+        grads, _ = brainstate.transform.grad(
+            loss, algo.param_states, return_value=True
+        )(x)
+        return grads[next(iter(grads))]
+
+    def test_symmetric_feedback_scales_with_readout_weights(self):
+        # Sanity check that the readout-scale knob is actually meaningful.
+        g_small = self._compute('symmetric', readout_scale=1.0)
+        g_large = self._compute('symmetric', readout_scale=5.0)
+        assert not jnp.allclose(g_small, g_large, atol=1e-4)
+
+    def test_random_feedback_invariant_to_readout_scale(self):
+        g_small = self._compute('random', readout_scale=1.0, seed=7)
+        g_large = self._compute('random', readout_scale=5.0, seed=7)
+        assert jnp.allclose(g_small, g_large, atol=1e-3)
+
+    def test_random_feedback_depends_on_seed(self):
+        g_seed1 = self._compute('random', readout_scale=1.0, seed=1)
+        g_seed2 = self._compute('random', readout_scale=1.0, seed=2)
+        assert not jnp.allclose(g_seed1, g_seed2, atol=1e-4)
 
 
 class FakeLIF(brainstate.HiddenState):

--- a/braintrace/_algorithm/io_dim_vjp.py
+++ b/braintrace/_algorithm/io_dim_vjp.py
@@ -560,6 +560,15 @@ class IODimVjpAlgorithm(ETraceVjpAlgorithm):
     hidden-to-hidden Jacobian, :math:`\mathbf{D}_f^t` the state-to-output
     Jacobian, and :math:`\mathbf{x}^t` the presynaptic input.
 
+    :math:`\mathbf{D}_f^t` is read off by
+    :meth:`~braintrace._algorithm.vjp_graph_executor.ETraceVjpGraphExecutor._compute_hid2weight_jacobian`
+    from a single all-ones-tangent ``jax.jvp`` of the ``y -> hidden`` map; see
+    that method's docstring for when this is exact (elementwise maps) versus
+    an approximation (non-elementwise maps, e.g. a normalization layer
+    between the weight op and the neuron) — the same approximation is shared
+    with :class:`~braintrace._algorithm.param_dim_vjp.ParamDimVjpAlgorithm`
+    (``D_RTRL``).
+
     The full per-parameter D-RTRL trace
     :math:`\boldsymbol{\epsilon}^t \in \mathbb{R}^{I\times O}` is approximated by
     the outer product of two exponentially-smoothed *vectors* — one over the

--- a/braintrace/_algorithm/io_dim_vjp.py
+++ b/braintrace/_algorithm/io_dim_vjp.py
@@ -627,7 +627,6 @@ class IODimVjpAlgorithm(ETraceVjpAlgorithm):
         name: Optional[str] = None,
         vjp_method: str = 'single-step',
         fast_solve: bool = True,
-        **kwargs: Any,
     ) -> None:
         super().__init__(model, name=name, vjp_method=vjp_method)
         self.decay, num_rank = _format_decay_and_rank(decay_or_rank)

--- a/braintrace/_algorithm/oracle_test.py
+++ b/braintrace/_algorithm/oracle_test.py
@@ -500,9 +500,10 @@ def test_pp_prop_conv_bias_known_limitation():
     require touching ``io_dim_vjp.py``, which is out of scope for this task
     (see module docstring / architecture notes: io_dim_vjp.py's core logic is
     never modified as part of this audit). This test pins the *current*
-    behavior with ``xfail(strict=True)`` so that a future fix is caught (the
-    xfail will start failing as an unexpected pass) rather than silently
-    going unnoticed.
+    behavior with ``pytest.raises(ValueError, ...)`` so that a future fix is
+    caught loudly (the raise will stop happening and this test will fail),
+    prompting promotion to an exactness assertion instead of silently going
+    unnoticed.
     """
     factory, seed = _FAMILIES['conv_nwc_bias']
     with brainstate.environ.context(precision=64):

--- a/braintrace/_algorithm/oracle_test.py
+++ b/braintrace/_algorithm/oracle_test.py
@@ -18,6 +18,7 @@ the headline exact-correctness proof (multi-step D_RTRL == BPTT), and the
 single-step naive recipe asserted as directionally aligned with BPTT (the
 former F-SINGLESTEP finding)."""
 
+import brainevent
 import brainstate
 import jax.numpy as jnp
 import numpy as np
@@ -173,3 +174,341 @@ def test_singlestep_naive_directionally_aligned_with_bptt():
         mag_bounds=(0.8, 1.3),
         keys=list(spec.etp_param_keys),
     )
+
+
+# =============================================================================
+# Audit Task 11: cross-family single-step oracle suite (T1, T3)
+# =============================================================================
+#
+# Every family below is an *exactly-diagonal* leaky-integrator model
+# (``h <- leak * h + drive``), so single-step D-RTRL's diagonal approximation
+# is exact and must reproduce a BPTT oracle element-wise for every parameter,
+# at every T. This is the "real test" the audit's T1 finding asked for: prior
+# coverage of the conv-kernel (Task 7) and LoRA-B (Task 6) fixes either used
+# an all-zero hidden state as the op's own *input* (making the weight/kernel
+# gradient trivially zero on both sides of the comparison) or never drove
+# the op with genuinely random, nonzero data at all. The factories here feed
+# real ``brainstate.random`` data through every op family, so the kernel and
+# weight gradients are actually exercised.
+#
+# ``pp_prop`` (ES-D-RTRL, an *approximate* algorithm) is exact only at T=1
+# (no history to factor/decay yet); for T>1 it is expected to diverge from
+# BPTT, so only a loose, structural-break-catching bound is asserted there
+# (rel < 1.0), never element-wise equality.
+
+LEAK = 0.5
+_TOL = 1e-10
+
+
+def _rel_err(a, b):
+    a = jnp.asarray(a)
+    b = jnp.asarray(b)
+    denom = float(jnp.maximum(jnp.abs(a).max(), 1e-12))
+    return float(jnp.abs(a - b).max() / denom)
+
+
+def _dense_mm_factory():
+    """Batched dense ``matmul`` (+bias) leaky-integrator, ``h`` shape ``(1, n_out)``."""
+    brainstate.random.seed(11)
+    n_in, n_out = 3, 4
+    w0 = 0.1 * brainstate.random.randn(n_in, n_out)
+    b0 = 0.05 * brainstate.random.randn(n_out)
+
+    class Net(brainstate.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.w = brainstate.ParamState(w0)
+            self.b = brainstate.ParamState(b0)
+            self.h = brainstate.HiddenState(jnp.zeros((1, n_out)))
+
+        def update(self, x):
+            drive = braintrace.matmul(x, self.w.value, bias=self.b.value)
+            self.h.value = LEAK * self.h.value + drive
+            return self.h.value
+
+    return Net()
+
+
+def _dense_mv_factory():
+    """Unbatched dense ``matmul`` leaky-integrator, ``h`` shape ``(n_out,)``."""
+    brainstate.random.seed(12)
+    n_in, n_out = 3, 4
+    w0 = 0.1 * brainstate.random.randn(n_in, n_out)
+
+    class Net(brainstate.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.w = brainstate.ParamState(w0)
+            self.h = brainstate.HiddenState(jnp.zeros((n_out,)))
+
+        def update(self, x):
+            drive = braintrace.matmul(x, self.w.value)
+            self.h.value = LEAK * self.h.value + drive
+            return self.h.value
+
+    return Net()
+
+
+def _elemwise_factory():
+    """Elementwise-scaled input leaky-integrator, ``h`` shape ``(n,)``."""
+    brainstate.random.seed(13)
+    n = 4
+    w0 = 0.5 + 0.1 * brainstate.random.randn(n)
+
+    class Net(brainstate.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.w = brainstate.ParamState(w0)
+            self.h = brainstate.HiddenState(jnp.zeros((n,)))
+
+        def update(self, x):
+            drive = x * braintrace.element_wise(self.w.value)
+            self.h.value = LEAK * self.h.value + drive
+            return self.h.value
+
+    return Net()
+
+
+def _conv_default_factory():
+    """1-D conv, JAX-default (NCH/OIH) layout, kernel width 3 (spatial extent > 1)."""
+    brainstate.random.seed(14)
+    in_ch, out_ch, kw, length = 2, 3, 3, 8
+    k0 = 0.1 * brainstate.random.randn(out_ch, in_ch, kw)
+
+    class Net(brainstate.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.k = brainstate.ParamState(k0)
+            self.h = brainstate.HiddenState(jnp.zeros((1, out_ch, length)))
+
+        def update(self, x):
+            drive = braintrace.conv(x, self.k.value, strides=(1,), padding='SAME')
+            self.h.value = LEAK * self.h.value + drive
+            return self.h.value
+
+    return Net()
+
+
+def _conv_nwc_bias_factory():
+    """1-D conv, channel-last (NWC/WIO) layout with a trainable bias."""
+    brainstate.random.seed(15)
+    in_ch, out_ch, kw, length = 2, 3, 3, 8
+    k0 = 0.1 * brainstate.random.randn(kw, in_ch, out_ch)
+    b0 = 0.05 * brainstate.random.randn(out_ch)
+
+    class Net(brainstate.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.k = brainstate.ParamState(k0)
+            self.b = brainstate.ParamState(b0)
+            self.h = brainstate.HiddenState(jnp.zeros((1, length, out_ch)))
+
+        def update(self, x):
+            drive = braintrace.conv(
+                x, self.k.value, self.b.value,
+                strides=(1,), padding='SAME',
+                dimension_numbers=('NWC', 'WIO', 'NWC'),
+            )
+            self.h.value = LEAK * self.h.value + drive
+            return self.h.value
+
+    return Net()
+
+
+def _sparse_csr():
+    dense_mask = np.array([
+        [1, 0, 1, 0],
+        [0, 1, 0, 1],
+        [1, 1, 0, 0],
+    ], dtype=bool)
+    return brainevent.CSR.fromdense(jnp.asarray(dense_mask, dtype=jnp.float64)), dense_mask.shape[1]
+
+
+def _sparse_unbatched_factory():
+    """Unbatched sparse ``matmul`` (real ``brainevent.CSR``), ``h`` shape ``(n_rec,)``."""
+    brainstate.random.seed(16)
+    csr, n_rec = _sparse_csr()
+    w0 = 0.1 * brainstate.random.randn(csr.data.shape[0])
+
+    class Net(brainstate.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.w = brainstate.ParamState(w0)
+            self.h = brainstate.HiddenState(jnp.zeros((n_rec,)))
+
+        def update(self, x):
+            drive = braintrace.sparse_matmul(x, self.w.value, sparse_mat=csr)
+            self.h.value = LEAK * self.h.value + drive
+            return self.h.value
+
+    return Net()
+
+
+def _sparse_batched_factory():
+    """Batched (batch=2) sparse ``matmul``, ``h`` shape ``(2, n_rec)``."""
+    brainstate.random.seed(17)
+    csr, n_rec = _sparse_csr()
+    batch = 2
+    w0 = 0.1 * brainstate.random.randn(csr.data.shape[0])
+
+    class Net(brainstate.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.w = brainstate.ParamState(w0)
+            self.h = brainstate.HiddenState(jnp.zeros((batch, n_rec)))
+
+        def update(self, x):
+            drive = braintrace.sparse_matmul(x, self.w.value, sparse_mat=csr)
+            self.h.value = LEAK * self.h.value + drive
+            return self.h.value
+
+    return Net()
+
+
+def _lora_factory():
+    """Batched LoRA ``lora_matmul`` with a trainable bias and ``alpha != 1``."""
+    brainstate.random.seed(18)
+    n_in, n_rec, rank = 3, 4, 2
+    b0_ = 0.1 * brainstate.random.randn(n_in, rank)
+    a0_ = 0.1 * brainstate.random.randn(rank, n_rec)
+    bias0 = 0.05 * brainstate.random.randn(n_rec)
+
+    class Net(brainstate.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.B = brainstate.ParamState(b0_)
+            self.A = brainstate.ParamState(a0_)
+            self.bias = brainstate.ParamState(bias0)
+            self.h = brainstate.HiddenState(jnp.zeros((1, n_rec)))
+
+        def update(self, x):
+            drive = braintrace.lora_matmul(
+                x, self.B.value, self.A.value, alpha=2.0, bias=self.bias.value,
+            )
+            self.h.value = LEAK * self.h.value + drive
+            return self.h.value
+
+    return Net()
+
+
+def _xs_for(name, T, seed):
+    brainstate.random.seed(seed)
+    shapes = {
+        'dense_mm': (T, 1, 3),
+        'dense_mv': (T, 3),
+        'elemwise': (T, 4),
+        'conv_default': (T, 1, 2, 8),
+        'conv_nwc_bias': (T, 1, 8, 2),
+        'sparse_unbatched': (T, 3),
+        'sparse_batched': (T, 2, 3),
+        'lora': (T, 1, 3),
+    }
+    return 0.3 * brainstate.random.randn(*shapes[name])
+
+
+# name -> (factory, xs seed)
+_FAMILIES = {
+    'dense_mm': (_dense_mm_factory, 101),
+    'dense_mv': (_dense_mv_factory, 102),
+    'elemwise': (_elemwise_factory, 103),
+    'conv_default': (_conv_default_factory, 104),
+    'conv_nwc_bias': (_conv_nwc_bias_factory, 105),
+    'sparse_unbatched': (_sparse_unbatched_factory, 106),
+    'sparse_batched': (_sparse_batched_factory, 107),
+    'lora': (_lora_factory, 108),
+}
+
+
+@pytest.mark.parametrize('name', sorted(_FAMILIES))
+@pytest.mark.parametrize('T', [1, 4])
+def test_d_rtrl_singlestep_matches_bptt_across_families(name, T):
+    """D_RTRL (param-dim, single-step) is an *exact* algorithm: for every op
+    family, driven by real nonzero random input, it must reproduce the BPTT
+    gradient element-wise for every trainable factor -- including the conv
+    kernel at spatial extent > 1 (Task 7) and ``lora_b`` (Task 6), neither of
+    which any pre-existing test exercised with a nonzero op input."""
+    factory, seed = _FAMILIES[name]
+    with brainstate.environ.context(precision=64):
+        xs = _xs_for(name, T, seed)
+        g_bptt = bptt_param_gradients(factory, xs)
+        g_online = online_param_gradients_singlestep_naive(
+            factory, xs,
+            algo_factory=lambda m: braintrace.D_RTRL(m, vjp_method='single-step'),
+        )
+        for key in g_bptt:
+            rel = _rel_err(g_bptt[key], g_online[key])
+            assert rel < _TOL, f'{name} T={T} {key}: D_RTRL vs BPTT rel={rel:.3e}'
+
+
+@pytest.mark.parametrize('name', sorted(set(_FAMILIES) - {'conv_nwc_bias'}))
+def test_pp_prop_singlestep_exact_at_t1_across_families(name):
+    """pp_prop (ES-D-RTRL, IO-dim, approximate) has no history to factor or
+    decay at T=1, so it must also match BPTT exactly there, for every family.
+
+    ``conv_nwc_bias`` is excluded here and covered separately by
+    ``test_pp_prop_conv_bias_known_limitation`` -- see that test's docstring
+    for the newly-discovered (pre-existing, out-of-scope-for-this-task) gap.
+    """
+    factory, seed = _FAMILIES[name]
+    with brainstate.environ.context(precision=64):
+        xs = _xs_for(name, 1, seed)
+        g_bptt = bptt_param_gradients(factory, xs)
+        g_online = online_param_gradients_singlestep_naive(
+            factory, xs,
+            algo_factory=lambda m: braintrace.pp_prop(m, decay_or_rank=0.9, vjp_method='single-step'),
+        )
+        for key in g_bptt:
+            rel = _rel_err(g_bptt[key], g_online[key])
+            assert rel < _TOL, f'{name} T=1 {key}: pp_prop vs BPTT rel={rel:.3e}'
+
+
+@pytest.mark.parametrize('name', sorted(set(_FAMILIES) - {'conv_nwc_bias'}))
+def test_pp_prop_singlestep_bounded_at_t2_across_families(name):
+    """pp_prop is an *approximate* algorithm beyond T=1: at T=2 it factors /
+    decays history and is **not** expected to match BPTT element-wise. This
+    only asserts a loose bound (rel < 1.0) to catch structural breaks (NaNs,
+    blow-ups, shape errors) without codifying the approximation's magnitude
+    as a spec.
+    """
+    factory, seed = _FAMILIES[name]
+    with brainstate.environ.context(precision=64):
+        xs = _xs_for(name, 2, seed)
+        g_bptt = bptt_param_gradients(factory, xs)
+        g_online = online_param_gradients_singlestep_naive(
+            factory, xs,
+            algo_factory=lambda m: braintrace.pp_prop(m, decay_or_rank=0.9, vjp_method='single-step'),
+        )
+        for key in g_bptt:
+            rel = _rel_err(g_bptt[key], g_online[key])
+            assert np.isfinite(rel) and rel < 1.0, (
+                f'{name} T=2 {key}: pp_prop vs BPTT rel={rel:.3e} (expected bounded, not exact)'
+            )
+
+
+def test_pp_prop_conv_bias_known_limitation():
+    """Documents a newly-discovered gap found while building this suite:
+    ``pp_prop``/``IODimVjpAlgorithm`` raises when a conv layer has a
+    trainable bias, regardless of layout (NCH or NWC) -- the custom-VJP bwd
+    rule returns the bias cotangent still shaped per-position
+    ``(batch, *spatial, out_ch)`` instead of reduced to the bias's own shape
+    ``(out_ch,)``.
+
+    This is unrelated to the Task 6/7 fixes under audit: ``D_RTRL``
+    (param-dim) handles conv+bias exactly (see
+    ``test_d_rtrl_singlestep_matches_bptt_across_families['conv_nwc_bias']``);
+    only the IO-dim path used by ``pp_prop`` is affected. Fixing it would
+    require touching ``io_dim_vjp.py``, which is out of scope for this task
+    (see module docstring / architecture notes: io_dim_vjp.py's core logic is
+    never modified as part of this audit). This test pins the *current*
+    behavior with ``xfail(strict=True)`` so that a future fix is caught (the
+    xfail will start failing as an unexpected pass) rather than silently
+    going unnoticed.
+    """
+    factory, seed = _FAMILIES['conv_nwc_bias']
+    with brainstate.environ.context(precision=64):
+        xs = _xs_for('conv_nwc_bias', 1, seed)
+        with pytest.raises(ValueError, match='Custom VJP bwd rule'):
+            online_param_gradients_singlestep_naive(
+                factory, xs,
+                algo_factory=lambda m: braintrace.pp_prop(m, decay_or_rank=0.9, vjp_method='single-step'),
+            )

--- a/braintrace/_algorithm/ostl.py
+++ b/braintrace/_algorithm/ostl.py
@@ -22,7 +22,11 @@ inherits the full, separately-tested machinery of an existing VJP algorithm —
 branching:
 
 - :class:`OSTLRecurrent` ('with-H') keeps ``H`` and is RTRL-exact for a single
-  recurrent layer (per-parameter D-RTRL trace, O(P·H)).
+  recurrent layer *whose hidden-to-hidden Jacobian is block-diagonal* (i.e. the
+  only path from one hidden unit to another is through a traced ETP recurrent
+  weight, not e.g. a hand-written mixing term) — per-parameter D-RTRL trace,
+  O(P·H). Genuine cross-hidden-unit coupling outside the traced weight is
+  dropped, so the rule is then only an approximation to BPTT.
 - :class:`OSTLFeedforward` ('without-H') drops ``H``; the temporal term vanishes
   and the update reduces to pp_prop with negligible decay (feedforward SNN).
 
@@ -52,8 +56,7 @@ class OSTLRecurrent(ParamDimVjpAlgorithm):
     OSTL derives an online rule by cleanly separating the gradient into a
     *temporal* eligibility trace and a *spatial* learning signal. The 'with-H'
     regime retains the hidden-to-hidden Jacobian, so the trace carries the full
-    temporal term and the rule is gradient-equivalent to BPTT for a single
-    recurrent layer:
+    temporal term:
 
     .. math::
 
@@ -68,6 +71,22 @@ class OSTLRecurrent(ParamDimVjpAlgorithm):
     the state-to-output Jacobian, and :math:`\mathbf{x}^t` the presynaptic input.
     This is exactly the per-parameter D-RTRL trace (memory :math:`O(P\cdot H)`),
     so the class delegates entirely to :class:`~braintrace.ParamDimVjpAlgorithm`.
+
+    **Accuracy caveat.** The D-RTRL trace machinery underlying this class only
+    ever retains the per-position *block-diagonal* of :math:`\mathbf{D}^t`
+    (:func:`HiddenGroup.diagonal_jacobian`, via ``block_diagonal_last_dim``):
+    cross-hidden-unit terms :math:`\partial h^t_p / \partial h^{t-1}_q` for
+    :math:`p \ne q` are retained only insofar as they flow through a *traced
+    ETP weight* (e.g. a recurrent :func:`~braintrace.matmul`); any other
+    hidden-to-hidden mixing (e.g. a hand-written convolution/roll/mixing term
+    not expressed as an ETP op) is *not* captured. Consequently the rule is
+    gradient-equivalent to BPTT only when the hidden-to-hidden Jacobian is
+    (effectively) block-diagonal in this sense — for a single recurrent layer
+    whose only cross-unit coupling is the traced ETP recurrent weight, the two
+    coincide to machine precision. If some other part of the model couples
+    hidden units directly (bypassing the traced weight), the two diverge; see
+    ``TestOSTLRecurrentVsBPTT`` in ``ostl_test.py`` for a worked example of both
+    regimes.
 
     Parameters
     ----------

--- a/braintrace/_algorithm/ostl.py
+++ b/braintrace/_algorithm/ostl.py
@@ -51,7 +51,7 @@ __all__ = ['OSTLRecurrent', 'OSTLFeedforward']
 
 
 class OSTLRecurrent(ParamDimVjpAlgorithm):
-    r"""OSTL 'with-H' regime — RTRL-exact single-layer factorization.
+    r"""OSTL 'with-H' regime — single-layer factorization, RTRL-exact only for block-diagonal hidden-to-hidden Jacobians.
 
     OSTL derives an online rule by cleanly separating the gradient into a
     *temporal* eligibility trace and a *spatial* learning signal. The 'with-H'

--- a/braintrace/_algorithm/ostl_test.py
+++ b/braintrace/_algorithm/ostl_test.py
@@ -282,3 +282,118 @@ def test_docstring_ostl_feedforward_compile_example_runs():
     assert y.shape == (1,)
     assert bool(jnp.all(jnp.isfinite(y)))
     assert len(learner.graph.hidden_param_op_relations) >= 1
+
+
+# ---------------------------------------------------------------------------
+# M3: OSTLRecurrent ("with-H") is gradient-equivalent to BPTT only when the
+# hidden-to-hidden Jacobian is block-diagonal (no cross-hidden-unit mixing
+# other than through the traced ETP recurrent weight). The per-parameter
+# D-RTRL trace machinery it inherits (``ParamDimVjpAlgorithm`` with
+# ``_include_recurrent_mixing=True``) discounts the weight trace by only the
+# per-position *diagonal block* of the recurrent Jacobian
+# (``HiddenGroup.diagonal_jacobian`` -> ``block_diagonal_last_dim``), so any
+# genuine cross-unit coupling that is not itself an ETP weight (e.g. a
+# ``jnp.roll`` mixing term) is dropped and the gradient departs from BPTT.
+# ---------------------------------------------------------------------------
+
+def _diagonal_recurrent_factory(n_in=3, n_rec=3, seed=0):
+    """Exactly block-diagonal hidden update: ``h_t = 0.5 * h_{t-1} + drive``.
+
+    The only path from ``h_{t-1}`` to ``h_t`` is the scalar leak (diagonal)
+    plus the traced ETP recurrent weight, so the D-RTRL diagonal
+    approximation is exact here.
+    """
+
+    def factory():
+        brainstate.random.seed(seed)
+
+        class Net(brainstate.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.w = brainstate.ParamState(0.1 * brainstate.random.randn(n_in, n_rec))
+                self.h = brainstate.HiddenState(jnp.zeros((1, n_rec)))
+
+            def update(self, x):
+                drive = braintrace.matmul(x, self.w.value)
+                self.h.value = 0.5 * self.h.value + drive
+                return self.h.value
+
+        return Net()
+
+    return factory
+
+
+def _off_block_diagonal_factory(n_in=3, n_rec=3, seed=0):
+    """Off-block-diagonal hidden update: adds a cross-hidden-unit
+    ``jnp.roll`` mixing term, so ``d h^t[p] / d h^{t-1}[q]`` is non-zero for
+    some ``p != q`` -- and that coupling is not carried by any ETP weight.
+    """
+
+    def factory():
+        brainstate.random.seed(seed)
+
+        class Net(brainstate.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.w = brainstate.ParamState(0.1 * brainstate.random.randn(n_in, n_rec))
+                self.h = brainstate.HiddenState(jnp.zeros((1, n_rec)))
+
+            def update(self, x):
+                drive = braintrace.matmul(x, self.w.value)
+                self.h.value = (
+                    0.5 * self.h.value + drive
+                    + 0.1 * jnp.roll(self.h.value, 1, axis=-1)
+                )
+                return self.h.value
+
+        return Net()
+
+    return factory
+
+
+def _ostl_recurrent_rel_err(factory, xs):
+    """Max relative error between the BPTT oracle and OSTLRecurrent's
+    single-step-naive online gradient, for the (single) ETP weight ``w``."""
+    from braintrace._algorithm.oracle import (
+        bptt_param_gradients,
+        online_param_gradients_singlestep_naive,
+    )
+
+    g_bptt = bptt_param_gradients(factory, xs)
+    g_online = online_param_gradients_singlestep_naive(
+        factory, xs,
+        algo_factory=lambda m: OSTLRecurrent(m, vjp_method='single-step'),
+    )
+    key = next(iter(g_bptt))
+    a = jnp.asarray(g_bptt[key])
+    b = jnp.asarray(g_online[key])
+    denom = jnp.maximum(jnp.abs(a).max(), 1e-12)
+    return float(jnp.abs(a - b).max() / denom)
+
+
+class TestOSTLRecurrentVsBPTT(unittest.TestCase):
+    """Pins the corrected M3 claim.
+
+    ``OSTLRecurrent`` matches BPTT exactly when the recurrent Jacobian is
+    block-diagonal, and is a genuine approximation (diverges from BPTT) once
+    hidden units mix through anything other than the traced ETP weight.
+    """
+
+    def test_exact_diagonal_model_matches_bptt(self):
+        with brainstate.environ.context(precision=64):
+            factory = _diagonal_recurrent_factory()
+            brainstate.random.seed(42)
+            xs = 0.3 * brainstate.random.randn(4, 1, 3)
+            rel = _ostl_recurrent_rel_err(factory, xs)
+        assert rel < 1e-10, f'expected an exact match on a diagonal model, got rel={rel:.3e}'
+
+    def test_off_block_diagonal_model_diverges_from_bptt(self):
+        with brainstate.environ.context(precision=64):
+            factory = _off_block_diagonal_factory()
+            brainstate.random.seed(42)
+            xs = 0.3 * brainstate.random.randn(4, 1, 3)
+            rel = _ostl_recurrent_rel_err(factory, xs)
+        assert rel > 1e-6, (
+            f'expected OSTLRecurrent to diverge from BPTT once the hidden '
+            f'update has off-block-diagonal mixing, got rel={rel:.3e}'
+        )

--- a/braintrace/_algorithm/osttp.py
+++ b/braintrace/_algorithm/osttp.py
@@ -34,6 +34,7 @@ import jax
 import jax.numpy as jnp
 
 from braintrace._typing import ArrayLike
+from ._common import extract_y_target
 from .param_dim_vjp import ParamDimVjpAlgorithm
 
 __all__ = ['OSTTP']
@@ -176,7 +177,19 @@ class OSTTP(ParamDimVjpAlgorithm):
                 )
 
     def update(self, x: ArrayLike, y_target: ArrayLike | None = None) -> Any:
-        """Call ``super().update(x)`` after stashing ``y_target`` for the hook."""
+        """Call ``super().update(x)`` after stashing ``y_target`` for ``_get_update_aux``.
+
+        The stash is read back synchronously by :meth:`_get_update_aux`
+        (called at the very start of the base class's ``update()``, before
+        any custom_vjp tracing happens) and threaded from there into
+        ``_true_update_fun`` as a genuine argument. This is required because
+        outer transforms (e.g. ``brainstate.transform.grad``) may stage the
+        forward trace and only invoke the custom_vjp fwd/bwd rules *after*
+        this Python-level call has already returned -- by then any
+        instance-attribute stash read directly inside ``_update_fn_fwd`` or
+        ``_update_fn_bwd`` would already see ``None``. Threading the value as
+        a real traced argument sidesteps that timing problem entirely.
+        """
         if self.target_timing == 'per-step' and y_target is None:
             raise ValueError(
                 "OSTTP(target_timing='per-step') requires y_target at every update() call."
@@ -187,9 +200,20 @@ class OSTTP(ParamDimVjpAlgorithm):
         finally:
             self._current_y_target = None
 
+    def _get_update_aux(self) -> Any:
+        """Supply ``y_target`` as the per-call auxiliary data (see base class)."""
+        return self._current_y_target
+
     def _compute_learning_signal(self, dl_autodiff: Any, args: Any) -> Any:
-        """Replace reverse-AD ``dL/dh`` with ``B_l @ y_target`` per HiddenGroup."""
-        y_target = self._current_y_target
+        """Replace reverse-AD ``dL/dh`` with ``B_l @ y_target`` per HiddenGroup.
+
+        ``args`` here is ``(x, y_target)`` -- the base class appends the
+        auxiliary data returned by :meth:`_get_update_aux` to the model's own
+        forward arguments before invoking this hook (see
+        ``ETraceVjpAlgorithm._update_fn_bwd``); :func:`extract_y_target`
+        pulls ``y_target`` from the trailing position.
+        """
+        y_target = extract_y_target(args)
         if y_target is None:
             # target_timing='sequence-end' with no y_target: zero out so traces
             # accumulate without emitting a weight update this step.

--- a/braintrace/_algorithm/osttp_test.py
+++ b/braintrace/_algorithm/osttp_test.py
@@ -127,7 +127,6 @@ class TestOSTTPLearningSignalNonzero(unittest.TestCase):
     """
 
     def _grad_for_target(self, y_target: jnp.ndarray, B: jnp.ndarray) -> jnp.ndarray:
-        brainstate.random.seed(0)
         net = _osttp_net()
         algo = OSTTP(net, B_list=[B])
         x = jnp.ones((1, 3))

--- a/braintrace/_algorithm/osttp_test.py
+++ b/braintrace/_algorithm/osttp_test.py
@@ -115,6 +115,50 @@ class TestOSTTPTargetProjection(unittest.TestCase):
         assert not jnp.allclose(g_osttp, g_drtrl, atol=1e-4)
 
 
+class TestOSTTPLearningSignalNonzero(unittest.TestCase):
+    """Regression test for the zero-learning-signal bug (C4).
+
+    OSTTP used to stash ``y_target`` on the instance during the forward
+    ``update()`` and clear it in a ``finally`` block before returning. The
+    learning-signal hook (``_compute_learning_signal``) only runs later,
+    inside the ``jax.custom_vjp`` backward pass -- by then the stash was
+    already ``None``, so the target-projected learning signal, and hence the
+    weight gradient, was identically zero regardless of ``y_target``.
+    """
+
+    def _grad_for_target(self, y_target: jnp.ndarray, B: jnp.ndarray) -> jnp.ndarray:
+        brainstate.random.seed(0)
+        net = _osttp_net()
+        algo = OSTTP(net, B_list=[B])
+        x = jnp.ones((1, 3))
+        algo.compile_graph(x)
+        algo.init_etrace_state()
+
+        def loss(x_):
+            out = algo.update(x_, y_target=y_target)
+            return (out ** 2).sum()
+
+        grads, _ = brainstate.transform.grad(
+            loss, algo.param_states, return_value=True
+        )(x)
+        return grads[next(iter(grads))]
+
+    def test_gradients_depend_on_target(self):
+        B = 0.1 * jax.random.normal(jax.random.PRNGKey(11), (4, 3))
+        y1 = jnp.ones((1, 4))
+        y2 = -5.0 * jnp.ones((1, 4))
+
+        g1 = self._grad_for_target(y1, B)
+        g2 = self._grad_for_target(y2, B)
+
+        # Different targets must yield different weight gradients -- if the
+        # learning signal were identically zero (the bug), g1 == g2 (both
+        # all-zero).
+        assert not jnp.allclose(g1, g2, atol=1e-6)
+        assert not jnp.allclose(g1, jnp.zeros_like(g1), atol=1e-8)
+        assert not jnp.allclose(g2, jnp.zeros_like(g2), atol=1e-8)
+
+
 class FakeLIF(brainstate.HiddenState):
     def __init__(self, iv, leak):
         super().__init__(iv)

--- a/braintrace/_algorithm/otpe.py
+++ b/braintrace/_algorithm/otpe.py
@@ -34,12 +34,17 @@ from typing import Any, Dict, Optional
 import brainstate
 import jax.numpy as jnp
 
-from braintrace._op import is_batched_primitive
+from braintrace._op import etp_mm_p, etp_mv_p, is_batched_primitive
 from braintrace._misc import etrace_df_key
 from ._common import _route_grads_by_path, _update_dict
 from .vjp_base import ETraceVjpAlgorithm
 
 __all__ = ['OTPE']
+
+# OTPE's per-parameter leaky trace only reduces correctly for dense matmul
+# relations. LoRA, sparse, conv, and element-wise (no x_var) relations are
+# excluded -- see the compile-time guard in `init_etrace_state`.
+_SUPPORTED_PRIMITIVES = frozenset({etp_mm_p, etp_mv_p})
 
 
 class OTPE(ETraceVjpAlgorithm):
@@ -111,7 +116,11 @@ class OTPE(ETraceVjpAlgorithm):
         Name of the algorithm instance.
     vjp_method : str, optional
         Forwarded to the base algorithm. Only ``'single-step'`` is supported by
-        OTPE v1; multi-step inputs raise :class:`NotImplementedError`.
+        OTPE v1 -- its trace update and weight-gradient formulas are derived
+        one step at a time. ``vjp_method='multi-step'`` is rejected with
+        :class:`ValueError` at construction; multi-step *inputs* (i.e. calling
+        the compiled learner with :class:`~braintrace.MultiStepData`) raise
+        :class:`NotImplementedError` instead, at call time.
 
     Limitations
     -----------
@@ -154,10 +163,16 @@ class OTPE(ETraceVjpAlgorithm):
     ------
     ValueError
         If ``mode`` is not ``'full'`` or ``'approx'``, if ``leak`` is not in
-        :math:`(0, 1)`, if a weight-to-hidden relation reaches more than one
-        HiddenGroup (OTPE v1 requires one-hop per-layer relations), or (at
-        :meth:`compile_graph`) if a trained connection projects into a hidden
-        group with ``num_state > 1``.
+        :math:`(0, 1)`, if ``vjp_method`` is not ``'single-step'``, if a
+        weight-to-hidden relation reaches more than one HiddenGroup (OTPE v1
+        requires one-hop per-layer relations), or (at :meth:`compile_graph`)
+        if a trained connection projects into a hidden group with
+        ``num_state > 1``.
+    NotImplementedError
+        At :meth:`compile_graph`, if a trained connection is routed through a
+        primitive other than dense ``matmul`` (batched or unbatched) -- e.g.
+        LoRA, sparse, or convolutional relations, whose weight-gradient chain
+        rule does not reduce to OTPE's per-parameter leaky trace.
 
     Examples
     --------
@@ -205,6 +220,13 @@ class OTPE(ETraceVjpAlgorithm):
             raise ValueError(f"mode must be 'full' or 'approx'; got {mode!r}")
         if not (0.0 < float(leak) < 1.0):
             raise ValueError(f'leak must be in (0, 1); got {leak}')
+        if vjp_method != 'single-step':
+            raise ValueError(
+                f"OTPE v1 only supports vjp_method='single-step': its trace "
+                f"update and weight-gradient formulas are derived one step at "
+                f"a time and have no multi-step form; got "
+                f"vjp_method={vjp_method!r}."
+            )
         super().__init__(model, name=name, vjp_method=vjp_method)
         self.mode = mode
         self.leak = float(leak)
@@ -212,60 +234,100 @@ class OTPE(ETraceVjpAlgorithm):
         self._R_hat: Dict[int, brainstate.ShortTermState] = {}
         self._R_hat_x: Dict[int, brainstate.ShortTermState] = {}
         self._R_hat_g: Dict[int, brainstate.ShortTermState] = {}
+        self._R_hat_bias: Dict[int, brainstate.ShortTermState] = {}
+        self._rid_is_batched: Dict[int, bool] = {}
 
     def compile_graph(self, *args: Any) -> None:
+        # `super().compile_graph()` builds the graph, calls `init_etrace_state`,
+        # and -- only once both succeed -- sets `self.is_compiled = True`. The
+        # validation below runs *after* that flag is already True, so any
+        # failure here must explicitly reset it (finding M6); otherwise a
+        # failed compile would leave `is_compiled` stuck True and silently
+        # short-circuit a later, valid `compile_graph` call (the base class's
+        # `if not self.is_compiled:` guard would treat it as already compiled).
         super().compile_graph(*args)
-        if self.mode == 'approx':
-            n_groups = len(self.graph.hidden_groups)
-            if n_groups > 1:
-                warnings.warn(
-                    "OTPE(mode='approx') bias compounds with network depth; "
-                    "consider F-OTPE or mode='full'.",
-                    UserWarning,
-                )
-        # Invariant: each relation maps to exactly one HiddenGroup in OTPE v1.
-        for rel in self.graph.hidden_param_op_relations:
-            if len(rel.hidden_groups) != 1:
-                raise ValueError(
-                    f'OTPE requires per-layer one-hop weight-to-hidden relations; '
-                    f'found relation reaching {len(rel.hidden_groups)} groups.'
-                )
-            # OTPE's derivation assumes a single scalar membrane state per neuron
-            # (the LIF case). A hidden group bundling several states (e.g. ALIF's
-            # membrane potential plus adaptation variable) cannot be handled: the
-            # leaky scalar estimate cannot assign per-state credit, and collapsing
-            # the num_state axis with a sum has no theoretical basis (see the
-            # *Limitations* section of the class docstring).
-            group = rel.hidden_groups[0]
-            if group.num_state > 1:
-                raise ValueError(
-                    f'OTPE only supports hidden groups with num_state == 1 '
-                    f'(single-state LIF-like neurons), but a trained connection '
-                    f'projects into a group with num_state == {group.num_state}. '
-                    f'Multi-state neurons (e.g. ALIF with an adaptation variable) '
-                    f'are outside the regime where OTPE is derived.'
-                )
+        try:
+            if self.mode == 'approx':
+                n_groups = len(self.graph.hidden_groups)
+                if n_groups > 1:
+                    warnings.warn(
+                        "OTPE(mode='approx') (F-OTPE) adds an extra outer-product "
+                        "approximation whose bias compounds with network depth; "
+                        "mode='full' reduces (but does not eliminate) this "
+                        "depth-dependent bias -- see the Limitations section of "
+                        "the class docstring.",
+                        UserWarning,
+                    )
+            # Invariant: each relation maps to exactly one HiddenGroup in OTPE v1.
+            for rel in self.graph.hidden_param_op_relations:
+                if len(rel.hidden_groups) != 1:
+                    raise ValueError(
+                        f'OTPE requires per-layer one-hop weight-to-hidden relations; '
+                        f'found relation reaching {len(rel.hidden_groups)} groups.'
+                    )
+                # OTPE's derivation assumes a single scalar membrane state per neuron
+                # (the LIF case). A hidden group bundling several states (e.g. ALIF's
+                # membrane potential plus adaptation variable) cannot be handled: the
+                # leaky scalar estimate cannot assign per-state credit, and collapsing
+                # the num_state axis with a sum has no theoretical basis (see the
+                # *Limitations* section of the class docstring).
+                group = rel.hidden_groups[0]
+                if group.num_state > 1:
+                    raise ValueError(
+                        f'OTPE only supports hidden groups with num_state == 1 '
+                        f'(single-state LIF-like neurons), but a trained connection '
+                        f'projects into a group with num_state == {group.num_state}. '
+                        f'Multi-state neurons (e.g. ALIF with an adaptation variable) '
+                        f'are outside the regime where OTPE is derived.'
+                    )
+        except Exception:
+            self.is_compiled = False
+            raise
 
     def init_etrace_state(self, *args: Any, **kwargs: Any) -> None:
         self._R_hat = {}
         self._R_hat_x = {}
         self._R_hat_g = {}
+        self._R_hat_bias = {}
+        self._rid_is_batched = {}
         for rel in self.graph.hidden_param_op_relations:
+            if rel.primitive not in _SUPPORTED_PRIMITIVES:
+                raise NotImplementedError(
+                    f'OTPE only supports dense matmul relations (etp_mm/etp_mv); '
+                    f'got a trained connection routed through primitive '
+                    f'{rel.primitive.name!r}. LoRA, sparse, convolutional, and '
+                    f'element-wise relations do not reduce to OTPE\'s '
+                    f'per-parameter leaky trace and are unsupported.'
+                )
+            if rel.x_var is None:
+                # Unreachable given the primitive guard above (both etp_mm and
+                # etp_mv always carry an x_var); kept as an explicit, message-
+                # bearing guard rather than a bare assert (see finding N3).
+                raise ValueError(
+                    f'OTPE requires a relation with an explicit presynaptic '
+                    f'input (x_var), but the relation for primitive '
+                    f'{rel.primitive.name!r} has none.'
+                )
             rid = id(rel.y_var)
-            assert rel.x_var is not None  # non-elemwise primitives always have an x_var
             in_shape = rel.x_var.aval.shape
             out_shape = rel.y_var.aval.shape
+            batched = is_batched_primitive(rel.primitive)
+            self._rid_is_batched[rid] = batched
             if self.mode == 'full':
                 weight_key = next(iter(rel.trainable_vars))
                 weight_var = rel.trainable_vars[weight_key]
                 weight_shape = weight_var.aval.shape
-                if is_batched_primitive(rel.primitive):
+                if batched:
                     shape = (in_shape[0], *weight_shape)
                 else:
                     shape = weight_shape
                 self._R_hat[rid] = brainstate.ShortTermState(
                     jnp.zeros(shape, dtype=jnp.float32)
                 )
+                if 'bias' in rel.trainable_vars:
+                    self._R_hat_bias[rid] = brainstate.ShortTermState(
+                        jnp.zeros(out_shape, dtype=jnp.float32)
+                    )
             else:
                 self._R_hat_x[rid] = brainstate.ShortTermState(
                     jnp.zeros(in_shape, dtype=jnp.float32)
@@ -277,18 +339,28 @@ class OTPE(ETraceVjpAlgorithm):
     def reset_state(self, batch_size: Optional[int] = None, **kwargs: Any) -> None:
         self.running_index.value = 0
 
-        def _rezero(state: Any) -> None:
+        def _rezero(rid: int, state: Any) -> None:
             shape = state.value.shape
-            new_shape = (batch_size, *shape[1:]) if batch_size is not None else shape
+            if batch_size is not None and self._rid_is_batched.get(rid, False):
+                new_shape = (batch_size, *shape[1:])
+            else:
+                # Unbatched relations (etp_mv) have no batch axis in their
+                # trace; `batch_size` does not apply to them, and reusing the
+                # stored shape as-is (rather than assuming shape[0] is a batch
+                # axis) avoids corrupting it -- see finding M4.
+                new_shape = shape
             state.value = jnp.zeros(new_shape, dtype=state.value.dtype)
 
-        for store in (self._R_hat, self._R_hat_x, self._R_hat_g):
-            for r in store.values():
-                _rezero(r)
+        for store in (self._R_hat, self._R_hat_x, self._R_hat_g, self._R_hat_bias):
+            for rid, r in store.items():
+                _rezero(rid, r)
 
     def _get_etrace_data(self) -> Any:
         if self.mode == 'full':
-            return {rid: r.value for rid, r in self._R_hat.items()}
+            return (
+                {rid: r.value for rid, r in self._R_hat.items()},
+                {rid: r.value for rid, r in self._R_hat_bias.items()},
+            )
         return (
             {rid: r.value for rid, r in self._R_hat_x.items()},
             {rid: r.value for rid, r in self._R_hat_g.items()},
@@ -296,8 +368,11 @@ class OTPE(ETraceVjpAlgorithm):
 
     def _assign_etrace_data(self, vals: Any) -> None:
         if self.mode == 'full':
-            for rid, v in vals.items():
+            vals_R, vals_bias = vals
+            for rid, v in vals_R.items():
                 self._R_hat[rid].value = v
+            for rid, v in vals_bias.items():
+                self._R_hat_bias[rid].value = v
         else:
             vals_x, vals_g = vals
             for rid, v in vals_x.items():
@@ -309,14 +384,23 @@ class OTPE(ETraceVjpAlgorithm):
         self, running_index: Any, hist_vals: Any,
         hid2weight_jac: Any, hid2hid_jac: Any, weight_vals: Any, input_is_multi_step: Any,
     ) -> Any:
-        """``R_hat ← λ·R_hat + ∂s/∂θ_local``. Ignores ``hid2hid_jac``."""
+        """``R_hat ← λ·R_hat + ∂s/∂θ_local``. Ignores ``hid2hid_jac``.
+
+        The bias companion trace ``R_hat_bias`` follows the same recursion
+        with the presynaptic input dropped (bias's local Jacobian has no ``x``
+        factor): ``R_hat_bias ← λ·R_hat_bias + df``, identical in form to
+        ``_R_hat_g`` (which the ``'approx'`` mode already maintains for its own
+        outer-product factorization).
+        """
         if input_is_multi_step:
             raise NotImplementedError('OTPE v1 supports single-step only')
         xs = hid2weight_jac[0]
         dfs = hid2weight_jac[1]
 
         if self.mode == 'full':
+            hist_R, hist_bias = hist_vals
             new_R = {}
+            new_bias = {}
             for rel in self.graph.hidden_param_op_relations:
                 rid = id(rel.y_var)
                 group = rel.hidden_groups[0]
@@ -327,13 +411,15 @@ class OTPE(ETraceVjpAlgorithm):
                     local = jnp.einsum('bi,bo->bio', x, df_proj)
                 else:
                     local = jnp.einsum('i,o->io', x, df_proj)
-                updated = self.leak * hist_vals[rid] + local
+                updated = self.leak * hist_R[rid] + local
                 if self.trace_clip_abs is not None:
                     updated = jnp.clip(
                         updated, -self.trace_clip_abs, self.trace_clip_abs
                     )
                 new_R[rid] = updated
-            return new_R
+                if rid in hist_bias:
+                    new_bias[rid] = self.leak * hist_bias[rid] + df_proj
+            return (new_R, new_bias)
         else:
             new_Rx = {}
             new_Rg = {}
@@ -353,16 +439,22 @@ class OTPE(ETraceVjpAlgorithm):
     ) -> Any:
         dG = {path: None for path in self.param_states}
         if self.mode == 'full':
+            R_map, Rbias_map = etrace_at_t
             for rel in self.graph.hidden_param_op_relations:
                 rid = id(rel.y_var)
-                R = etrace_at_t[rid]
+                R = R_map[rid]
                 group = rel.hidden_groups[0]
                 L = dl_to_hidden_groups[group.index].sum(axis=-1)
+                per_key = {}
                 if is_batched_primitive(rel.primitive):
-                    dw = jnp.einsum('bo,bio->io', L, R)
+                    per_key['weight'] = jnp.einsum('bo,bio->io', L, R)
+                    if 'bias' in rel.trainable_vars:
+                        per_key['bias'] = jnp.einsum('bo,bo->o', L, Rbias_map[rid])
                 else:
-                    dw = jnp.einsum('o,io->io', L, R)
-                _route_grads_by_path(rel, {'weight': dw}, weight_vals, dG)
+                    per_key['weight'] = jnp.einsum('o,io->io', L, R)
+                    if 'bias' in rel.trainable_vars:
+                        per_key['bias'] = L * Rbias_map[rid]
+                _route_grads_by_path(rel, per_key, weight_vals, dG)
         else:
             Rx_map, Rg_map = etrace_at_t
             for rel in self.graph.hidden_param_op_relations:
@@ -371,11 +463,20 @@ class OTPE(ETraceVjpAlgorithm):
                 L = dl_to_hidden_groups[group.index].sum(axis=-1)
                 Rx = Rx_map[rid]
                 Rg = Rg_map[rid]
+                Lg = L * Rg
+                per_key = {}
                 if is_batched_primitive(rel.primitive):
-                    dw = jnp.einsum('bi,bo->io', Rx, L * Rg)
+                    per_key['weight'] = jnp.einsum('bi,bo->io', Rx, Lg)
+                    if 'bias' in rel.trainable_vars:
+                        # Bias has no "in" dimension: sum the per-batch-row
+                        # contributions directly (matches the 'b' contraction
+                        # the weight einsum performs above).
+                        per_key['bias'] = Lg.sum(axis=0)
                 else:
-                    dw = jnp.einsum('i,o->io', Rx, L * Rg)
-                _route_grads_by_path(rel, {'weight': dw}, weight_vals, dG)
+                    per_key['weight'] = jnp.einsum('i,o->io', Rx, Lg)
+                    if 'bias' in rel.trainable_vars:
+                        per_key['bias'] = Lg
+                _route_grads_by_path(rel, per_key, weight_vals, dG)
 
         for path, dg in dl_to_nonetws_at_t.items():
             _update_dict(dG, path, dg)

--- a/braintrace/_algorithm/otpe.py
+++ b/braintrace/_algorithm/otpe.py
@@ -200,7 +200,6 @@ class OTPE(ETraceVjpAlgorithm):
         name: Optional[str] = None,
         vjp_method: str = 'single-step',
         trace_clip_abs: Optional[float] = None,
-        **kwargs: Any,
     ) -> None:
         if mode not in ('full', 'approx'):
             raise ValueError(f"mode must be 'full' or 'approx'; got {mode!r}")

--- a/braintrace/_algorithm/otpe.py
+++ b/braintrace/_algorithm/otpe.py
@@ -314,7 +314,10 @@ class OTPE(ETraceVjpAlgorithm):
             batched = is_batched_primitive(rel.primitive)
             self._rid_is_batched[rid] = batched
             if self.mode == 'full':
-                weight_key = next(iter(rel.trainable_vars))
+                # 'weight' always exists: the primitive guard above restricts
+                # relations to etp_mm/etp_mv, whose dense-matmul rules key
+                # trainable_vars with 'weight' (and, optionally, 'bias').
+                weight_key = 'weight'
                 weight_var = rel.trainable_vars[weight_key]
                 weight_shape = weight_var.aval.shape
                 if batched:

--- a/braintrace/_algorithm/otpe_test.py
+++ b/braintrace/_algorithm/otpe_test.py
@@ -20,6 +20,7 @@ import jax
 import jax.numpy as jnp
 
 import braintrace
+from braintrace._algorithm import oracle
 from braintrace._algorithm.otpe import OTPE
 
 
@@ -64,6 +65,78 @@ def _two_state_net():
     return net
 
 
+def _lora_net():
+    """Net trained through `braintrace.lora_matmul` -- LoRA relations are outside
+    OTPE's supported primitive set (see finding H5)."""
+
+    class Net(brainstate.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.B = brainstate.ParamState(
+                0.1 * jax.random.normal(jax.random.PRNGKey(0), (3, 2))
+            )
+            self.A = brainstate.ParamState(
+                0.1 * jax.random.normal(jax.random.PRNGKey(1), (2, 3))
+            )
+            self.v = brainstate.HiddenState(jnp.zeros((1, 3)))
+
+        def update(self, x):
+            self.v.value = 0.9 * self.v.value + braintrace.lora_matmul(
+                x, self.B.value, self.A.value
+            )
+            return self.v.value
+
+    net = Net()
+    brainstate.nn.init_all_states(net, batch_size=1)
+    return net
+
+
+def _bias_net():
+    """Net trained through a recurrent `braintrace.matmul(..., bias=...)`, whose
+    recurrence coefficient (0.9) matches the `leak` OTTT/OTPE are given -- the
+    "exactly diagonal" regime in which both algorithms claim BPTT-exact gradients."""
+
+    class Net(brainstate.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.w = brainstate.ParamState(
+                0.1 * jax.random.normal(jax.random.PRNGKey(0), (3, 3))
+            )
+            self.b = brainstate.ParamState(jnp.zeros(3))
+            self.v = brainstate.HiddenState(jnp.zeros((1, 3)))
+
+        def update(self, x):
+            self.v.value = 0.9 * self.v.value + braintrace.matmul(
+                x, self.w.value, self.b.value
+            )
+            return self.v.value
+
+    net = Net()
+    brainstate.nn.init_all_states(net, batch_size=1)
+    return net
+
+
+def _unbatched_net():
+    """Net with an unbatched hidden state (no leading batch axis) -- exercises
+    OTPE's `reset_state` on `etp_mv` relations (see finding M4)."""
+
+    class Net(brainstate.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.w = brainstate.ParamState(
+                0.1 * jax.random.normal(jax.random.PRNGKey(0), (3, 3))
+            )
+            self.v = brainstate.HiddenState(jnp.zeros((3,)))
+
+        def update(self, x):
+            self.v.value = 0.9 * self.v.value + braintrace.matmul(x, self.w.value)
+            return self.v.value
+
+    net = Net()
+    brainstate.nn.init_all_states(net)  # no batch_size -> unbatched
+    return net
+
+
 class TestOTPEConstruction(unittest.TestCase):
     def test_default_mode_full(self):
         algo = OTPE(_otpe_net_single_layer(), leak=0.9)
@@ -81,6 +154,14 @@ class TestOTPEConstruction(unittest.TestCase):
     def test_leak_out_of_range_raises(self):
         with self.assertRaises(ValueError):
             OTPE(_otpe_net_single_layer(), leak=1.5)
+
+    def test_multi_step_vjp_method_rejected_at_construction(self):
+        """N6: OTPE's trace update/weight-gradient rules are derived one step at
+        a time and have no multi-step form; `vjp_method='multi-step'` must be
+        rejected eagerly at construction, not silently accepted until the first
+        (multi-step) call fails."""
+        with self.assertRaises(ValueError):
+            OTPE(_otpe_net_single_layer(), leak=0.9, vjp_method='multi-step')
 
     def test_num_state_gt_one_raises(self):
         """Multi-state hidden groups are outside OTPE's LIF regime."""
@@ -140,6 +221,119 @@ class TestOTPEApproxMode(unittest.TestCase):
         )(x)
         g = grads[next(iter(grads))]
         assert g.shape == (3, 3)
+
+
+class TestOTPEBiasGradient(unittest.TestCase):
+    """H5: the weight-gradient solvers indexed only the ``'weight'`` key of each
+    relation's trainable dict, so `braintrace.matmul(x, w, bias=b)` silently got
+    a zero bias gradient. Must route every key (here also ``'bias'``) through
+    `relation.trainable_paths`, exactly as `_common._route_grads_by_path` does.
+
+    OTPE's docstring claims gradient-exactness for a single hidden layer under
+    the scalar-leak (LIF) assumption. In the "exactly diagonal" regime -- the
+    model's recurrence coefficient equals the `leak` OTPE is given -- both
+    'full' and 'approx' modes are exact for bias specifically: bias's local
+    Jacobian dy/db=1 has no "in" dimension, so 'approx' mode's outer-product
+    factorization (which only approximates the joint x-times-df weight trace)
+    introduces no approximation error for bias -- its ``R_hat_g``/``R_hat_bias``
+    companion trace follows the identical recursion in both modes. So we assert
+    *element-wise* equality with the BPTT oracle for bias in both modes.
+    """
+
+    def test_bias_gradient_matches_bptt_full_mode(self):
+        inputs = jnp.stack([jnp.ones((1, 3)) * (i + 1) * 0.1 for i in range(4)])
+        bptt = oracle.bptt_param_gradients(_bias_net, inputs)
+        online = oracle.online_param_gradients_singlestep_naive(
+            _bias_net, inputs, algo_factory=lambda m: OTPE(m, leak=0.9, mode='full')
+        )
+        assert bool(jnp.any(online[('b',)] != 0.0)), 'bias gradient must not be zero (H5)'
+        oracle.assert_param_gradients_close(
+            online, bptt, atol=1e-4, keys=[('b',), ('w',)]
+        )
+
+    def test_bias_gradient_matches_bptt_approx_mode(self):
+        inputs = jnp.stack([jnp.ones((1, 3)) * (i + 1) * 0.1 for i in range(4)])
+        bptt = oracle.bptt_param_gradients(_bias_net, inputs)
+        online = oracle.online_param_gradients_singlestep_naive(
+            _bias_net, inputs, algo_factory=lambda m: OTPE(m, leak=0.9, mode='approx')
+        )
+        assert bool(jnp.any(online[('b',)] != 0.0)), 'bias gradient must not be zero (H5)'
+        # Only the bias key is asserted exact here -- 'approx' mode's weight
+        # gradient is *not* BPTT-exact (its outer-product factorization is a
+        # genuine additional approximation), covered separately in
+        # TestOTPEApproxMode.
+        oracle.assert_param_gradients_close(online, bptt, atol=1e-4, keys=[('b',)])
+
+
+class TestOTPEUnsupportedRelationGuard(unittest.TestCase):
+    """H5: LoRA/conv/sparse relations don't reduce to OTPE's per-parameter
+    leaky trace; they must raise a compile-time `NotImplementedError` naming
+    the offending primitive rather than crashing opaquely or silently
+    mishandling the relation."""
+
+    def test_lora_relation_raises_named_primitive_at_compile_time(self):
+        algo = OTPE(_lora_net(), leak=0.9, mode='full')
+        with self.assertRaises(NotImplementedError) as ctx:
+            algo.compile_graph(jnp.ones((1, 3)))
+        assert 'etp_lora_mm' in str(ctx.exception)
+
+    def test_is_compiled_stays_false_after_repeated_guard_failure(self):
+        """M6: a failed compile-time validation must not leave `is_compiled`
+        stuck True -- otherwise `base.compile_graph`'s ``if not
+        self.is_compiled:`` guard would silently skip re-validation (and
+        `init_etrace_state`) on a subsequent call. Calling `compile_graph`
+        twice on the same (permanently invalid) model must raise both times."""
+        algo = OTPE(_lora_net(), leak=0.9, mode='full')
+        x = jnp.ones((1, 3))
+        with self.assertRaises(NotImplementedError):
+            algo.compile_graph(x)
+        assert algo.is_compiled is False
+
+        with self.assertRaises(NotImplementedError):
+            algo.compile_graph(x)
+        assert algo.is_compiled is False
+
+        # A fresh, valid model must still compile normally afterward.
+        ok_algo = OTPE(_otpe_net_single_layer(), leak=0.9, mode='full')
+        ok_algo.compile_graph(x)
+        assert ok_algo.is_compiled is True
+
+
+class TestOTPEUnbatchedResetState(unittest.TestCase):
+    """M4: `OTPE.reset_state` assumed a leading batch axis and corrupted
+    unbatched trace shapes (e.g. replacing the real leading `in`/`out` dim with
+    `batch_size`). Must derive reset shapes from the stored trace values
+    instead of assuming a batch axis is present."""
+
+    def test_reset_preserves_unbatched_trace_shapes_full_mode(self):
+        net = _unbatched_net()
+        algo = OTPE(net, leak=0.9, mode='full')
+        x = jnp.ones((3,))
+        algo.compile_graph(x)
+        algo.init_etrace_state()
+        algo.update(x)  # populate traces with real (non-init) values first
+
+        before = {rid: r.value.shape for rid, r in algo._R_hat.items()}
+        algo.reset_state(batch_size=4)  # unbatched relations must ignore this
+        after = {rid: r.value.shape for rid, r in algo._R_hat.items()}
+        assert before == after
+        assert all(v.value.shape == (3, 3) for v in algo._R_hat.values())
+
+    def test_reset_preserves_unbatched_trace_shapes_approx_mode(self):
+        net = _unbatched_net()
+        algo = OTPE(net, leak=0.9, mode='approx')
+        x = jnp.ones((3,))
+        algo.compile_graph(x)
+        algo.init_etrace_state()
+        algo.update(x)
+
+        before_x = {rid: r.value.shape for rid, r in algo._R_hat_x.items()}
+        before_g = {rid: r.value.shape for rid, r in algo._R_hat_g.items()}
+        algo.reset_state(batch_size=4)
+        after_x = {rid: r.value.shape for rid, r in algo._R_hat_x.items()}
+        after_g = {rid: r.value.shape for rid, r in algo._R_hat_g.items()}
+        assert before_x == after_x
+        assert before_g == after_g
 
 
 def _toy_net():

--- a/braintrace/_algorithm/otpe_test.py
+++ b/braintrace/_algorithm/otpe_test.py
@@ -72,12 +72,9 @@ def _lora_net():
     class Net(brainstate.nn.Module):
         def __init__(self):
             super().__init__()
-            self.B = brainstate.ParamState(
-                0.1 * jax.random.normal(jax.random.PRNGKey(0), (3, 2))
-            )
-            self.A = brainstate.ParamState(
-                0.1 * jax.random.normal(jax.random.PRNGKey(1), (2, 3))
-            )
+            brainstate.random.seed(0)
+            self.B = brainstate.ParamState(0.1 * brainstate.random.normal(size=(3, 2)))
+            self.A = brainstate.ParamState(0.1 * brainstate.random.normal(size=(2, 3)))
             self.v = brainstate.HiddenState(jnp.zeros((1, 3)))
 
         def update(self, x):
@@ -99,9 +96,8 @@ def _bias_net():
     class Net(brainstate.nn.Module):
         def __init__(self):
             super().__init__()
-            self.w = brainstate.ParamState(
-                0.1 * jax.random.normal(jax.random.PRNGKey(0), (3, 3))
-            )
+            brainstate.random.seed(0)
+            self.w = brainstate.ParamState(0.1 * brainstate.random.normal(size=(3, 3)))
             self.b = brainstate.ParamState(jnp.zeros(3))
             self.v = brainstate.HiddenState(jnp.zeros((1, 3)))
 
@@ -123,9 +119,8 @@ def _unbatched_net():
     class Net(brainstate.nn.Module):
         def __init__(self):
             super().__init__()
-            self.w = brainstate.ParamState(
-                0.1 * jax.random.normal(jax.random.PRNGKey(0), (3, 3))
-            )
+            brainstate.random.seed(0)
+            self.w = brainstate.ParamState(0.1 * brainstate.random.normal(size=(3, 3)))
             self.v = brainstate.HiddenState(jnp.zeros((3,)))
 
         def update(self, x):
@@ -164,10 +159,29 @@ class TestOTPEConstruction(unittest.TestCase):
             OTPE(_otpe_net_single_layer(), leak=0.9, vjp_method='multi-step')
 
     def test_num_state_gt_one_raises(self):
-        """Multi-state hidden groups are outside OTPE's LIF regime."""
+        """Multi-state hidden groups are outside OTPE's LIF regime.
+
+        M6: unlike the `NotImplementedError` in
+        `TestOTPEUnsupportedRelationGuard` (which fires inside
+        `init_etrace_state`, *before* `base.compile_graph` ever sets
+        `is_compiled = True`), this `ValueError` fires in OTPE's own
+        post-`super().compile_graph()` validation -- i.e. *after* the base
+        class has already set `is_compiled = True`. That validation's
+        try/except must explicitly reset the flag on failure, or a failed
+        compile would leave `is_compiled` stuck `True` and the base class's
+        `if not self.is_compiled:` guard would silently skip re-validation
+        (and `init_etrace_state`) on a subsequent `compile_graph` call."""
         algo = OTPE(_two_state_net(), leak=0.9)
+        x = jnp.ones((1, 3))
         with self.assertRaises(ValueError):
-            algo.compile_graph(jnp.ones((1, 3)))
+            algo.compile_graph(x)
+        assert algo.is_compiled is False
+
+        # A second call on the same (permanently invalid) model must raise
+        # again, not silently pass because `is_compiled` was left True.
+        with self.assertRaises(ValueError):
+            algo.compile_graph(x)
+        assert algo.is_compiled is False
 
     def test_compile_allocates_R_hat(self):
         algo = OTPE(_otpe_net_single_layer(), leak=0.9)

--- a/braintrace/_algorithm/ottt.py
+++ b/braintrace/_algorithm/ottt.py
@@ -165,7 +165,6 @@ class OTTT(ETraceVjpAlgorithm):
         leak: float,
         name: Optional[str] = None,
         vjp_method: str = 'single-step',
-        **kwargs: Any,
     ) -> None:
         if mode not in ('A', 'O'):
             raise ValueError(f"mode must be 'A' or 'O'; got {mode!r}")

--- a/braintrace/_algorithm/ottt.py
+++ b/braintrace/_algorithm/ottt.py
@@ -32,11 +32,25 @@ from typing import Any, Dict, Optional
 import brainstate
 import jax.numpy as jnp
 
-from braintrace._op import is_batched_primitive
+from braintrace._op import etp_mm_p, etp_mv_p, is_batched_primitive
 from ._common import PresynapticTrace, _route_grads_by_path, _update_dict
 from .vjp_base import ETraceVjpAlgorithm
 
 __all__ = ['OTTT']
+
+# OTTT's math (outer product of a single scalar/vector presynaptic trace with the
+# learning signal) only reduces correctly for dense matmul relations. LoRA,
+# sparse, conv, and element-wise (no x_var) relations are excluded -- see the
+# compile-time guard in `init_etrace_state`.
+_SUPPORTED_PRIMITIVES = frozenset({etp_mm_p, etp_mv_p})
+
+# Sentinel key for the bias companion trace inside the etrace-vals dict.
+# ``rid`` keys are ``id(...)`` values, which CPython guarantees are
+# non-negative, so a negative int can never collide with one. This must stay
+# an ``int`` (not e.g. a string): the etrace-vals dict is a JAX pytree that
+# flows through `grad`/`jit` tracing, and dict pytree flattening sorts keys --
+# sorting a dict with mixed ``str``/``int`` keys raises `TypeError`.
+_BIAS_KEY = -1
 
 
 class OTTT(ETraceVjpAlgorithm):
@@ -92,7 +106,11 @@ class OTTT(ETraceVjpAlgorithm):
         Name of the algorithm instance.
     vjp_method : str, optional
         Forwarded to the base algorithm. Only ``'single-step'`` is supported by
-        OTTT v1; multi-step inputs raise :class:`NotImplementedError`.
+        OTTT v1 -- its trace update and weight-gradient formulas are derived
+        one step at a time. ``vjp_method='multi-step'`` is rejected with
+        :class:`ValueError` at construction; multi-step *inputs* (i.e. calling
+        the compiled learner with :class:`~braintrace.MultiStepData`) raise
+        :class:`NotImplementedError` instead, at call time.
 
     Limitations
     -----------
@@ -121,8 +139,14 @@ class OTTT(ETraceVjpAlgorithm):
     ------
     ValueError
         If ``mode`` is not ``'A'`` or ``'O'``, if ``leak`` is not in
-        :math:`(0, 1)`, or (at :meth:`compile_graph`) if a trained connection
-        projects into a hidden group with ``num_state > 1``.
+        :math:`(0, 1)`, if ``vjp_method`` is not ``'single-step'``, or (at
+        :meth:`compile_graph`) if a trained connection projects into a hidden
+        group with ``num_state > 1``.
+    NotImplementedError
+        At :meth:`compile_graph`, if a trained connection is routed through a
+        primitive other than dense ``matmul`` (batched or unbatched) -- e.g.
+        LoRA, sparse, or convolutional relations, whose weight-gradient chain
+        rule does not reduce to OTTT's single presynaptic-trace outer product.
 
     Examples
     --------
@@ -170,14 +194,31 @@ class OTTT(ETraceVjpAlgorithm):
             raise ValueError(f"mode must be 'A' or 'O'; got {mode!r}")
         if not (0.0 < float(leak) < 1.0):
             raise ValueError(f'leak must be in (0, 1); got {leak}')
+        if vjp_method != 'single-step':
+            raise ValueError(
+                f"OTTT v1 only supports vjp_method='single-step': its trace "
+                f"update and weight-gradient formulas are derived one step at "
+                f"a time and have no multi-step form; got "
+                f"vjp_method={vjp_method!r}."
+            )
         super().__init__(model, name=name, vjp_method=vjp_method)
         self.mode = mode
         self.leak = float(leak)
         self._pre_traces: Dict[int, PresynapticTrace] = {}
+        self._bias_trace: Optional[brainstate.ShortTermState] = None
 
     def init_etrace_state(self, *args: Any, **kwargs: Any) -> None:
         self._pre_traces = {}
+        has_bias = False
         for rel in self.graph.hidden_param_op_relations:
+            if rel.primitive not in _SUPPORTED_PRIMITIVES:
+                raise NotImplementedError(
+                    f'OTTT only supports dense matmul relations (etp_mm/etp_mv); '
+                    f'got a trained connection routed through primitive '
+                    f'{rel.primitive.name!r}. LoRA, sparse, convolutional, and '
+                    f'element-wise relations do not reduce to a single '
+                    f'presynaptic-trace outer product and are unsupported.'
+                )
             for group in rel.hidden_groups:
                 if group.num_state > 1:
                     raise ValueError(
@@ -189,33 +230,63 @@ class OTTT(ETraceVjpAlgorithm):
                         f'variable) has no theoretical basis for OTTT; the leaky '
                         f'scalar presynaptic trace cannot assign per-state credit.'
                     )
+            if 'bias' in rel.trainable_vars:
+                has_bias = True
             rid = id(rel.x_var)
             if rid in self._pre_traces:
                 continue
-            assert rel.x_var is not None  # non-elemwise primitives always have an x_var
+            if rel.x_var is None:
+                # Unreachable given the primitive guard above (both etp_mm and
+                # etp_mv always carry an x_var); kept as an explicit, message-
+                # bearing guard rather than a bare assert (see finding N3).
+                raise ValueError(
+                    f'OTTT requires a relation with an explicit presynaptic '
+                    f'input (x_var), but the relation for primitive '
+                    f'{rel.primitive.name!r} has none.'
+                )
             shape = rel.x_var.aval.shape
             dtype = rel.x_var.aval.dtype
             self._pre_traces[rid] = PresynapticTrace(
                 jnp.zeros(shape, dtype=dtype), leak=self.leak
             )
+        self._bias_trace = (
+            brainstate.ShortTermState(jnp.zeros((), dtype=jnp.float32))
+            if has_bias else None
+        )
 
     def reset_state(self, batch_size: Optional[int] = None, **kwargs: Any) -> None:
         self.running_index.value = 0
         for t in self._pre_traces.values():
             t.reset_state(batch_size=batch_size)
+        if self._bias_trace is not None:
+            # The bias companion trace has no batch axis: bias's local
+            # Jacobian dy/db = 1 is identical for every batch row, so it is
+            # always a scalar regardless of `batch_size`.
+            self._bias_trace.value = jnp.zeros((), dtype=self._bias_trace.value.dtype)
 
     def _get_etrace_data(self) -> Any:
-        return {rid: t.value for rid, t in self._pre_traces.items()}
+        d = {rid: t.value for rid, t in self._pre_traces.items()}
+        if self._bias_trace is not None:
+            d[_BIAS_KEY] = self._bias_trace.value
+        return d
 
     def _assign_etrace_data(self, vals: Any) -> None:
-        for rid, v in vals.items():
-            self._pre_traces[rid].value = v
+        for rid, t in self._pre_traces.items():
+            t.value = vals[rid]
+        if self._bias_trace is not None:
+            self._bias_trace.value = vals[_BIAS_KEY]
 
     def _update_etrace_data(
         self, running_index: Any, hist_vals: Any,
         hid2weight_jac: Any, hid2hid_jac: Any, weight_vals: Any, input_is_multi_step: Any,
     ) -> Any:
         """``â ← λ·â + x_t`` (mode='A') or ``â := x_t`` (mode='O').
+
+        The bias companion trace ``ĉ`` follows the identical recursion with the
+        presynaptic input replaced by ``1`` (bias's local Jacobian ``dy/db``):
+        ``ĉ ← λ·ĉ + 1`` (mode='A') or ``ĉ := 1`` (mode='O'). It is a single
+        scalar shared by every relation, since ``self.leak`` is one global
+        constant for the whole algorithm instance.
 
         Ignores ``hid2hid_jac`` — OTTT's core approximation.
         """
@@ -225,19 +296,29 @@ class OTTT(ETraceVjpAlgorithm):
 
         new_vals = {}
         for rid, old in hist_vals.items():
+            if rid == _BIAS_KEY:
+                continue
             x_t = xs_at_t[rid]
             if self.mode == 'A':
                 new_vals[rid] = self.leak * old + x_t
             else:
                 new_vals[rid] = x_t
+        if self._bias_trace is not None:
+            old_c = hist_vals[_BIAS_KEY]
+            if self.mode == 'A':
+                new_vals[_BIAS_KEY] = self.leak * old_c + 1.0
+            else:
+                new_vals[_BIAS_KEY] = jnp.ones_like(old_c)
         return new_vals
 
     def _solve_weight_gradients(
         self, running_index: Any, etrace_at_t: Any, dl_to_hidden_groups: Any,
         weight_vals: Any, dl_to_nonetws_at_t: Any, dl_to_etws_at_t: Any,
     ) -> Any:
-        """``ΔW = outer(â, L)`` where ``L`` is the (already σ'-propagated) signal."""
+        """``ΔW = outer(â, L)``; ``Δb = ĉ · L`` (bias has no "in" dimension), where
+        ``L`` is the (already σ'-propagated) signal."""
         dG = {path: None for path in self.param_states}
+        c_hat = etrace_at_t.get(_BIAS_KEY) if self._bias_trace is not None else None
         for rel in self.graph.hidden_param_op_relations:
             a_hat = etrace_at_t[id(rel.x_var)]
             for group in rel.hidden_groups:
@@ -246,12 +327,19 @@ class OTTT(ETraceVjpAlgorithm):
                 # compile time (see init_etrace_state), so this drops the singleton
                 # tail rather than summing across genuinely distinct hidden states.
                 L_proj = L.sum(axis=-1)
+                per_key = {}
                 if is_batched_primitive(rel.primitive):
                     # a_hat: (batch, in), L_proj: (batch, out). ΔW: (in, out)
-                    dw = jnp.einsum('bi,bo->io', a_hat, L_proj)
+                    per_key['weight'] = jnp.einsum('bi,bo->io', a_hat, L_proj)
+                    if 'bias' in rel.trainable_vars:
+                        # c_hat is batch-independent (dy/db = 1 for every row);
+                        # contributions from every batch row simply sum.
+                        per_key['bias'] = c_hat * L_proj.sum(axis=0)
                 else:
-                    dw = jnp.einsum('i,o->io', a_hat, L_proj)
-                _route_grads_by_path(rel, {'weight': dw}, weight_vals, dG)
+                    per_key['weight'] = jnp.einsum('i,o->io', a_hat, L_proj)
+                    if 'bias' in rel.trainable_vars:
+                        per_key['bias'] = c_hat * L_proj
+                _route_grads_by_path(rel, per_key, weight_vals, dG)
 
         for path, dg in dl_to_nonetws_at_t.items():
             _update_dict(dG, path, dg)

--- a/braintrace/_algorithm/ottt_test.py
+++ b/braintrace/_algorithm/ottt_test.py
@@ -20,6 +20,7 @@ import jax
 import jax.numpy as jnp
 
 import braintrace
+from braintrace._algorithm import oracle
 from braintrace._algorithm.ottt import OTTT
 
 
@@ -64,6 +65,57 @@ def _two_state_net():
     return net
 
 
+def _lora_net():
+    """Net trained through `braintrace.lora_matmul` -- LoRA relations are outside
+    OTTT's supported primitive set (see finding H5)."""
+
+    class Net(brainstate.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.B = brainstate.ParamState(
+                0.1 * jax.random.normal(jax.random.PRNGKey(0), (3, 2))
+            )
+            self.A = brainstate.ParamState(
+                0.1 * jax.random.normal(jax.random.PRNGKey(1), (2, 3))
+            )
+            self.v = brainstate.HiddenState(jnp.zeros((1, 3)))
+
+        def update(self, x):
+            self.v.value = 0.9 * self.v.value + braintrace.lora_matmul(
+                x, self.B.value, self.A.value
+            )
+            return self.v.value
+
+    net = Net()
+    brainstate.nn.init_all_states(net, batch_size=1)
+    return net
+
+
+def _bias_net():
+    """Net trained through a recurrent `braintrace.matmul(..., bias=...)`, whose
+    recurrence coefficient (0.9) matches the `leak` OTTT/OTPE are given -- the
+    "exactly diagonal" regime in which both algorithms claim BPTT-exact gradients."""
+
+    class Net(brainstate.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.w = brainstate.ParamState(
+                0.1 * jax.random.normal(jax.random.PRNGKey(0), (3, 3))
+            )
+            self.b = brainstate.ParamState(jnp.zeros(3))
+            self.v = brainstate.HiddenState(jnp.zeros((1, 3)))
+
+        def update(self, x):
+            self.v.value = 0.9 * self.v.value + braintrace.matmul(
+                x, self.w.value, self.b.value
+            )
+            return self.v.value
+
+    net = Net()
+    brainstate.nn.init_all_states(net, batch_size=1)
+    return net
+
+
 class TestOTTTConstruction(unittest.TestCase):
     def test_default_mode_is_A(self):
         algo = OTTT(_ottt_net(), leak=0.9)
@@ -81,6 +133,14 @@ class TestOTTTConstruction(unittest.TestCase):
     def test_leak_out_of_range_raises(self):
         with self.assertRaises(ValueError):
             OTTT(_ottt_net(), leak=1.5)
+
+    def test_multi_step_vjp_method_rejected_at_construction(self):
+        """N6: OTTT's trace update/weight-gradient rules are derived one step at
+        a time and have no multi-step form; `vjp_method='multi-step'` must be
+        rejected eagerly at construction, not silently accepted until the first
+        (multi-step) call fails."""
+        with self.assertRaises(ValueError):
+            OTTT(_ottt_net(), leak=0.9, vjp_method='multi-step')
 
     def test_num_state_gt_one_raises(self):
         """Multi-state hidden groups have no theoretical basis for OTTT."""
@@ -134,6 +194,68 @@ class TestOTTTEnd2End(unittest.TestCase):
         g_A = compute('A')
         g_O = compute('O')
         assert not jnp.allclose(g_A, g_O, atol=1e-4)
+
+
+class TestOTTTBiasGradient(unittest.TestCase):
+    """H5: the weight-gradient solver indexed only the ``'weight'`` key of each
+    relation's trainable dict, so `braintrace.matmul(x, w, bias=b)` silently got
+    a zero bias gradient. Must route every key (here also ``'bias'``) through
+    `relation.trainable_paths`, exactly as `_common._route_grads_by_path` does.
+
+    OTTT's docstring claims it keeps BPTT's *spatial* credit assignment exactly
+    and only drops the *temporal* (hidden-to-hidden) Jacobian. In the "exactly
+    diagonal" regime -- the model's recurrence coefficient equals the `leak`
+    OTTT is given, mode='A' -- this is provably exact: both the outer-product
+    weight term and the scalar bias term reduce, via summation-order exchange,
+    to the same double sum BPTT computes. So we assert *element-wise* equality
+    with the BPTT oracle, not just non-zero/same-sign -- this model is squarely
+    in that exact regime.
+    """
+
+    def test_bias_gradient_matches_bptt_in_exactly_diagonal_regime(self):
+        inputs = jnp.stack([jnp.ones((1, 3)) * (i + 1) * 0.1 for i in range(4)])
+        bptt = oracle.bptt_param_gradients(_bias_net, inputs)
+        online = oracle.online_param_gradients_singlestep_naive(
+            _bias_net, inputs, algo_factory=lambda m: OTTT(m, leak=0.9)
+        )
+        assert bool(jnp.any(online[('b',)] != 0.0)), 'bias gradient must not be zero (H5)'
+        oracle.assert_param_gradients_close(
+            online, bptt, atol=1e-4, keys=[('b',), ('w',)]
+        )
+
+
+class TestOTTTUnsupportedRelationGuard(unittest.TestCase):
+    """H5: LoRA/conv/sparse relations don't reduce to OTTT's single
+    presynaptic-trace outer product; they must raise a compile-time
+    `NotImplementedError` naming the offending primitive rather than crashing
+    opaquely or silently mishandling the relation."""
+
+    def test_lora_relation_raises_named_primitive_at_compile_time(self):
+        algo = OTTT(_lora_net(), leak=0.9)
+        with self.assertRaises(NotImplementedError) as ctx:
+            algo.compile_graph(jnp.ones((1, 3)))
+        assert 'etp_lora_mm' in str(ctx.exception)
+
+    def test_is_compiled_stays_false_after_repeated_guard_failure(self):
+        """M6: a failed compile-time validation must not leave `is_compiled`
+        stuck True -- otherwise `base.compile_graph`'s ``if not
+        self.is_compiled:`` guard would silently skip re-validation (and
+        `init_etrace_state`) on a subsequent call. Calling `compile_graph`
+        twice on the same (permanently invalid) model must raise both times."""
+        algo = OTTT(_lora_net(), leak=0.9)
+        x = jnp.ones((1, 3))
+        with self.assertRaises(NotImplementedError):
+            algo.compile_graph(x)
+        assert algo.is_compiled is False
+
+        with self.assertRaises(NotImplementedError):
+            algo.compile_graph(x)
+        assert algo.is_compiled is False
+
+        # A fresh, valid model must still compile normally afterward.
+        ok_algo = OTTT(_ottt_net(), leak=0.9)
+        ok_algo.compile_graph(x)
+        assert ok_algo.is_compiled is True
 
 
 def _toy_net():

--- a/braintrace/_algorithm/ottt_test.py
+++ b/braintrace/_algorithm/ottt_test.py
@@ -72,12 +72,9 @@ def _lora_net():
     class Net(brainstate.nn.Module):
         def __init__(self):
             super().__init__()
-            self.B = brainstate.ParamState(
-                0.1 * jax.random.normal(jax.random.PRNGKey(0), (3, 2))
-            )
-            self.A = brainstate.ParamState(
-                0.1 * jax.random.normal(jax.random.PRNGKey(1), (2, 3))
-            )
+            brainstate.random.seed(0)
+            self.B = brainstate.ParamState(0.1 * brainstate.random.normal(size=(3, 2)))
+            self.A = brainstate.ParamState(0.1 * brainstate.random.normal(size=(2, 3)))
             self.v = brainstate.HiddenState(jnp.zeros((1, 3)))
 
         def update(self, x):
@@ -99,9 +96,8 @@ def _bias_net():
     class Net(brainstate.nn.Module):
         def __init__(self):
             super().__init__()
-            self.w = brainstate.ParamState(
-                0.1 * jax.random.normal(jax.random.PRNGKey(0), (3, 3))
-            )
+            brainstate.random.seed(0)
+            self.w = brainstate.ParamState(0.1 * brainstate.random.normal(size=(3, 3)))
             self.b = brainstate.ParamState(jnp.zeros(3))
             self.v = brainstate.HiddenState(jnp.zeros((1, 3)))
 

--- a/braintrace/_algorithm/param_dim_vjp.py
+++ b/braintrace/_algorithm/param_dim_vjp.py
@@ -76,14 +76,21 @@ def _init_param_dim_state(
     etrace_bwg: Dict[ETraceWG_Key, brainstate.State],
     relation: HiddenParamOpRelation,
     trace_dtype: Optional[DTypeLike] = None,
+    fast_solve: bool = True,
 ) -> None:
     """
     Initialize the eligibility trace states for parameter dimensions.
 
     Traces are stored as ``Dict[str, Array]`` keyed by the primitive's
-    trainable-input names (dict-based rule API). When ``trace_dtype`` is set and
-    the primitive uses the elementwise fast path (mm/mv/elemwise), the trace is
-    allocated at that reduced precision; conv/sparse/LoRA keep native precision.
+    trainable-input names (dict-based rule API). When ``trace_dtype`` is set,
+    the trace is only allocated at that reduced precision when the runtime
+    update will actually take the fast path for this relation — i.e. the same
+    predicate used by :func:`_update_param_dim_etrace_scan_fn` /
+    :func:`_solve_param_dim_weight_gradients`: ``fast_solve and fp is not None
+    and fp.applicable(relation.eqn_params)``. Otherwise the trace stays at
+    native precision, because the legacy (non-fast) update always emits
+    native-precision arrays and a mismatched scan-carry dtype would raise at
+    trace time.
     """
     group: HiddenGroup
     for group in relation.hidden_groups:
@@ -108,7 +115,9 @@ def _init_param_dim_state(
                 f'Primitive {relation.primitive.name} init_drtrl must return a dict; '
                 f'got {type(init_val).__name__}.'
             )
-        if get_fast_path_rules(relation.primitive) is not None:
+        fp = get_fast_path_rules(relation.primitive)
+        use_fast = fast_solve and fp is not None and fp.applicable(relation.eqn_params)
+        if use_fast:
             init_val = _cast_to_dtype(init_val, trace_dtype)
         etrace_bwg[bwg_key] = EligibilityTrace(init_val)
 
@@ -630,7 +639,14 @@ class ParamDimVjpAlgorithm(ETraceVjpAlgorithm):
         self.fast_solve = fast_solve
         # Optional reduced-precision storage for the eligibility trace (e.g.
         # ``jnp.bfloat16`` / ``jnp.float16``); ``None`` keeps native fp32. Only
-        # the mm/mv/elemwise fast path honors it.
+        # applies on the fast path: a relation's trace is cast to
+        # ``trace_dtype`` iff ``fast_solve`` is ``True`` *and* the relation's
+        # primitive has a registered fast-path bundle whose ``applicable``
+        # gate accepts its ``eqn_params`` (false, e.g., when a ``weight_fn`` /
+        # ``bias_fn`` transform is active). When that predicate is false the
+        # trace stays at native precision, since the legacy update always
+        # produces native-precision arrays and a mismatched scan-carry dtype
+        # would raise at trace time.
         self.trace_dtype = trace_dtype
 
     def init_etrace_state(self, *args: Any, **kwargs: Any) -> None:
@@ -642,7 +658,9 @@ class ParamDimVjpAlgorithm(ETraceVjpAlgorithm):
         # The states of batched weight gradients
         self.etrace_bwg = dict()
         for relation in self.graph.hidden_param_op_relations:
-            _init_param_dim_state(self.etrace_bwg, relation, self.trace_dtype)
+            _init_param_dim_state(
+                self.etrace_bwg, relation, self.trace_dtype, self.fast_solve,
+            )
 
     def reset_state(self, batch_size: int | None = None, **kwargs: Any) -> None:
         """Reset the eligibility trace states.

--- a/braintrace/_algorithm/param_dim_vjp.py
+++ b/braintrace/_algorithm/param_dim_vjp.py
@@ -32,6 +32,10 @@ from braintrace._op import (
     is_batched_primitive,
     get_fast_path_rules,
 )
+from braintrace._op._registries import (
+    get_instant_drtrl_rule,
+    get_solve_drtrl_rule,
+)
 from braintrace._misc import etrace_df_key
 from braintrace._typing import (
     PyTree,
@@ -201,7 +205,14 @@ def _update_param_dim_etrace_scan_fn(
             for key in relation.trainable_vars
         }
 
-        xy_to_dw_rule = ETP_RULES_XY_TO_DW[relation.primitive]
+        # Instantaneous-term rule: a primitive whose trace structure differs
+        # from its parameter structure registers a dedicated ``instant_drtrl``
+        # rule (same call signature as ``xy_to_dw``); everyone else falls back
+        # to ``xy_to_dw`` — the historical, byte-identical default.
+        xy_to_dw_rule = (
+            get_instant_drtrl_rule(relation.primitive)
+            or ETP_RULES_XY_TO_DW[relation.primitive]
+        )
         yw_to_w_rule = ETP_RULES_YW_TO_W[relation.primitive]
         eqn_params = relation.eqn_params
         is_elemwise = relation.primitive is etp_elemwise_p
@@ -361,6 +372,7 @@ def _solve_param_dim_weight_gradients(
     batched_paths: set = set()
     for relation in weight_hidden_relations:
         yw_to_w_rule = ETP_RULES_YW_TO_W[relation.primitive]
+        solve_drtrl_rule = get_solve_drtrl_rule(relation.primitive)
         eqn_params = relation.eqn_params
         batched = is_batched_primitive(relation.primitive)
         if batched:
@@ -370,8 +382,29 @@ def _solve_param_dim_weight_gradients(
         fp = get_fast_path_rules(relation.primitive)
         use_fast = fast_solve and fp is not None and fp.applicable(eqn_params)
 
-        def _call_yw_to_w_dict(d: Any, trace_: Any, _rule: Any = yw_to_w_rule, _params: Any = eqn_params) -> Any:
-            return _rule(d, trace_, **_params)
+        if solve_drtrl_rule is not None:
+            # Dedicated solve rule (trace structure != parameter structure,
+            # e.g. LoRA's effective-weight trace): chain the learning signal
+            # through the current weights. The rule sees batch-free,
+            # num_state-free slices — the vmap scaffolding below is shared
+            # with the legacy ``yw_to_w`` path.
+            weights_dict = {
+                key: _extract_leaf(
+                    weight_vals[relation.trainable_paths[key]],
+                    relation.trainable_leaf_indices[key],
+                )
+                for key in relation.trainable_vars
+            }
+
+            def _call_yw_to_w_dict(
+                d: Any, trace_: Any,
+                _rule: Any = solve_drtrl_rule, _params: Any = eqn_params,
+                _weights: Any = weights_dict,
+            ) -> Any:
+                return _rule(d, trace_, _weights, **_params)
+        else:
+            def _call_yw_to_w_dict(d: Any, trace_: Any, _rule: Any = yw_to_w_rule, _params: Any = eqn_params) -> Any:
+                return _rule(d, trace_, **_params)
 
         yw_to_w = (
             jax.vmap(_call_yw_to_w_dict)

--- a/braintrace/_algorithm/param_dim_vjp.py
+++ b/braintrace/_algorithm/param_dim_vjp.py
@@ -382,6 +382,7 @@ def _solve_param_dim_weight_gradients(
         fp = get_fast_path_rules(relation.primitive)
         use_fast = fast_solve and fp is not None and fp.applicable(eqn_params)
 
+        _call_rule_dict: Callable[..., Any]
         if solve_drtrl_rule is not None:
             # Dedicated solve rule (trace structure != parameter structure,
             # e.g. LoRA's effective-weight trace): chain the learning signal
@@ -396,20 +397,24 @@ def _solve_param_dim_weight_gradients(
                 for key in relation.trainable_vars
             }
 
-            def _call_yw_to_w_dict(
+            def _call_solve_drtrl_dict(
                 d: Any, trace_: Any,
                 _rule: Any = solve_drtrl_rule, _params: Any = eqn_params,
                 _weights: Any = weights_dict,
             ) -> Any:
                 return _rule(d, trace_, _weights, **_params)
+
+            _call_rule_dict = _call_solve_drtrl_dict
         else:
             def _call_yw_to_w_dict(d: Any, trace_: Any, _rule: Any = yw_to_w_rule, _params: Any = eqn_params) -> Any:
                 return _rule(d, trace_, **_params)
 
+            _call_rule_dict = _call_yw_to_w_dict
+
         yw_to_w = (
-            jax.vmap(_call_yw_to_w_dict)
+            jax.vmap(_call_rule_dict)
             if batched
-            else _call_yw_to_w_dict
+            else _call_rule_dict
         )
 
         group: HiddenGroup

--- a/braintrace/_algorithm/param_dim_vjp.py
+++ b/braintrace/_algorithm/param_dim_vjp.py
@@ -621,7 +621,6 @@ class ParamDimVjpAlgorithm(ETraceVjpAlgorithm):
         vjp_method: str = 'single-step',
         fast_solve: bool = True,
         trace_dtype: Optional[DTypeLike] = None,
-        **kwargs: Any,
     ) -> None:
         super().__init__(model, name=name, vjp_method=vjp_method)
         # ``fast_solve=True`` enables closed-form einsum kernels for

--- a/braintrace/_algorithm/param_dim_vjp.py
+++ b/braintrace/_algorithm/param_dim_vjp.py
@@ -609,6 +609,13 @@ class ParamDimVjpAlgorithm(ETraceVjpAlgorithm):
     :math:`\partial \mathcal{L}^{t'}/\partial \mathbf{h}^{t'}` the learning
     signal back-propagated from the loss at each step.
 
+    :math:`\mathbf{D}_f^t` is read off by
+    :meth:`~braintrace._algorithm.vjp_graph_executor.ETraceVjpGraphExecutor._compute_hid2weight_jacobian`
+    from a single all-ones-tangent ``jax.jvp`` of the ``y -> hidden`` map; see
+    that method's docstring for when this is exact (elementwise maps) versus
+    an approximation (non-elementwise maps, e.g. a normalization layer
+    between the weight op and the neuron).
+
     Real-Time Recurrent Learning (RTRL) propagates the full sensitivity
     :math:`\partial \mathbf{h}^t/\partial \boldsymbol{\theta}` forward in time,
     which costs :math:`O(|\theta| \cdot H)` memory. D-RTRL keeps only the

--- a/braintrace/_algorithm/param_dim_vjp.py
+++ b/braintrace/_algorithm/param_dim_vjp.py
@@ -614,7 +614,8 @@ class ParamDimVjpAlgorithm(ETraceVjpAlgorithm):
     from a single all-ones-tangent ``jax.jvp`` of the ``y -> hidden`` map; see
     that method's docstring for when this is exact (elementwise maps) versus
     an approximation (non-elementwise maps, e.g. a normalization layer
-    between the weight op and the neuron).
+    between the weight op and the neuron) — the same approximation is shared
+    with :class:`~braintrace._algorithm.io_dim_vjp.IODimVjpAlgorithm`.
 
     Real-Time Recurrent Learning (RTRL) propagates the full sensitivity
     :math:`\partial \mathbf{h}^t/\partial \boldsymbol{\theta}` forward in time,

--- a/braintrace/_algorithm/param_dim_vjp.py
+++ b/braintrace/_algorithm/param_dim_vjp.py
@@ -25,6 +25,7 @@ import brainunit as u
 
 from braintrace._compiler import HiddenParamOpRelation, HiddenGroup
 from braintrace._op import (
+    etp_conv_p,
     etp_elemwise_p,
     ETP_RULES_YW_TO_W,
     ETP_RULES_XY_TO_DW,
@@ -104,9 +105,15 @@ def _init_param_dim_state(
         init_fn = ETP_RULES_INIT_DRTRL[relation.primitive]
         # ``etp_elemwise`` has no x/y batch carrier (its output is the weight),
         # so it needs the hidden group to size the trace's leading (position /
-        # batch) axes. Only that primitive accepts ``group``; others are
-        # unchanged.
-        init_kw = {'group': group} if relation.primitive is etp_elemwise_p else {}
+        # batch) axes. ``etp_conv``'s per-position trace shape depends on the
+        # equation's layout (``dimension_numbers`` / ``strides``) and grouped
+        # convolutions must be rejected at init, so it receives the eqn
+        # params. Other primitives are unchanged.
+        init_kw: dict = {}
+        if relation.primitive is etp_elemwise_p:
+            init_kw['group'] = group
+        elif relation.primitive is etp_conv_p:
+            init_kw['eqn_params'] = relation.eqn_params
         init_val = init_fn(
             relation.x_var,
             relation.y_var,
@@ -614,13 +621,21 @@ class ParamDimVjpAlgorithm(ETraceVjpAlgorithm):
     and is sensitive to the context/mode of the computation. In particular, it is
     sensitive to ``brainstate.mixin.Batching`` behavior.
 
-    This algorithm has :math:`O(B\theta)` memory complexity, where
-    :math:`\theta` is the number of parameters and :math:`B` the batch size.
-    For a convolutional layer, the weight gradients are computed with
-    :math:`O(B\theta)` memory complexity, where :math:`\theta` is the dimension
-    of the convolutional kernel. For a linear transformation layer, the weight
-    gradients are computed with :math:`O(BIO)` computational complexity, where
-    :math:`I` and :math:`O` are the number of input and output dimensions.
+    For dense (linear) transformation layers this algorithm has
+    :math:`O(B\theta)` memory complexity, where :math:`\theta` is the number
+    of parameters and :math:`B` the batch size — the weight gradients are
+    computed with :math:`O(BIO)` complexity, where :math:`I` and :math:`O`
+    are the number of input and output dimensions.
+
+    For a convolutional layer the exact eligibility trace must keep one
+    kernel-shaped slot **per spatial output position** — the kernel is
+    spatially shared while the diagonal discount acts per output element,
+    so a spatially pre-summed (kernel-shaped) trace cannot follow the
+    recurrence. The conv trace therefore costs :math:`O(B S \theta)` memory,
+    where :math:`S` is the number of spatial output positions and
+    :math:`\theta` the kernel parameter count. For large convolutions prefer
+    the IO-dim algorithm (``pp_prop`` / :class:`IODimVjpAlgorithm`), whose
+    conv trace stays output-shaped.
 
     For more details, please see `the D-RTRL algorithm presented in our manuscript <https://www.biorxiv.org/content/10.1101/2024.09.24.614728v2>`_.
 

--- a/braintrace/_algorithm/param_dim_vjp_test.py
+++ b/braintrace/_algorithm/param_dim_vjp_test.py
@@ -346,6 +346,70 @@ class TestTraceDtypeGateMatchesRuntimePredicate:
         self._run(fast_solve=False)
 
 
+def _leaky_plain_model(n_in=3, n_h=4, seed=3):
+    """Leaky integrator driven by a *plain* dense ETP matmul — no
+    ``weight_fn``/``bias_fn`` hook at all.
+
+    Unlike ``_leaky_weight_fn_model``, nothing here makes
+    ``fp.applicable(eqn_params)`` return ``False`` on its own: per
+    ``_dense_fast_applicable``, the dense fast path for ``etp_mm_p`` is
+    genuinely applicable to this equation. That isolates the ``fast_solve``
+    conjunct of the init-gate predicate — with ``fast_solve=False``, the
+    *only* way ``use_fast`` can come out ``False`` is if ``fast_solve`` is
+    actually being consulted (as opposed to a test that also relies on
+    ``fp.applicable`` being ``False`` for an unrelated reason).
+    """
+    brainstate.random.seed(seed)
+
+    class Net(brainstate.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.w = brainstate.ParamState(brainstate.random.randn(n_in, n_h) * 0.2)
+            self.h = brainstate.HiddenState(jnp.zeros((1, n_h)))
+
+        def update(self, x):
+            drive = braintrace.matmul(x, self.w.value)
+            self.h.value = 0.5 * self.h.value + drive
+            return self.h.value
+
+    return Net()
+
+
+class TestFastSolveConjunctIsolated:
+    """Regression test for the review finding on
+    ``TestTraceDtypeGateMatchesRuntimePredicate``: that class's
+    ``test_fast_solve_false_runs`` reused the ``weight_fn=jnp.tanh`` model,
+    which already makes ``fp.applicable(...)`` False on its own — so that
+    test would pass even if the implementation dropped the ``fast_solve``
+    conjunct from the init-gate predicate entirely. This test uses a model
+    with no ``weight_fn``/``bias_fn`` (``fp.applicable`` is True), so
+    ``fast_solve=False`` is the *only* thing that can make ``use_fast``
+    False in the init gate.
+    """
+
+    def test_fast_solve_false_no_weight_fn_runs(self):
+        model = _leaky_plain_model()
+        brainstate.nn.init_all_states(model, batch_size=1)
+        inputs = brainstate.random.randn(4, 1, 3)  # (T, B=1, n_in)
+        algo = D_RTRL(
+            model, vjp_method='multi-step',
+            fast_solve=False, trace_dtype=jnp.bfloat16,
+        )
+        algo.compile_graph(inputs[0])
+        algo.init_etrace_state()
+
+        weights = model.states(brainstate.ParamState)
+
+        def loss(inp):
+            return algo(braintrace.MultiStepData(inp)).sum()
+
+        grads = brainstate.transform.grad(loss, weights)(inputs)
+        leaves = jax.tree.leaves(grads)
+        assert leaves
+        for leaf in leaves:
+            assert bool(jnp.all(jnp.isfinite(u.get_mantissa(leaf))))
+
+
 # ---------------------------------------------------------------------------
 # RNN-cell sweep — finite gradients across the public cell zoo
 # ---------------------------------------------------------------------------

--- a/braintrace/_algorithm/param_dim_vjp_test.py
+++ b/braintrace/_algorithm/param_dim_vjp_test.py
@@ -612,7 +612,7 @@ class TestInstantSolveDrtrlDispatch:
     per-primitive registries.
 
     A primitive whose trace structure differs from its parameter structure
-    (LoRA, and later conv) registers both rules; every other primitive is
+    (LoRA and conv) registers both rules; every other primitive is
     unregistered and must take the historical code path byte-identically.
     The tests here exercise the *dispatch scaffolding* itself by temporarily
     registering rules for the dense ``mm`` primitive that replicate the
@@ -629,7 +629,9 @@ class TestInstantSolveDrtrlDispatch:
         )
 
     def test_accessors_default_none_for_legacy_primitives(self):
-        """Dense / elemwise / sparse / conv register neither optional rule."""
+        """Dense / elemwise / sparse register neither optional rule; conv
+        (per-position kernel trace) and LoRA (effective-weight trace)
+        register both."""
         from braintrace._op import (
             etp_conv_p, etp_elemwise_p, etp_mm_p, etp_mv_p,
             etp_sp_mm_p, etp_sp_mv_p,
@@ -638,9 +640,11 @@ class TestInstantSolveDrtrlDispatch:
             get_instant_drtrl_rule, get_solve_drtrl_rule,
         )
         for prim in (etp_mm_p, etp_mv_p, etp_elemwise_p,
-                     etp_sp_mm_p, etp_sp_mv_p, etp_conv_p):
+                     etp_sp_mm_p, etp_sp_mv_p):
             assert get_instant_drtrl_rule(prim) is None
             assert get_solve_drtrl_rule(prim) is None
+        assert get_instant_drtrl_rule(etp_conv_p) is not None
+        assert get_solve_drtrl_rule(etp_conv_p) is not None
 
     def test_registered_rules_replicating_legacy_are_identical(self):
         """Routing through the new dispatch with rules that replicate the

--- a/braintrace/_algorithm/param_dim_vjp_test.py
+++ b/braintrace/_algorithm/param_dim_vjp_test.py
@@ -508,7 +508,10 @@ def _accumulate_online_grads(model, algo_ctor, inputs, targets, batched):
     @brainstate.transform.jit
     def run(inputs, targets):
         if batched:
-            online = algo_ctor(model, mode=brainstate.mixin.Batching())
+            # ``mode`` was a dead kwarg (never forwarded; batching is detected
+            # from the batched states created by ``init_all_states``) and the
+            # constructors no longer swallow unknown kwargs.
+            online = algo_ctor(model)
             brainstate.nn.init_all_states(model, batch_size=inputs.shape[1])
         else:
             online = algo_ctor(model)

--- a/braintrace/_algorithm/param_dim_vjp_test.py
+++ b/braintrace/_algorithm/param_dim_vjp_test.py
@@ -270,6 +270,83 @@ class TestGradientCorrectness:
 
 
 # ---------------------------------------------------------------------------
+# H2 regression: the trace_dtype init gate must mirror the runtime fast-path
+# predicate (fast_solve AND fp is not None AND fp.applicable(eqn_params)).
+# ---------------------------------------------------------------------------
+
+def _leaky_weight_fn_model(n_in=3, n_h=4, seed=3):
+    """Leaky integrator driven by a dense ETP matmul with an active
+    ``weight_fn`` transform hook.
+
+    ``weight_fn=jnp.tanh`` makes ``fp.applicable(eqn_params)`` return
+    ``False`` at runtime (see ``_dense_fast_applicable``), even though a
+    fast-path bundle is registered for ``etp_mm_p``. ``w`` reaches every
+    future hidden state through the leaky carry, so it is a genuine ETP
+    relation (mirrors ``oracle_models.leaky_linear``).
+    """
+    brainstate.random.seed(seed)
+
+    class Net(brainstate.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.w = brainstate.ParamState(brainstate.random.randn(n_in, n_h) * 0.2)
+            self.h = brainstate.HiddenState(jnp.zeros((1, n_h)))
+
+        def update(self, x):
+            drive = braintrace.matmul(x, self.w.value, weight_fn=jnp.tanh)
+            self.h.value = 0.5 * self.h.value + drive
+            return self.h.value
+
+    return Net()
+
+
+class TestTraceDtypeGateMatchesRuntimePredicate:
+    """Before the fix, ``_init_param_dim_state`` cast the trace to
+    ``trace_dtype`` whenever ``get_fast_path_rules(primitive) is not None`` —
+    i.e. whenever a bundle *existed* for the primitive — regardless of
+    whether the runtime predicate (``fast_solve and fp is not None and
+    fp.applicable(eqn_params)``) would actually select the fast path. With
+    ``trace_dtype=jnp.bfloat16`` and a ``weight_fn`` on a dense op (or with
+    ``fast_solve=False``), the scan carry was allocated bfloat16 at init but
+    the legacy (non-fast) update emitted float32, raising a
+    ``jax.lax.scan`` carry-dtype ``TypeError``.
+    """
+
+    @staticmethod
+    def _run(*, fast_solve):
+        model = _leaky_weight_fn_model()
+        brainstate.nn.init_all_states(model, batch_size=1)
+        inputs = brainstate.random.randn(4, 1, 3)  # (T, B=1, n_in)
+        algo = ParamDimVjpAlgorithm(
+            model, vjp_method='multi-step',
+            fast_solve=fast_solve, trace_dtype=jnp.bfloat16,
+        )
+        algo.compile_graph(inputs[0])
+        algo.init_etrace_state()
+
+        weights = model.states(brainstate.ParamState)
+
+        def loss(inp):
+            return algo(braintrace.MultiStepData(inp)).sum()
+
+        grads = brainstate.transform.grad(loss, weights)(inputs)
+        leaves = jax.tree.leaves(grads)
+        assert leaves
+        for leaf in leaves:
+            assert bool(jnp.all(jnp.isfinite(u.get_mantissa(leaf))))
+
+    def test_fast_solve_true_with_weight_fn_runs(self):
+        # fp exists for etp_mm_p, but weight_fn makes fp.applicable False ->
+        # use_fast is False at runtime despite fast_solve=True.
+        self._run(fast_solve=True)
+
+    def test_fast_solve_false_runs(self):
+        # fast_solve=False alone also disagrees with the old init gate
+        # (which only checked "does a fast-path bundle exist").
+        self._run(fast_solve=False)
+
+
+# ---------------------------------------------------------------------------
 # RNN-cell sweep — finite gradients across the public cell zoo
 # ---------------------------------------------------------------------------
 

--- a/braintrace/_algorithm/param_dim_vjp_test.py
+++ b/braintrace/_algorithm/param_dim_vjp_test.py
@@ -601,3 +601,117 @@ def test_docstring_compile_example_runs():
     assert y.shape == (1,)
     assert bool(jnp.all(jnp.isfinite(y)))
     assert len(learner.graph.hidden_param_op_relations) >= 1
+
+
+# ---------------------------------------------------------------------------
+# Optional instant_drtrl / solve_drtrl per-primitive dispatch
+# ---------------------------------------------------------------------------
+
+class TestInstantSolveDrtrlDispatch:
+    """Dispatch contract of the optional ``instant_drtrl`` / ``solve_drtrl``
+    per-primitive registries.
+
+    A primitive whose trace structure differs from its parameter structure
+    (LoRA, and later conv) registers both rules; every other primitive is
+    unregistered and must take the historical code path byte-identically.
+    The tests here exercise the *dispatch scaffolding* itself by temporarily
+    registering rules for the dense ``mm`` primitive that replicate the
+    legacy behavior — the LoRA oracle tests in ``lora_test.py`` cover the
+    real registered rules end-to-end.
+    """
+
+    def _grads(self, spec, inputs, **algo_kwargs):
+        return oracle.online_param_gradients(
+            spec.factory, inputs,
+            algo_factory=lambda m: braintrace.D_RTRL(
+                m, vjp_method='multi-step', **algo_kwargs
+            ),
+        )
+
+    def test_accessors_default_none_for_legacy_primitives(self):
+        """Dense / elemwise / sparse / conv register neither optional rule."""
+        from braintrace._op import (
+            etp_conv_p, etp_elemwise_p, etp_mm_p, etp_mv_p,
+            etp_sp_mm_p, etp_sp_mv_p,
+        )
+        from braintrace._op._registries import (
+            get_instant_drtrl_rule, get_solve_drtrl_rule,
+        )
+        for prim in (etp_mm_p, etp_mv_p, etp_elemwise_p,
+                     etp_sp_mm_p, etp_sp_mv_p, etp_conv_p):
+            assert get_instant_drtrl_rule(prim) is None
+            assert get_solve_drtrl_rule(prim) is None
+
+    def test_registered_rules_replicating_legacy_are_identical(self):
+        """Routing through the new dispatch with rules that replicate the
+        legacy ``xy_to_dw`` / ``yw_to_w`` behavior must reproduce the same
+        gradients — proving the ``weights_dict`` plumbing and the batch /
+        num_state vmap scaffolding are wired consistently."""
+        from braintrace._op import (
+            ETP_RULES_XY_TO_DW, ETP_RULES_YW_TO_W, etp_mm_p,
+        )
+        from braintrace._op._registries import (
+            ETP_RULES_INSTANT_DRTRL, ETP_RULES_SOLVE_DRTRL,
+        )
+
+        spec = om.leaky_linear(n_in=3, n_rec=4, leak=0.9, seed=0)
+        brainstate.random.seed(1)
+        inputs = brainstate.random.randn(5, 3).astype('float32')
+
+        xy_rule = ETP_RULES_XY_TO_DW[etp_mm_p]
+        yw_rule = ETP_RULES_YW_TO_W[etp_mm_p]
+        seen_weight_keys = []
+
+        def instant(x, df, weights, **params):
+            return xy_rule(x, df, weights, **params)
+
+        def solve(dg_hidden, trace, weights, **params):
+            # Executed at trace time: record the weights_dict the dispatch
+            # built for this relation.
+            seen_weight_keys.append(tuple(sorted(weights.keys())))
+            return yw_rule(dg_hidden, trace, **params)
+
+        # ``fast_solve=False`` so the rule path (not the closed-form fast
+        # path) is what runs, exercising both new dispatch sites.
+        baseline = self._grads(spec, inputs, fast_solve=False)
+        try:
+            ETP_RULES_INSTANT_DRTRL[etp_mm_p] = instant
+            ETP_RULES_SOLVE_DRTRL[etp_mm_p] = solve
+            routed = self._grads(spec, inputs, fast_solve=False)
+        finally:
+            ETP_RULES_INSTANT_DRTRL.pop(etp_mm_p, None)
+            ETP_RULES_SOLVE_DRTRL.pop(etp_mm_p, None)
+
+        assert seen_weight_keys and all(
+            keys == ('weight',) for keys in seen_weight_keys
+        ), f'solve rule saw unexpected weights_dict keys: {seen_weight_keys}'
+        oracle.assert_param_gradients_close(routed, baseline, atol=0.0, rtol=0.0)
+
+    def test_fast_path_precedence_over_registered_rules(self):
+        """With ``fast_solve=True`` a fast-path primitive must keep using the
+        closed-form kernels even when the optional rules are registered: the
+        gradients stay identical and the rules are never invoked."""
+        from braintrace._op import etp_mm_p
+        from braintrace._op._registries import (
+            ETP_RULES_INSTANT_DRTRL, ETP_RULES_SOLVE_DRTRL,
+        )
+
+        spec = om.leaky_linear(n_in=3, n_rec=4, leak=0.9, seed=0)
+        brainstate.random.seed(2)
+        inputs = brainstate.random.randn(5, 3).astype('float32')
+
+        def _must_not_run(*args, **kwargs):
+            raise AssertionError(
+                'instant/solve drtrl rule invoked despite the fast path'
+            )
+
+        baseline = self._grads(spec, inputs, fast_solve=True)
+        try:
+            ETP_RULES_INSTANT_DRTRL[etp_mm_p] = _must_not_run
+            ETP_RULES_SOLVE_DRTRL[etp_mm_p] = _must_not_run
+            routed = self._grads(spec, inputs, fast_solve=True)
+        finally:
+            ETP_RULES_INSTANT_DRTRL.pop(etp_mm_p, None)
+            ETP_RULES_SOLVE_DRTRL.pop(etp_mm_p, None)
+
+        oracle.assert_param_gradients_close(routed, baseline, atol=0.0, rtol=0.0)

--- a/braintrace/_algorithm/tests/exact_correctness_test.py
+++ b/braintrace/_algorithm/tests/exact_correctness_test.py
@@ -235,16 +235,22 @@ def test_multistep_method_is_the_exact_path():
 
 def test_ottt_otpe_reject_multistep_oracle_F19():
     """F-19: OTTT/OTPE are single-step only, so the multi-step BPTT oracle path is
-    structurally unavailable. We pin that the multi-step call raises 'single-step
-    only', which (with F-SINGLESTEP blocking the naive single-step accumulation)
-    is why their multi-step temporal correctness is deferred, not asserted."""
+    structurally unavailable. N6 moved this rejection from a lazy failure deep
+    inside the multi-step VJP machinery to an eager `ValueError` raised by the
+    constructor itself (`algo_factory(model)`, the first thing
+    `online_param_gradients` does); we pin that both algorithms still reject
+    `vjp_method='multi-step'`, which (with F-SINGLESTEP blocking the naive
+    single-step accumulation) is why their multi-step temporal correctness is
+    deferred, not asserted."""
     spec = tanh_rnn(n_in=3, n_rec=4, seed=0)
     inputs = _inputs(6, 3)
-    for algo_factory in (
-        lambda m: braintrace.OTTT(m, mode='A', leak=0.9, vjp_method='multi-step'),
-        lambda m: braintrace.OTPE(m, mode='full', leak=0.9, vjp_method='multi-step'),
+    for algo_factory, match in (
+        (lambda m: braintrace.OTTT(m, mode='A', leak=0.9, vjp_method='multi-step'),
+         r"OTTT v1 only supports vjp_method='single-step'"),
+        (lambda m: braintrace.OTPE(m, mode='full', leak=0.9, vjp_method='multi-step'),
+         r"OTPE v1 only supports vjp_method='single-step'"),
     ):
-        with pytest.raises(NotImplementedError, match='single-step only'):
+        with pytest.raises(ValueError, match=match):
             online_param_gradients(spec.factory, inputs, algo_factory=algo_factory)
 
 

--- a/braintrace/_algorithm/vjp_base.py
+++ b/braintrace/_algorithm/vjp_base.py
@@ -255,6 +255,17 @@ class ETraceVjpAlgorithm(ETraceAlgorithm):
         # etrace data
         last_etrace_vals = self._get_etrace_data()
 
+        # Optional per-call auxiliary data (e.g. OSTTP's `y_target`) that a
+        # subclass needs inside `_compute_learning_signal` but that must not be
+        # forwarded to the model itself. Read synchronously here -- before the
+        # custom_vjp machinery runs -- so it becomes a genuine argument of
+        # `_true_update_fun` rather than an instance-attribute side channel:
+        # outer transforms (e.g. `brainstate.transform.grad`) may stage the
+        # forward trace and only invoke the fwd/bwd rules after this `update()`
+        # call has already returned, by which point any such stash would
+        # already be gone.
+        aux = self._get_update_aux()
+
         # update all states
         #
         # [KEY] The key here is that we change the object-oriented attributes as the function arguments.
@@ -273,7 +284,8 @@ class ETraceVjpAlgorithm(ETraceAlgorithm):
             hidden_vals,
             other_vals,
             last_etrace_vals,
-            self.running_index.value
+            self.running_index.value,
+            aux,
         )
 
         # assign/restore the weight values back
@@ -310,6 +322,7 @@ class ETraceVjpAlgorithm(ETraceAlgorithm):
         oth_state_vals: StateVals,
         etrace_vals: ETraceVals,
         running_index: Any,
+        aux: Any = None,
     ) -> Tuple[Outputs, HiddenVals, StateVals, ETraceVals]:
         """
         The main function to update the [model] and the [eligibility trace] states.
@@ -329,6 +342,10 @@ class ETraceVjpAlgorithm(ETraceAlgorithm):
 
         Note that the weight values are assumed not changed in this function.
 
+        The ``aux`` argument (see :meth:`_get_update_aux`) is unused on this
+        plain (non-differentiating) path; it only matters on the
+        ``_update_fn_fwd``/``_update_fn_bwd`` path, where it is threaded to
+        ``_compute_learning_signal``.
         """
         input_is_multi_step = has_multistep_data(*args)
 
@@ -386,6 +403,7 @@ class ETraceVjpAlgorithm(ETraceAlgorithm):
         othstate_vals: StateVals,
         etrace_vals: ETraceVals,
         running_index: int,
+        aux: Any = None,
     ) -> Tuple[Tuple[Outputs, HiddenVals, StateVals, ETraceVals], Any]:
         """
         The forward function to update the [model] and the [eligibility trace] states when computing
@@ -474,6 +492,7 @@ class ETraceVjpAlgorithm(ETraceAlgorithm):
             weight_vals,
             running_index,
             args,  # threaded to _update_fn_bwd for the learning-signal hook
+            aux,  # per-call auxiliary data (see _get_update_aux), also threaded to the hook
         )
         return fwd_out, fwd_res
 
@@ -481,7 +500,7 @@ class ETraceVjpAlgorithm(ETraceAlgorithm):
         self,
         fwd_res: Any,
         grads: Any,
-    ) -> Tuple[dG_Inputs, dG_Weight, dG_Hidden, dG_State, None, None]:
+    ) -> Tuple[dG_Inputs, dG_Weight, dG_Hidden, dG_State, None, None, None]:
         """
         The backward function to compute the VJP gradients when the learning signal is arrived at
         this time step.
@@ -503,6 +522,7 @@ class ETraceVjpAlgorithm(ETraceAlgorithm):
             weight_vals,  # the weight id to its value mapping
             running_index,  # the running index
             args,  # original update(*args) tuple, used by _compute_learning_signal
+            aux,  # per-call auxiliary data from _get_update_aux, also used by _compute_learning_signal
         ) = fwd_res
 
         (
@@ -600,8 +620,13 @@ class ETraceVjpAlgorithm(ETraceAlgorithm):
         # Hook: subclasses may replace the reverse-AD learning signal with an
         # alternative (e.g. target projection in OSTTP, κ-filtered signal in EProp).
         #
+        # `aux` (see `_get_update_aux`) is appended to `args` here, not inside
+        # `args` itself, so it never reaches the model's own forward call --
+        # only this hook sees it. Algorithms that don't use it (the default
+        # `_get_update_aux` returns None) are unaffected: the base
+        # implementation and EProp's override both ignore `args` entirely.
         dl2h_at_t_or_t_minus_1 = self._compute_learning_signal(
-            dl2h_at_t_or_t_minus_1, args
+            dl2h_at_t_or_t_minus_1, (*args, aux)
         )
 
         #
@@ -621,9 +646,11 @@ class ETraceVjpAlgorithm(ETraceAlgorithm):
             dg_etrace_params,
         )
 
-        # Note that there are no gradients flowing through the etrace data and the running index.
+        # Note that there are no gradients flowing through the etrace data, the
+        # running index, or the auxiliary data (e.g. OSTTP's y_target).
         dg_etrace = None
         dg_running_index = None
+        dg_aux = None
 
         return (
             dg_args,
@@ -631,8 +658,37 @@ class ETraceVjpAlgorithm(ETraceAlgorithm):
             dg_last_hiddens,
             dg_oth_states,
             dg_etrace,
-            dg_running_index
+            dg_running_index,
+            dg_aux,
         )
+
+    def _get_update_aux(self) -> Any:
+        """Override hook. Return per-call auxiliary data threaded to `_compute_learning_signal`.
+
+        Called synchronously at the start of `update()`, before the custom_vjp
+        forward/backward machinery runs, and passed to `_true_update_fun` as a
+        genuine argument (see `_update_fn`/`_update_fn_fwd`/`_update_fn_bwd`).
+        This makes the value a real data dependency of the traced computation.
+
+        This is deliberately *not* read lazily from an instance attribute
+        inside `_update_fn_fwd`/`_update_fn_bwd`/`_compute_learning_signal`:
+        outer transforms (e.g. `brainstate.transform.grad`) may stage the
+        forward trace and only invoke the custom_vjp fwd/bwd rules after the
+        `update()` call that set such a stash has already returned, so a
+        lazy read would silently observe a cleared/stale value.
+
+        Default returns `None` (unused). Subclasses that need auxiliary data
+        not already part of the model's own forward arguments (e.g. OSTTP's
+        `y_target`, which must not be forwarded to the model call) should
+        override this and read whatever they stashed on `self` during their
+        own `update()` override, at this exact call site.
+
+        Returns:
+            Any pytree (or `None`). Appended to the `args` tuple seen by
+            `_compute_learning_signal` (see below); never forwarded to the
+            model's forward call.
+        """
+        return None
 
     def _compute_learning_signal(
         self,
@@ -647,9 +703,13 @@ class ETraceVjpAlgorithm(ETraceAlgorithm):
         Args:
             dl_to_hidden_from_autodiff: Sequence of per-hidden-group gradients produced
                 by reverse-AD inside `_update_fn_bwd`.
-            args: The exact `*args` tuple passed to the most recent `update()` call,
-                made available so subclasses can pull auxiliary tensors (e.g.
-                ``y_target``) that were stashed elsewhere (e.g. on ``self``).
+            args: The `*args` tuple passed to the most recent `update()` call,
+                with the per-call auxiliary data from `_get_update_aux` appended
+                as the trailing element. Subclasses that override
+                `_get_update_aux` (e.g. OSTTP) can pull their auxiliary tensor
+                (e.g. ``y_target``) from there (see `extract_y_target` in
+                `_common.py`); subclasses that don't (the default `None`) can
+                ignore `args` entirely, as the base implementation does.
 
         Returns:
             Sequence of per-hidden-group gradient arrays, one per HiddenGroup. Must

--- a/braintrace/_algorithm/vjp_graph_executor.py
+++ b/braintrace/_algorithm/vjp_graph_executor.py
@@ -234,6 +234,31 @@ class ETraceVjpGraphExecutor(ETraceGraphExecutor):
 
         Returns:
             The weight x and df values.
+
+        Notes
+        -----
+        ``df`` is read off with a single all-ones-tangent :func:`jax.jvp` of
+        each relation's ``y -> hidden group`` map (see the ``[ KEY ]`` comment
+        in the loop body below). This is *exact* when that map is elementwise
+        — the common case where an ETP op output feeds exactly one neuron —
+        because the all-ones jvp then returns the map's Jacobian diagonal.
+
+        When a non-elementwise op sits between the weight op and the hidden
+        state (e.g. ``conv -> LayerNorm -> IF``), the true ``dh/dy`` is not
+        diagonal and the all-ones jvp instead returns its *row sums*. Both
+        :class:`~braintrace._algorithm.param_dim_vjp.ParamDimVjpAlgorithm`
+        (``D_RTRL``) and
+        :class:`~braintrace._algorithm.io_dim_vjp.IODimVjpAlgorithm`
+        (``pp_prop`` / ``ES_D_RTRL``) consume this ``df`` as their
+        :math:`\\mathbf{D}_f^t` term, so the approximation is shared by both
+        algorithm families: for a mean-subtracting (shift-invariant) op the
+        row sums happen to be exactly zero — the correct answer, since such
+        an op has no eligibility gradient to give upstream — but a
+        variance-style normalization computed with ``use_fast_variance=True``
+        leaves a small float32 residual instead of an exact zero, which
+        downstream recurrence/solve contractions can amplify. Prefer
+        ``use_fast_variance=False`` on any normalization layer that feeds an
+        ETP-traced op.
         """
 
         # the weight x

--- a/braintrace/_op/_primitive.py
+++ b/braintrace/_op/_primitive.py
@@ -247,9 +247,17 @@ def register_primitive(
     )
 
     def _jvp(primals: Any, tangents: Any, **params: Any) -> Any:
+        # ``ad.Zero`` carries the mathematically-correct tangent aval on
+        # ``t.aval``: for inexact (float/complex) primals that's the
+        # primal's own shape/dtype, but for int/bool primals JAX's tangent
+        # space is the zero-sized ``float0`` dtype. Materializing zeros as
+        # ``jnp.zeros(pr.shape, pr.dtype)`` (the primal's dtype) is wrong for
+        # int/bool primals and raises inside ``jax.jvp``. Delegate to JAX's
+        # own ``instantiate_zeros``, which reads ``t.aval`` and is therefore
+        # correct for both cases.
         tans = tuple(
-            jnp.zeros(pr.shape, pr.dtype) if isinstance(t, ad.Zero) else t
-            for pr, t in zip(primals, tangents)
+            ad.instantiate_zeros(t) if isinstance(t, ad.Zero) else t
+            for t in tangents
         )
         return jax.jvp(partial(impl_fn, **params), primals, tans)
 

--- a/braintrace/_op/_primitive_test.py
+++ b/braintrace/_op/_primitive_test.py
@@ -174,6 +174,83 @@ class TestJITAndJVP:
         np.testing.assert_allclose(g, 5.0)
 
 
+class TestIntBoolPrimalZeroTangent:
+    """Symbolic-zero tangents for int/bool primals must be materialized with
+    JAX's ``float0`` tangent dtype, not the primal's own dtype.
+
+    A non-inexact (int/bool) primal's *real* tangent type in JAX is the
+    zero-sized ``float0`` dtype. The auto-derived ``_jvp`` in
+    ``register_primitive`` used to instantiate ``ad.Zero`` tangents as
+    ``jnp.zeros(pr.shape, pr.dtype)`` unconditionally, which produced an
+    ``int32``/``bool`` tangent array for such primals. Passing that array
+    into ``jax.jvp`` alongside an int/bool primal raises a ``TypeError``
+    because JAX requires the tangent dtype to be exactly ``float0`` in that
+    case. This matters in practice whenever an ETP op consumes an integer
+    or boolean input (e.g. spike counts, masks) while only some *other*
+    input (e.g. the weight) is being differentiated.
+    """
+
+    def test_jvp_int_primal_zero_tangent_does_not_raise(self):
+        p = register_primitive(_fresh_name('int_zero'), lambda x, y: x * y)
+
+        # Differentiate only wrt the float `y` — the int `x`'s tangent is
+        # symbolic zero and must be materialized as float0, not int32.
+        def f(y):
+            x = jnp.asarray(3, dtype=jnp.int32)
+            return p.bind(x, y)
+
+        primal, tangent = jax.jvp(f, (jnp.asarray(2.0),), (jnp.asarray(1.0),))
+        np.testing.assert_allclose(primal, 6.0)
+        np.testing.assert_allclose(tangent, 3.0)  # d(x*y)/dy = x = 3
+
+    def test_jvp_bool_primal_zero_tangent_does_not_raise(self):
+        p = register_primitive(
+            _fresh_name('bool_zero'),
+            lambda mask, y: jnp.where(mask, y, 0.0),
+        )
+
+        def f(y):
+            mask = jnp.asarray(True)
+            return p.bind(mask, y)
+
+        primal, tangent = jax.jvp(f, (jnp.asarray(2.0),), (jnp.asarray(1.0),))
+        np.testing.assert_allclose(primal, 2.0)
+        np.testing.assert_allclose(tangent, 1.0)
+
+    def test_grad_int_primal_matches_float_cast(self):
+        """``jax.grad`` through an ETP op with an int input must agree with
+        the gradient computed from the float-cast version of that input."""
+        import braintrace
+
+        x_int = jnp.ones((2, 3), dtype=jnp.int32)
+        w = jnp.ones((3, 4))
+
+        def loss(w, x):
+            return braintrace.matmul(x, w).sum()
+
+        g_int = jax.grad(loss, argnums=0)(w, x_int)
+        g_float = jax.grad(loss, argnums=0)(w, x_int.astype(jnp.float32))
+
+        assert jnp.all(jnp.isfinite(g_int))
+        np.testing.assert_allclose(g_int, g_float)
+
+    def test_grad_bool_primal_matches_float_cast(self):
+        """Same contract, for a boolean ETP input."""
+        import braintrace
+
+        x_bool = jnp.ones((2, 3), dtype=bool)
+        w = jnp.ones((3, 4))
+
+        def loss(w, x):
+            return braintrace.matmul(x, w).sum()
+
+        g_bool = jax.grad(loss, argnums=0)(w, x_bool)
+        g_float = jax.grad(loss, argnums=0)(w, x_bool.astype(jnp.float32))
+
+        assert jnp.all(jnp.isfinite(g_bool))
+        np.testing.assert_allclose(g_bool, g_float)
+
+
 class TestVmap:
 
     def test_vmap_in_axes_zero(self):

--- a/braintrace/_op/_primitive_test.py
+++ b/braintrace/_op/_primitive_test.py
@@ -222,8 +222,6 @@ class TestIntBoolPrimalZeroTangent:
     def test_grad_int_primal_matches_float_cast(self):
         """``jax.grad`` through an ETP op with an int input must agree with
         the gradient computed from the float-cast version of that input."""
-        import braintrace
-
         x_int = jnp.ones((2, 3), dtype=jnp.int32)
         w = jnp.ones((3, 4))
 
@@ -238,8 +236,6 @@ class TestIntBoolPrimalZeroTangent:
 
     def test_grad_bool_primal_matches_float_cast(self):
         """Same contract, for a boolean ETP input."""
-        import braintrace
-
         x_bool = jnp.ones((2, 3), dtype=bool)
         w = jnp.ones((3, 4))
 

--- a/braintrace/_op/_registries.py
+++ b/braintrace/_op/_registries.py
@@ -40,6 +40,16 @@ optional per-primitive closed-form param-dim D-RTRL "fast-path" kernel
 bundle (:class:`FastPathRules`). Only primitives with an elementwise
 ``yw_to_w`` rule register one; it is queried through
 :func:`get_fast_path_rules`.
+
+Two further *optional* rule dictionaries —
+:data:`ETP_RULES_INSTANT_DRTRL` and :data:`ETP_RULES_SOLVE_DRTRL` — let a
+primitive override the param-dim D-RTRL algorithm's default use of
+``xy_to_dw`` (instantaneous trace term) and ``yw_to_w`` (solve-time
+contraction) when the trace structure it carries differs from its
+parameter structure (e.g. LoRA's effective-weight trace). They are queried
+through :func:`get_instant_drtrl_rule` / :func:`get_solve_drtrl_rule`,
+which return ``None`` for unregistered primitives — the algorithm then
+falls back to the legacy rules, byte-identically.
 """
 
 from typing import Callable, Dict, NamedTuple, Optional
@@ -66,6 +76,10 @@ __all__ = [
     'FastPathRules',
     'ETP_FAST_PATH_RULES',
     'get_fast_path_rules',
+    'ETP_RULES_INSTANT_DRTRL',
+    'ETP_RULES_SOLVE_DRTRL',
+    'get_instant_drtrl_rule',
+    'get_solve_drtrl_rule',
 ]
 
 ETP_PRIMITIVES: set = set()
@@ -204,3 +218,69 @@ def get_fast_path_rules(primitive) -> Optional[FastPathRules]:
         fast path (e.g. conv / sparse / LoRA).
     """
     return ETP_FAST_PATH_RULES.get(primitive)
+
+
+ETP_RULES_INSTANT_DRTRL: Dict[Primitive, Callable] = {}
+r"""Optional trace-structured instantaneous term for param-dim D-RTRL.
+
+``(x, df, weights_dict, **eqn_params) -> Dict[str, Array]`` — same call
+signature as :data:`ETP_RULES_XY_TO_DW`, but the returned dict is
+*trace*-structured rather than parameter-structured. Register it when the
+D-RTRL trace a primitive carries does not have the parameter's shape (e.g.
+LoRA's effective-weight trace under its ``'lora_b'`` key). The rule sees
+**batch-free, num_state-free slices**: the algorithm handles both axes by
+``vmap`` exactly as it does for the legacy ``xy_to_dw`` rule. Unregistered
+primitives fall back to :data:`ETP_RULES_XY_TO_DW`.
+"""
+
+ETP_RULES_SOLVE_DRTRL: Dict[Primitive, Callable] = {}
+r"""Optional solve-time weight-gradient rule for param-dim D-RTRL.
+
+``(dg_hidden, trace_dict, weights_dict, **eqn_params) -> Dict[str, Array]``
+— contracts the learning signal ``dg_hidden`` with the eligibility trace
+``trace_dict`` and chains through the current weights ``weights_dict``,
+returning **param-shaped** gradients keyed by the primitive's trainable
+names. Register it (together with :data:`ETP_RULES_INSTANT_DRTRL`) when the
+trace structure differs from the parameter structure, so the solve step can
+no longer be expressed by ``yw_to_w`` alone. The rule sees **batch-free,
+num_state-free slices** (the algorithm vmaps over both axes, mirroring the
+legacy ``yw_to_w`` scaffolding). Unregistered primitives fall back to
+:data:`ETP_RULES_YW_TO_W`.
+"""
+
+
+def get_instant_drtrl_rule(primitive) -> Optional[Callable]:
+    """Return the param-dim D-RTRL instantaneous-term rule, or ``None``.
+
+    Parameters
+    ----------
+    primitive : Primitive
+        The ETP primitive to look up.
+
+    Returns
+    -------
+    Callable or None
+        Rule ``(x, df, weights_dict, **eqn_params) -> dict`` producing the
+        trace-structured instantaneous term, or ``None`` if the primitive
+        did not register one (the algorithm then uses ``xy_to_dw``).
+    """
+    return ETP_RULES_INSTANT_DRTRL.get(primitive)
+
+
+def get_solve_drtrl_rule(primitive) -> Optional[Callable]:
+    """Return the param-dim D-RTRL solve-time gradient rule, or ``None``.
+
+    Parameters
+    ----------
+    primitive : Primitive
+        The ETP primitive to look up.
+
+    Returns
+    -------
+    Callable or None
+        Rule ``(dg_hidden, trace_dict, weights_dict, **eqn_params) -> dict``
+        producing param-shaped gradients keyed by trainable names, or
+        ``None`` if the primitive did not register one (the algorithm then
+        uses ``yw_to_w``).
+    """
+    return ETP_RULES_SOLVE_DRTRL.get(primitive)

--- a/braintrace/_op/conv.py
+++ b/braintrace/_op/conv.py
@@ -40,29 +40,56 @@ Jacobian is fundamentally different from the kernel's.
 Let :math:`\mathbf{D}_f^t = \partial h / \partial y` (one cotangent per
 output element). The conv primitive implements:
 
-* ``xy_to_dw`` — for the *kernel*, uses the conv VJP to produce the full
-  weight Jacobian :math:`\partial h / \partial K` (requires :math:`x`).
-  For the *bias*, stores the per-position cotangent
+* ``xy_to_dw`` — **param-shaped** instantaneous Jacobian, consumed by the
+  IO-dim (ES-D-RTRL) algorithm at solve time. For the *kernel*, uses the
+  conv VJP to produce the full weight Jacobian
+  :math:`\partial h / \partial K` (requires :math:`x`). For the *bias*,
+  stores the per-position cotangent
   :math:`\partial h / \partial b_k = (\partial h / \partial y)_{b,\mathbf{s},k}`
-  **without** summing over spatial positions. The spatial summation is
-  deferred to ``yw_to_w`` during trace propagation — because the bias is
-  spatially shared, the "true" bias gradient requires summing the
-  cotangent along spatial axes, but doing the sum *inside* the trace
-  rather than at the instantaneous step keeps the linear algebra
-  consistent with the D-RTRL recurrence (the trace must accumulate
-  :math:`\mathbf{D}^t \boldsymbol{\epsilon}^{t-1}` with the *same*
-  spatial shape the executor feeds in).
+  **without** summing over spatial positions (the sum happens at the
+  consumer's contraction step).
 
-* ``yw_to_w`` — applies :math:`\partial h / \partial y` to the trace.
-  For the kernel: reduces ``hidden_dim`` over spatial axes
-  (the kernel is spatially shared) and broadcasts the result across the
-  kernel's spatial dims. For the bias: elementwise multiply with
-  ``hidden_dim`` then sum over spatial axes — this is the deferred
-  spatial reduction that implements :math:`\sum_{\mathbf{s}} \partial h/\partial b_k`.
+* ``instant_drtrl`` / ``yw_to_w`` / ``solve_drtrl`` — the param-dim
+  D-RTRL trace machinery. Because the kernel is *spatially shared*
+  (every output position reads the same :math:`K`) while the D-RTRL
+  discount :math:`\mathbf{D}^t` acts per output element, no kernel-shaped
+  (spatially pre-summed) trace can be exact: it multiplies a sum by a sum
+  where a sum of products is required. The exact trace keeps the spatial
+  output axes — for a diagonal hidden state :math:`h_{b,\mathbf{s},k}`,
 
-* ``init_drtrl`` — allocates weight-shaped :math:`\boldsymbol{\epsilon}_K`
-  plus per-position :math:`\boldsymbol{\epsilon}_b` with output-shape
-  (kept spatial so the trace can accumulate before the deferred sum).
+  .. math::
+
+      \epsilon^t_{b,\mathbf{s},\mathbf{u},c,k}
+        = D^t_{b,\mathbf{s},k}\, \epsilon^{t-1}_{b,\mathbf{s},\mathbf{u},c,k}
+          + (\mathbf{D}_f^t)_{b,\mathbf{s},k}\,
+            \mathrm{patch}^t_{b,\mathbf{s},\mathbf{u},c},
+
+  where :math:`\mathrm{patch}^t` is the receptive-field window of
+  :math:`x^t` extracted by :func:`_conv_extract_patches`.
+
+  - ``instant_drtrl`` adds the per-position term
+    :math:`(\mathbf{D}_f^t)_{b,\mathbf{s},k}\,\mathrm{patch}^t_{b,\mathbf{s},\mathbf{u},c}`
+    for the kernel, and the per-position cotangent (with the ``bias_fn``
+    chain) for the bias.
+  - ``yw_to_w`` (recurrence only) multiplies every trace slot by the
+    per-position factor :math:`D^t_{b,\mathbf{s},k}` — no spatial sums
+    anywhere.
+  - ``solve_drtrl`` contracts the learning signal with the trace,
+    performing the deferred spatial sum:
+    :math:`\nabla K_{\mathbf{u},c,k} = \sum_{\mathbf{s}}
+    g_{\mathbf{s},k}\, \epsilon_{\mathbf{s},\mathbf{u},c,k}` and
+    :math:`\nabla b_k = \sum_{\mathbf{s}} g_{\mathbf{s},k}\,
+    \epsilon_{b,\mathbf{s},k}`.
+
+* ``init_drtrl`` — allocates the per-position kernel trace
+  :math:`\boldsymbol{\epsilon}_K` of shape
+  ``(batch, *spatial_out, *kernel_shape, n_state)`` plus the per-position
+  :math:`\boldsymbol{\epsilon}_b` with output shape. This costs
+  :math:`O(B\, S\, |K|)` memory (``S`` = spatial output size) — the price
+  of exactness for a spatially shared kernel; for large convolutions
+  prefer the IO-dim algorithm (``pp_prop`` / ``IODimVjpAlgorithm``).
+  Grouped convolutions (``feature_group_count`` / ``batch_group_count``
+  != 1) are rejected with ``NotImplementedError``.
 
 * ``init_pp`` — allocates the pp-prop output-shaped df trace; the
   :math:`\boldsymbol{\epsilon}_x` factor in ES-D-RTRL is the full
@@ -73,13 +100,15 @@ output element). The conv primitive implements:
 The primitive accepts two optional transform hooks in its ``eqn.params``:
 ``kernel_fn`` (computes ``y = conv(x, kernel_fn(kernel))`` — note the
 kernel-facing name, not ``weight_fn``) and ``bias_fn`` (adds
-``bias_fn(b)``). The forward impl and :func:`_conv_xy_to_dw` apply them; the
-eligibility trace and gradient are always taken w.r.t. the **raw** kernel /
-bias, so the transform Jacobian :math:`f'` enters *only* through
-``xy_to_dw`` via :func:`jax.vjp` (``kernel_fn`` through a full kernel VJP,
-``bias_fn`` as an elementwise per-channel diagonal factor). The ``yw_to_w``
-rule and the trace initialisers are transform-free and stay exact (they
-operate on :math:`\partial h / \partial K_{\text{raw}}`).
+``bias_fn(b)``). The forward impl, :func:`_conv_xy_to_dw` and
+:func:`_conv_instant_drtrl` apply them; the eligibility trace and gradient
+are always taken w.r.t. the **raw** kernel / bias, so the transform
+Jacobian :math:`f'` enters *only* through the instantaneous rules via
+:func:`jax.vjp` (``kernel_fn`` through a kernel VJP — applied per output
+position in ``instant_drtrl`` — ``bias_fn`` as an elementwise per-channel
+diagonal factor). The ``yw_to_w`` / ``solve_drtrl`` rules and the trace
+initialisers are transform-free and stay exact (they operate on
+:math:`\partial h / \partial K_{\text{raw}}`).
 
 This primitive has **no fast path** — it always uses the generic rule path,
 which threads :math:`f'` correctly when a transform hook is present.
@@ -94,6 +123,7 @@ import jax.numpy as jnp
 import brainunit as u
 
 from ._primitive import register_primitive
+from ._registries import ETP_RULES_INSTANT_DRTRL, ETP_RULES_SOLVE_DRTRL
 from braintrace._typing import ArrayLike, WeightFn
 
 __all__ = [
@@ -219,123 +249,66 @@ def _conv_layout(params: dict[str, Any]) -> tuple[int, int, int, int]:
 
 
 def _conv_yw_to_w(hidden_dim: Any, trace: dict[str, Any], **params: Any) -> dict[str, Any]:
-    r"""Propagate :math:`\partial h / \partial y` through the conv trace.
+    r"""Apply the recurrence factor :math:`D^t = \partial h^t / \partial y`
+    to the per-position conv trace — a pure elementwise multiply.
 
-    **Role in D-RTRL.** Implements the :math:`y \to (K, b)` chain factor
-    in the :math:`\mathbf{D}^t \boldsymbol{\epsilon}^{t-1}` term. Unlike
-    dense matmul, the kernel is *spatially shared*: every output position
-    reads the same :math:`K`. Differentiating the forward equation gives
-
-    .. math::
-
-        \frac{\partial y_{b, \mathbf{s}, k}}{\partial K_{\mathbf{u}, c, k'}}
-          \;=\; \delta_{k k'}\, x_{b,\, \mathbf{s}+\mathbf{u},\, c}, \qquad
-        \frac{\partial y_{b, \mathbf{s}, k}}{\partial b_{k'}}
-          \;=\; \delta_{k k'}.
-
-    Pulling back a hidden cotangent :math:`g = \partial h / \partial y`
-    therefore contracts :math:`\mathbf{s}` for the kernel and the bias
-    (they are shared along spatial axes):
+    **Role in D-RTRL.** Implements the :math:`\mathbf{D}^t
+    \boldsymbol{\epsilon}^{t-1}` term of the trace recurrence. The trace
+    keeps the spatial output axes (see :func:`_conv_init_drtrl`), so the
+    recurrence is exact per position:
 
     .. math::
 
-        \frac{\partial h}{\partial K_{\mathbf{u}, c, k}}
-          \;=\; \sum_{\mathbf{s}} g_{b, \mathbf{s}, k}\, x_{b, \mathbf{s}+\mathbf{u}, c}, \qquad
-        \frac{\partial h}{\partial b_k}
-          \;=\; \sum_{\mathbf{s}} g_{b, \mathbf{s}, k}.
+        \epsilon^t_{b, \mathbf{s}, \mathbf{u}, c, k}
+          \;=\; D^t_{b, \mathbf{s}, k}\,
+                \epsilon^{t-1}_{b, \mathbf{s}, \mathbf{u}, c, k}, \qquad
+        \epsilon^t_{b_{\text{ias}},\, b, \mathbf{s}, k}
+          \;=\; D^t_{b, \mathbf{s}, k}\,
+                \epsilon^{t-1}_{b_{\text{ias}},\, b, \mathbf{s}, k}.
 
-    Applied to a trace :math:`\boldsymbol{\epsilon}^{t-1}`, only the
-    out-channel axis :math:`k` survives on the hidden-dim side of the
-    product; spatial axes are summed. The kernel's spatial axes remain
-    free (the trace stores one slot per kernel position), so after
-    reducing :math:`g` over :math:`\mathbf{s}` we broadcast the resulting
-    per-out-channel vector over the kernel's spatial and in-channel axes.
+    No spatial sums appear anywhere — the spatial contraction with the
+    learning signal is performed once, at solve time, by
+    :func:`_conv_solve_drtrl`. (The old kernel-shaped trace summed
+    :math:`D^t` over :math:`\mathbf{s}` here, turning the required sum of
+    products into a product of sums — wrong for the kernel even at
+    :math:`T = 1` and corrupting the bias recurrence for :math:`T \geq 2`.)
 
-    **Two execution contexts (detected from ``hidden_dim.ndim``):**
+    **Shapes (recurrence context; the solve path uses**
+    :func:`_conv_solve_drtrl` **instead):**
 
-    1. trace-update path (batch retained):
-       ``hidden_dim   : (batch, *spatial_out, out_ch)`` (or permuted),
-       ``trace['weight'] : (batch, *kernel_dims)`` (batch prefix present),
-       ``trace['bias']   : (batch, *spatial_out, out_ch)``.
+        ``hidden_dim      : (batch, *y_layout)`` — the per-position
+        :math:`D^t` factor, laid out like the conv output ``y``,
+        ``trace['weight'] : (batch, *spatial_out, *kernel_shape)``,
+        ``trace['bias']   : (batch, *y_layout)``.
 
-    2. gradient-solve path (outer batch-vmap strips batch):
-       ``hidden_dim   : (*spatial_out, out_ch)`` (batch-free),
-       ``trace['weight'] : (*kernel_dims)``,
-       ``trace['bias']   : (*spatial_out, out_ch)``.
-
-    **Bias gradient is deferred.** ``xy_to_dw`` stores the per-position
-    cotangent as ``trace['bias']`` (no spatial sum). Here we complete the
-    bias Jacobian by multiplying by :math:`g` and summing spatial axes —
-    that deferral keeps the D-RTRL trace recurrence consistent
-    (each :math:`\boldsymbol{\epsilon}^{t-1}` leaf has the same shape as
-    :math:`(\partial h/\partial y)^{t-1}` before the reduction).
-
-    **Layout awareness.** Spatial axes and the kernel out-channel axis
-    are derived from ``dimension_numbers`` / ``strides``, handling NHWC /
-    HWIO / NCHW / OIHW etc. The 0-D ``hidden_dim`` degenerate case is
-    handled directly by elementwise multiply.
+    **Layout awareness.** The batch / channel / spatial positions of
+    ``hidden_dim`` and the kernel's out-channel axis are derived from
+    ``dimension_numbers`` / ``strides`` (NHWC / HWIO / NCHW / OIHW etc.);
+    ``hidden_dim`` is transposed to ``(batch, *spatial_out, out_ch)`` and
+    broadcast over the kernel axes with ``out_ch`` aligned to the kernel's
+    out-channel axis.
     """
     has_bias = params.get('has_bias', False)
+    n_spatial, channel_axis, batch_axis, kernel_out_axis = _conv_layout(params)
     w_trace = trace['weight']
 
-    if hidden_dim.ndim == 0:
-        # Scalar (degenerate) case: multiply all trace entries elementwise.
-        out = {'weight': w_trace * hidden_dim}
-        if has_bias:
-            out['bias'] = jnp.sum(trace['bias'] * hidden_dim)
-        return out
+    # hidden_dim: (batch, *y_layout) -> (batch, *spatial_out, out_ch), with
+    # spatial axes in y-array order (matching the trace's spatial prefix).
+    spatial_axes = tuple(
+        sorted(set(range(hidden_dim.ndim)) - {batch_axis, channel_axis})
+    )
+    hd = jnp.transpose(hidden_dim, (batch_axis, *spatial_axes, channel_axis))
 
-    # ── Determine layout from params ──────────────────────────────────────────
-    # Detect which call context we are in from hidden_dim rank:
-    #   scan context:  hidden_dim.ndim == n_spatial + 2  (batch + spatial + ch)
-    #   grad context:  hidden_dim.ndim == n_spatial + 1  (spatial + ch only)
-    n_spatial, channel_axis_batched, batch_axis_batched, kernel_out_axis = _conv_layout(params)
-    has_batch_prefix = (hidden_dim.ndim == n_spatial + 2)
+    # Broadcast over the kernel block with out_ch aligned to kernel_out_axis.
+    kernel_rank = w_trace.ndim - 1 - n_spatial  # minus batch and spatial_out
+    target_shape = hd.shape[:1 + n_spatial] + tuple(
+        hd.shape[-1] if j == kernel_out_axis else 1 for j in range(kernel_rank)
+    )
+    out = {'weight': w_trace * hd.reshape(target_shape)}
 
-    # Compute spatial axes in hidden_dim (same permutation as y output).
-    if has_batch_prefix:
-        # Axes in full output: {batch_axis_batched, channel_axis_batched} excluded.
-        spatial_axes_hd = tuple(
-            sorted(set(range(hidden_dim.ndim)) - {batch_axis_batched, channel_axis_batched})
-        )
-        # channel_axis in hidden_dim (same as in y).
-        ch_axis_hd = channel_axis_batched
-    else:
-        # Batch axis is stripped.  Remaining axes: spatial + channel.
-        # The original channel_axis_batched and batch_axis_batched are for the
-        # batched layout.  After stripping the batch axis, remaining axes are
-        # renumbered: remove batch_axis_batched from the set.
-        all_axes = set(range(n_spatial + 2))
-        remaining = sorted(all_axes - {batch_axis_batched})
-        # remaining[i] is the original axis index; map to new (shifted) index.
-        ch_axis_hd = remaining.index(channel_axis_batched)
-        spatial_axes_hd = tuple(i for i in range(len(remaining)) if i != ch_axis_hd)
-
-    # ── Weight: reduce hidden_dim over spatial axes, then broadcast ───────────
-    # Target shape after reduction: only batch (if present) and ch_axis_hd survive.
-    hd_reduced = jnp.sum(hidden_dim, axis=spatial_axes_hd) if spatial_axes_hd else hidden_dim
-    # hd_reduced shape: (*batch_prefix, out_ch)  [only batch and ch axes survive]
-
-    # Determine where out_ch sits in w_trace:
-    #   scan context: w_trace has batch prefix at axis 0, so kernel_out_axis shifts by 1.
-    #   grad context: w_trace has no batch prefix, use kernel_out_axis directly.
-    w_out_axis = kernel_out_axis + 1 if has_batch_prefix else kernel_out_axis
-
-    # Build broadcast shape: all-ones except batch (axis 0 when present) and out_ch axis.
-    target_shape = [1] * w_trace.ndim
-    if has_batch_prefix:
-        target_shape[0] = w_trace.shape[0]  # batch size
-    target_shape[w_out_axis] = w_trace.shape[w_out_axis]  # out_ch size
-    hd_for_weight = jnp.reshape(hd_reduced, target_shape)
-
-    out = {'weight': w_trace * hd_for_weight}
-
-    # ── Bias: trace['bias'] has y-output shape; sum over spatial axes ─────────
     if has_bias:
-        b_trace = trace['bias']
-        # b_trace has same ndim as hidden_dim (same layout).
-        b_sum_axes = spatial_axes_hd
-        out['bias'] = jnp.sum(b_trace * hidden_dim, axis=b_sum_axes) if b_sum_axes else b_trace * hidden_dim
+        # Per-position multiply — the trace and D^t share the y layout.
+        out['bias'] = trace['bias'] * hidden_dim
     return out
 
 
@@ -441,22 +414,266 @@ def _conv_xy_to_dw(x: Any, hidden_dim: Any, weights: dict[str, Any], **params: A
     return out
 
 
+def _conv_extract_patches(x: Any, kernel_shape: Sequence[int],
+                          params: dict[str, Any]) -> Any:
+    r"""Extract per-output-position input patches for the conv primitive.
+
+    Wraps :func:`jax.lax.conv_general_dilated_patches` and unpacks its
+    packed channel axis into an explicit ``(c_in, *kernel_spatial)`` block
+    so that
+
+    .. math::
+
+        y_{b, \mathbf{s}, k}
+          \;=\; \sum_{\mathbf{u}, c}
+                \mathrm{patch}_{b, \mathbf{s}, c, \mathbf{u}}\,
+                K_{\mathbf{u}, c, k}
+
+    reproduces the forward convolution exactly. The packed-channel
+    convention (channel-major: index ``c * prod(kernel_spatial) +
+    flat(u)``) is pinned *numerically* by
+    ``conv_test.py::TestConvPatchExtraction`` rather than trusted from the
+    docs.
+
+    Parameters
+    ----------
+    x : Array
+        Batched input tensor, laid out per ``params['dimension_numbers']``.
+    kernel_shape : Sequence[int]
+        Shape of the (raw) kernel array; the spatial filter shape is read
+        from it through the rhs spec.
+    params : dict
+        Conv eqn params (``strides`` / ``padding`` / ``lhs_dilation`` /
+        ``rhs_dilation`` / ``dimension_numbers``). Group counts must be 1
+        (enforced upstream by :func:`_conv_init_drtrl`).
+
+    Returns
+    -------
+    Array
+        Patches of shape ``(batch, *spatial_out, c_in, *kernel_spatial)``,
+        with ``spatial_out`` in the output tensor's axis order and
+        ``kernel_spatial`` in the canonical (strides) order.
+    """
+    dn = jax.lax.conv_dimension_numbers(
+        x.shape, tuple(kernel_shape), params.get('dimension_numbers', None)
+    )
+    filter_shape = tuple(kernel_shape[a] for a in dn.rhs_spec[2:])
+    patches = jax.lax.conv_general_dilated_patches(
+        lhs=x,
+        filter_shape=filter_shape,
+        window_strides=tuple(params.get('strides', (1,))),
+        padding=params.get('padding', 'SAME'),
+        lhs_dilation=params.get('lhs_dilation', None),
+        rhs_dilation=params.get('rhs_dilation', None),
+        dimension_numbers=dn,
+    )
+    # patches follows the output layout with a packed channel axis of size
+    # c_in * prod(filter_shape); bring it to (batch, *spatial_out, packed).
+    batch_ax, ch_ax = dn.out_spec[0], dn.out_spec[1]
+    spatial_axes = tuple(sorted(set(range(patches.ndim)) - {batch_ax, ch_ax}))
+    patches = jnp.transpose(patches, (batch_ax, *spatial_axes, ch_ax))
+    c_in = x.shape[dn.lhs_spec[1]]
+    return patches.reshape(patches.shape[:-1] + (c_in,) + filter_shape)
+
+
+def _conv_instant_bias(hidden_dim: Any, weights: dict[str, Any],
+                       params: dict[str, Any]) -> Any:
+    r"""Per-position instantaneous bias term with the ``bias_fn`` chain.
+
+    Mirrors the bias path of :func:`_conv_xy_to_dw` byte-for-byte in
+    behaviour: the instantaneous bias Jacobian at each output position is
+    the cotangent itself, optionally multiplied by the elementwise
+    ``bias_fn`` Jacobian diagonal along the layout's channel axis. The
+    channel position is located relative to the trailing axes, so the
+    helper accepts both batched and batch-free cotangents.
+    """
+    bias_fn = params.get('bias_fn', None)
+    bias_grad = hidden_dim
+    if bias_fn is not None:
+        b = weights['bias']
+        _, b_vjp = jax.vjp(bias_fn, b)
+        db = u.get_mantissa(b_vjp(jnp.ones_like(b))[0])  # bias_fn'(b), shape (out_ch,)
+        n_spatial, channel_axis, _, _ = _conv_layout(params)
+        batched_rank = n_spatial + 2  # (batch, *spatial, channel) up to permutation
+        axes_right_of_channel = batched_rank - 1 - channel_axis
+        ax = bias_grad.ndim - 1 - axes_right_of_channel
+        shape = [1] * bias_grad.ndim
+        shape[ax] = db.shape[0]
+        bias_grad = bias_grad * db.reshape(shape)
+    return bias_grad
+
+
+def _conv_instant_drtrl(x: Any, hidden_dim: Any, weights: dict[str, Any],
+                        **params: Any) -> dict[str, Any]:
+    r"""Per-position instantaneous term for param-dim D-RTRL.
+
+    **Role.** Supplies the :math:`\operatorname{diag}(\mathbf{D}_f^t)
+    \otimes \mathbf{x}^t` term added to :math:`\mathbf{D}^t
+    \boldsymbol{\epsilon}^{t-1}` each step, in the *trace* structure of
+    :func:`_conv_init_drtrl` (spatial output axes retained) rather than
+    the parameter structure produced by :func:`_conv_xy_to_dw` (which
+    pre-sums over spatial positions — exact for the IO-dim solve but
+    incompatible with the per-position D-RTRL recurrence):
+
+    .. math::
+
+        \left(\frac{\partial h}{\partial K}\right)_{\mathbf{s}, \mathbf{u}, c, k}
+          \;=\; (\mathbf{D}_f^t)_{\mathbf{s}, k}\,
+                \mathrm{patch}^t_{\mathbf{s}, \mathbf{u}, c}, \qquad
+        \left(\frac{\partial h}{\partial b}\right)_{\mathbf{s}, k}
+          \;=\; (\mathbf{D}_f^t)_{\mathbf{s}, k},
+
+    where :math:`\mathrm{patch}^t` is the receptive-field window of
+    :math:`x^t` from :func:`_conv_extract_patches`.
+
+    **Transform hooks.** ``kernel_fn``'s Jacobian enters exactly as in
+    :func:`_conv_xy_to_dw` — through :func:`jax.vjp` of ``kernel_fn`` —
+    applied to each per-position kernel-shaped cotangent (the VJP is
+    linear in the cotangent, so the per-position application sums to the
+    legacy behaviour). ``bias_fn`` enters through
+    :func:`_conv_instant_bias`, unchanged from the ``xy_to_dw`` bias path.
+
+    **Shapes.** The algorithm vmaps over the batch axis and the trailing
+    ``num_state`` axis, so this rule sees batch-free slices:
+    ``x : (*x_layout)``, ``hidden_dim : (*y_layout)``, returning
+    ``{'weight': (*spatial_out, *kernel_shape)[, 'bias': (*y_layout)]}``.
+    A batched call (``x.ndim == n_spatial + 2``) is also supported,
+    returning batch-prefixed arrays.
+    """
+    has_bias = params.get('has_bias', False)
+    kernel_fn = params.get('kernel_fn', None)
+    kernel = u.get_mantissa(weights['weight'])
+    n_spatial = len(params.get('strides', (1,)))
+
+    unbatched = (x.ndim == n_spatial + 1)
+    x_in = x[None] if unbatched else x
+    hd_in = hidden_dim[None] if unbatched else hidden_dim
+
+    dn = jax.lax.conv_dimension_numbers(
+        x_in.shape, kernel.shape, params.get('dimension_numbers', None)
+    )
+    # (batch, *spatial_out, c_in, *kernel_spatial)
+    patches = _conv_extract_patches(x_in, kernel.shape, params)
+
+    # df -> (batch, *spatial_out, out_ch), spatial in output-tensor order
+    # (matching the trace's spatial prefix).
+    batch_ax, ch_ax = dn.out_spec[0], dn.out_spec[1]
+    spatial_axes = tuple(sorted(set(range(hd_in.ndim)) - {batch_ax, ch_ax}))
+    df_t = jnp.transpose(hd_in, (batch_ax, *spatial_axes, ch_ax))
+
+    # Outer product over the kernel block: (batch, *s, c_in, *u, out_ch).
+    lead = 1 + n_spatial  # batch + spatial_out prefix
+    df_b = df_t.reshape(
+        df_t.shape[:lead] + (1,) * (1 + n_spatial) + df_t.shape[-1:]
+    )
+    eff = patches[..., None] * df_b
+
+    # Rearrange the kernel block (c_in, *u, out_ch) into the raw kernel
+    # layout given by the rhs spec (OIH / HWIO / ...).
+    rhs_spec = dn.rhs_spec
+    src = {rhs_spec[1]: lead, rhs_spec[0]: lead + 1 + n_spatial}
+    for m, ax in enumerate(rhs_spec[2:]):
+        src[ax] = lead + 1 + m
+    perm = tuple(range(lead)) + tuple(src[j] for j in range(kernel.ndim))
+    inst = jnp.transpose(eff, perm)  # (batch, *spatial_out, *kernel_shape)
+
+    if kernel_fn is not None:
+        # Chain kernel_fn' via the same VJP _conv_xy_to_dw composes, applied
+        # per output position (linear in the cotangent, hence exact).
+        _, vjp_fn = jax.vjp(kernel_fn, kernel)
+        flat = inst.reshape((-1,) + tuple(kernel.shape))
+        flat = jax.vmap(lambda ct: u.get_mantissa(vjp_fn(ct)[0]))(flat)
+        inst = flat.reshape(inst.shape)
+
+    if unbatched:
+        inst = inst[0]
+    out = {'weight': inst}
+
+    if has_bias:
+        out['bias'] = _conv_instant_bias(hidden_dim, weights, params)
+    return out
+
+
+def _conv_solve_drtrl(dg_hidden: Any, trace: dict[str, Any],
+                      weights: dict[str, Any], **params: Any) -> dict[str, Any]:
+    r"""Solve-time weight gradients from the per-position conv trace.
+
+    **Role.** Contracts the learning signal :math:`g = \partial \mathcal{L}
+    / \partial h` with the eligibility trace, performing the spatial sum
+    that the per-position recurrence deferred:
+
+    .. math::
+
+        \nabla K_{\mathbf{u}, c, k}
+          \;=\; \sum_{\mathbf{s}} g_{\mathbf{s}, k}\,
+                \epsilon_{\mathbf{s}, \mathbf{u}, c, k}, \qquad
+        \nabla b_k
+          \;=\; \sum_{\mathbf{s}} g_{\mathbf{s}, k}\,
+                \epsilon_{b,\, \mathbf{s}, k}.
+
+    The transform Jacobians (``kernel_fn'`` / ``bias_fn'``) are **not**
+    re-applied here — they already entered the trace through
+    :func:`_conv_instant_drtrl`, mirroring the legacy ``xy_to_dw``
+    behaviour; ``weights`` is unused (kept for the registry signature).
+
+    **Shapes.** The algorithm vmaps over the batch axis and the trailing
+    ``num_state`` axis, so this rule sees batch-free, state-free slices:
+    ``dg_hidden : (*y_layout)``,
+    ``trace['weight'] : (*spatial_out, *kernel_shape)``,
+    ``trace['bias'] : (*y_layout)``. Returns param-shaped gradients
+    ``{'weight': (*kernel_shape)[, 'bias': (out_ch,)]}``.
+    """
+    has_bias = params.get('has_bias', False)
+    n_spatial, channel_axis_b, batch_axis_b, kernel_out_axis = _conv_layout(params)
+
+    # Batch-free renumbering (the algorithm vmapped the batch axis away).
+    remaining = sorted(set(range(n_spatial + 2)) - {batch_axis_b})
+    ch_axis = remaining.index(channel_axis_b)
+    spatial_axes = tuple(i for i in range(len(remaining)) if i != ch_axis)
+
+    dg_t = jnp.transpose(dg_hidden, (*spatial_axes, ch_axis))  # (*spatial_out, out_ch)
+    w_trace = trace['weight']                                  # (*spatial_out, *kernel)
+    kernel_rank = w_trace.ndim - n_spatial
+    target_shape = dg_t.shape[:n_spatial] + tuple(
+        dg_t.shape[-1] if j == kernel_out_axis else 1 for j in range(kernel_rank)
+    )
+    out = {
+        'weight': jnp.sum(
+            w_trace * dg_t.reshape(target_shape), axis=tuple(range(n_spatial))
+        )
+    }
+    if has_bias:
+        out['bias'] = jnp.sum(trace['bias'] * dg_hidden, axis=spatial_axes)
+    return out
+
+
 def _conv_init_drtrl(x_var: Any, y_var: Any, weight_vars: dict[str, Any],
-                     num_hidden_state: int) -> dict[str, Any]:
-    r"""Initialise conv D-RTRL weight-shaped trace.
+                     num_hidden_state: int, *, eqn_params: dict[str, Any]) -> dict[str, Any]:
+    r"""Initialise the per-position conv D-RTRL trace.
 
     .. math::
 
         \boldsymbol{\epsilon}_K \in
-          \mathbb{R}^{B \times \text{(kernel dims)} \times n_{\text{state}}}, \qquad
+          \mathbb{R}^{B \times \text{(spatial out)} \times \text{(kernel dims)}
+          \times n_{\text{state}}}, \qquad
         \boldsymbol{\epsilon}_b \in
           \mathbb{R}^{B \times \text{(spatial out)} \times O \times n_{\text{state}}}.
 
-    The bias trace intentionally keeps spatial dims so that
-    :func:`_conv_yw_to_w` can apply the :math:`\partial h / \partial y`
-    cotangent elementwise before collapsing them. The spatial sum
-    implementing :math:`\sum_{\mathbf{s}} \partial h/\partial b_k` is
-    performed on the trace-update side, not at the ``xy_to_dw`` step.
+    The kernel trace keeps one kernel-shaped slot **per spatial output
+    position**: the kernel is spatially shared while the D-RTRL discount
+    :math:`\mathbf{D}^t` acts per output element, so a spatially pre-summed
+    (kernel-shaped) trace cannot follow the recurrence exactly. The
+    spatial-output axes come from ``y_var``'s shape via :func:`_conv_layout`
+    (in y-array order); the kernel axes follow the raw weight layout. This
+    costs :math:`O(B\, S\, |K|\, n_{\text{state}})` memory — for large
+    convolutions prefer the IO-dim algorithm (``pp_prop`` /
+    ``IODimVjpAlgorithm``), whose conv trace stays output-shaped.
+
+    The bias trace keeps spatial dims so :func:`_conv_yw_to_w` can apply
+    the per-position :math:`D^t` factor elementwise; the spatial sum
+    implementing :math:`\sum_{\mathbf{s}} g_{\mathbf{s}} \partial
+    h/\partial b_k` is performed at solve time by
+    :func:`_conv_solve_drtrl`.
 
     Zero-initialised (matches :math:`\boldsymbol{\epsilon}^0 = \mathbf{0}`).
 
@@ -464,21 +681,56 @@ def _conv_init_drtrl(x_var: Any, y_var: Any, weight_vars: dict[str, Any],
     avals via :func:`jax.numpy.result_type` rather than left to ``jnp.zeros``'
     default (which silently follows the global x64 flag instead of the
     operands' actual dtype).
+
+    Parameters
+    ----------
+    x_var, y_var : jax variables
+        The equation's input / output variables (batched shapes).
+    weight_vars : dict
+        Trainable variables keyed by name (``'weight'`` and optionally
+        ``'bias'``).
+    num_hidden_state : int
+        Number of hidden states in the group (trailing trace axis).
+    eqn_params : dict
+        The conv equation's params — required to derive the output layout
+        (``dimension_numbers`` / ``strides``) and to reject grouped
+        convolutions.
+
+    Raises
+    ------
+    NotImplementedError
+        If ``feature_group_count != 1`` or ``batch_group_count != 1`` —
+        per-position patch extraction for grouped convolutions is not
+        supported; use ``pp_prop`` (``IODimVjpAlgorithm``) instead.
     """
+    if (eqn_params.get('feature_group_count', 1) != 1
+            or eqn_params.get('batch_group_count', 1) != 1):
+        raise NotImplementedError(
+            'param-dim D-RTRL (ParamDimVjpAlgorithm / D_RTRL) does not support '
+            'grouped convolutions (feature_group_count != 1 or '
+            'batch_group_count != 1): the exact per-position kernel trace '
+            'requires ungrouped input patches. Use the IO-dim algorithm '
+            '(pp_prop / IODimVjpAlgorithm) for grouped convolutions.'
+        )
     batch = x_var.aval.shape[0]
     dtype = jnp.result_type(
         x_var.aval.dtype, y_var.aval.dtype,
         *(v.aval.dtype for v in weight_vars.values()),
     )
+    n_spatial, channel_axis, batch_axis, _ = _conv_layout(eqn_params)
+    y_shape = y_var.aval.shape
+    spatial_out_axes = sorted(set(range(len(y_shape))) - {batch_axis, channel_axis})
+    spatial_out = tuple(y_shape[a] for a in spatial_out_axes)
     out = {
         'weight': jnp.zeros(
-            (batch, *weight_vars['weight'].aval.shape, num_hidden_state), dtype=dtype
+            (batch, *spatial_out, *weight_vars['weight'].aval.shape, num_hidden_state),
+            dtype=dtype,
         )
     }
     if 'bias' in weight_vars:
         # y_var.aval.shape = (batch, *spatial, out_ch); strip the batch dim.
         out['bias'] = jnp.zeros(
-            (batch, *y_var.aval.shape[1:], num_hidden_state), dtype=dtype
+            (batch, *y_shape[1:], num_hidden_state), dtype=dtype
         )
     return out
 
@@ -512,6 +764,12 @@ etp_conv_p.register_etp_rules(
     init_drtrl=_conv_init_drtrl,
     init_pp=_conv_init_pp,
 )
+# Param-dim D-RTRL overrides: the per-position kernel trace (spatial output
+# axes retained) differs from the parameter structure, so the instantaneous
+# term and the solve-time contraction cannot be expressed by xy_to_dw /
+# yw_to_w alone. IO-dim (ES-D-RTRL) keeps using xy_to_dw.
+ETP_RULES_INSTANT_DRTRL[etp_conv_p] = _conv_instant_drtrl
+ETP_RULES_SOLVE_DRTRL[etp_conv_p] = _conv_solve_drtrl
 
 
 def conv(
@@ -577,9 +835,11 @@ def conv(
         Default ``None`` (identity, bit-identical to the pre-transform behaviour).
     bias_fn : callable or None, optional
         Optional transform applied to the bias *inside* the primitive before
-        adding it to the output. Because the bias trace is deferred (spatial
-        summation happens in ``yw_to_w``), the derivative ``bias_fn'(b)`` is
-        applied as an explicit per-output-channel factor in ``xy_to_dw``.
+        adding it to the output. Because the bias trace is per-position (the
+        spatial summation is deferred to the solve-time contraction), the
+        derivative ``bias_fn'(b)`` is applied as an explicit
+        per-output-channel factor in the instantaneous rules (``xy_to_dw``
+        and the D-RTRL ``instant`` rule).
         **``bias_fn`` must be an elementwise (per-channel) map**; the bias
         gradient is recovered as a per-channel Jacobian-diagonal factor via
         ``jax.vjp(bias_fn, b)(ones)`` and is therefore exact only when the

--- a/braintrace/_op/conv.py
+++ b/braintrace/_op/conv.py
@@ -443,17 +443,26 @@ def _conv_init_drtrl(x_var: Any, y_var: Any, weight_vars: dict[str, Any],
     performed on the trace-update side, not at the ``xy_to_dw`` step.
 
     Zero-initialised (matches :math:`\boldsymbol{\epsilon}^0 = \mathbf{0}`).
+
+    The trace dtype is derived from the participating ``x``/``y``/weight
+    avals via :func:`jax.numpy.result_type` rather than left to ``jnp.zeros``'
+    default (which silently follows the global x64 flag instead of the
+    operands' actual dtype).
     """
     batch = x_var.aval.shape[0]
+    dtype = jnp.result_type(
+        x_var.aval.dtype, y_var.aval.dtype,
+        *(v.aval.dtype for v in weight_vars.values()),
+    )
     out = {
         'weight': jnp.zeros(
-            (batch, *weight_vars['weight'].aval.shape, num_hidden_state)
+            (batch, *weight_vars['weight'].aval.shape, num_hidden_state), dtype=dtype
         )
     }
     if 'bias' in weight_vars:
         # y_var.aval.shape = (batch, *spatial, out_ch); strip the batch dim.
         out['bias'] = jnp.zeros(
-            (batch, *y_var.aval.shape[1:], num_hidden_state)
+            (batch, *y_var.aval.shape[1:], num_hidden_state), dtype=dtype
         )
     return out
 

--- a/braintrace/_op/conv.py
+++ b/braintrace/_op/conv.py
@@ -133,6 +133,22 @@ def _etp_conv_impl(
         b = args[2]
         if bias_fn is not None:
             b = bias_fn(b)
+        if b.ndim == 1:
+            # Canonical per-output-channel bias vector: broadcast it along
+            # the layout's channel axis. The channel axis is NOT always
+            # trailing -- the default (``dimension_numbers=None``) layout is
+            # NCH-style, with the channel axis at position 1, so a naive
+            # ``y + b`` broadcasts against the trailing spatial axis instead
+            # (raising when sizes differ, silently corrupting the output
+            # when a spatial size happens to equal ``out_channels``).
+            # Bias arrays with rank > 1 are assumed to already be pre-shaped
+            # by the caller for direct broadcasting and are left untouched.
+            _, channel_axis, _, _ = _conv_layout(
+                {'strides': strides, 'dimension_numbers': dimension_numbers}
+            )
+            shape = [1] * y.ndim
+            shape[channel_axis] = b.shape[0]
+            b = b.reshape(shape)
         y = y + b
     return y
 

--- a/braintrace/_op/conv.py
+++ b/braintrace/_op/conv.py
@@ -543,8 +543,15 @@ def conv(
         Input tensor with a leading batch dimension.
     kernel : ArrayLike
         Convolution kernel, with layout governed by ``dimension_numbers``.
-    bias : ArrayLike or None, optional
-        Per-output-channel bias. Default ``None``.
+    bias : Array, optional
+        Bias added to the convolution output. A 1-D array of shape
+        ``(out_channels,)`` is automatically reshaped to broadcast along the
+        output's channel axis as determined by ``dimension_numbers`` (so it is
+        correct for channel-first layouts such as the default NCH/NCHW as well
+        as channel-last ones). An array of rank > 1 is added as-is and must
+        already be broadcast-compatible with the layout-dependent output shape
+        (this is how ``braintrace.nn.Conv1d/2d/3d`` pass their pre-shaped
+        bias). Default ``None``.
     strides : Sequence[int], optional
         Window strides. Default ``(1,)``.
     padding : str, optional

--- a/braintrace/_op/conv_test.py
+++ b/braintrace/_op/conv_test.py
@@ -526,6 +526,85 @@ class TestPublicAPIRoundTrip:
         assert braintrace.conv is conv
 
 
+# ---------------------------------------------------------------------------
+# Bias broadcasts along the layout's channel axis (H3)
+# ---------------------------------------------------------------------------
+
+class TestConvBiasChannelAxis:
+    """A ``(out_channels,)`` bias must broadcast along the layout's channel
+    axis, not just whatever axis happens to be trailing. The default
+    (``dimension_numbers=None``) layout is NCH-style, so the channel axis is
+    at position 1 -- not the trailing spatial axis.
+    """
+
+    def test_default_layout_bias_broadcasts_channel_axis(self):
+        # x: (batch=2, C_in=2, L=8); kernel: (C_out=4, C_in=2, kw=3); bias: (C_out=4,)
+        x = jnp.arange(2 * 2 * 8, dtype=jnp.float32).reshape(2, 2, 8)
+        k = jnp.arange(4 * 2 * 3, dtype=jnp.float32).reshape(4, 2, 3)
+        b = jnp.arange(4.0)
+        out = conv(x, k, b, strides=(1,), padding='SAME')
+        ref = _ref_conv(x, k, **_BASE_CONV_KW) + b.reshape(1, -1, 1)
+        np.testing.assert_allclose(out, ref)
+
+    def test_default_layout_bias_hazard_when_spatial_equals_out_channels(self):
+        """Regression guard for the silent-corruption hazard: spatial length
+        ``L`` happens to equal ``C_out``. Before the fix this shape
+        coincidence let the buggy trailing-axis broadcast succeed silently
+        (no ``ValueError``) while producing the wrong numbers.
+        """
+        # L == C_out == 4
+        x = jnp.arange(2 * 2 * 4, dtype=jnp.float32).reshape(2, 2, 4)
+        k = jnp.arange(4 * 2 * 3, dtype=jnp.float32).reshape(4, 2, 3)
+        b = jnp.arange(1.0, 5.0)
+        out = conv(x, k, b, strides=(1,), padding='SAME')
+        ref = _ref_conv(x, k, **_BASE_CONV_KW) + b.reshape(1, -1, 1)
+        np.testing.assert_allclose(out, ref)
+        # Must differ from the old (buggy) trailing-axis broadcast -- proves
+        # this test actually discriminates correct vs. silently-corrupted output.
+        buggy = _ref_conv(x, k, **_BASE_CONV_KW) + b.reshape(1, 1, -1)
+        assert not np.allclose(out, buggy)
+
+    def test_channel_last_layout_bias_still_works(self):
+        """Channel-last (`NWC`/`WIO`/`NWC`) layout regression guard -- the
+        channel axis is already trailing here, so this must keep working.
+        """
+        x = jnp.arange(2 * 8 * 2, dtype=jnp.float32).reshape(2, 8, 2)  # (N, W, C_in)
+        k = jnp.arange(3 * 2 * 4, dtype=jnp.float32).reshape(3, 2, 4)  # (W, I, O)
+        b = jnp.arange(4.0)
+        dn = ('NWC', 'WIO', 'NWC')
+        out = conv(x, k, b, strides=(1,), padding='SAME', dimension_numbers=dn)
+        ref = _ref_conv(
+            x, k, window_strides=(1,), padding='SAME', dimension_numbers=dn
+        ) + b.reshape(1, 1, -1)
+        np.testing.assert_allclose(out, ref)
+
+    def test_grad_through_biased_default_layout_conv(self):
+        """``jax.grad`` through a biased default-layout (NCH) conv must work.
+
+        All standard rules (JVP / transpose) are auto-derived from
+        ``_etp_conv_impl`` (see ``register_primitive``), so the channel-axis
+        reshape added to fix the bias broadcast must itself be
+        differentiable -- verify kernel and bias gradients match a
+        hand-written reference that performs the same reshape.
+        """
+        x = jnp.ones((2, 2, 8))
+        k = jnp.ones((4, 2, 3)) * 0.1
+        b = jnp.arange(4.0)
+
+        def loss(k_, b_):
+            return conv(x, k_, b_, strides=(1,), padding='SAME').sum()
+
+        gk, gb = jax.grad(loss, argnums=(0, 1))(k, b)
+
+        def ref_loss(k_, b_):
+            y = _ref_conv(x, k_, **_BASE_CONV_KW)
+            return (y + b_.reshape(1, -1, 1)).sum()
+
+        gk_ref, gb_ref = jax.grad(ref_loss, argnums=(0, 1))(k, b)
+        np.testing.assert_allclose(gk, gk_ref)
+        np.testing.assert_allclose(gb, gb_ref)
+
+
 class TestConvKernelFnBiasFn:
 
     def test_forward_applies_kernel_fn(self):

--- a/braintrace/_op/conv_test.py
+++ b/braintrace/_op/conv_test.py
@@ -936,7 +936,7 @@ class TestInstantSolveDrtrlFirstPrinciplesFromJacobian:
 
     def test_instant_drtrl_weight_matches_jacobian_repeated_index_contraction(self):
         brainstate.random.seed(701)
-        in_ch, out_ch, kw, L = 2, 3, 3, 6  # odd kernel width: symmetric SAME pad
+        in_ch, out_ch, kw, L = 2, 4, 3, 6  # odd kernel width: symmetric SAME pad
         x = brainstate.random.randn(in_ch, L)  # unbatched, default NCH-style
         K0 = brainstate.random.randn(out_ch, in_ch, kw)  # default OIH kernel
 
@@ -981,7 +981,7 @@ class TestInstantSolveDrtrlFirstPrinciplesFromJacobian:
 
     def test_instant_drtrl_matches_jacobian_with_kernel_fn_and_bias_fn(self):
         brainstate.random.seed(702)
-        in_ch, out_ch, kw, L = 2, 3, 3, 6
+        in_ch, out_ch, kw, L = 2, 4, 3, 6
         x = brainstate.random.randn(in_ch, L)
         K0 = brainstate.random.randn(out_ch, in_ch, kw)
         b0 = brainstate.random.randn(out_ch)
@@ -1020,7 +1020,7 @@ class TestInstantSolveDrtrlFirstPrinciplesFromJacobian:
     def test_solve_drtrl_matches_independent_spatial_sum_reference(self):
         from braintrace._op.conv import _conv_solve_drtrl
         brainstate.random.seed(703)
-        in_ch, out_ch, kw, L = 2, 3, 3, 6
+        in_ch, out_ch, kw, L = 2, 4, 3, 6
         K0 = brainstate.random.randn(out_ch, in_ch, kw)
 
         trace_w = brainstate.random.randn(L, out_ch, in_ch, kw)  # (*spatial_out, *kernel)

--- a/braintrace/_op/conv_test.py
+++ b/braintrace/_op/conv_test.py
@@ -36,6 +36,7 @@ import brainstate
 import jax
 import jax.numpy as jnp
 import numpy as np
+import pytest
 import brainunit as u
 
 import braintrace
@@ -204,55 +205,62 @@ class TestConvEtpRules:
 
     def test_yw_to_w_broadcasts_hidden_no_bias(self):
         rule = ETP_RULES_YW_TO_W[etp_conv_p]
-        # Simulate the scan/etrace-update call (batch prefix retained).
+        # Simulate the scan/etrace-update (recurrence) call — batch retained.
         # 1-D NHC-HIO conv: kernel (H_k=3, in_ch=4, out_ch=4), output (N, H_out=6, C=4).
-        # In the update path hidden_dim has the full batched output shape
-        # (batch, H_out, out_ch) before spatial reduction.
-        # trace['weight'] = (batch, H_k, in_ch, out_ch) — batch prefix present.
-        # dimension_numbers and strides must be supplied so _conv_layout can derive
-        # the spatial rank and kernel out-channel axis.
+        # hidden_dim (the per-position D^t factor) has the full batched output
+        # shape (batch, H_out, out_ch); the per-position kernel trace is
+        # (batch, H_out, H_k, in_ch, out_ch). No spatial sums anywhere.
         batch = 1
         out_ch = 4
         H_out = 6
-        # hidden_dim has full batched-output shape: (batch, H_out, out_ch)
-        hidden = jnp.ones((batch, H_out, out_ch)) * jnp.arange(1, 5)  # (1, 6, 4)
-        w_trace = jnp.ones((batch, 3, 4, out_ch))  # (1, H_k, in_ch, out_ch)
+        brainstate.random.seed(0)
+        hidden = brainstate.random.randn(batch, H_out, out_ch)
+        w_trace = brainstate.random.randn(batch, H_out, 3, 4, out_ch)
         trace = {'weight': w_trace}
         params = dict(has_bias=False, strides=(1,), dimension_numbers=('NHC', 'HIO', 'NHC'))
         out = rule(hidden, trace, **params)
-        assert out['weight'].shape == (1, 3, 4, 4)
+        assert out['weight'].shape == (1, H_out, 3, 4, out_ch)
         assert 'bias' not in out
-        # For NHC/HIO: has_batch_prefix=True (ndim=3 == n_spatial+2=3).
-        # Spatial is summed: hd_reduced = hidden.sum(axis=1) → (1, 4).
-        # w_out_axis = kernel_out_axis + 1 = 2+1 = 3 (O is at index 2 in HIO, +1 for batch).
-        # target_shape = [1, 1, 1, 4] broadcast against (1, 3, 4, 4).
-        hd_reduced = hidden.sum(axis=1)  # (1, 4) — sum over H_out
-        expected = w_trace * hd_reduced[:, None, None, :]  # (1, 3, 4, 4)
+        # Per-position multiply: hd[b, s, k] broadcast over (H_k, in_ch).
+        expected = w_trace * hidden[:, :, None, None, :]
         np.testing.assert_allclose(out['weight'], expected)
 
     def test_yw_to_w_broadcasts_hidden_with_bias(self):
         rule = ETP_RULES_YW_TO_W[etp_conv_p]
-        # Simulate post-n_state-vmap shapes for 1-D conv NHC-HIO with spatial output.
-        # hidden_dim = (batch=1, H_out=6, out_ch=4) — spatial output retained.
-        # trace['weight'] = (batch=1, H_k=3, in_ch=4, out_ch=4).
-        # trace['bias']   = (batch=1, H_out=6, out_ch=4)  ← same as y output (per-position).
-        # dimension_numbers and strides must be supplied so _conv_layout can derive
-        # the spatial rank and channel-axis position.
+        # Recurrence context for 1-D conv NHC-HIO.
+        # hidden_dim = (batch=1, H_out=6, out_ch=4).
+        # trace['weight'] = (batch=1, H_out=6, H_k=3, in_ch=4, out_ch=4).
+        # trace['bias']   = (batch=1, H_out=6, out_ch=4)  ← y-shaped (per-position).
         batch = 1
-        hidden = jnp.ones((batch, 6, 4))  # (1, H_out, out_ch)
-        w_trace = jnp.ones((batch, 3, 4, 4))  # (1, H_k, in_ch, out_ch)
-        b_trace = jnp.ones((batch, 6, 4)) * 2.0  # (1, H_out, out_ch) — per-position trace
+        brainstate.random.seed(1)
+        hidden = brainstate.random.randn(batch, 6, 4)
+        w_trace = brainstate.random.randn(batch, 6, 3, 4, 4)
+        b_trace = brainstate.random.randn(batch, 6, 4)
         trace = {'weight': w_trace, 'bias': b_trace}
         params = dict(has_bias=True, strides=(1,), dimension_numbers=('NHC', 'HIO', 'NHC'))
         out = rule(hidden, trace, **params)
         assert 'weight' in out
         assert 'bias' in out
-        assert out['weight'].shape == (1, 3, 4, 4)
-        # bias result: sum over H_out of (b_trace * hidden) → (1, out_ch)
-        assert out['bias'].shape == (1, 4)
-        # bias update: elementwise product then sum over spatial (axis 1)
-        expected_bias = jnp.sum(b_trace * hidden, axis=1)  # sum over H_out → (1, 4)
-        np.testing.assert_allclose(out['bias'], expected_bias)
+        assert out['weight'].shape == (1, 6, 3, 4, 4)
+        # Bias recurrence is a pure per-position multiply — NO spatial sum
+        # (the old spatially-summed multiplier corrupted the recurrence for
+        # T >= 2; the sum now lives in the solve rule).
+        assert out['bias'].shape == (1, 6, 4)
+        np.testing.assert_allclose(out['bias'], b_trace * hidden)
+
+    def test_yw_to_w_default_nch_layout(self):
+        """Default (NCH/OIH) layout: hd must be transposed to (batch, s, k)
+        and its channel aligned to the kernel's out-channel axis (0 in OIH)."""
+        rule = ETP_RULES_YW_TO_W[etp_conv_p]
+        batch, c_out, length = 1, 3, 8
+        brainstate.random.seed(2)
+        hidden = brainstate.random.randn(batch, c_out, length)      # NCH
+        w_trace = brainstate.random.randn(batch, length, c_out, 2, 3)  # (b, s, O, I, H)
+        params = dict(has_bias=False, strides=(1,), dimension_numbers=None)
+        out = rule(hidden, {'weight': w_trace}, **params)
+        hd = jnp.transpose(hidden, (0, 2, 1))  # (b, s, k)
+        expected = w_trace * hd[:, :, :, None, None]
+        np.testing.assert_allclose(out['weight'], expected)
 
     def test_xy_to_dw_matches_jax_vjp(self):
         """The rule forwards its kwargs straight to
@@ -296,10 +304,14 @@ class TestConvEtpRules:
     def test_init_drtrl_shape_no_bias(self):
         rule = ETP_RULES_INIT_DRTRL[etp_conv_p]
         x_var = _fake_var((1, 3, 8))
-        y_var = _fake_var((1, 4, 8))
+        y_var = _fake_var((1, 4, 8))  # NCH: spatial_out = (8,)
         weight_vars = {'weight': _fake_var((4, 3, 3))}
-        out = rule(x_var, y_var, weight_vars, num_hidden_state=2)
-        assert out['weight'].shape == (1, 4, 3, 3, 2)
+        eqn_params = dict(strides=(1,), dimension_numbers=None,
+                          feature_group_count=1, batch_group_count=1)
+        out = rule(x_var, y_var, weight_vars, num_hidden_state=2,
+                   eqn_params=eqn_params)
+        # Per-position kernel trace: (batch, *spatial_out, *kernel, n_state).
+        assert out['weight'].shape == (1, 8, 4, 3, 3, 2)
         assert 'bias' not in out
 
     def test_init_drtrl_shape_with_bias(self):
@@ -308,10 +320,35 @@ class TestConvEtpRules:
         y_var = _fake_var((1, 4, 8))
         # bias has shape (4,) but the trace stores per-position ∂h/∂b
         weight_vars = {'weight': _fake_var((4, 3, 3)), 'bias': _fake_var((4,))}
-        out = rule(x_var, y_var, weight_vars, num_hidden_state=2)
-        assert out['weight'].shape == (1, 4, 3, 3, 2)
+        eqn_params = dict(strides=(1,), dimension_numbers=None,
+                          feature_group_count=1, batch_group_count=1)
+        out = rule(x_var, y_var, weight_vars, num_hidden_state=2,
+                   eqn_params=eqn_params)
+        assert out['weight'].shape == (1, 8, 4, 3, 3, 2)
         # bias trace: (batch, *y_shape[1:], n_state) = (1, 4, 8, 2)
         assert out['bias'].shape == (1, 4, 8, 2)
+
+    def test_init_drtrl_shape_channel_last(self):
+        rule = ETP_RULES_INIT_DRTRL[etp_conv_p]
+        x_var = _fake_var((1, 8, 3))   # NWC
+        y_var = _fake_var((1, 8, 4))   # NWC: spatial_out = (8,)
+        weight_vars = {'weight': _fake_var((3, 3, 4))}  # WIO
+        eqn_params = dict(strides=(1,), dimension_numbers=('NWC', 'WIO', 'NWC'),
+                          feature_group_count=1, batch_group_count=1)
+        out = rule(x_var, y_var, weight_vars, num_hidden_state=2,
+                   eqn_params=eqn_params)
+        assert out['weight'].shape == (1, 8, 3, 3, 4, 2)
+
+    def test_init_drtrl_rejects_grouped_conv(self):
+        rule = ETP_RULES_INIT_DRTRL[etp_conv_p]
+        x_var = _fake_var((1, 4, 8))
+        y_var = _fake_var((1, 4, 8))
+        weight_vars = {'weight': _fake_var((4, 2, 3))}
+        eqn_params = dict(strides=(1,), dimension_numbers=None,
+                          feature_group_count=2, batch_group_count=1)
+        with pytest.raises(NotImplementedError, match='pp_prop'):
+            rule(x_var, y_var, weight_vars, num_hidden_state=1,
+                 eqn_params=eqn_params)
 
     def test_init_pp_shape(self):
         rule = ETP_RULES_INIT_PP[etp_conv_p]
@@ -648,3 +685,221 @@ class TestConvKernelFnBiasFn:
         # bias_fn'(b) = 2*b, broadcast along channel axis=1 of the (batch, ch, spatial) trace.
         expected = hidden * (2.0 * b).reshape(1, 4, 1)
         np.testing.assert_allclose(out['bias'], expected, atol=1e-4)
+
+
+# ---------------------------------------------------------------------------
+# Patch-extraction ground truth (conv == einsum over extracted patches)
+# ---------------------------------------------------------------------------
+
+class TestConvPatchExtraction:
+    """Pin the ``conv_general_dilated_patches`` channel-ordering convention.
+
+    The per-position D-RTRL kernel trace relies on
+    ``_conv_extract_patches`` returning patches laid out as
+    ``(batch, *spatial_out, c_in, *kernel_spatial)`` such that
+
+    .. math::  y_{b,\\mathbf{s},k} = \\sum_{\\mathbf{u},c}
+               \\mathrm{patch}_{b,\\mathbf{s},c,\\mathbf{u}}\\, K_{...}
+
+    reproduces ``jax.lax.conv_general_dilated`` exactly. This is verified
+    *numerically* (not trusted from the docs) for the default NCH/OIH
+    layout, a strided conv, VALID padding and a channel-last layout.
+    """
+
+    def _patches(self, x, kernel_shape, **params):
+        from braintrace._op.conv import _conv_extract_patches
+        return _conv_extract_patches(x, kernel_shape, params)
+
+    def test_patches_match_conv_default_layout(self):
+        brainstate.random.seed(0)
+        x = brainstate.random.randn(2, 3, 8)        # NCH
+        k = brainstate.random.randn(4, 3, 3)        # OIH
+        params = dict(strides=(1,), padding='SAME', dimension_numbers=None)
+        patches = self._patches(x, k.shape, **params)
+        assert patches.shape == (2, 8, 3, 3)        # (b, s, c_in, u)
+        y = jnp.einsum('bscu,kcu->bks', patches, k)  # back to NCH
+        ref = jax.lax.conv_general_dilated(x, k, window_strides=(1,), padding='SAME')
+        np.testing.assert_allclose(y, ref, atol=1e-5)
+
+    def test_patches_match_conv_strided(self):
+        brainstate.random.seed(1)
+        x = brainstate.random.randn(2, 3, 8)
+        k = brainstate.random.randn(4, 3, 3)
+        params = dict(strides=(2,), padding='SAME', dimension_numbers=None)
+        patches = self._patches(x, k.shape, **params)
+        y = jnp.einsum('bscu,kcu->bks', patches, k)
+        ref = jax.lax.conv_general_dilated(x, k, window_strides=(2,), padding='SAME')
+        np.testing.assert_allclose(y, ref, atol=1e-5)
+
+    def test_patches_match_conv_valid_padding(self):
+        brainstate.random.seed(2)
+        x = brainstate.random.randn(2, 3, 8)
+        k = brainstate.random.randn(4, 3, 3)
+        params = dict(strides=(1,), padding='VALID', dimension_numbers=None)
+        patches = self._patches(x, k.shape, **params)
+        assert patches.shape == (2, 6, 3, 3)        # L_out = 8 - 3 + 1
+        y = jnp.einsum('bscu,kcu->bks', patches, k)
+        ref = jax.lax.conv_general_dilated(x, k, window_strides=(1,), padding='VALID')
+        np.testing.assert_allclose(y, ref, atol=1e-5)
+
+    def test_patches_match_conv_channel_last(self):
+        brainstate.random.seed(3)
+        x = brainstate.random.randn(2, 8, 3)        # NWC
+        k = brainstate.random.randn(3, 3, 4)        # WIO
+        dn = ('NWC', 'WIO', 'NWC')
+        params = dict(strides=(1,), padding='SAME', dimension_numbers=dn)
+        patches = self._patches(x, k.shape, **params)
+        assert patches.shape == (2, 8, 3, 3)        # (b, s, c_in, u)
+        y = jnp.einsum('bscu,uco->bso', patches, k)  # back to NWC
+        ref = jax.lax.conv_general_dilated(
+            x, k, window_strides=(1,), padding='SAME', dimension_numbers=dn
+        )
+        np.testing.assert_allclose(y, ref, atol=1e-5)
+
+
+# ---------------------------------------------------------------------------
+# Exact-gradient oracle: param-dim D-RTRL vs BPTT (per-position kernel trace)
+# ---------------------------------------------------------------------------
+
+class TestConvOnlineLearningExact:
+    """Single-step D-RTRL must reproduce BPTT exactly for conv kernel + bias.
+
+    The models are exactly diagonal (leaky-integrator dynamics
+    ``h <- leak * h + drive``), so D-RTRL's diagonal approximation is exact
+    and every parameter gradient must match a BPTT oracle element-wise
+    (``rel < 1e-10`` in float64). This covers the audit finding that the
+    kernel-shaped (spatially pre-summed) trace multiplied a sum by a sum
+    where a sum of products is required — kernel gradients were wrong even
+    at T=1 (measured rel err 1.0–47.8) and the bias recurrence used the
+    spatially-summed multiplier (exact at T=1, rel err ~6 at T=3).
+    """
+
+    LEAK = 0.5
+    TOL = 1e-10
+
+    @staticmethod
+    def _rel_err(a, b):
+        a = jnp.asarray(a)
+        b = jnp.asarray(b)
+        denom = jnp.maximum(jnp.abs(a).max(), 1e-12)
+        return float(jnp.abs(a - b).max() / denom)
+
+    def _assert_exact(self, factory, xs):
+        from braintrace._algorithm.oracle import (
+            bptt_param_gradients,
+            online_param_gradients_singlestep_naive,
+        )
+        g_bptt = bptt_param_gradients(factory, xs)
+        g_online = online_param_gradients_singlestep_naive(
+            factory, xs,
+            algo_factory=lambda m: braintrace.D_RTRL(m, vjp_method='single-step'),
+        )
+        for key in g_bptt:
+            rel = self._rel_err(g_bptt[key], g_online[key])
+            assert rel < self.TOL, (
+                f'D-RTRL diverges from BPTT for {key} at T={xs.shape[0]}: '
+                f'max_rel_err={rel:.3e}'
+            )
+
+    def test_default_layout_kernel_exact(self):
+        """NCH/OIH default layout: kernel gradient exact at T=1 and T=4."""
+        c_in, c_out, length = 2, 3, 8
+        leak = self.LEAK
+        with brainstate.environ.context(precision=64):
+            brainstate.random.seed(0)
+            k0 = 0.1 * brainstate.random.randn(c_out, c_in, 3)  # OIH
+
+            def factory():
+                class Net(brainstate.nn.Module):
+                    def __init__(self):
+                        super().__init__()
+                        self.k = brainstate.ParamState(k0)
+                        self.h = brainstate.HiddenState(jnp.zeros((1, c_out, length)))  # NCH
+
+                    def update(self, x):
+                        drive = braintrace.conv(
+                            x, self.k.value, strides=(1,), padding='SAME'
+                        )
+                        self.h.value = leak * self.h.value + drive
+                        return self.h.value
+
+                return Net()
+
+            for T in (1, 4):
+                brainstate.random.seed(42)
+                xs = 0.3 * brainstate.random.randn(T, 1, c_in, length)
+                self._assert_exact(factory, xs)
+
+    def test_channel_last_with_bias_exact(self):
+        """NWC/WIO/NWC layout with a bias: kernel *and* bias exact at T=3.
+
+        Pins the bias-recurrence fix — with the old spatially-summed
+        recurrence multiplier the bias gradient failed at T >= 2 (rel err ~6).
+        """
+        c_in, c_out, width = 2, 3, 8
+        leak = self.LEAK
+        dn = ('NWC', 'WIO', 'NWC')
+        with brainstate.environ.context(precision=64):
+            brainstate.random.seed(1)
+            k0 = 0.1 * brainstate.random.randn(3, c_in, c_out)  # WIO
+            b0 = 0.05 * brainstate.random.randn(c_out)
+
+            def factory():
+                class Net(brainstate.nn.Module):
+                    def __init__(self):
+                        super().__init__()
+                        self.k = brainstate.ParamState(k0)
+                        self.b = brainstate.ParamState(b0)
+                        self.h = brainstate.HiddenState(jnp.zeros((1, width, c_out)))  # NWC
+
+                    def update(self, x):
+                        drive = braintrace.conv(
+                            x, self.k.value, self.b.value,
+                            strides=(1,), padding='SAME', dimension_numbers=dn,
+                        )
+                        self.h.value = leak * self.h.value + drive
+                        return self.h.value
+
+                return Net()
+
+            brainstate.random.seed(43)
+            xs = 0.3 * brainstate.random.randn(3, 1, width, c_in)
+            self._assert_exact(factory, xs)
+
+
+# ---------------------------------------------------------------------------
+# Grouped-conv rejection under param-dim D-RTRL
+# ---------------------------------------------------------------------------
+
+class TestGroupedConvDrtrlRejection:
+    """``feature_group_count != 1`` has no per-position patch extraction under
+    the exact param-dim D-RTRL kernel trace; trace init must reject it with a
+    pointer to the IO-dim alternative (``pp_prop``)."""
+
+    def test_feature_group_count_rejected_with_pp_prop_pointer(self):
+        c_in, c_out, length = 4, 4, 8
+        with brainstate.environ.context(precision=64):
+            brainstate.random.seed(0)
+            k0 = 0.1 * brainstate.random.randn(c_out, c_in // 2, 3)  # OIH, groups=2
+
+            class Net(brainstate.nn.Module):
+                def __init__(self):
+                    super().__init__()
+                    self.k = brainstate.ParamState(k0)
+                    self.h = brainstate.HiddenState(jnp.zeros((1, c_out, length)))
+
+                def update(self, x):
+                    drive = braintrace.conv(
+                        x, self.k.value, strides=(1,), padding='SAME',
+                        feature_group_count=2,
+                    )
+                    self.h.value = 0.5 * self.h.value + drive
+                    return self.h.value
+
+            net = Net()
+            brainstate.nn.init_all_states(net, batch_size=1)
+            algo = braintrace.D_RTRL(net, vjp_method='single-step')
+            # ``compile_graph`` initialises the trace states, which is where
+            # the per-position trace allocation rejects grouped convs.
+            with pytest.raises(NotImplementedError, match='pp_prop'):
+                algo.compile_graph(jnp.zeros((1, c_in, length)))

--- a/braintrace/_op/conv_test.py
+++ b/braintrace/_op/conv_test.py
@@ -903,3 +903,140 @@ class TestGroupedConvDrtrlRejection:
             # the per-position trace allocation rejects grouped convs.
             with pytest.raises(NotImplementedError, match='pp_prop'):
                 algo.compile_graph(jnp.zeros((1, c_in, length)))
+
+
+# ---------------------------------------------------------------------------
+# Audit Task 11 (T3): first-principles ``instant_drtrl`` / ``solve_drtrl``
+# from ``jax.jacobian``
+# ---------------------------------------------------------------------------
+
+class TestInstantSolveDrtrlFirstPrinciplesFromJacobian:
+    """Derive ``_conv_instant_drtrl`` / ``_conv_solve_drtrl`` from
+    ``jax.jacobian`` of the primitive's own forward, on tiny shapes, default
+    (OIH kernel / NCH data) layout, unbatched.
+
+    ``instant_drtrl``'s documented formula is
+    ``(dh/dK)_{s,u,c,k} = D_f^t_{s,k} * patch_{s,u,c}``, i.e. the per-position
+    (spatial index ``s`` never summed) contraction of the cotangent against
+    the raw conv Jacobian ``dy_{k,s}/dK_{k2,c,u} = delta(k,k2) * patch_{s,u,c}``.
+    This test builds the full Jacobian via ``jax.jacobian`` (never via the
+    rule's own patch-extraction helper), verifies its diagonal-in-out-channel
+    structure against an independently hand-built "SAME"-padding patch
+    (plain zero-padding + indexing, not :func:`_conv_extract_patches`), then
+    contracts the raw Jacobian with a random cotangent via a *repeated*-index
+    ``einsum`` (the spatial axis ``s`` appears in both operands and the
+    output, so it is kept rather than summed) and compares against the
+    rule's actual output.
+
+    ``solve_drtrl`` is checked separately: it performs a plain spatial-sum
+    contraction between a random loss cotangent and a random trace (no
+    forward model to differentiate), reimplemented here independently of
+    the rule's own axis bookkeeping.
+    """
+
+    def test_instant_drtrl_weight_matches_jacobian_repeated_index_contraction(self):
+        brainstate.random.seed(701)
+        in_ch, out_ch, kw, L = 2, 3, 3, 6  # odd kernel width: symmetric SAME pad
+        x = brainstate.random.randn(in_ch, L)  # unbatched, default NCH-style
+        K0 = brainstate.random.randn(out_ch, in_ch, kw)  # default OIH kernel
+
+        def fwd(K):
+            y = jax.lax.conv_general_dilated(
+                x[None], K, window_strides=(1,), padding='SAME',
+            )
+            return y[0]  # (out_ch, L)
+
+        J = jax.jacobian(fwd)(K0)  # (k, s, k2, c, u)
+
+        pad = (kw - 1) // 2
+        x_padded = jnp.pad(x, ((0, 0), (pad, pad)))
+
+        def manual_patch(s, u, c):
+            return x_padded[c, s + u]
+
+        for k in range(out_ch):
+            for s in range(L):
+                for k2 in range(out_ch):
+                    for c in range(in_ch):
+                        for u in range(kw):
+                            expected = float(manual_patch(s, u, c)) if k == k2 else 0.0
+                            np.testing.assert_allclose(
+                                J[k, s, k2, c, u], expected, atol=1e-6,
+                                err_msg=f'Jacobian mismatch at k={k},s={s},k2={k2},c={c},u={u}',
+                            )
+
+        g = brainstate.random.randn(out_ch, L)  # hidden_dim, (k, s) layout
+
+        # Repeated-index einsum: 's' appears in both operands and the output
+        # so it is NOT summed -- only the y-channel index (labelled 'k' on
+        # the cotangent, 'm' on the Jacobian's differentiation side) is
+        # contracted, matching the plan's "g-contraction ... per position".
+        ref_inst = jnp.einsum('ks,ksmcu->smcu', g, J)
+
+        from braintrace._op.conv import _conv_instant_drtrl
+        out = _conv_instant_drtrl(
+            x, g, {'weight': K0}, strides=(1,), padding='SAME', has_bias=False,
+        )
+        np.testing.assert_allclose(out['weight'], ref_inst, atol=1e-6)
+
+    def test_instant_drtrl_matches_jacobian_with_kernel_fn_and_bias_fn(self):
+        brainstate.random.seed(702)
+        in_ch, out_ch, kw, L = 2, 3, 3, 6
+        x = brainstate.random.randn(in_ch, L)
+        K0 = brainstate.random.randn(out_ch, in_ch, kw)
+        b0 = brainstate.random.randn(out_ch)
+
+        kernel_fn = lambda K: 1.5 * K + 0.1 * K ** 2
+        bias_fn = lambda b: jnp.tanh(b)
+
+        def fwd(K):
+            y = jax.lax.conv_general_dilated(
+                x[None], kernel_fn(K), window_strides=(1,), padding='SAME',
+            )
+            return y[0]
+
+        J = jax.jacobian(fwd)(K0)  # w.r.t. the RAW kernel; kernel_fn is inside fwd
+        g = brainstate.random.randn(out_ch, L)
+        ref_inst = jnp.einsum('ks,ksmcu->smcu', g, J)
+
+        from braintrace._op.conv import _conv_instant_drtrl
+        out = _conv_instant_drtrl(
+            x, g, {'weight': K0}, strides=(1,), padding='SAME', has_bias=False,
+            kernel_fn=kernel_fn,
+        )
+        np.testing.assert_allclose(out['weight'], ref_inst, atol=1e-5)
+
+        # Bias: jacobian of bias_fn itself (diagonal), never assumed.
+        J_b = jax.jacobian(bias_fn)(b0)
+        db = jnp.diagonal(J_b)
+        ref_bias = g * db[:, None]  # channel axis is axis 0 in (k, s) layout
+
+        out_b = _conv_instant_drtrl(
+            x, g, {'weight': K0, 'bias': b0}, strides=(1,), padding='SAME',
+            has_bias=True, bias_fn=bias_fn,
+        )
+        np.testing.assert_allclose(out_b['bias'], ref_bias, atol=1e-6)
+
+    def test_solve_drtrl_matches_independent_spatial_sum_reference(self):
+        from braintrace._op.conv import _conv_solve_drtrl
+        brainstate.random.seed(703)
+        in_ch, out_ch, kw, L = 2, 3, 3, 6
+        K0 = brainstate.random.randn(out_ch, in_ch, kw)
+
+        trace_w = brainstate.random.randn(L, out_ch, in_ch, kw)  # (*spatial_out, *kernel)
+        trace_b = brainstate.random.randn(out_ch, L)  # (*y_layout)
+        dg_hidden = brainstate.random.randn(out_ch, L)  # (*y_layout)
+
+        # Independent reimplementation of the documented spatial-sum
+        # contraction, built without reusing `_conv_layout` or any of the
+        # rule's own axis-alignment code.
+        dg_t = jnp.transpose(dg_hidden, (1, 0))  # (s, k)
+        ref_w = jnp.einsum('sk,skcu->kcu', dg_t, trace_w)
+        ref_b = jnp.sum(trace_b * dg_hidden, axis=1)
+
+        out = _conv_solve_drtrl(
+            dg_hidden, {'weight': trace_w, 'bias': trace_b}, {'weight': K0},
+            strides=(1,), padding='SAME', has_bias=True,
+        )
+        np.testing.assert_allclose(out['weight'], ref_w, atol=1e-6)
+        np.testing.assert_allclose(out['bias'], ref_b, atol=1e-6)

--- a/braintrace/_op/dense.py
+++ b/braintrace/_op/dense.py
@@ -84,6 +84,16 @@ are always taken w.r.t. the **raw** weight/bias, so the transform Jacobian
 :math:`f'` enters *only* through ``xy_to_dw`` via :func:`jax.vjp`. The
 ``yw_to_w`` rule does **not** apply :math:`f'`.
 
+Both hooks are threaded through ``eqn.params``, which JAX treats as a
+*static* (hashed-by-identity) part of the equation. Two textually identical
+``lambda`` expressions are two distinct Python objects, so passing a fresh
+``lambda`` each call (e.g. ``matmul(x, w, weight_fn=lambda ww: ww ** 2)``
+inside a loop or inside a jitted function called repeatedly) silently
+produces a cache miss / retrace every time even though the transform is
+unchanged. Pass a module-level (or otherwise stably-identified) function
+instead of a fresh ``lambda`` when ``weight_fn`` / ``bias_fn`` is used
+inside a hot path.
+
 **Fast path**
 
 A closed-form param-dim D-RTRL kernel bundle (:class:`FastPathRules`,
@@ -630,7 +640,9 @@ def matmul(
     Parameters
     ----------
     x : ArrayLike
-        Input array, shape ``(..., in_features)`` or ``(in_features,)``.
+        Input array, shape ``(batch, in_features)`` or ``(in_features,)``.
+        Higher-rank ``x`` (``x.ndim > 2``) is rejected with a ``ValueError``:
+        every ETP trace rule assumes one of these two layouts.
     weight : ArrayLike
         Weight matrix, shape ``(in_features, out_features)``.
     bias : ArrayLike or None, optional
@@ -642,17 +654,24 @@ def matmul(
         The transform operates on the unitless mantissa; physical units are
         split off before and recombined after.
         Default ``None`` (identity).
+        Pass a module-level function, not a fresh ``lambda``, if this is
+        called repeatedly (e.g. once per step): ``weight_fn`` is stored as a
+        static ``eqn.params`` entry hashed by object identity, so two
+        textually identical ``lambda`` objects are cache misses and silently
+        retrace every call.
     bias_fn : Callable or None, optional
         Elementwise transform applied to ``bias`` inside the primitive
         (``+ bias_fn(bias)``). Ignored when ``bias is None``.
         The transform operates on the unitless mantissa; physical units are
         split off before and recombined after.
         Default ``None``.
+        Same re-tracing caveat as ``weight_fn``: pass a module-level
+        function rather than a fresh ``lambda``.
 
     Returns
     -------
     ArrayLike
-        Output array, shape ``(..., out_features)`` or ``(out_features,)``.
+        Output array, shape ``(batch, out_features)`` or ``(out_features,)``.
 
     Examples
     --------
@@ -680,6 +699,15 @@ def matmul(
         >>> print(y2.shape)
         (16, 4)
     """
+    if x.ndim > 2:  # type: ignore[union-attr]
+        raise ValueError(
+            f'matmul() supports x.ndim of 1 (unbatched `(in_features,)`) or 2 '
+            f'(batched `(batch, in_features)`); got x.ndim={x.ndim} '
+            f'(shape={x.shape}). Every ETP trace rule for etp_mm_p / etp_mv_p '
+            f'assumes one of those two layouts, so higher-rank inputs (e.g. '
+            f'`(batch, time, in_features)`) are not supported -- reshape/vmap '
+            f'over the extra axes before calling matmul().'
+        )
     p = etp_mm_p if x.ndim >= 2 else etp_mv_p  # type: ignore[union-attr]  # x is an array here; ArrayLike also admits scalars without .ndim
     x_v, x_u = u.split_mantissa_unit(x)
     weight_v, weight_u = u.split_mantissa_unit(weight)

--- a/braintrace/_op/dense.py
+++ b/braintrace/_op/dense.py
@@ -255,16 +255,25 @@ def _mm_init_drtrl(x_var: Any, y_var: Any, weight_vars: dict[str, Any],
     in the recurrence
     :math:`\boldsymbol{\epsilon}^t \approx \mathbf{D}^t \boldsymbol{\epsilon}^{t-1}
                                            + \operatorname{diag}(\mathbf{D}_f^t)\otimes \mathbf{x}^t`.
+
+    The trace dtype is derived from the participating ``x``/``y``/weight
+    avals via :func:`jax.numpy.result_type` rather than left to ``jnp.zeros``'
+    default (which silently follows the global x64 flag instead of the
+    operands' actual dtype).
     """
     batch = x_var.aval.shape[0]
+    dtype = jnp.result_type(
+        x_var.aval.dtype, y_var.aval.dtype,
+        *(v.aval.dtype for v in weight_vars.values()),
+    )
     out = {
         'weight': jnp.zeros(
-            (batch, *weight_vars['weight'].aval.shape, num_hidden_state)
+            (batch, *weight_vars['weight'].aval.shape, num_hidden_state), dtype=dtype
         )
     }
     if 'bias' in weight_vars:
         out['bias'] = jnp.zeros(
-            (batch, *weight_vars['bias'].aval.shape, num_hidden_state)
+            (batch, *weight_vars['bias'].aval.shape, num_hidden_state), dtype=dtype
         )
     return out
 
@@ -543,15 +552,24 @@ def _mv_init_drtrl(x_var: Any, y_var: Any, weight_vars: dict[str, Any],
         \boldsymbol{\epsilon}_b \in \mathbb{R}^{O \times n_{\text{state}}}.
 
     Zero-initialised (matches :math:`\boldsymbol{\epsilon}^0 = \mathbf{0}`).
+
+    The trace dtype is derived from the participating ``x``/``y``/weight
+    avals via :func:`jax.numpy.result_type` rather than left to ``jnp.zeros``'
+    default (which silently follows the global x64 flag instead of the
+    operands' actual dtype).
     """
+    dtype = jnp.result_type(
+        x_var.aval.dtype, y_var.aval.dtype,
+        *(v.aval.dtype for v in weight_vars.values()),
+    )
     out = {
         'weight': jnp.zeros(
-            (*weight_vars['weight'].aval.shape, num_hidden_state)
+            (*weight_vars['weight'].aval.shape, num_hidden_state), dtype=dtype
         )
     }
     if 'bias' in weight_vars:
         out['bias'] = jnp.zeros(
-            (*weight_vars['bias'].aval.shape, num_hidden_state)
+            (*weight_vars['bias'].aval.shape, num_hidden_state), dtype=dtype
         )
     return out
 

--- a/braintrace/_op/dense_test.py
+++ b/braintrace/_op/dense_test.py
@@ -790,3 +790,100 @@ class TestDenseFastPath:
         np.testing.assert_allclose(
             folded['bias'], unfolded['bias'].sum(axis=0), atol=1e-5
         )
+
+
+# ---------------------------------------------------------------------------
+# Audit Task 11 (T3): first-principles ``yw_to_w`` from ``jax.jacobian``
+# ---------------------------------------------------------------------------
+
+class TestYwToWFirstPrinciplesFromJacobian:
+    """Derive ``_mm_yw_to_w`` / ``_mv_yw_to_w`` from ``jax.jacobian`` of the
+    primitive's own forward, rather than trusting the rule's own formula.
+
+    ``y = x @ w`` has ``partial y_o / partial w_{i, o'} = delta(o, o') x_i`` —
+    diagonal in the two "out" indices. This is a *structural* fact about the
+    op, confirmed here numerically via ``jax.jacobian`` on non-square shapes
+    (``in != out``, so a wrong-axis broadcast would not silently line up).
+    Because the Jacobian is diagonal, the general chain-rule contraction of a
+    cotangent ``g`` against the full Jacobian collapses to an elementwise
+    broadcast-multiply — exactly what ``yw_to_w`` implements. Each test
+    builds the "general" contraction via an explicit ``jnp.einsum`` over the
+    *raw* Jacobian tensor (never the rule's own broadcast code) and compares
+    it, for a random (never all-ones) cotangent and random incoming trace,
+    against the rule's actual output.
+    """
+
+    def test_mm_yw_to_w_weight_and_bias_match_jacobian_contraction(self):
+        from braintrace._op.dense import _mm_yw_to_w
+        brainstate.random.seed(301)
+        batch, n_in, n_out = 2, 3, 5  # non-square: exercises axis=-2 broadcast
+        x = brainstate.random.randn(batch, n_in)
+        w0 = brainstate.random.randn(n_in, n_out)
+        b0 = brainstate.random.randn(n_out)
+
+        J_w = jax.jacobian(lambda w: x @ w)(w0)  # (batch, out, in, out)
+        J_b = jax.jacobian(lambda b: x @ w0 + b)(b0)  # (batch, out, out)
+
+        # Structural fact relied on by the rule: both Jacobians are diagonal
+        # in the two "out" axes.
+        for o in range(n_out):
+            for o2 in range(n_out):
+                expected_w = x if o == o2 else jnp.zeros_like(x)
+                np.testing.assert_allclose(
+                    J_w[:, o, :, o2], expected_w, atol=1e-10,
+                    err_msg=f'weight Jacobian not diagonal at o={o}, o2={o2}',
+                )
+                expected_b = jnp.ones(batch) if o == o2 else jnp.zeros(batch)
+                np.testing.assert_allclose(
+                    J_b[:, o, o2], expected_b, atol=1e-10,
+                    err_msg=f'bias Jacobian not diagonal at o={o}, o2={o2}',
+                )
+
+        # Random cotangent and random incoming trace — never all-ones.
+        g = brainstate.random.randn(batch, n_out)
+        trace_w = brainstate.random.randn(batch, n_in, n_out)
+        trace_b = brainstate.random.randn(batch, n_out)
+
+        # Because the Jacobian block above was shown to be nonzero only on
+        # the diagonal o == o2, contracting an arbitrary weight-shaped trace
+        # against it degenerates to a per-`o` broadcast multiply — the
+        # cross terms (o != o2) that a naive full contraction would include
+        # are provably zero, so they are omitted here deliberately, not by
+        # oversight. This is the "general contraction, specialized by the
+        # proven-diagonal structure" reference, built independently of the
+        # rule's own implementation.
+        ref_w = jnp.einsum('bo,bio->bio', g, trace_w)
+        ref_b = jnp.einsum('bo,bo->bo', g, trace_b)
+
+        out = _mm_yw_to_w(g, {'weight': trace_w, 'bias': trace_b}, has_bias=True)
+        np.testing.assert_allclose(out['weight'], ref_w, atol=1e-10)
+        np.testing.assert_allclose(out['bias'], ref_b, atol=1e-10)
+
+    def test_mv_yw_to_w_weight_and_bias_match_jacobian_contraction(self):
+        from braintrace._op.dense import _mv_yw_to_w
+        brainstate.random.seed(302)
+        n_in, n_out = 3, 5  # non-square
+        x = brainstate.random.randn(n_in)
+        w0 = brainstate.random.randn(n_in, n_out)
+        b0 = brainstate.random.randn(n_out)
+
+        J_w = jax.jacobian(lambda w: x @ w)(w0)  # (out, in, out)
+        J_b = jax.jacobian(lambda b: x @ w0 + b)(b0)  # (out, out)
+
+        for o in range(n_out):
+            for o2 in range(n_out):
+                expected_w = x if o == o2 else jnp.zeros_like(x)
+                np.testing.assert_allclose(J_w[o, :, o2], expected_w, atol=1e-10)
+                expected_b = 1.0 if o == o2 else 0.0
+                np.testing.assert_allclose(J_b[o, o2], expected_b, atol=1e-10)
+
+        g = brainstate.random.randn(n_out)
+        trace_w = brainstate.random.randn(n_in, n_out)
+        trace_b = brainstate.random.randn(n_out)
+
+        ref_w = jnp.einsum('o,io->io', g, trace_w)
+        ref_b = jnp.einsum('o,o->o', g, trace_b)
+
+        out = _mv_yw_to_w(g, {'weight': trace_w, 'bias': trace_b}, has_bias=True)
+        np.testing.assert_allclose(out['weight'], ref_w, atol=1e-10)
+        np.testing.assert_allclose(out['bias'], ref_b, atol=1e-10)

--- a/braintrace/_op/dense_test.py
+++ b/braintrace/_op/dense_test.py
@@ -19,6 +19,8 @@ Coverage:
 
 * Auto-dispatch — ``x.ndim >= 2`` selects ``etp_mm_p``; otherwise
   ``etp_mv_p``. Verified by jaxpr inspection.
+* Rank guard — ``x.ndim > 2`` raises ``ValueError`` (every ETP trace rule
+  assumes a ``(batch, in)`` layout); rank 1 / 2 remain accepted.
 * Forward correctness — agrees with ``x @ w (+ b)``.
 * Bias presence — ``has_bias`` parameter is propagated through ``bind``.
 * brainunit support — quantities, mixed units, unitless inputs.
@@ -35,6 +37,7 @@ import jax.numpy as jnp
 import numpy as np
 import numpy.testing as npt
 import brainunit as u
+import pytest
 
 import braintrace
 from braintrace._op import (
@@ -81,12 +84,6 @@ class TestForwardCorrectness:
         out = matmul(x, w, bias=b)
         np.testing.assert_allclose(out, x @ w + b)
 
-    def test_higher_rank_input(self):
-        x = jnp.ones((2, 5, 3))
-        w = jnp.ones((3, 4))
-        out = matmul(x, w)
-        np.testing.assert_allclose(out, x @ w)
-
 
 class TestAutoDispatch:
 
@@ -103,6 +100,40 @@ class TestAutoDispatch:
         jaxpr = jax.make_jaxpr(lambda x, w: matmul(x, w))(x, w)
         assert any(eqn.primitive is etp_mm_p for eqn in jaxpr.jaxpr.eqns)
         assert not any(eqn.primitive is etp_mv_p for eqn in jaxpr.jaxpr.eqns)
+
+
+# ---------------------------------------------------------------------------
+# Rank guard (M5) — every ETP trace rule assumes a (batch, in) layout, so
+# rank>2 ``x`` (which used to run silently in the forward pass) must be
+# rejected at the user-API boundary rather than produce a primitive whose
+# trace rules are structurally wrong.
+# ---------------------------------------------------------------------------
+
+class TestRankGuard:
+
+    def test_rank3_input_raises_valueerror(self):
+        x = jnp.ones((2, 5, 3))
+        w = jnp.ones((3, 4))
+        with pytest.raises(ValueError, match=r'ndim'):
+            matmul(x, w)
+
+    def test_rank4_input_raises_valueerror(self):
+        x = jnp.ones((2, 5, 6, 3))
+        w = jnp.ones((3, 4))
+        with pytest.raises(ValueError, match=r'ndim'):
+            matmul(x, w)
+
+    def test_rank1_input_still_accepted(self):
+        x = jnp.ones((3,))
+        w = jnp.ones((3, 4))
+        out = matmul(x, w)
+        np.testing.assert_allclose(out, x @ w)
+
+    def test_rank2_input_still_accepted(self):
+        x = jnp.ones((2, 3))
+        w = jnp.ones((3, 4))
+        out = matmul(x, w)
+        np.testing.assert_allclose(out, x @ w)
 
 
 class TestHasBiasParam:

--- a/braintrace/_op/elemwise.py
+++ b/braintrace/_op/elemwise.py
@@ -202,7 +202,9 @@ def _elemwise_init_drtrl(x_var: Any, y_var: Any, weight_vars: dict[str, Any],
     Args:
         x_var: Unused (``x_invar_index=None``).
         y_var: Output variable descriptor with shape.
-        weight_vars: Dict with key 'weight' (unused in body).
+        weight_vars: Dict with key 'weight'. Only its dtype is consulted
+            (unused otherwise); falls back to ``y_var``'s dtype alone when
+            ``None`` (e.g. direct unit tests).
         num_hidden_state: Number of hidden states :math:`n_{\text{state}}`.
         group: The owning :class:`HiddenGroup`. When supplied, its (possibly
             batched) ``varshape`` is used for the trace leading axes; falls back
@@ -210,9 +212,22 @@ def _elemwise_init_drtrl(x_var: Any, y_var: Any, weight_vars: dict[str, Any],
 
     Returns:
         ``{'weight': zeros(*leading_shape, n_state)}``.
+
+    Notes
+    -----
+    The trace dtype is derived from the weight leaf and ``y_var`` (the
+    hidden-group output) via :func:`jax.numpy.result_type` rather than left
+    to ``jnp.zeros``' default (which silently follows the global x64 flag
+    instead of the operands' actual dtype). ``x_var`` is unused here
+    (``x_invar_index=None`` for this primitive), so it is excluded from the
+    dtype computation.
     """
     leading = tuple(group.varshape) if group is not None else tuple(y_var.aval.shape)
-    return {'weight': jnp.zeros((*leading, num_hidden_state))}
+    dtype = (
+        jnp.result_type(y_var.aval.dtype, weight_vars['weight'].aval.dtype)
+        if weight_vars is not None else y_var.aval.dtype
+    )
+    return {'weight': jnp.zeros((*leading, num_hidden_state), dtype=dtype)}
 
 
 def _elemwise_init_pp(x_var: Any, y_var: Any, weight_vars: dict[str, Any],

--- a/braintrace/_op/elemwise_test.py
+++ b/braintrace/_op/elemwise_test.py
@@ -392,3 +392,55 @@ class TestElemwiseFastPath:
         np.testing.assert_allclose(
             folded['weight'], unfolded['weight'].sum(axis=0), atol=1e-5
         )
+
+
+# ---------------------------------------------------------------------------
+# Audit Task 11 (T3): first-principles ``yw_to_w`` from ``jax.jacobian``
+# ---------------------------------------------------------------------------
+
+class TestYwToWFirstPrinciplesFromJacobian:
+    """Derive ``_elemwise_yw_to_w`` from ``jax.jacobian`` of the primitive's
+    own (``weight_fn=None``) forward, rather than trusting its formula.
+
+    With ``weight_fn=None``, ``y = w`` elementwise, so
+    ``partial y_j / partial w_k = delta(j, k)`` — the identity matrix. A
+    general chain-rule contraction of a cotangent ``g`` against that
+    Jacobian, applied to an arbitrary weight-shaped trace, degenerates to a
+    plain elementwise product ``g * trace`` — exactly what ``_elemwise_yw_to_w``
+    computes. This is verified with a random (never all-ones) cotangent and
+    a random trace, independent of the rule's own code.
+    """
+
+    def test_yw_to_w_matches_identity_jacobian_contraction(self):
+        from braintrace._op.elemwise import _elemwise_yw_to_w
+        brainstate.random.seed(401)
+        n = 5
+        w0 = brainstate.random.randn(n)
+
+        J = jax.jacobian(lambda w: w)(w0)  # (n, n), should be identity
+        np.testing.assert_allclose(J, jnp.eye(n), atol=1e-10)
+
+        g = brainstate.random.randn(n)
+        trace = brainstate.random.randn(n)
+
+        # General chain-rule contraction against the raw (proven-identity)
+        # Jacobian: propagate `trace` through J, then multiply by the
+        # cotangent — built independently of the rule's own broadcast code.
+        # Because J == I this reduces to the elementwise product `g * trace`,
+        # but the reduction is not assumed here, only its inputs are used.
+        propagated = jnp.einsum('jk,k->j', J, trace)
+        ref = g * propagated
+
+        out = _elemwise_yw_to_w(g, {'weight': trace})
+        np.testing.assert_allclose(out['weight'], ref, atol=1e-10)
+
+    def test_yw_to_w_matches_identity_jacobian_contraction_batched(self):
+        from braintrace._op.elemwise import _elemwise_yw_to_w
+        brainstate.random.seed(402)
+        batch, n = 3, 5
+        g = brainstate.random.randn(batch, n)
+        trace = brainstate.random.randn(batch, n)
+
+        ref = g * trace
+        out = _elemwise_yw_to_w(g, {'weight': trace})
+        np.testing.assert_allclose(out['weight'], ref, atol=1e-10)

--- a/braintrace/_op/lora.py
+++ b/braintrace/_op/lora.py
@@ -588,7 +588,9 @@ def lora_matmul(
     Parameters
     ----------
     x : ArrayLike
-        Input array, shape ``(..., in_features)`` or ``(in_features,)``.
+        Input array, shape ``(batch, in_features)`` or ``(in_features,)``.
+        Higher-rank ``x`` (``x.ndim > 2``) is rejected with a ``ValueError``:
+        every ETP trace rule assumes one of these two layouts.
     B : ArrayLike
         Low-rank matrix :math:`B`, shape ``(in_features, rank)``.
     A : ArrayLike
@@ -605,22 +607,30 @@ def lora_matmul(
         gradients w.r.t. the raw ``lora_b`` weights are correct.
         The transform operates on the unitless mantissa; physical units are
         split off before and recombined after.
+        Pass a module-level function, not a fresh ``lambda``, if this is
+        called repeatedly: the hook is stored as a static ``eqn.params``
+        entry hashed by object identity, so two textually identical
+        ``lambda`` objects are cache misses and silently retrace every call.
     a_fn : callable or None, optional
         Elementwise transform applied to the ``A`` factor before the
         matrix multiplication.  ``a_fn(A)`` must return an array of the
         same shape as ``A``.  ``None`` means identity.
         The transform operates on the unitless mantissa; physical units are
         split off before and recombined after.
+        Same re-tracing caveat as ``b_fn``: pass a module-level function
+        rather than a fresh ``lambda``.
     bias_fn : callable or None, optional
         Elementwise transform applied to ``bias`` before adding.
         ``None`` means identity.
         The transform operates on the unitless mantissa; physical units are
         split off before and recombined after.
+        Same re-tracing caveat as ``b_fn``: pass a module-level function
+        rather than a fresh ``lambda``.
 
     Returns
     -------
     ArrayLike
-        Output array, shape ``(..., out_features)`` or ``(out_features,)``.
+        Output array, shape ``(batch, out_features)`` or ``(out_features,)``.
 
     Examples
     --------
@@ -637,6 +647,15 @@ def lora_matmul(
         >>> print(y.shape)
         (16, 4)
     """
+    if x.ndim > 2:  # type: ignore[union-attr]
+        raise ValueError(
+            f'lora_matmul() supports x.ndim of 1 (unbatched `(in_features,)`) or 2 '
+            f'(batched `(batch, in_features)`); got x.ndim={x.ndim} '
+            f'(shape={x.shape}). Every ETP trace rule for etp_lora_mm_p / '
+            f'etp_lora_mv_p assumes one of those two layouts, so higher-rank '
+            f'inputs (e.g. `(batch, time, in_features)`) are not supported -- '
+            f'reshape/vmap over the extra axes before calling lora_matmul().'
+        )
     p = etp_lora_mm_p if x.ndim >= 2 else etp_lora_mv_p  # type: ignore[union-attr]  # x is an array here; ArrayLike also admits scalars without .ndim
     x_v, x_u = u.split_mantissa_unit(x)
     B_v, B_u = u.split_mantissa_unit(B)

--- a/braintrace/_op/lora.py
+++ b/braintrace/_op/lora.py
@@ -294,17 +294,26 @@ def _lora_mm_init_drtrl(x_var: Any, y_var: Any, weight_vars: dict[str, Any],
     Memory cost :math:`\mathcal{O}(B\, r\, (I + O))` versus
     :math:`\mathcal{O}(B\, I\, O)` for a dense layer — the whole point
     of LoRA. Zero-initialised.
+
+    The trace dtype is derived from the participating ``x``/``y``/weight
+    avals via :func:`jax.numpy.result_type` rather than left to ``jnp.zeros``'
+    default (which silently follows the global x64 flag instead of the
+    operands' actual dtype).
     """
     batch = x_var.aval.shape[0]
     B_shape = weight_vars['lora_b'].aval.shape
     A_shape = weight_vars['lora_a'].aval.shape
+    dtype = jnp.result_type(
+        x_var.aval.dtype, y_var.aval.dtype,
+        *(v.aval.dtype for v in weight_vars.values()),
+    )
     out = {
-        'lora_b': jnp.zeros((batch, *B_shape, num_hidden_state)),
-        'lora_a': jnp.zeros((batch, *A_shape, num_hidden_state)),
+        'lora_b': jnp.zeros((batch, *B_shape, num_hidden_state), dtype=dtype),
+        'lora_a': jnp.zeros((batch, *A_shape, num_hidden_state), dtype=dtype),
     }
     if 'bias' in weight_vars:
         out['bias'] = jnp.zeros(
-            (batch, *weight_vars['bias'].aval.shape, num_hidden_state)
+            (batch, *weight_vars['bias'].aval.shape, num_hidden_state), dtype=dtype
         )
     return out
 
@@ -336,16 +345,25 @@ def _lora_mv_init_drtrl(x_var: Any, y_var: Any, weight_vars: dict[str, Any],
         \boldsymbol{\epsilon}_b \in \mathbb{R}^{O \times n_{\text{state}}}.
 
     Zero-initialised.
+
+    The trace dtype is derived from the participating ``x``/``y``/weight
+    avals via :func:`jax.numpy.result_type` rather than left to ``jnp.zeros``'
+    default (which silently follows the global x64 flag instead of the
+    operands' actual dtype).
     """
     B_shape = weight_vars['lora_b'].aval.shape
     A_shape = weight_vars['lora_a'].aval.shape
+    dtype = jnp.result_type(
+        x_var.aval.dtype, y_var.aval.dtype,
+        *(v.aval.dtype for v in weight_vars.values()),
+    )
     out = {
-        'lora_b': jnp.zeros((*B_shape, num_hidden_state)),
-        'lora_a': jnp.zeros((*A_shape, num_hidden_state)),
+        'lora_b': jnp.zeros((*B_shape, num_hidden_state), dtype=dtype),
+        'lora_a': jnp.zeros((*A_shape, num_hidden_state), dtype=dtype),
     }
     if 'bias' in weight_vars:
         out['bias'] = jnp.zeros(
-            (*weight_vars['bias'].aval.shape, num_hidden_state)
+            (*weight_vars['bias'].aval.shape, num_hidden_state), dtype=dtype
         )
     return out
 

--- a/braintrace/_op/lora.py
+++ b/braintrace/_op/lora.py
@@ -49,25 +49,39 @@ Let :math:`g = \partial h / \partial y`. The chain rule yields
 
 * ``xy_to_dw`` — VJP of :math:`y = \alpha\, x B A + b` over the whole
   dict ``{'lora_b', 'lora_a', 'bias'}``. JAX's autodiff delivers all
-  three pullbacks from a single ``jax.vjp`` call, giving the
-  instantaneous :math:`\operatorname{diag}(\mathbf{D}_f^t)\otimes \mathbf{x}^t`
-  term of D-RTRL (and the solve-time factor of ES-D-RTRL).
+  three pullbacks from a single ``jax.vjp`` call. This **param-shaped**
+  rule is what the IO-dim (ES-D-RTRL) algorithm applies at solve time.
 
-* ``yw_to_w`` — only propagates :math:`g` through the :math:`A` factor
-  (plus elementwise through the bias). Intuition: :math:`A` is the
-  "output-facing" factor, so :math:`\partial y / \partial A` attaches a
-  :math:`g`-shaped scaling to the :math:`A` trace, exactly like dense
-  matmul's :math:`y \to W` link. :math:`B` is "input-facing" and has
-  no such :math:`y`-dependent scaling in the linearised view — its
-  trace is carried unchanged through the :math:`y \to W` step. (The
-  full :math:`B` gradient *does* depend on :math:`A`, but that
-  dependence enters via ``xy_to_dw``, not through the trace
-  propagation.)
+* ``instant_drtrl`` / ``yw_to_w`` / ``solve_drtrl`` — the param-dim
+  D-RTRL trace machinery. No :math:`B`-shaped ``(in, rank)`` trace can
+  be exact: the hidden-to-hidden discount :math:`\mathbf{D}^t` acts on
+  the *output* axis, which :math:`B`'s shape lacks (:math:`\partial h /
+  \partial B` couples to the output only through :math:`A`). The trace
+  stored under the ``'lora_b'`` key is therefore a **dense-style trace
+  of the effective weight** :math:`W_{\text{eff}} = \alpha\, b\_fn(B)\,
+  a\_fn(A)` of shape ``(batch?, in, out, n_state)``:
 
-* ``init_drtrl`` — allocates separate leaves for :math:`\boldsymbol{\epsilon}_B`,
-  :math:`\boldsymbol{\epsilon}_A`, and optionally :math:`\boldsymbol{\epsilon}_b`,
-  each of shape ``(*factor_shape, n_state)`` (plus batch prefix in the
-  batched primitive).
+  - ``instant_drtrl`` adds :math:`x_i\, (\mathbf{D}_f^t)_o` to
+    :math:`\boldsymbol{\epsilon}_{W}` (the exact dense instantaneous
+    term for :math:`y = x\,W_{\text{eff}}`), while the :math:`A` and
+    bias entries reuse the exact ``xy_to_dw`` pullbacks.
+  - ``yw_to_w`` scales *every* trace along the output axis by
+    :math:`g = \partial h / \partial y` (the dense :math:`y \to W`
+    link) — including the :math:`W_{\text{eff}}` trace.
+  - ``solve_drtrl`` contracts the learning signal with each trace and
+    chains :math:`W_{\text{eff}}` back to the raw factor:
+    :math:`\nabla_B = \operatorname{VJP}_{b\_fn}\!\big(\alpha\, G\,
+    a\_fn(A)^\top\big)` with :math:`G_{io} = \sum_t g_t^{(o)}
+    \boldsymbol{\epsilon}_{W,t}^{(io)}`. The chain is linear in
+    :math:`G`, so applying it per step / per state / per batch and
+    summing is exact for parameters held fixed over the gradient
+    window.
+
+* ``init_drtrl`` — allocates :math:`\boldsymbol{\epsilon}_W` of shape
+  ``(batch?, in, out, n_state)`` under the ``'lora_b'`` key (the key
+  keeps its name so gradient routing is untouched), plus the
+  :math:`A`-shaped :math:`\boldsymbol{\epsilon}_A` and optionally the
+  bias-shaped :math:`\boldsymbol{\epsilon}_b`.
 
 * ``init_pp`` — output-shaped df trace; same as dense.
 
@@ -76,8 +90,17 @@ Let :math:`g = \partial h / \partial y`. The chain rule yields
 Both primitives declare ``trainable_invars_fn``, which returns
 ``{'lora_b': 1, 'lora_a': 2}`` when ``has_bias=False`` and
 ``{'lora_b': 1, 'lora_a': 2, 'bias': 3}`` when ``has_bias=True``.
-Keys ``'lora_b'`` / ``'lora_a'`` match the pytree leaf names in
-``braintrace.nn.LoRALinear``'s merged ``ParamState``.
+
+**Naming convention.** In this module ``lora_b`` is the *input-facing*
+``(in, rank)`` factor (the first matrix applied to ``x``) and ``lora_a``
+the *output-facing* ``(rank, out)`` factor — the classic LoRA-paper
+:math:`B A` order for :math:`y = x B A`. Note that
+:class:`braintrace.nn.LoRA` (following upstream ``brainstate.nn.LoRA``)
+names its ``ParamState`` leaves the other way round: its ``'lora_a'``
+leaf is the ``(in, rank)`` factor that flows into this primitive's
+``lora_b`` operand, and its ``'lora_b'`` leaf the ``(rank, out)`` factor
+that flows into ``lora_a``. Gradient routing is by dataflow (invar
+position), not by leaf name, so the transposed naming is cosmetic.
 
 **Transform hooks**
 
@@ -86,12 +109,14 @@ Both primitives accept three optional elementwise transform hooks in their
 ``y = alpha * x @ b_fn(B) @ a_fn(A)``) and ``bias_fn`` (adds ``bias_fn(b)``).
 Note the per-factor names ``b_fn`` / ``a_fn`` rather than a single
 ``weight_fn``. The forward impl and :func:`_lora_xy_to_dw` apply them; the
-eligibility trace and gradient are always taken w.r.t. the **raw** factors /
-bias, so each transform Jacobian :math:`f'` enters *only* through
-``xy_to_dw`` via :func:`jax.vjp` (the single fused VJP threads ``b_fn'``,
-``a_fn'`` and ``bias_fn'`` simultaneously). The ``yw_to_w`` rule and the
-trace initialisers are transform-free and stay exact (they operate on the
-raw-factor Jacobians).
+gradients are always taken w.r.t. the **raw** factors / bias. In the
+param-dim D-RTRL path, ``a_fn'`` and ``bias_fn'`` enter through
+:func:`_lora_instant_drtrl` (which reuses the fused ``xy_to_dw`` VJP for
+the :math:`A` / bias trace entries), while ``b_fn'`` enters at solve time
+through :func:`_lora_solve_drtrl` via :func:`jax.vjp` (the effective-weight
+trace itself is transform-free). In the IO-dim path all three Jacobians
+enter through ``xy_to_dw``'s single fused VJP. The ``yw_to_w`` rule and the
+trace initialisers are transform-free.
 
 These primitives have **no fast path** — they always use the generic rule
 path, which threads each :math:`f'` correctly when a transform hook is
@@ -107,6 +132,7 @@ import jax.numpy as jnp
 import brainunit as u
 
 from ._primitive import register_primitive
+from ._registries import ETP_RULES_INSTANT_DRTRL, ETP_RULES_SOLVE_DRTRL
 from braintrace._typing import ArrayLike, WeightFn
 
 __all__ = [
@@ -145,51 +171,51 @@ def _lora_mm_yw_to_w(hidden_dim: Any, trace: dict[str, Any], *, alpha: float = 1
                      has_bias: bool = False, b_fn: WeightFn | None = None,
                      a_fn: WeightFn | None = None, bias_fn: WeightFn | None = None) -> dict[str, Any]:
     r"""Batched LoRA ``yw_to_w`` — propagate :math:`\partial h / \partial y`
-    through the :math:`y \to A` link.
+    through every trace along the output axis.
 
-    **Role in D-RTRL.** Realises the :math:`y \to (A, B, b)` chain factor
-    of :math:`\mathbf{D}^t \boldsymbol{\epsilon}^{t-1}` for the LoRA op.
-    Differentiating :math:`y_k = \alpha \sum_r (xB)_r A_{r,k}` gives
+    **Role in D-RTRL.** Realises the :math:`y \to` chain factor of
+    :math:`\mathbf{D}^t \boldsymbol{\epsilon}^{t-1}` for the LoRA op,
+    after the executor has already absorbed the :math:`\mathbf{D}^t`
+    contraction along the hidden axis into ``hidden_dim`` :math:`= g`.
 
-    .. math::
-
-        \frac{\partial y_k}{\partial A_{r, k'}} = \delta_{k k'}\, \alpha\, (xB)_r,
-        \qquad
-        \frac{\partial y_k}{\partial B_{i, r}} =
-          \alpha\, A_{r, k}\, x_i.
-
-    After the executor has already absorbed the :math:`\mathbf{D}^t`
-    contraction along the hidden axis, only the :math:`y \to` link
-    remains for ``yw_to_w``. For :math:`A` this link is a simple
-    broadcast of :math:`g = \partial h / \partial y` across the ``rank``
-    axis of the trace:
+    The ``'lora_b'`` entry stores the **effective-weight trace**
+    :math:`\boldsymbol{\epsilon}_W` for :math:`W_{\text{eff}} =
+    \alpha\, b\_fn(B)\, a\_fn(A)` (see the module docstring): since
+    :math:`y = x\, W_{\text{eff}}`, its :math:`y \to W_{\text{eff}}`
+    link is the dense-matmul one,
 
     .. math::
 
-        \epsilon^t_{A, r, k} = g_k\, \epsilon^{t-1}_{A, r, k}.
+        \epsilon^t_{W, io} = g_o\, \epsilon^{t-1}_{W, io},
 
-    For :math:`B`, the :math:`y \to B` link additionally carries an
-    :math:`A` factor which *does* depend on :math:`y` via the hidden
-    state. In the D-RTRL diagonal approximation used here, this
-    cross-coupling is absorbed into the instantaneous contribution
-    supplied by ``xy_to_dw`` each step rather than carried through the
-    trace. Consequently the :math:`B`-trace is left unchanged by
-    :func:`yw_to_w` — propagation only touches :math:`A` (and the
-    bias, which is diagonal as usual).
+    identical to the (verified-exact) dense ``mm`` rule. The
+    :math:`A`-trace keeps its exact per-factor recurrence — for
+    :math:`y_k = \alpha \sum_r (x\,b\_fn(B))_r\, a\_fn(A)_{r,k}` the
+    :math:`y \to A` link broadcasts :math:`g` across the ``rank`` axis:
+
+    .. math::
+
+        \epsilon^t_{A, rk} = g_k\, \epsilon^{t-1}_{A, rk},
+
+    and the bias trace is elementwise as usual. No trace propagates
+    unchanged: a raw :math:`B`-shaped trace cannot be discounted
+    correctly (the discount acts on the output axis :math:`B` lacks),
+    which is exactly why :math:`\boldsymbol{\epsilon}_W` replaced it.
 
     **Broadcast rule.** ``jnp.expand_dims(hidden_dim, axis=-2)`` inserts
-    a singleton at the ``rank`` position in both execution contexts:
+    a singleton before the output axis in both execution contexts, for
+    both matrix-shaped traces:
 
-        (out,)        → (1, out)         broadcasts with (rank, out)        ✓
-        (batch, out)  → (batch, 1, out)  broadcasts with (batch, rank, out) ✓
+        (out,)        → (1, out)         broadcasts with (in|rank, out)        ✓
+        (batch, out)  → (batch, 1, out)  broadcasts with (batch, in|rank, out) ✓
 
     **Shapes.**
-        trace['lora_b'] : ``(..., in, rank)``   — unchanged
+        trace['lora_b'] : ``(..., in, out)``    — :math:`\boldsymbol{\epsilon}_W`, scaled by ``g``
         trace['lora_a'] : ``(..., rank, out)``  — scaled by ``g``
         trace['bias']   : ``(..., out)``        — elementwise :math:`g`
     """
-    trace_A = trace['lora_a'] * jnp.expand_dims(hidden_dim, axis=-2)
-    out = {'lora_b': trace['lora_b'], 'lora_a': trace_A}
+    g = jnp.expand_dims(hidden_dim, axis=-2)
+    out = {'lora_b': trace['lora_b'] * g, 'lora_a': trace['lora_a'] * g}
     if has_bias:
         out['bias'] = trace['bias'] * hidden_dim
     return out
@@ -200,19 +226,18 @@ def _lora_mv_yw_to_w(hidden_dim: Any, trace: dict[str, Any], *, alpha: float = 1
                      a_fn: WeightFn | None = None, bias_fn: WeightFn | None = None) -> dict[str, Any]:
     r"""Unbatched LoRA ``yw_to_w`` — identical algebra with no batch axis.
 
-    Trace shapes:
-        ``trace['lora_b'] : (in, rank, n_state)``   — unchanged
-        ``trace['lora_a'] : (rank, out, n_state)``  — scaled by :math:`g`
-        ``trace['bias']   : (out, n_state)``        — elementwise :math:`g`
+    Trace shapes (recurrence context, after the ``n_state``-vmap):
+        ``trace['lora_b'] : (in, out)``    — :math:`\boldsymbol{\epsilon}_W`, scaled by :math:`g`
+        ``trace['lora_a'] : (rank, out)``  — scaled by :math:`g`
+        ``trace['bias']   : (out,)``       — elementwise :math:`g`
 
-    ``jnp.expand_dims(hidden_dim, axis=0)`` turns ``(out,) → (1, out)``
-    so it broadcasts against the ``(rank, out)`` leading axes of the
-    :math:`A` trace. As in the batched case, only :math:`A` (and the
-    bias) are touched; the :math:`B`-trace propagates unchanged (its
-    :math:`y \to B` chain factor is deferred to ``xy_to_dw``).
+    ``jnp.expand_dims(hidden_dim, axis=-2)`` turns ``(out,) → (1, out)``
+    so it broadcasts against both the ``(in, out)`` effective-weight
+    trace and the ``(rank, out)`` :math:`A` trace. See
+    :func:`_lora_mm_yw_to_w` for the algebra.
     """
-    trace_A = trace['lora_a'] * jnp.expand_dims(hidden_dim, axis=0)
-    out = {'lora_b': trace['lora_b'], 'lora_a': trace_A}
+    g = jnp.expand_dims(hidden_dim, axis=-2)
+    out = {'lora_b': trace['lora_b'] * g, 'lora_a': trace['lora_a'] * g}
     if has_bias:
         out['bias'] = trace['bias'] * hidden_dim
     return out
@@ -279,21 +304,139 @@ def _lora_xy_to_dw(x: Any, hidden_dim: Any, weights: dict[str, Any], *, alpha: f
     return jax.tree.map(u.get_mantissa, vjp_fn(hidden_dim)[0])
 
 
+def _lora_instant_drtrl(x: Any, hidden_dim: Any, weights: dict[str, Any], *,
+                        alpha: float = 1.0, has_bias: bool = False,
+                        b_fn: WeightFn | None = None, a_fn: WeightFn | None = None,
+                        bias_fn: WeightFn | None = None) -> dict[str, Any]:
+    r"""Trace-structured instantaneous term for param-dim D-RTRL (mm and mv).
+
+    **Role.** Supplies the :math:`\operatorname{diag}(\mathbf{D}_f^t)
+    \otimes \mathbf{x}^t` term added to :math:`\mathbf{D}^t
+    \boldsymbol{\epsilon}^{t-1}` each step, in the *trace* structure
+    rather than the parameter structure:
+
+    * ``'lora_b'`` holds the effective-weight increment. Since
+      :math:`y = x\, W_{\text{eff}}` with :math:`W_{\text{eff}} =
+      \alpha\, b\_fn(B)\, a\_fn(A)`, the exact dense instantaneous term is
+      the outer product
+
+      .. math::
+
+          \frac{\partial h}{\partial W_{\text{eff}, io}}
+            = x_i\, g_o, \qquad g = \partial h / \partial y,
+
+      with **no** :math:`\alpha` / :math:`b\_fn` / :math:`a\_fn` factor —
+      those live inside :math:`W_{\text{eff}}` and are chained back to the
+      raw :math:`B` only at solve time (:func:`_lora_solve_drtrl`).
+
+    * ``'lora_a'`` and ``'bias'`` reuse the exact param-shaped
+      :func:`_lora_xy_to_dw` pullbacks (which thread ``a_fn'`` /
+      ``bias_fn'`` through the fused VJP); their per-factor traces are
+      already exact under the dense-style ``yw_to_w`` recurrence. The
+      VJP's unused ``'lora_b'`` pullback is dead code eliminated under
+      ``jit``.
+
+    **Shapes.** The algorithm vmaps over the batch axis (mm) and the
+    trailing ``num_state`` axis, so this rule always sees batch-free
+    slices: ``x : (in,)``, ``hidden_dim : (out,)``, returning
+    ``{'lora_b': (in, out), 'lora_a': (rank, out)[, 'bias': (out,)]}``.
+    """
+    out = dict(_lora_xy_to_dw(
+        x, hidden_dim, weights,
+        alpha=alpha, has_bias=has_bias, b_fn=b_fn, a_fn=a_fn, bias_fn=bias_fn,
+    ))
+    x_v = u.get_mantissa(x)
+    g_v = u.get_mantissa(hidden_dim)
+    out['lora_b'] = jnp.expand_dims(x_v, axis=-1) * jnp.expand_dims(g_v, axis=-2)
+    return out
+
+
+def _lora_solve_drtrl(dg_hidden: Any, trace: dict[str, Any], weights: dict[str, Any], *,
+                      alpha: float = 1.0, has_bias: bool = False,
+                      b_fn: WeightFn | None = None, a_fn: WeightFn | None = None,
+                      bias_fn: WeightFn | None = None) -> dict[str, Any]:
+    r"""Solve-time weight gradients from the LoRA D-RTRL traces (mm and mv).
+
+    **Role.** Contracts the learning signal :math:`g = \partial \mathcal{L} /
+    \partial h` with each eligibility trace and returns **param-shaped**
+    gradients keyed by trainable name:
+
+    * ``'lora_b'`` — chain the effective-weight trace back to the raw
+      factor. With :math:`G_{io} = g_o\, \boldsymbol{\epsilon}_{W, io}`
+      (per slice) and :math:`W_{\text{eff}} = \alpha\, b\_fn(B)\,
+      a\_fn(A)`:
+
+      .. math::
+
+          \nabla_{b\_fn(B)} = \alpha\, G\, a\_fn(A)^\top, \qquad
+          \nabla_B = \operatorname{VJP}_{b\_fn}\big(\nabla_{b\_fn(B)}\big).
+
+      The chain is linear in :math:`G`, so the algorithm's per-state /
+      per-batch application followed by summation is exact for
+      parameters held fixed over the gradient window.
+
+    * ``'lora_a'`` / ``'bias'`` — the same contraction the generic
+      ``yw_to_w`` solve path produced (it was exact): broadcast-multiply
+      the signal along the output axis. ``a_fn'`` / ``bias_fn'`` are
+      **not** re-applied here — they already entered the traces through
+      :func:`_lora_instant_drtrl`.
+
+    **Shapes.** The algorithm vmaps over the batch axis (mm) and the
+    trailing ``num_state`` axis, so this rule sees batch-free,
+    state-free slices: ``dg_hidden : (out,)`` (possibly with leading
+    broadcast axes from a batched hidden state feeding the unbatched
+    mv primitive — summed away below, which is exact by linearity),
+    ``trace['lora_b'] : (in, out)``, ``trace['lora_a'] : (rank, out)``,
+    ``trace['bias'] : (out,)``. Returns ``{'lora_b': (in, rank),
+    'lora_a': (rank, out)[, 'bias': (out,)]}`` — ``'lora_a'`` /
+    ``'bias'`` may keep leading broadcast axes, which the algorithm's
+    trailing reduction collapses exactly as it did for the generic path.
+    """
+    g = jnp.expand_dims(u.get_mantissa(dg_hidden), axis=-2)
+
+    # Effective-weight contraction G[i, o] = g[o] * eps_W[i, o]; collapse any
+    # leading broadcast axes so the b_fn VJP sees a (in, out)-shaped cotangent
+    # source (exact by linearity of the chain in G).
+    G = trace['lora_b'] * g
+    if G.ndim > 2:
+        G = jnp.sum(G, axis=tuple(range(G.ndim - 2)))
+
+    B = jnp.asarray(u.get_mantissa(weights['lora_b']))
+    A = jnp.asarray(u.get_mantissa(weights['lora_a']))
+    A_eff = jnp.asarray(a_fn(A)) if a_fn is not None else A
+    dB_eff = alpha * (G @ A_eff.T)
+    if b_fn is not None:
+        _, vjp_b = jax.vjp(b_fn, B)
+        dB = vjp_b(dB_eff)[0]
+    else:
+        dB = dB_eff
+
+    out = {'lora_b': dB, 'lora_a': trace['lora_a'] * g}
+    if has_bias:
+        out['bias'] = trace['bias'] * u.get_mantissa(dg_hidden)
+    return out
+
+
 def _lora_mm_init_drtrl(x_var: Any, y_var: Any, weight_vars: dict[str, Any],
                         num_hidden_state: int) -> dict[str, Any]:
     r"""Initialise batched LoRA D-RTRL trace.
 
-    Each LoRA factor gets its own trace leaf:
+    The ``'lora_b'`` leaf holds the dense-style **effective-weight**
+    trace :math:`\boldsymbol{\epsilon}_W` for :math:`W_{\text{eff}} =
+    \alpha\, b\_fn(B)\, a\_fn(A)` (see the module docstring — no
+    :math:`B`-shaped trace can be exact); ``'lora_a'`` / ``'bias'`` keep
+    their factor shapes:
 
     .. math::
 
-        \boldsymbol{\epsilon}_B \in \mathbb{R}^{B \times I \times r \times n_{\text{state}}}, \quad
+        \boldsymbol{\epsilon}_W \in \mathbb{R}^{B \times I \times O \times n_{\text{state}}}, \quad
         \boldsymbol{\epsilon}_A \in \mathbb{R}^{B \times r \times O \times n_{\text{state}}}, \quad
         \boldsymbol{\epsilon}_b \in \mathbb{R}^{B \times O \times n_{\text{state}}}.
 
-    Memory cost :math:`\mathcal{O}(B\, r\, (I + O))` versus
-    :math:`\mathcal{O}(B\, I\, O)` for a dense layer — the whole point
-    of LoRA. Zero-initialised.
+    The effective-weight trace costs :math:`\mathcal{O}(B\, I\, O)` —
+    dense-trace memory is the price of exact ``lora_b`` gradients under
+    param-dim D-RTRL (the low-rank parameter count is unchanged).
+    Zero-initialised.
 
     The trace dtype is derived from the participating ``x``/``y``/weight
     avals via :func:`jax.numpy.result_type` rather than left to ``jnp.zeros``'
@@ -308,7 +451,9 @@ def _lora_mm_init_drtrl(x_var: Any, y_var: Any, weight_vars: dict[str, Any],
         *(v.aval.dtype for v in weight_vars.values()),
     )
     out = {
-        'lora_b': jnp.zeros((batch, *B_shape, num_hidden_state), dtype=dtype),
+        'lora_b': jnp.zeros(
+            (batch, B_shape[0], A_shape[-1], num_hidden_state), dtype=dtype
+        ),
         'lora_a': jnp.zeros((batch, *A_shape, num_hidden_state), dtype=dtype),
     }
     if 'bias' in weight_vars:
@@ -338,9 +483,13 @@ def _lora_mv_init_drtrl(x_var: Any, y_var: Any, weight_vars: dict[str, Any],
                         num_hidden_state: int) -> dict[str, Any]:
     r"""Initialise unbatched LoRA D-RTRL trace.
 
+    The ``'lora_b'`` leaf holds the effective-weight trace
+    :math:`\boldsymbol{\epsilon}_W` (see :func:`_lora_mm_init_drtrl`);
+    no batch axis anywhere:
+
     .. math::
 
-        \boldsymbol{\epsilon}_B \in \mathbb{R}^{I \times r \times n_{\text{state}}}, \quad
+        \boldsymbol{\epsilon}_W \in \mathbb{R}^{I \times O \times n_{\text{state}}}, \quad
         \boldsymbol{\epsilon}_A \in \mathbb{R}^{r \times O \times n_{\text{state}}}, \quad
         \boldsymbol{\epsilon}_b \in \mathbb{R}^{O \times n_{\text{state}}}.
 
@@ -358,7 +507,9 @@ def _lora_mv_init_drtrl(x_var: Any, y_var: Any, weight_vars: dict[str, Any],
         *(v.aval.dtype for v in weight_vars.values()),
     )
     out = {
-        'lora_b': jnp.zeros((*B_shape, num_hidden_state), dtype=dtype),
+        'lora_b': jnp.zeros(
+            (B_shape[0], A_shape[-1], num_hidden_state), dtype=dtype
+        ),
         'lora_a': jnp.zeros((*A_shape, num_hidden_state), dtype=dtype),
     }
     if 'bias' in weight_vars:
@@ -392,6 +543,12 @@ etp_lora_mm_p.register_etp_rules(
     init_drtrl=_lora_mm_init_drtrl,
     init_pp=_lora_mm_init_pp,
 )
+# Param-dim D-RTRL overrides: the trace structure ('lora_b' holds the
+# effective-weight trace) differs from the parameter structure, so the
+# instantaneous term and the solve-time contraction cannot be expressed by
+# xy_to_dw / yw_to_w alone. IO-dim (ES-D-RTRL) keeps using xy_to_dw.
+ETP_RULES_INSTANT_DRTRL[etp_lora_mm_p] = _lora_instant_drtrl
+ETP_RULES_SOLVE_DRTRL[etp_lora_mm_p] = _lora_solve_drtrl
 
 etp_lora_mv_p = register_primitive(
     'etp_lora_mv',
@@ -406,6 +563,8 @@ etp_lora_mv_p.register_etp_rules(
     init_drtrl=_lora_mv_init_drtrl,
     init_pp=_lora_mv_init_pp,
 )
+ETP_RULES_INSTANT_DRTRL[etp_lora_mv_p] = _lora_instant_drtrl
+ETP_RULES_SOLVE_DRTRL[etp_lora_mv_p] = _lora_solve_drtrl
 
 
 def lora_matmul(

--- a/braintrace/_op/lora_test.py
+++ b/braintrace/_op/lora_test.py
@@ -36,6 +36,7 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 import brainunit as u
+import pytest
 
 import braintrace
 from braintrace._op import (
@@ -118,6 +119,43 @@ class TestAutoDispatch:
         )(x, B, A)
         assert any(eqn.primitive is etp_lora_mm_p for eqn in jaxpr.jaxpr.eqns)
         assert not any(eqn.primitive is etp_lora_mv_p for eqn in jaxpr.jaxpr.eqns)
+
+
+# ---------------------------------------------------------------------------
+# Rank guard (M5) — mirrors the dense ``matmul`` guard: every ETP trace rule
+# assumes a (batch, in) layout, so rank>2 ``x`` must be rejected rather than
+# silently running through ``etp_lora_mm_p``.
+# ---------------------------------------------------------------------------
+
+class TestRankGuard:
+
+    def test_rank3_input_raises_valueerror(self):
+        x = jnp.ones((2, 5, 3))
+        B = jnp.ones((3, 2))
+        A = jnp.ones((2, 4))
+        with pytest.raises(ValueError, match=r'ndim'):
+            lora_matmul(x, B, A)
+
+    def test_rank4_input_raises_valueerror(self):
+        x = jnp.ones((2, 5, 6, 3))
+        B = jnp.ones((3, 2))
+        A = jnp.ones((2, 4))
+        with pytest.raises(ValueError, match=r'ndim'):
+            lora_matmul(x, B, A)
+
+    def test_rank1_input_still_accepted(self):
+        x = jnp.ones((3,))
+        B = jnp.ones((3, 2))
+        A = jnp.ones((2, 4))
+        out = lora_matmul(x, B, A)
+        np.testing.assert_allclose(out, x @ B @ A)
+
+    def test_rank2_input_still_accepted(self):
+        x = jnp.ones((2, 3))
+        B = jnp.ones((3, 2))
+        A = jnp.ones((2, 4))
+        out = lora_matmul(x, B, A)
+        np.testing.assert_allclose(out, x @ B @ A)
 
 
 # ---------------------------------------------------------------------------

--- a/braintrace/_op/lora_test.py
+++ b/braintrace/_op/lora_test.py
@@ -620,3 +620,105 @@ class TestLoraFactorFns:
 
         assert_xy_to_dw_matches_vjp(rule=rule, impl=impl, x=x, hidden_dim=hidden,
                                     weights=weights, params=params, atol=1e-4)
+
+
+# ---------------------------------------------------------------------------
+# Audit Task 11 (T3): first-principles ``instant_drtrl`` / ``solve_drtrl``
+# from ``jax.jacobian``
+# ---------------------------------------------------------------------------
+
+class TestInstantSolveDrtrlFirstPrinciplesFromJacobian:
+    """Derive ``_lora_instant_drtrl``'s ``'lora_b'`` trace and
+    ``_lora_solve_drtrl`` independently of their own source.
+
+    The ``'lora_b'`` trace holds an effective-weight (dense-style) trace for
+    :math:`W_{\\text{eff}} = \\alpha\\, b\\_fn(B)\\, a\\_fn(A)` (per
+    ``lora.py``'s module docstring, "no alpha/b_fn/a_fn factor" enters the
+    instantaneous term — those are chained back only at solve time). Since
+    ``y = x @ W_eff`` is exactly the dense-matmul forward, its Jacobian
+    ``dy_o/dW_eff[i, o']`` is diagonal in the two "out" indices — the same
+    structural fact exploited by :mod:`dense`'s ``yw_to_w``. This test
+    builds that Jacobian via ``jax.jacobian`` on the *unscaled, untransformed*
+    effective weight, confirms the diagonal structure, and checks the
+    rule's ``'lora_b'`` output against the raw-Jacobian contraction for a
+    random cotangent.
+
+    ``solve_drtrl`` has no new forward to differentiate (it contracts an
+    already-built trace); it is checked by an independent reimplementation
+    of the documented formula, built without reusing the rule's own code.
+    """
+
+    def test_instant_drtrl_lora_b_matches_jacobian_contraction(self):
+        import brainstate
+        from braintrace._op.lora import _lora_instant_drtrl
+        brainstate.random.seed(901)
+        n_in, n_out, rank = 4, 5, 2
+        B0 = brainstate.random.randn(n_in, rank)
+        A0 = brainstate.random.randn(rank, n_out)
+        x = brainstate.random.randn(n_in)
+
+        # Unscaled, untransformed effective weight -- matches the documented
+        # convention that the instant 'lora_b' term carries no alpha/b_fn/a_fn.
+        W_eff0 = B0 @ A0
+
+        def fwd_weff(W):
+            return x @ W
+
+        J = jax.jacobian(fwd_weff)(W_eff0)  # (out, in, out)
+        for o in range(n_out):
+            for o2 in range(n_out):
+                expected = x if o == o2 else jnp.zeros_like(x)
+                np.testing.assert_allclose(
+                    J[o, :, o2], expected, atol=1e-10,
+                    err_msg=f'Jacobian not diagonal at o={o}, o2={o2}',
+                )
+
+        g = brainstate.random.randn(n_out)
+        # Repeated-index-style contraction against the raw Jacobian (sum
+        # over the y-side out-index `m`, keep the trace's own out-index):
+        # built from J/g directly, never from the rule's own outer product.
+        ref_lora_b = jnp.einsum('m,mio->io', g, J)
+
+        out = _lora_instant_drtrl(
+            x, g, {'lora_b': B0, 'lora_a': A0}, alpha=2.0, has_bias=False,
+        )
+        np.testing.assert_allclose(out['lora_b'], ref_lora_b, atol=1e-10)
+
+    def test_solve_drtrl_matches_independent_reimplementation_with_transforms(self):
+        import brainstate
+        from braintrace._op.lora import _lora_solve_drtrl
+        brainstate.random.seed(902)
+        n_in, n_out, rank = 4, 5, 2
+        alpha = 2.0
+        B0 = brainstate.random.randn(n_in, rank)
+        A0 = brainstate.random.randn(rank, n_out)
+        b0 = brainstate.random.randn(n_out)
+
+        trace_lora_b = brainstate.random.randn(n_in, n_out)  # W_eff-shaped
+        trace_lora_a = brainstate.random.randn(rank, n_out)
+        trace_bias = brainstate.random.randn(n_out)
+        dg_hidden = brainstate.random.randn(n_out)
+
+        b_fn = lambda B: jnp.tanh(B)
+        a_fn = lambda A: 1.5 * A
+
+        # Independent reimplementation of the documented solve-time formula
+        # (never calls `_lora_solve_drtrl`'s own code):
+        g = dg_hidden[None, :]
+        G = trace_lora_b * g
+        A_eff = a_fn(A0)
+        dB_eff = alpha * (G @ A_eff.T)
+        _, vjp_b = jax.vjp(b_fn, B0)
+        ref_lora_b = vjp_b(dB_eff)[0]
+        ref_lora_a = trace_lora_a * g
+        ref_bias = trace_bias * dg_hidden
+
+        out = _lora_solve_drtrl(
+            dg_hidden,
+            {'lora_b': trace_lora_b, 'lora_a': trace_lora_a, 'bias': trace_bias},
+            {'lora_b': B0, 'lora_a': A0, 'bias': b0},
+            alpha=alpha, has_bias=True, b_fn=b_fn, a_fn=a_fn,
+        )
+        np.testing.assert_allclose(out['lora_b'], ref_lora_b, atol=1e-8)
+        np.testing.assert_allclose(out['lora_a'], ref_lora_a, atol=1e-10)
+        np.testing.assert_allclose(out['bias'], ref_bias, atol=1e-10)

--- a/braintrace/_op/lora_test.py
+++ b/braintrace/_op/lora_test.py
@@ -540,6 +540,10 @@ class TestLoRAOnlineLearningExact:
         denom = jnp.maximum(jnp.abs(a).max(), 1e-12)
         return float(jnp.abs(a - b).max() / denom)
 
+    @staticmethod
+    def _mantissa(a):
+        return u.get_mantissa(a) if isinstance(a, u.Quantity) else a
+
     def _assert_exact(self, **factory_kwargs):
         import brainstate
         from braintrace._algorithm.oracle import (
@@ -564,6 +568,10 @@ class TestLoRAOnlineLearningExact:
                     ),
                 )
                 for key in g_bptt:
+                    assert jnp.abs(self._mantissa(g_bptt[key])).max() > 0, (
+                        f'BPTT gradient for {key} at T={T} is all-zero; '
+                        f'the exactness check below would pass vacuously'
+                    )
                     rel = self._rel_err(g_bptt[key], g_online[key])
                     assert rel < self.TOL, (
                         f'D-RTRL diverges from BPTT for {key} at T={T}: '

--- a/braintrace/_op/lora_test.py
+++ b/braintrace/_op/lora_test.py
@@ -17,9 +17,15 @@
 
 LoRA factorises a dense weight into two low-rank factors
 ``B`` (in, rank) and ``A`` (rank, out), optionally scaled by
-``alpha``. The ETP trace and gradient state are pytrees keyed by
-``'lora_b'`` / ``'lora_a'`` (and optionally ``'bias'``), matching the
-``ParamState`` pytree structure used by ``braintrace.nn.LoRALinear``.
+``alpha``. The ETP gradient state is a pytree keyed by ``'lora_b'`` /
+``'lora_a'`` (and optionally ``'bias'``). Under param-dim D-RTRL the
+``'lora_b'`` *trace* entry holds the dense-style effective-weight trace
+for ``W_eff = alpha * b_fn(B) @ a_fn(A)`` (see ``lora.py``); the
+gradient returned for ``'lora_b'`` is still ``(in, rank)``-shaped.
+
+Note: :class:`braintrace.nn.LoRA` names its ``ParamState`` leaves the
+other way round (its ``'lora_a'`` is the ``(in, rank)`` factor feeding
+this primitive's ``lora_b`` operand); routing is by dataflow, not name.
 """
 
 
@@ -194,30 +200,33 @@ class TestJAXRules:
 class TestLoraMmEtpRules:
 
     def test_yw_to_w_pytree_structure(self):
-        """``yw_to_w`` broadcasts ``hidden`` across the ``rank`` axis of
-        ``trace['lora_a']`` using ``expand_dims(hidden, axis=-2)``.
+        """``yw_to_w`` broadcasts ``hidden`` across the leading matrix axis of
+        BOTH traces via ``expand_dims(hidden, axis=-2)``: the ``'lora_b'``
+        entry is the effective-weight trace ``(in, out)`` (dense-style
+        recurrence), the ``'lora_a'`` entry the factor trace ``(rank, out)``.
 
         Two equivalent shapes are tested:
-          * ``(out,)`` — as called from ``_solve_param_dim_weight_gradients``
+          * ``(out,)`` — per-slice context (batch stripped by the algorithm's vmap)
           * ``(batch, out)`` — as called from ``_update_param_dim_etrace_scan_fn``
         """
         rule = ETP_RULES_YW_TO_W[etp_lora_mm_p]
 
-        # Test 1: unbatched gradient-solve context — hidden=(out=4,), trace_A=(rank=2, out=4)
+        # Test 1: slice context — hidden=(out=4,)
         hidden = jnp.array([1.0, 2.0, 3.0, 4.0])  # (out=4,)
-        trace_B = jnp.ones((4, 2))  # (in=4, rank=2)
+        trace_W = jnp.ones((3, 4))  # effective-weight trace (in=3, out=4)
         trace_A = jnp.ones((2, 4))  # (rank=2, out=4)
-        out = rule(hidden, {'lora_b': trace_B, 'lora_a': trace_A})
+        out = rule(hidden, {'lora_b': trace_W, 'lora_a': trace_A})
         assert set(out.keys()) == {'lora_b', 'lora_a'}
-        np.testing.assert_allclose(out['lora_b'], trace_B)
-        # expected: trace_A * hidden[None, :] = (2, 4) * (1, 4) = (2, 4)
+        # Both traces are scaled along the output axis (dense y -> W link).
+        np.testing.assert_allclose(out['lora_b'], trace_W * hidden[None, :])
         np.testing.assert_allclose(out['lora_a'], trace_A * hidden[None, :])
 
-        # Test 2: batched trace-update context — hidden=(batch=1, out=4), trace_A=(batch=1, rank=2, out=4)
-        hidden_b = jnp.ones((1, 4))  # (batch=1, out=4)
+        # Test 2: batched trace-update context — hidden=(batch=1, out=4)
+        hidden_b = jnp.arange(1.0, 5.0).reshape(1, 4)  # (batch=1, out=4)
+        trace_W_b = jnp.arange(12.0).reshape(1, 3, 4)  # (batch=1, in=3, out=4)
         trace_A_b = jnp.arange(8.0).reshape(1, 2, 4)  # (batch=1, rank=2, out=4)
-        out_b = rule(hidden_b, {'lora_b': jnp.ones((1, 4, 2)), 'lora_a': trace_A_b})
-        # expected: trace_A_b * hidden_b[:, None, :] = (1, 2, 4) * (1, 1, 4) = (1, 2, 4)
+        out_b = rule(hidden_b, {'lora_b': trace_W_b, 'lora_a': trace_A_b})
+        np.testing.assert_allclose(out_b['lora_b'], trace_W_b * hidden_b[:, None, :])
         np.testing.assert_allclose(out_b['lora_a'], trace_A_b * hidden_b[:, None, :])
 
     def test_xy_to_dw_pytree_and_values(self):
@@ -248,12 +257,14 @@ class TestLoraMmEtpRules:
         np.testing.assert_allclose(d_half['lora_a'], d1['lora_a'] * 0.5)
 
     def test_init_drtrl_shape(self):
+        """``'lora_b'`` allocates the effective-weight trace
+        ``(batch, in, out, n_state)`` — NOT the ``(in, rank)`` factor shape."""
         rule = ETP_RULES_INIT_DRTRL[etp_lora_mm_p]
         x_var = _fake_var((2, 3))
         y_var = _fake_var((2, 4))
         weight_vars = {'lora_b': _fake_var((3, 2)), 'lora_a': _fake_var((2, 4))}
         out = rule(x_var, y_var, weight_vars, num_hidden_state=5)
-        assert out['lora_b'].shape == (2, 3, 2, 5)
+        assert out['lora_b'].shape == (2, 3, 4, 5)
         assert out['lora_a'].shape == (2, 2, 4, 5)
 
     def test_init_drtrl_shape_with_bias(self):
@@ -266,7 +277,7 @@ class TestLoraMmEtpRules:
             'bias': _fake_var((4,)),
         }
         out = rule(x_var, y_var, weight_vars, num_hidden_state=5)
-        assert out['lora_b'].shape == (2, 3, 2, 5)
+        assert out['lora_b'].shape == (2, 3, 4, 5)
         assert out['lora_a'].shape == (2, 2, 4, 5)
         assert out['bias'].shape == (2, 4, 5)
 
@@ -282,25 +293,27 @@ class TestLoraMmEtpRules:
 class TestLoraMvEtpRules:
 
     def test_yw_to_w_pytree_structure(self):
-        """mv-variant: expand_dims axis=0 → broadcasts ``hidden`` across the
-        rank axis of ``trace['lora_a']``."""
+        """mv-variant: ``expand_dims(hidden, axis=-2)`` broadcasts ``hidden``
+        along the output axis of BOTH the effective-weight trace ``(in, out)``
+        and the ``(rank, out)`` A-trace."""
         rule = ETP_RULES_YW_TO_W[etp_lora_mv_p]
         hidden = jnp.array([1.0, 2.0, 3.0, 4.0])  # (out=4,)
-        trace_B = jnp.ones((3, 2))  # (in=3, rank=2)
+        trace_W = jnp.ones((3, 4))  # effective-weight trace (in=3, out=4)
         trace_A = jnp.ones((2, 4))  # (rank=2, out=4)
-        out = rule(hidden, {'lora_b': trace_B, 'lora_a': trace_A})
+        out = rule(hidden, {'lora_b': trace_W, 'lora_a': trace_A})
         assert set(out.keys()) == {'lora_b', 'lora_a'}
-        np.testing.assert_allclose(out['lora_b'], trace_B)
-        # expand_dims(hidden, axis=0) = (1, 4); (2, 4) * (1, 4) = (2, 4)
+        np.testing.assert_allclose(out['lora_b'], trace_W * hidden[None, :])
         np.testing.assert_allclose(out['lora_a'], trace_A * hidden[None, :])
 
     def test_init_drtrl_shape(self):
+        """``'lora_b'`` allocates the effective-weight trace
+        ``(in, out, n_state)`` with no batch axis anywhere."""
         rule = ETP_RULES_INIT_DRTRL[etp_lora_mv_p]
         x_var = _fake_var((3,))
         y_var = _fake_var((4,))
         weight_vars = {'lora_b': _fake_var((3, 2)), 'lora_a': _fake_var((2, 4))}
         out = rule(x_var, y_var, weight_vars, num_hidden_state=5)
-        assert out['lora_b'].shape == (3, 2, 5)
+        assert out['lora_b'].shape == (3, 4, 5)
         assert out['lora_a'].shape == (2, 4, 5)
 
     def test_init_pp_shape(self):
@@ -312,6 +325,110 @@ class TestLoraMvEtpRules:
         assert out.shape == (4, 5)
 
 
+class TestLoraInstantSolveDrtrlRules:
+    """The param-dim D-RTRL overrides: trace-structured instantaneous term
+    and solve-time chaining of the effective-weight trace to the raw B."""
+
+    def _weights(self, with_bias=False):
+        B = jnp.arange(6.0).reshape(3, 2) * 0.1  # (in=3, rank=2)
+        A = jnp.arange(8.0).reshape(2, 4) * 0.1  # (rank=2, out=4)
+        w = {'lora_b': B, 'lora_a': A}
+        if with_bias:
+            w['bias'] = jnp.arange(4.0) * 0.1
+        return w
+
+    def test_registered_for_both_primitives(self):
+        from braintrace._op._registries import (
+            get_instant_drtrl_rule, get_solve_drtrl_rule,
+        )
+        for prim in (etp_lora_mm_p, etp_lora_mv_p):
+            assert get_instant_drtrl_rule(prim) is not None
+            assert get_solve_drtrl_rule(prim) is not None
+
+    def test_instant_lora_b_is_outer_product_without_alpha(self):
+        """The effective-weight increment is ``outer(x, df)`` — alpha and the
+        factor transforms live inside W_eff and enter only at solve time."""
+        from braintrace._op._registries import get_instant_drtrl_rule
+        rule = get_instant_drtrl_rule(etp_lora_mm_p)
+        x = jnp.array([1.0, 2.0, 3.0])  # (in=3,)
+        df = jnp.array([0.5, -1.0, 2.0, 0.25])  # (out=4,)
+        out = rule(x, df, self._weights(), alpha=0.5)
+        assert out['lora_b'].shape == (3, 4)
+        np.testing.assert_allclose(out['lora_b'], jnp.outer(x, df))
+
+    def test_instant_lora_a_and_bias_match_xy_to_dw(self):
+        """The A / bias entries reuse the exact param-shaped pullbacks."""
+        from braintrace._op._registries import get_instant_drtrl_rule
+        rule = get_instant_drtrl_rule(etp_lora_mm_p)
+        xy = ETP_RULES_XY_TO_DW[etp_lora_mm_p]
+        x = jnp.array([1.0, 2.0, 3.0])
+        df = jnp.array([0.5, -1.0, 2.0, 0.25])
+        w = self._weights(with_bias=True)
+        params = dict(alpha=0.5, has_bias=True, b_fn=None, a_fn=jnp.tanh,
+                      bias_fn=None)
+        out = rule(x, df, w, **params)
+        ref = xy(x, df, w, **params)
+        np.testing.assert_allclose(out['lora_a'], ref['lora_a'])
+        np.testing.assert_allclose(out['bias'], ref['bias'])
+
+    def test_solve_chains_effective_weight_to_raw_B(self):
+        """``lora_b`` gradient is ``alpha * (g * eps_W) @ a_fn(A)^T`` pulled
+        back through ``b_fn``; ``lora_a`` / ``bias`` match the generic path."""
+        from braintrace._op._registries import get_solve_drtrl_rule
+        rule = get_solve_drtrl_rule(etp_lora_mm_p)
+        w = self._weights(with_bias=True)
+        dg = jnp.array([0.5, -1.0, 2.0, 0.25])  # (out=4,)
+        trace = {
+            'lora_b': jnp.arange(12.0).reshape(3, 4) * 0.1,  # eps_W (in, out)
+            'lora_a': jnp.arange(8.0).reshape(2, 4) * 0.2,
+            'bias': jnp.arange(4.0) * 0.3,
+        }
+        alpha = 2.0
+        out = rule(dg, trace, w, alpha=alpha, has_bias=True)
+        G = trace['lora_b'] * dg[None, :]
+        np.testing.assert_allclose(out['lora_b'], alpha * (G @ w['lora_a'].T))
+        np.testing.assert_allclose(out['lora_a'], trace['lora_a'] * dg[None, :])
+        np.testing.assert_allclose(out['bias'], trace['bias'] * dg)
+        assert out['lora_b'].shape == (3, 2)  # param-shaped, not trace-shaped
+
+    def test_solve_pulls_back_through_b_fn_vjp(self):
+        from braintrace._op._registries import get_solve_drtrl_rule
+        rule = get_solve_drtrl_rule(etp_lora_mv_p)
+        w = self._weights()
+        dg = jnp.array([0.5, -1.0, 2.0, 0.25])
+        trace = {
+            'lora_b': jnp.arange(12.0).reshape(3, 4) * 0.1,
+            'lora_a': jnp.arange(8.0).reshape(2, 4) * 0.2,
+        }
+        out = rule(dg, trace, w, alpha=1.0, b_fn=jnp.tanh, a_fn=jnp.tanh)
+        G = trace['lora_b'] * dg[None, :]
+        cot = G @ jnp.tanh(w['lora_a']).T
+        # d tanh(B)/dB = 1 - tanh(B)^2, elementwise
+        expected = (1.0 - jnp.tanh(w['lora_b']) ** 2) * cot
+        np.testing.assert_allclose(out['lora_b'], expected, rtol=1e-6)
+
+    def test_solve_collapses_leading_broadcast_axis_on_signal(self):
+        """A batched hidden state feeding the unbatched mv primitive hands the
+        solve rule a ``(1, out)`` signal; the ``lora_b`` gradient must still
+        come back param-shaped (the leading axis is summed, exact by
+        linearity), while ``lora_a`` keeps it for the algorithm's trailing
+        reduction — mirroring the generic path."""
+        from braintrace._op._registries import get_solve_drtrl_rule
+        rule = get_solve_drtrl_rule(etp_lora_mv_p)
+        w = self._weights()
+        dg = jnp.array([[0.5, -1.0, 2.0, 0.25]])  # (1, out)
+        trace = {
+            'lora_b': jnp.arange(12.0).reshape(3, 4) * 0.1,
+            'lora_a': jnp.arange(8.0).reshape(2, 4) * 0.2,
+        }
+        out = rule(dg, trace, w, alpha=1.0)
+        ref = rule(dg[0], trace, w, alpha=1.0)
+        assert out['lora_b'].shape == (3, 2)
+        np.testing.assert_allclose(out['lora_b'], ref['lora_b'])
+        assert out['lora_a'].shape == (1, 2, 4)
+        np.testing.assert_allclose(out['lora_a'][0], ref['lora_a'])
+
+
 class TestPublicAPIRoundTrip:
 
     def test_public_alias(self):
@@ -319,92 +436,117 @@ class TestPublicAPIRoundTrip:
 
 
 # ---------------------------------------------------------------------------
-# End-to-end online learning: D-RTRL vs BPTT
+# End-to-end online learning: D-RTRL vs BPTT oracle (exactly-diagonal regime)
 # ---------------------------------------------------------------------------
 
-class TestLoRAOnlineLearning:
-    """D-RTRL gradient correctness for etp_lora_mm_p with B, A, and bias."""
+class TestLoRAOnlineLearningExact:
+    """Single-step D-RTRL must reproduce BPTT exactly for every LoRA factor.
 
-    def test_drtrl_lora_mm_grad_matches_bptt(self):
+    The model is exactly diagonal (leaky-integrator dynamics
+    ``h <- leak * h + drive``), so D-RTRL's diagonal approximation is exact
+    and every parameter gradient must match a BPTT oracle element-wise
+    (``rel < 1e-10`` in float64). This covers the audit finding that
+    ``lora_b`` gradients were wrong even at T=1 (rel err ~4) because the
+    B-factor trace was propagated unchanged through ``yw_to_w``.
+    """
+
+    LEAK = 0.5
+    N_IN, N_REC, RANK = 3, 4, 2
+    TOL = 1e-10
+
+    def _make_factory(self, *, alpha=1.0, with_bias=False, b_fn=None,
+                      batched=True, seed=0):
         import brainstate
-        import jax
-        import jax.numpy as jnp
-        import numpy.testing as npt
-        import braintrace
 
-        rank = 2
-        B_init = jnp.ones((4, rank)) * 0.1
-        A_init = jnp.ones((rank, 4)) * 0.1
-        bias_init = jnp.ones((4,)) * 0.05
+        n_in, n_rec, rank = self.N_IN, self.N_REC, self.RANK
+        leak = self.LEAK
+        brainstate.random.seed(seed)
+        B0 = 0.1 * brainstate.random.randn(n_in, rank)
+        A0 = 0.1 * brainstate.random.randn(rank, n_rec)
+        bias0 = 0.05 * brainstate.random.randn(n_rec) if with_bias else None
+        w0 = 0.1 * brainstate.random.randn(n_in, n_rec)
 
-        class Cell(brainstate.nn.Module):
-            def __init__(self):
-                super().__init__()
-                self.p = brainstate.ParamState({
-                    'lora_b': B_init,
-                    'lora_a': A_init,
-                    'bias': bias_init,
-                })
-                self.h = brainstate.HiddenState(jnp.zeros((1, 4)))
+        # The mv (unbatched) primitive carries no batch axis anywhere, so its
+        # hidden state must be unbatched too; the mm variant pairs a batched
+        # input with a (1, n_rec) hidden state.
+        h_shape = (1, n_rec) if batched else (n_rec,)
 
-            def update(self, x):
-                p = self.p.value
-                y = braintrace.lora_matmul(
-                    self.h.value, p['lora_b'], p['lora_a'],
-                    alpha=1.0, bias=p['bias'],
+        def factory():
+            class Net(brainstate.nn.Module):
+                def __init__(self):
+                    super().__init__()
+                    self.B = brainstate.ParamState(B0)
+                    self.A = brainstate.ParamState(A0)
+                    if with_bias:
+                        self.bias = brainstate.ParamState(bias0)
+                    self.h = brainstate.HiddenState(jnp.zeros(h_shape))
+
+                def update(self, x):
+                    drive = braintrace.lora_matmul(
+                        x, self.B.value, self.A.value,
+                        alpha=alpha,
+                        bias=self.bias.value if with_bias else None,
+                        b_fn=b_fn,
+                    ) + x @ w0
+                    self.h.value = leak * self.h.value + drive
+                    return self.h.value
+
+            return Net()
+
+        return factory
+
+    @staticmethod
+    def _rel_err(a, b):
+        a = jnp.asarray(a)
+        b = jnp.asarray(b)
+        denom = jnp.maximum(jnp.abs(a).max(), 1e-12)
+        return float(jnp.abs(a - b).max() / denom)
+
+    def _assert_exact(self, **factory_kwargs):
+        import brainstate
+        from braintrace._algorithm.oracle import (
+            bptt_param_gradients,
+            online_param_gradients_singlestep_naive,
+        )
+
+        batched = factory_kwargs.get('batched', True)
+        with brainstate.environ.context(precision=64):
+            for T in (1, 2, 4):
+                factory = self._make_factory(**factory_kwargs)
+                brainstate.random.seed(42)
+                if batched:
+                    xs = 0.3 * brainstate.random.randn(T, 1, self.N_IN)
+                else:
+                    xs = 0.3 * brainstate.random.randn(T, self.N_IN)
+                g_bptt = bptt_param_gradients(factory, xs)
+                g_online = online_param_gradients_singlestep_naive(
+                    factory, xs,
+                    algo_factory=lambda m: braintrace.D_RTRL(
+                        m, vjp_method='single-step'
+                    ),
                 )
-                self.h.value = jnp.tanh(x + y)
-                return self.h.value
+                for key in g_bptt:
+                    rel = self._rel_err(g_bptt[key], g_online[key])
+                    assert rel < self.TOL, (
+                        f'D-RTRL diverges from BPTT for {key} at T={T}: '
+                        f'max_rel_err={rel:.3e}'
+                    )
 
-        cell = Cell()
-        brainstate.nn.init_all_states(cell, batch_size=1)
+    def test_lora_mm_exact_plain(self):
+        """Batched (mm) variant: B and A gradients exact at T=1/2/4."""
+        self._assert_exact(alpha=1.0, with_bias=False)
 
-        alg = braintrace.D_RTRL(cell)
-        alg.compile_graph(jnp.zeros((1, 4)))
+    def test_lora_mm_exact_alpha_and_bias(self):
+        """alpha=2.0 scaling plus a trainable bias: all three factors exact."""
+        self._assert_exact(alpha=2.0, with_bias=True)
 
-        x = jnp.ones((1, 4)) * 0.3
+    def test_lora_mm_exact_b_fn_tanh(self):
+        """B-factor transform hook: gradient chained through tanh VJP exactly."""
+        self._assert_exact(alpha=1.0, with_bias=False, b_fn=jnp.tanh)
 
-        # --- ETP gradient via D-RTRL ---
-        @brainstate.transform.jit
-        def etrace_grad_step(inp):
-            return brainstate.transform.grad(
-                lambda inp: alg(inp).sum(),
-                cell.states(brainstate.ParamState),
-            )(inp)
-
-        grads_etrace = etrace_grad_step(x)
-
-        # grads_etrace is keyed by path; cell.p is a dict-valued ParamState
-        grad_p = list(grads_etrace.values())[0]
-        assert isinstance(grad_p, dict), (
-            f'Expected dict gradient for merged ParamState, got {type(grad_p)}'
-        )
-
-        # --- BPTT reference ---
-        def bptt_loss(params):
-            h = jnp.zeros((1, 4))
-            y = 1.0 * (h @ params['lora_b'] @ params['lora_a']) + params['bias']
-            h = jnp.tanh(x + y)
-            return h.sum()
-
-        bptt = jax.grad(bptt_loss)({
-            'lora_b': cell.p.value['lora_b'],
-            'lora_a': cell.p.value['lora_a'],
-            'bias': cell.p.value['bias'],
-        })
-
-        # Non-zero sanity check on bias gradient
-        assert jnp.abs(bptt['bias']).max() > 1e-3, (
-            f'BPTT bias gradient is unexpectedly near-zero: {bptt["bias"]}'
-        )
-
-        # Compare all three: lora_b, lora_a, bias
-        npt.assert_allclose(grad_p['lora_b'], bptt['lora_b'], atol=1e-5,
-                            err_msg='D-RTRL d(lora_b) does not match BPTT')
-        npt.assert_allclose(grad_p['lora_a'], bptt['lora_a'], atol=1e-5,
-                            err_msg='D-RTRL d(lora_a) does not match BPTT')
-        npt.assert_allclose(grad_p['bias'], bptt['bias'], atol=1e-5,
-                            err_msg='D-RTRL d(bias) does not match BPTT (was it zero?)')
+    def test_lora_mv_exact_plain(self):
+        """Unbatched (mv) variant: no batch axis anywhere in the trace."""
+        self._assert_exact(alpha=1.0, with_bias=False, batched=False)
 
 
 # ---------------------------------------------------------------------------

--- a/braintrace/_op/op_rule_oracle_test.py
+++ b/braintrace/_op/op_rule_oracle_test.py
@@ -14,8 +14,8 @@
 # ==============================================================================
 
 """Operator-rule correctness: each primitive's xy_to_dw must equal jax.vjp of its
-impl; init_drtrl/init_pp shape contract; lora partial-propagation; multi-primitive
-composition gradients. Fills gaps left by dense_test/elemwise_test."""
+impl; init_drtrl/init_pp shape contract; lora effective-weight trace recurrence;
+multi-primitive composition gradients. Fills gaps left by dense_test/elemwise_test."""
 
 from collections import namedtuple
 
@@ -124,14 +124,20 @@ def test_lora_xy_to_dw_matches_vjp():
     )
 
 
-def test_lora_yw_to_w_leaves_B_trace_unchanged():
-    """yw_to_w propagates hidden through lora_a only; lora_b trace passes through."""
+def test_lora_yw_to_w_scales_both_traces_along_output_axis():
+    """yw_to_w applies the dense ``y -> W`` link to BOTH traces: the
+    ``'lora_b'`` entry is the effective-weight trace ``(in, out)`` for
+    ``W_eff = alpha * b_fn(B) @ a_fn(A)`` and follows the same recurrence as
+    the dense ``mm`` rule (a raw B-shaped trace cannot be discounted along
+    the output axis it lacks — the old pass-through made ``lora_b``
+    gradients wrong even at T=1)."""
     rule = ETP_RULES_YW_TO_W[etp_lora_mm_p]
-    rank, out_dim = 3, 4
+    in_dim, rank, out_dim = 6, 3, 4
     hidden = jnp.arange(1.0, out_dim + 1.0)            # (out,)
-    trace = {'lora_b': jnp.ones((6, rank)), 'lora_a': jnp.ones((rank, out_dim))}
+    trace = {'lora_b': jnp.ones((in_dim, out_dim)), 'lora_a': jnp.ones((rank, out_dim))}
     out = rule(hidden, trace)
-    np.testing.assert_allclose(out['lora_b'], trace['lora_b'])
+    np.testing.assert_allclose(out['lora_b'], trace['lora_b'] * hidden[None, :])
+    np.testing.assert_allclose(out['lora_a'], trace['lora_a'] * hidden[None, :])
 
 
 # --- Task 5: init_drtrl / init_pp shape contract -----------------------------

--- a/braintrace/_op/sparse.py
+++ b/braintrace/_op/sparse.py
@@ -111,15 +111,64 @@ __all__ = [
 ]
 
 
+class _HashableSparseMat:
+    r"""Identity-hashable wrapper around a validated ``brainevent.DataRepresentation``.
+
+    ``brainevent.DataRepresentation`` subclasses (e.g. :class:`brainevent.CSR`)
+    define ``__eq__`` (structural/dense comparison) without a matching
+    ``__hash__``, so binding one directly as a jaxpr equation parameter raises
+    ``TypeError: parameters to jaxpr equations must have __hash__`` under
+    JAX >= 0.7 — the documented ``sparse_matmul`` usage otherwise fails
+    outright (audit finding H1).
+
+    This wrapper carries the already-validated structure opaquely and relies
+    on the inherited ``object.__hash__``/``object.__eq__`` (identity), which
+    is exactly what a static jaxpr parameter needs: the *same* Python sparse
+    object compares equal to itself (cache/jit-trace reuse), while two
+    distinct sparse objects are correctly unequal, even if their dense forms
+    happen to coincide.
+
+    Attributes
+    ----------
+    mat : brainevent.DataRepresentation
+        The wrapped, pre-validated sparse structure.
+    """
+
+    __slots__ = ('mat',)
+
+    def __init__(self, mat: brainevent.DataRepresentation) -> None:
+        self.mat = mat
+
+
+def _unwrap_sparse_mat(sparse_mat: Any) -> Any:
+    """Return the underlying sparse structure, unwrapping ``_HashableSparseMat``.
+
+    ``sparse_matmul`` binds a ``_HashableSparseMat`` wrapper (see above) so the
+    equation parameter is hashable. Every consumer of ``params['sparse_mat']``
+    (the forward impl -- and therefore also the auto-derived abstract-eval,
+    lowering, JVP and batching rules -- plus the ``yw_to_w``/``xy_to_dw`` ETP
+    rules) must unwrap it before calling the sparse-matrix protocol methods.
+
+    Direct (non-``sparse_matmul``) call sites -- e.g. the rule-level unit
+    tests in this module and in ``op_rule_oracle_test.py`` -- pass an
+    already-unwrapped ``DataRepresentation`` (or test stub) straight to the
+    impl/rule functions; those are returned unchanged.
+    """
+    if isinstance(sparse_mat, _HashableSparseMat):
+        return sparse_mat.mat
+    return sparse_mat
+
+
 def _etp_sp_matmul_impl(*args: Any,
                         sparse_mat: brainevent.DataRepresentation | None = None,
                         has_bias: bool = False,
                         weight_fn: WeightFn | None = None,
                         bias_fn: WeightFn | None = None) -> Any:
     x, weight_data = args[0], args[1]
+    mat = _unwrap_sparse_mat(sparse_mat)
     if weight_fn is not None:
         weight_data = weight_fn(weight_data)
-    w = sparse_mat.with_data(weight_data)  # type: ignore[union-attr]  # sparse_mat is always supplied at bind time
+    w = mat.with_data(weight_data)  # type: ignore[union-attr]  # sparse_mat is always supplied at bind time
     y = x @ w
     if has_bias:
         b = args[2]
@@ -179,8 +228,24 @@ def _sp_mm_yw_to_w(hidden_dim: Any, trace: dict[str, Any], *,
                       ``trace['weight'] : (batch, nnz)``,
                       ``trace['bias']   : (batch, out)``.
         solve context: batch axis dropped by the outer vmap.
+
+    **Batching (audit C3).** The scan-context call above hands this rule a
+    2-D ``hidden_dim``/``trace['weight']`` pair straight from the online
+    trace-recurrence update (no outer vmap — unlike the solve context).
+    ``brainevent``'s ``yw_to_w_transposed`` kernel (``csrmv_yw2y_p_call``)
+    only accepts 1-D operands, so when ``hidden_dim.ndim == 2`` this rule
+    ``jax.vmap``\ s the sparse call over the leading batch axis of both
+    operands instead of handing it the batched arrays directly.
     """
-    out = {'weight': sparse_mat.yw_to_w_transposed(hidden_dim, trace['weight'])}  # type: ignore[union-attr]  # sparse_mat is always supplied at bind time
+    mat = _unwrap_sparse_mat(sparse_mat)
+    weight_trace = trace['weight']
+    if hidden_dim.ndim == 2:
+        # (batch, out), (batch, nnz) -> vmap the 1-D-only brainevent kernel
+        # over the leading batch axis.
+        weight_out = jax.vmap(mat.yw_to_w_transposed)(hidden_dim, weight_trace)
+    else:
+        weight_out = mat.yw_to_w_transposed(hidden_dim, weight_trace)  # type: ignore[union-attr]  # sparse_mat is always supplied at bind time
+    out = {'weight': weight_out}
     if has_bias:
         out['bias'] = trace['bias'] * hidden_dim
     return out
@@ -219,12 +284,13 @@ def _sp_xy_to_dw(x: Any, hidden_dim: Any, weights: dict[str, Any], *,
     Both weight and bias pullbacks are fused into one ``jax.vjp`` over a
     dict-valued forward function.
     """
+    mat = _unwrap_sparse_mat(sparse_mat)
 
     def _fwd(w_dict: dict[str, Any]) -> Any:
         wd = w_dict['weight']
         if weight_fn is not None:
             wd = weight_fn(wd)
-        y = x @ sparse_mat.with_data(wd)  # type: ignore[union-attr]  # sparse_mat is always supplied at bind time
+        y = x @ mat.with_data(wd)  # type: ignore[union-attr]  # sparse_mat is always supplied at bind time
         if has_bias:
             b = w_dict['bias']
             if bias_fn is not None:
@@ -308,7 +374,8 @@ def _sp_mv_yw_to_w(hidden_dim: Any, trace: dict[str, Any], *,
              ``trace['weight'] : (nnz,)``,
              ``trace['bias']   : (out,)``.
     """
-    out = {'weight': sparse_mat.yw_to_w_transposed(hidden_dim, trace['weight'])}  # type: ignore[union-attr]  # sparse_mat is always supplied at bind time
+    mat = _unwrap_sparse_mat(sparse_mat)
+    out = {'weight': mat.yw_to_w_transposed(hidden_dim, trace['weight'])}  # type: ignore[union-attr]  # sparse_mat is always supplied at bind time
     if has_bias:
         out['bias'] = trace['bias'] * hidden_dim
     return out
@@ -453,11 +520,15 @@ def sparse_matmul(
     x_v, x_u = u.split_mantissa_unit(x)
     w_v, w_u = u.split_mantissa_unit(weight)
     unit = x_u * w_u
+    # Bind an identity-hashable wrapper, not the DataRepresentation itself:
+    # brainevent structures define __eq__ without __hash__, which JAX >= 0.7
+    # rejects as a jaxpr equation parameter (audit finding H1).
+    wrapped_mat = _HashableSparseMat(sparse_mat)
     if bias is not None:
         bias_v = u.Quantity(bias).to_decimal(unit)
-        r = p.bind(x_v, w_v, bias_v, sparse_mat=sparse_mat, has_bias=True,
+        r = p.bind(x_v, w_v, bias_v, sparse_mat=wrapped_mat, has_bias=True,
                    weight_fn=weight_fn, bias_fn=bias_fn)
     else:
-        r = p.bind(x_v, w_v, sparse_mat=sparse_mat, has_bias=False,
+        r = p.bind(x_v, w_v, sparse_mat=wrapped_mat, has_bias=False,
                    weight_fn=weight_fn, bias_fn=bias_fn)
     return u.maybe_decimal(r * x_u * w_u)

--- a/braintrace/_op/sparse.py
+++ b/braintrace/_op/sparse.py
@@ -111,7 +111,8 @@ __all__ = [
 ]
 
 
-def _etp_sp_matmul_impl(*args: Any, sparse_mat: brainevent.DataRepresentation | None = None,
+def _etp_sp_matmul_impl(*args: Any,
+                        sparse_mat: brainevent.DataRepresentation | None = None,
                         has_bias: bool = False,
                         weight_fn: WeightFn | None = None,
                         bias_fn: WeightFn | None = None) -> Any:

--- a/braintrace/_op/sparse.py
+++ b/braintrace/_op/sparse.py
@@ -248,13 +248,22 @@ def _sp_mm_init_drtrl(x_var: Any, y_var: Any, weight_vars: dict[str, Any],
 
     ``nnz`` can be orders of magnitude smaller than :math:`I \cdot O`
     for typical connectivity matrices. Zero-initialised.
+
+    The trace dtype is derived from the participating ``x``/``y``/weight
+    avals via :func:`jax.numpy.result_type` rather than left to ``jnp.zeros``'
+    default (which silently follows the global x64 flag instead of the
+    operands' actual dtype).
     """
     batch = x_var.aval.shape[0]
     nnz = weight_vars['weight'].aval.shape[0]
-    out = {'weight': jnp.zeros((batch, nnz, num_hidden_state))}
+    dtype = jnp.result_type(
+        x_var.aval.dtype, y_var.aval.dtype,
+        *(v.aval.dtype for v in weight_vars.values()),
+    )
+    out = {'weight': jnp.zeros((batch, nnz, num_hidden_state), dtype=dtype)}
     if 'bias' in weight_vars:
         out['bias'] = jnp.zeros(
-            (batch, *weight_vars['bias'].aval.shape, num_hidden_state)
+            (batch, *weight_vars['bias'].aval.shape, num_hidden_state), dtype=dtype
         )
     return out
 
@@ -314,12 +323,21 @@ def _sp_mv_init_drtrl(x_var: Any, y_var: Any, weight_vars: dict[str, Any],
         \boldsymbol{\epsilon}_b \in \mathbb{R}^{O \times n_{\text{state}}}.
 
     Zero-initialised.
+
+    The trace dtype is derived from the participating ``x``/``y``/weight
+    avals via :func:`jax.numpy.result_type` rather than left to ``jnp.zeros``'
+    default (which silently follows the global x64 flag instead of the
+    operands' actual dtype).
     """
     nnz = weight_vars['weight'].aval.shape[0]
-    out = {'weight': jnp.zeros((nnz, num_hidden_state))}
+    dtype = jnp.result_type(
+        x_var.aval.dtype, y_var.aval.dtype,
+        *(v.aval.dtype for v in weight_vars.values()),
+    )
+    out = {'weight': jnp.zeros((nnz, num_hidden_state), dtype=dtype)}
     if 'bias' in weight_vars:
         out['bias'] = jnp.zeros(
-            (*weight_vars['bias'].aval.shape, num_hidden_state)
+            (*weight_vars['bias'].aval.shape, num_hidden_state), dtype=dtype
         )
     return out
 

--- a/braintrace/_op/sparse_test.py
+++ b/braintrace/_op/sparse_test.py
@@ -616,3 +616,111 @@ class TestSparseWeightFnBiasFn:
             rule=rule, impl=impl, x=x, hidden_dim=hidden,
             weights=weights, params=params, atol=1e-4,
         )
+
+
+# ---------------------------------------------------------------------------
+# Audit C3/H1 regression: stock (unwrapped) brainevent.CSR usability +
+# batched D-RTRL trace recurrence.
+# ---------------------------------------------------------------------------
+
+class TestStockCSRHashable:
+    """H1: a stock ``brainevent.CSR`` — exactly as the module docstring shows,
+    with no user-side wrapper — must work as ``sparse_mat`` under
+    ``jax.jit``/``jax.grad``.
+
+    ``brainevent.CSR`` (like every ``DataRepresentation``) defines ``__eq__``
+    without a matching ``__hash__``, so binding it directly as a jaxpr
+    equation parameter previously raised ``TypeError: parameters to jaxpr
+    equations must have __hash__`` under JAX >= 0.7 -- the documented usage
+    failed outright.
+    """
+
+    def test_stock_csr_runs_under_jit_and_grad(self):
+        with brainstate.environ.context(precision=64):
+            mask = np.array([
+                [1, 0, 1, 0],
+                [0, 1, 0, 1],
+                [1, 1, 0, 0],
+            ], dtype=bool)
+            csr = brainevent.CSR.fromdense(jnp.asarray(mask, dtype=float))
+            x = jnp.ones((2, 3))
+
+            @jax.jit
+            def f(w):
+                return braintrace.sparse_matmul(x, w, sparse_mat=csr).sum()
+
+            out = f(csr.data)
+            assert bool(jnp.isfinite(out))
+
+            g = jax.grad(f)(csr.data)
+            assert g.shape == csr.data.shape
+            assert bool(jnp.all(jnp.isfinite(g)))
+
+
+class TestBatchedSparseDRTRLOracle:
+    """C3: ``_sp_mm_yw_to_w`` (the ``etp_sp_mm_p`` D-RTRL trace-recurrence rule)
+    is handed a leading batch axis -- ``hidden_dim: (batch, out)``,
+    ``trace['weight']: (batch, nnz)`` -- straight from the online-trace update.
+    ``brainevent``'s ``yw_to_w_transposed`` kernel only accepts 1-D operands, so
+    the rule must ``jax.vmap`` internally rather than handing it the batched
+    arrays directly. Exactly-diagonal recurrence: D-RTRL (an *exact* algorithm)
+    must match the BPTT oracle element-wise for a batch > 1 model.
+    """
+
+    def test_batched_drtrl_matches_bptt(self):
+        from braintrace._algorithm.oracle import (
+            bptt_param_gradients,
+            online_param_gradients_singlestep_naive,
+        )
+
+        with brainstate.environ.context(precision=64):
+            leak = 0.5
+            n_rec = 4
+            batch = 2
+            dense_mask = np.array([
+                [1, 0, 1, 0],
+                [0, 1, 0, 1],
+                [1, 1, 0, 0],
+            ], dtype=bool)
+            csr = brainevent.CSR.fromdense(jnp.asarray(dense_mask, dtype=jnp.float64))
+            n_in = dense_mask.shape[0]
+            nnz = csr.data.shape[0]
+
+            class Net(brainstate.nn.Module):
+                def __init__(self):
+                    super().__init__()
+                    self.w = brainstate.ParamState(0.1 * brainstate.random.randn(nnz))
+                    self.h = brainstate.HiddenState(jnp.zeros((batch, n_rec)))
+
+                def update(self, x):
+                    drive = braintrace.sparse_matmul(x, self.w.value, sparse_mat=csr)
+                    self.h.value = leak * self.h.value + drive
+                    return self.h.value
+
+            def factory():
+                # Deterministic weight init: bptt_param_gradients and
+                # online_param_gradients_singlestep_naive each call ``factory()``
+                # independently, so re-seeding here (rather than relying on
+                # ambient RNG state) is what makes the two models start from
+                # the *same* weights -- otherwise the "gradient mismatch" would
+                # just be two different random points, not a genuine algorithm
+                # discrepancy.
+                brainstate.random.seed(0)
+                return Net()
+
+            xs = 0.3 * brainstate.random.randn(3, batch, n_in)
+
+            g_bptt = bptt_param_gradients(factory, xs)
+            g_online = online_param_gradients_singlestep_naive(
+                factory, xs,
+                algo_factory=lambda m: braintrace.D_RTRL(m, vjp_method='single-step'),
+            )
+
+            assert set(g_bptt.keys()) == set(g_online.keys())
+            for key in g_bptt:
+                a = jnp.asarray(g_bptt[key])
+                b = jnp.asarray(g_online[key])
+                assert a.shape == b.shape
+                denom = max(float(jnp.abs(a).max()), 1e-12)
+                rel = float(jnp.abs(a - b).max() / denom)
+                assert rel < 1e-10, f'{key}: max_rel_err={rel:.3e}'

--- a/braintrace/_op/sparse_test.py
+++ b/braintrace/_op/sparse_test.py
@@ -724,3 +724,135 @@ class TestBatchedSparseDRTRLOracle:
                 denom = max(float(jnp.abs(a).max()), 1e-12)
                 rel = float(jnp.abs(a - b).max() / denom)
                 assert rel < 1e-10, f'{key}: max_rel_err={rel:.3e}'
+
+
+# ---------------------------------------------------------------------------
+# Audit Task 11 (T3): first-principles ``yw_to_w`` from ``jax.jacobian``
+# ---------------------------------------------------------------------------
+
+def _sparse_row_col_of_nnz(csr):
+    """Derive per-nnz (row, col) indices directly from CSR structure.
+
+    Built independently of ``yw_to_w_transposed`` so it can serve as ground
+    truth: ``csr.indices`` already *is* the per-nnz column index (standard
+    CSR layout), and the per-nnz row index is recovered from ``indptr`` by
+    repeating each row index by its nnz count.
+    """
+    indptr = np.asarray(csr.indptr)
+    row_of_nnz = np.repeat(np.arange(indptr.shape[0] - 1), np.diff(indptr))
+    col_of_nnz = np.asarray(csr.indices)
+    return row_of_nnz, col_of_nnz
+
+
+def _random_masked_csr(mask: np.ndarray, seed: int):
+    brainstate.random.seed(seed)
+    values = brainstate.random.randn(*mask.shape)
+    dense = jnp.where(jnp.asarray(mask), values, 0.0)
+    return brainevent.CSR.fromdense(dense)
+
+
+class TestYwToWFirstPrinciplesFromJacobian:
+    """Derive ``_sp_mv_yw_to_w`` / ``_sp_mm_yw_to_w`` from ``jax.jacobian`` of
+    the primitive's own forward on a real, non-diagonal :class:`brainevent.CSR`.
+
+    For ``y = x @ W`` with ``W`` sparse, ``partial y_o / partial data_k`` is
+    nonzero only for the nnz entries ``k`` whose column equals ``o``, in
+    which case it equals ``x`` at that entry's row — a structural fact
+    confirmed here numerically against ``row_of_nnz`` / ``col_of_nnz``
+    derived directly from the CSR's own ``indptr`` / ``indices`` (never from
+    ``yw_to_w_transposed``). Because the Jacobian is "diagonal" in this
+    per-nnz-column sense, the general contraction of a cotangent against it
+    reduces to indexing the cotangent by each nnz's column and multiplying
+    into the trace — exactly what the production rule computes. Checked
+    with random (never all-ones) cotangents and traces.
+    """
+
+    @staticmethod
+    def _mask():
+        return np.array([
+            [1, 0, 1, 0],
+            [0, 1, 0, 1],
+            [1, 1, 0, 0],
+        ], dtype=bool)  # (in=3, out=4), deliberately non-diagonal/non-square
+
+    def test_mv_yw_to_w_matches_jacobian_contraction(self):
+        from braintrace._op.sparse import _sp_mv_yw_to_w
+        csr = self._random_masked_csr_mv()
+        n_in, n_out = csr.shape
+        row_of_nnz, col_of_nnz = _sparse_row_col_of_nnz(csr)
+        nnz = csr.data.shape[0]
+
+        brainstate.random.seed(511)
+        x0 = brainstate.random.randn(n_in)
+
+        def fwd(w):
+            return x0 @ csr.with_data(w)
+
+        J = jax.jacobian(fwd)(csr.data)  # (out, nnz)
+        for o in range(n_out):
+            for k in range(nnz):
+                expected = x0[row_of_nnz[k]] if col_of_nnz[k] == o else 0.0
+                np.testing.assert_allclose(
+                    J[o, k], expected, atol=1e-10,
+                    err_msg=f'Jacobian mismatch at o={o}, k={k}',
+                )
+
+        g = brainstate.random.randn(n_out)
+        trace_w = brainstate.random.randn(nnz)
+        trace_b = brainstate.random.randn(n_out)
+
+        # General contraction, specialized by the proven per-column-diagonal
+        # structure: each nnz only "sees" the cotangent component at its own
+        # column. Built from `col_of_nnz` (raw CSR structure), never from
+        # the rule's own `yw_to_w_transposed` call.
+        ref_w = trace_w * g[col_of_nnz]
+        ref_b = trace_b * g
+
+        out = _sp_mv_yw_to_w(
+            g, {'weight': trace_w, 'bias': trace_b}, sparse_mat=csr, has_bias=True,
+        )
+        np.testing.assert_allclose(out['weight'], ref_w, atol=1e-10)
+        np.testing.assert_allclose(out['bias'], ref_b, atol=1e-10)
+
+    def test_mm_yw_to_w_matches_jacobian_contraction(self):
+        from braintrace._op.sparse import _sp_mm_yw_to_w
+        csr = self._random_masked_csr_mm()
+        n_in, n_out = csr.shape
+        row_of_nnz, col_of_nnz = _sparse_row_col_of_nnz(csr)
+        nnz = csr.data.shape[0]
+        batch = 2
+
+        brainstate.random.seed(512)
+        x0 = brainstate.random.randn(batch, n_in)
+
+        def fwd(w):
+            return x0 @ csr.with_data(w)
+
+        J = jax.jacobian(fwd)(csr.data)  # (batch, out, nnz)
+        for b in range(batch):
+            for o in range(n_out):
+                for k in range(nnz):
+                    expected = x0[b, row_of_nnz[k]] if col_of_nnz[k] == o else 0.0
+                    np.testing.assert_allclose(
+                        J[b, o, k], expected, atol=1e-10,
+                        err_msg=f'Jacobian mismatch at b={b}, o={o}, k={k}',
+                    )
+
+        g = brainstate.random.randn(batch, n_out)
+        trace_w = brainstate.random.randn(batch, nnz)
+        trace_b = brainstate.random.randn(batch, n_out)
+
+        ref_w = trace_w * g[:, col_of_nnz]
+        ref_b = trace_b * g
+
+        out = _sp_mm_yw_to_w(
+            g, {'weight': trace_w, 'bias': trace_b}, sparse_mat=csr, has_bias=True,
+        )
+        np.testing.assert_allclose(out['weight'], ref_w, atol=1e-10)
+        np.testing.assert_allclose(out['bias'], ref_b, atol=1e-10)
+
+    def _random_masked_csr_mv(self):
+        return _random_masked_csr(self._mask(), seed=513)
+
+    def _random_masked_csr_mm(self):
+        return _random_masked_csr(self._mask(), seed=514)

--- a/braintrace/_op/sparse_test.py
+++ b/braintrace/_op/sparse_test.py
@@ -164,7 +164,13 @@ class TestForwardWithCSR:
 
 class _HashableStubMat(_StubSparseMat):
     """Stub that is also ``__hash__``-able so JAX accepts it as a static
-    primitive parameter (CSR itself is not hashable in JAX 0.7+)."""
+    primitive parameter.
+
+    Predates the H1 fix that makes ``sparse_matmul`` wrap any
+    ``sparse_mat`` (including a stock, non-hashable ``brainevent.CSR``) in a
+    hashable ``_HashableSparseMat`` internally. Kept here as a lightweight
+    stand-in for rule-level and dispatch tests that don't need a real CSR's
+    sparse-matrix semantics."""
 
     def __hash__(self):
         return id(self)
@@ -624,23 +630,19 @@ class TestSparseWeightFnBiasFn:
 
 class TestSparseVmapPromotion:
     def test_vmap_sparse_matmul_promotes_to_etp_sp_mm(self):
-        # NOTE: real `brainevent.CSR` is not hashable under JAX 0.7+, so it
-        # cannot be a static primitive param under `jax.make_jaxpr`/`jit` —
-        # this is a pre-existing, unrelated limitation (reproduces even for
-        # the already-registered *unbatched* `etp_sp_mv` path with no vmap
-        # involved at all; see `TestAutoDispatch` above, which already works
-        # around it with `_HashableStubMat` for the same reason). Use the
-        # same hashable stub here so this test exercises vmap promotion
-        # rather than tripping the unrelated hashability bug.
+        # A real `brainevent.CSR` works directly here: `sparse_matmul` wraps
+        # it internally in a `_HashableSparseMat` (see the H1 fix in
+        # `sparse.py`), so it no longer needs a hashable stand-in to survive
+        # `jax.make_jaxpr`/`jit` under vmap.
         dense = jnp.where(brainstate.random.rand(3, 5) < 0.5,
                           brainstate.random.randn(3, 5), 0.0)
-        stub = _HashableStubMat(dense)
-        data = dense.reshape(-1)
+        csr = _csr_from_dense(dense)
+        data = csr.data
         x = brainstate.random.randn(4, 3)
-        fn = jax.vmap(lambda xi: braintrace.sparse_matmul(xi, data, sparse_mat=stub))
+        fn = jax.vmap(lambda xi: braintrace.sparse_matmul(xi, data, sparse_mat=csr))
         names = [e.primitive.name for e in jax.make_jaxpr(fn)(x).jaxpr.eqns]
         assert 'etp_sp_mm' in names
-        ref = braintrace.sparse_matmul(x, data, sparse_mat=stub)
+        ref = braintrace.sparse_matmul(x, data, sparse_mat=csr)
         assert jnp.allclose(fn(x), ref, atol=1e-6)
 
 

--- a/braintrace/nn/_linear.py
+++ b/braintrace/nn/_linear.py
@@ -32,6 +32,45 @@ __all__ = [
 ]
 
 
+def _fold_leading_axes(x: ArrayLike):
+    """Fold all leading axes of ``x`` into a single batch axis.
+
+    The rank-guarded ETP ops (:func:`braintrace.matmul`,
+    :func:`braintrace.lora_matmul`) accept only rank-1/rank-2 inputs, while
+    the nn layers document an ``(..., in_size)`` contract.  This helper
+    bridges the two: for ``x.ndim > 2`` it returns the rank-2 view
+    ``x.reshape(-1, in_size)`` plus an ``unfold`` callable that restores the
+    original leading axes on the op output; for ``x.ndim <= 2`` it returns
+    ``x`` unchanged and an identity ``unfold``, so the rank-1/rank-2 paths
+    are untouched.
+
+    ``reshape`` goes through ``brainunit`` so physical-unit quantities keep
+    their units on both the fold and the unfold.
+
+    Parameters
+    ----------
+    x : ArrayLike
+        Input array (or unit-carrying quantity) of shape ``(..., in_size)``.
+
+    Returns
+    -------
+    tuple
+        ``(x2, unfold)`` where ``x2`` has shape ``(prod(leading), in_size)``
+        (or is ``x`` itself when ``x.ndim <= 2``) and ``unfold`` maps an
+        output of shape ``(prod(leading), out_size)`` back to
+        ``(*leading, out_size)``.
+    """
+    if x.ndim <= 2:  # type: ignore[union-attr]  # scalars never reach here: callers feed (..., in_size)
+        return x, lambda y: y
+    lead_shape = x.shape[:-1]
+    x2 = u.math.reshape(x, (-1, x.shape[-1]))
+
+    def unfold(y: ArrayLike) -> ArrayLike:
+        return u.math.reshape(y, (*lead_shape, y.shape[-1]))
+
+    return x2, unfold
+
+
 class Linear(brainstate.nn.Linear):
     __module__ = 'braintrace.nn'
     __doc__ = (brainstate.nn.Linear.__doc__ or '').replace('brainstate', 'braintrace')
@@ -55,10 +94,11 @@ class Linear(brainstate.nn.Linear):
         """
         w = self.weight.value['weight']
         b = self.weight.value.get('bias')
+        x2, unfold = _fold_leading_axes(x)
         if self.w_mask is not None:
             mask = self.w_mask
-            return matmul(x, w, b, weight_fn=lambda ww: ww * mask)
-        return matmul(x, w, b)
+            return unfold(matmul(x2, w, b, weight_fn=lambda ww: ww * mask))
+        return unfold(matmul(x2, w, b))
 
 
 class SignedWLinear(brainstate.nn.SignedWLinear):
@@ -84,9 +124,10 @@ class SignedWLinear(brainstate.nn.SignedWLinear):
         """
         w = self.weight.value
         sign = self.w_sign
+        x2, unfold = _fold_leading_axes(x)
         if sign is not None:
-            return matmul(x, w, weight_fn=lambda ww: u.math.abs(ww) * sign)
-        return matmul(x, w, weight_fn=lambda ww: u.math.abs(ww))
+            return unfold(matmul(x2, w, weight_fn=lambda ww: u.math.abs(ww) * sign))
+        return unfold(matmul(x2, w, weight_fn=lambda ww: u.math.abs(ww)))
 
 
 class ScaledWSLinear(brainstate.nn.ScaledWSLinear):
@@ -146,7 +187,8 @@ class ScaledWSLinear(brainstate.nn.ScaledWSLinear):
         b = params.get('bias', None)
         # Do NOT pass bias into matmul; add it after gain so that bias is not
         # scaled by gain.  Correct forward: (x @ std(w)*mask) * gain + b.
-        result = matmul(x, params['weight'], weight_fn=_wfn)
+        x2, unfold = _fold_leading_axes(x)
+        result = unfold(matmul(x2, params['weight'], weight_fn=_wfn))
         if gain is not None:
             result = result * gain
         if b is not None:
@@ -285,7 +327,8 @@ class LoRA(brainstate.nn.LoRA):
         # ``lora_a`` is the input-facing ``(in, rank)`` factor and must be
         # applied before ``lora_b`` the ``(rank, out)`` factor:
         # ``y = alpha * x @ lora_a @ lora_b``.
-        out = lora_matmul(x, param['lora_a'], param['lora_b'], alpha=1.0 / lora_rank)
+        x2, unfold = _fold_leading_axes(x)
+        out = unfold(lora_matmul(x2, param['lora_a'], param['lora_b'], alpha=1.0 / lora_rank))
         if self.base_module is not None:
             if not callable(self.base_module):
                 raise ValueError('`self.base_module` must be callable.')

--- a/braintrace/nn/_readout.py
+++ b/braintrace/nn/_readout.py
@@ -25,6 +25,7 @@ import brainunit as u
 
 from braintrace._op import matmul
 from braintrace._typing import Size, ArrayLike, as_size_tuple
+from braintrace.nn._linear import _fold_leading_axes
 
 __all__ = [
     'LeakyRateReadout',
@@ -148,6 +149,7 @@ class LeakyRateReadout(brainstate.nn.Module):
         ArrayLike
             The updated readout state, of shape ``(..., out_size)``.
         """
-        r = self.decay * self.r.value + matmul(x, self.W.value)
+        x2, unfold = _fold_leading_axes(x)
+        r = self.decay * self.r.value + unfold(matmul(x2, self.W.value))
         self.r.value = r
         return r

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,20 @@
+# jax >= 0.9 removed the ``jax_pmap_shmap_merge`` config option, but optax
+# 0.2.7 (imported transitively via braintools) still sets it at import time,
+# which breaks ``import braintrace`` in such environments.  Swallow only that
+# one failing update so the suite can import; all other options behave
+# normally.
+import jax
+
+_orig_update = jax.config.update
+
+
+def _compat_update(name, value):
+    try:
+        return _orig_update(name, value)
+    except (AttributeError, KeyError, ValueError):
+        if name == 'jax_pmap_shmap_merge':
+            return None
+        raise
+
+
+jax.config.update = _compat_update


### PR DESCRIPTION
## Summary

Fixes every finding from the `braintrace/_op` and `_algorithm` audit (`dev/2026-07-02-issues.md`, not tracked in this diff — gitignored dev scratch): 4 Critical, 6 High, 6 Medium, 2 test-infrastructure findings, and 8 Minor. Each fix went through an independent implementer + reviewer + fix-loop cycle, followed by a whole-branch review (verdict: "Ready to merge — with fixes"; those fixes are included).

**Critical fixes:**
- **C1** — Conv kernel/bias gradients under param-dim D-RTRL were structurally wrong (a product-of-sums where a sum-of-products was required). Replaced with an exact per-position kernel trace; kernel+bias now match BPTT to `rel < 1e-10` (was 1.0–8.2).
- **C2** — LoRA's `lora_b` gradient was wrong under D-RTRL (`yw_to_w` passed the trace through unchanged). Fixed via an effective-weight trace plus two new optional per-primitive registries (`instant_drtrl`/`solve_drtrl`) that let ops opt into exact trace/solve math without disturbing the legacy path for everyone else.
- **C3** — Batched sparse D-RTRL crashed in the trace recurrence; fixed via an identity-hash wrapper making stock `brainevent.CSR` usable as a jaxpr equation parameter.
- **C4** — OSTTP's learning signal was always zero (target stashed on `self`, already `None` by the time the `custom_vjp` backward pass ran). Threaded through the VJP residuals instead.

**Also fixed:** trace_dtype gate mismatch, conv bias broadcast for channel-not-last layouts, EProp κ-filter cross-state contamination + random-feedback scale-invariance, OTTT/OTPE dropped bias gradients + missing guards, int/bool autodiff, rank guards for `matmul`/`lora_matmul` (with nn-layer axis-folding to preserve their `(..., in_size)` contract), OSTL's exactness claim scoped correctly, and a new cross-family single-step BPTT oracle suite plus first-principles Jacobian-derived rule tests replacing several vacuous existing tests.

## Test plan

- [x] Every fix has a dedicated regression/oracle test (RED before, GREEN after)
- [x] Full suite green at HEAD: 1840 passed, 3 skipped, 0 failed
- [x] Whole-branch review completed independently of per-task reviews
- [x] No `Co-Authored-By`/AI attribution in any commit