### PR TITLE
scan support: inner-scan unrolling in etrace compilation (Phase 2)

### DIFF
--- a/braintrace/__init___test.py
+++ b/braintrace/__init___test.py
@@ -148,7 +148,12 @@ def test_weight_used_inside_scan_raises_not_implemented():
     within a control-flow op. Previously (F-SCAN-WEIGHT) the message construction
     indexed the hidden-path map with the weight var and a KeyError escaped instead;
     the message now renders the weight variable directly, so the intended
-    NotImplementedError surfaces."""
+    NotImplementedError surfaces.
+
+    Since Phase 2 canonicalization, statically short scans are unrolled at
+    extraction time instead of erroring, so this uses a length above
+    ``ControlFlowPolicy.scan_unroll_limit`` to reach the unsupported-op path
+    (after a SCAN_UNROLL_SKIPPED warning)."""
 
     class ScanModel(brainstate.nn.Module):
         def __init__(self):
@@ -160,7 +165,7 @@ def test_weight_used_inside_scan_raises_not_implemented():
         def update(self, x):
             def body(carry, _):
                 return braintrace.matmul(carry, self.w.value), None  # weight inside scan
-            out, _ = jax.lax.scan(body, self.h.value, xs=None, length=2)
+            out, _ = jax.lax.scan(body, self.h.value, xs=None, length=64)
             self.h.value = jax.nn.tanh(out)
             return self.h.value
 
@@ -168,7 +173,8 @@ def test_weight_used_inside_scan_raises_not_implemented():
     brainstate.nn.init_all_states(model, batch_size=1)
     algo = braintrace.D_RTRL(model)
     with pytest.raises(NotImplementedError):
-        algo.compile_graph(jnp.ones((1, 4), dtype='float32'))
+        with pytest.warns(UserWarning, match='NOT unrolled'):
+            algo.compile_graph(jnp.ones((1, 4), dtype='float32'))
 
 
 # --- Task 6: legacy + nn deprecations emit DeprecationWarning ----------------

--- a/braintrace/_algorithm/oracle_models.py
+++ b/braintrace/_algorithm/oracle_models.py
@@ -195,6 +195,39 @@ def batched_tanh_rnn(n_in: int = 3, n_rec: int = 4, batch: int = 4, seed: int = 
     return ModelSpec(factory=factory, etp_param_keys=(('w',),), plain_param_keys=(('win',),))
 
 
+def tied_weight_rnn(n_rec: int = 4, seed: int = 0) -> ModelSpec:
+    """Tanh RNN whose single weight is consumed by TWO ETP matmuls.
+
+    ``h = tanh(matmul(x, w) + matmul(h, w))`` — one ParamState, two call
+    sites, so the compiler registers two relations sharing one weight path.
+    Locks the multi-eqn-per-weight invariant the scan-unrolling pass depends
+    on: trace state is keyed per relation instance (``id(y_var)``, group) and
+    per-path gradient contributions accumulate across relations. Exact
+    algorithms must match BPTT element-wise (verified bit-exact at adoption).
+    Requires ``x`` with ``n_rec`` features (square weight applied to both).
+    """
+
+    def factory():
+        class Net(brainstate.nn.Module):
+            def __init__(self):
+                super().__init__()
+                with brainstate.random.seed_context(seed):
+                    self.w = brainstate.ParamState(
+                        0.1 * brainstate.random.randn(n_rec, n_rec)
+                    )
+                self.h = brainstate.HiddenState(jnp.zeros((1, n_rec)))
+
+            def update(self, x):
+                a = braintrace.matmul(x.reshape(1, -1), self.w.value)
+                b = braintrace.matmul(self.h.value, self.w.value)
+                self.h.value = jax.nn.tanh(a + b)
+                return self.h.value
+
+        return Net()
+
+    return ModelSpec(factory=factory, etp_param_keys=(('w',),), plain_param_keys=())
+
+
 def cond_gate_rnn(n_in: int = 3, n_rec: int = 4, leak: float = 0.9, seed: int = 0) -> ModelSpec:
     """Leaky integrator whose drive is a ``lax.cond`` between two ETP matmuls.
 

--- a/braintrace/_algorithm/oracle_models.py
+++ b/braintrace/_algorithm/oracle_models.py
@@ -266,3 +266,45 @@ def cond_gate_rnn(n_in: int = 3, n_rec: int = 4, leak: float = 0.9, seed: int = 
     return ModelSpec(
         factory=factory, etp_param_keys=(('w_a',), ('w_b',)), plain_param_keys=()
     )
+
+
+def scan_body_rnn(n_rec: int = 4, loops: int = 3, seed: int = 0) -> ModelSpec:
+    """Tanh RNN whose per-step update is an inner ``for_loop`` of sub-steps.
+
+    Each of the ``loops`` sub-steps applies two ETP matmuls
+    (``h <- tanh(matmul(x, w) + matmul(h, w))``), all inside a
+    ``brainstate.transform.for_loop`` that lowers to ``lax.scan``. The
+    compiler unrolls the inner scan at extraction time (Phase 2
+    canonicalization), after which only the *last* sub-step's ETP ops become
+    relations — earlier sub-steps reach the hidden state through another
+    trainable ETP op (the weight->weight->hidden invariant). Exact algorithms
+    must match BPTT element-wise on the unrolled program.
+    Requires ``x`` with ``n_rec`` features (square weight applied to both).
+    """
+
+    def factory():
+        class Net(brainstate.nn.Module):
+            def __init__(self):
+                super().__init__()
+                with brainstate.random.seed_context(seed):
+                    self.w = brainstate.ParamState(
+                        0.1 * brainstate.random.randn(n_rec, n_rec)
+                    )
+                self.h = brainstate.HiddenState(jnp.zeros((1, n_rec)))
+
+            def update(self, x):
+                x_row = x.reshape(1, -1)
+
+                def substep(_):
+                    self.h.value = jax.nn.tanh(
+                        braintrace.matmul(x_row, self.w.value)
+                        + braintrace.matmul(self.h.value, self.w.value)
+                    )
+                    return self.h.value
+
+                outs = brainstate.transform.for_loop(substep, jnp.arange(loops))
+                return outs[-1]
+
+        return Net()
+
+    return ModelSpec(factory=factory, etp_param_keys=(('w',),), plain_param_keys=())

--- a/braintrace/_algorithm/tests/exact_correctness_test.py
+++ b/braintrace/_algorithm/tests/exact_correctness_test.py
@@ -35,6 +35,7 @@ from braintrace._algorithm.oracle_models import (
     leaky_linear,
     stacked_tanh_rnn,
     tanh_rnn,
+    tied_weight_rnn,
 )
 
 ATOL_BPTT = 1e-4
@@ -92,9 +93,14 @@ _EXACT_MULTISTEP_ALGOS = {
 # (model_name, algo_name) pairs verified exact by the P4 spikes.
 # cond_gate exercises the Phase 1 cond -> select_n canonicalization: ETP
 # matmuls inside `lax.cond` branches must stay BPTT-exact after conversion.
+# tied_weight locks the multi-eqn-per-weight invariant (one ParamState, two
+# relations): trace state keyed per relation instance + per-path gradient
+# accumulation. Scan unrolling (Phase 2) multiplies relations per weight and
+# depends on it.
 _EXACT_CASES = (
     [('tanh_rnn', a) for a in _EXACT_MULTISTEP_ALGOS]
     + [('stacked_tanh_rnn', a) for a in _EXACT_MULTISTEP_ALGOS]
+    + [('tied_weight', a) for a in _EXACT_MULTISTEP_ALGOS]
     + [('leaky_linear', 'D_RTRL')]
     + [('cond_gate', 'D_RTRL')]
 )
@@ -109,7 +115,30 @@ def _model_spec(name):
         return leaky_linear(n_in=3, n_rec=4, leak=0.9, seed=0)
     if name == 'cond_gate':
         return cond_gate_rnn(n_in=3, n_rec=4, leak=0.9, seed=0)
+    if name == 'tied_weight':
+        return tied_weight_rnn(n_rec=3, seed=0)
     raise KeyError(name)
+
+
+def test_tied_weight_traces_keyed_per_relation_instance():
+    """One ParamState through two ETP call sites must yield two relations and
+    two distinct D-RTRL trace states keyed by ``(id(y_var), group index)`` —
+    not one shared per-weight entry."""
+    spec = tied_weight_rnn(n_rec=3, seed=0)
+    model = spec.factory()
+    brainstate.nn.init_all_states(model, batch_size=1)
+    algo = braintrace.D_RTRL(model, vjp_method='multi-step')
+    algo.compile_graph(_inputs(1, 3)[0])
+    algo.init_etrace_state()
+
+    rels = algo.graph.hidden_param_op_relations
+    assert len(rels) == 2
+    assert all(r.trainable_paths['weight'] == ('w',) for r in rels)
+    assert rels[0].y_var is not rels[1].y_var
+    assert len(algo.etrace_bwg) == 2
+    assert set(algo.etrace_bwg) == {
+        (id(r.y_var), g.index) for r in rels for g in r.hidden_groups
+    }
 
 
 @pytest.mark.parametrize('model_name,algo_name', _EXACT_CASES,

--- a/braintrace/_algorithm/tests/exact_correctness_test.py
+++ b/braintrace/_algorithm/tests/exact_correctness_test.py
@@ -33,6 +33,7 @@ from braintrace._algorithm.oracle import (
 from braintrace._algorithm.oracle_models import (
     cond_gate_rnn,
     leaky_linear,
+    scan_body_rnn,
     stacked_tanh_rnn,
     tanh_rnn,
     tied_weight_rnn,
@@ -97,10 +98,14 @@ _EXACT_MULTISTEP_ALGOS = {
 # relations): trace state keyed per relation instance + per-path gradient
 # accumulation. Scan unrolling (Phase 2) multiplies relations per weight and
 # depends on it.
+# scan_body exercises the Phase 2 inner-scan unrolling: ETP matmuls inside a
+# `for_loop` body must stay BPTT-exact after the scan is unrolled at
+# extraction time.
 _EXACT_CASES = (
     [('tanh_rnn', a) for a in _EXACT_MULTISTEP_ALGOS]
     + [('stacked_tanh_rnn', a) for a in _EXACT_MULTISTEP_ALGOS]
     + [('tied_weight', a) for a in _EXACT_MULTISTEP_ALGOS]
+    + [('scan_body', a) for a in _EXACT_MULTISTEP_ALGOS]
     + [('leaky_linear', 'D_RTRL')]
     + [('cond_gate', 'D_RTRL')]
 )
@@ -117,6 +122,8 @@ def _model_spec(name):
         return cond_gate_rnn(n_in=3, n_rec=4, leak=0.9, seed=0)
     if name == 'tied_weight':
         return tied_weight_rnn(n_rec=3, seed=0)
+    if name == 'scan_body':
+        return scan_body_rnn(n_rec=3, loops=3, seed=0)
     raise KeyError(name)
 
 

--- a/braintrace/_compiler/__init__.py
+++ b/braintrace/_compiler/__init__.py
@@ -22,7 +22,9 @@ from braintrace._compiler.base import (
 from braintrace._compiler.canonicalize import (
     ControlFlowPolicy,
     DEFAULT_CONTROL_FLOW_POLICY,
+    canonicalize_control_flow,
     if_convert_conds,
+    unroll_inner_scans,
 )
 from braintrace._compiler.diagnostics import (
     CompilationRecord,

--- a/braintrace/_compiler/canonicalize.py
+++ b/braintrace/_compiler/canonicalize.py
@@ -32,12 +32,20 @@ and Jacobians — the canonicalized jaxpr is exact in both value and
 derivative (see :class:`ControlFlowPolicy` for the dead-branch NaN/Inf
 caveat under reverse mode).
 
-Inner-``scan`` unrolling is Phase 2; the ``scan_unroll_limit`` knob on
-:class:`ControlFlowPolicy` is reserved for it.
+Phase 2 implements inner-``scan`` unrolling (:func:`unroll_inner_scans`):
+every ETP-relevant ``scan`` equation with static length at most
+``policy.scan_unroll_limit`` is replaced by ``length`` clones of its body
+(fresh variables per iteration, carry threaded between them), with per-
+iteration ``xs`` slices materialized as ``slice``/``squeeze`` equations and
+consumed stacked ``ys`` rebuilt with ``broadcast_in_dim``/``concatenate``.
+Unrolling is semantically identical — values and all derivatives are exact.
+
+:func:`canonicalize_control_flow` runs both passes to a joint fixpoint, so
+a ``cond`` inside a ``scan`` body (and vice versa) canonicalizes fully.
 """
 
 from dataclasses import dataclass
-from typing import Any, Callable, Container, Dict, Iterable, List, Optional
+from typing import Any, Callable, Container, Dict, Iterable, List, Optional, Set, Tuple
 
 import jax
 
@@ -55,12 +63,14 @@ from braintrace._compatible_imports import (
 )
 from braintrace._op import is_etp_primitive
 from .diagnostics import DiagnosticKind, DiagnosticLevel, emit
-from .jaxpr_graph import inline_jit_calls
+from .jaxpr_graph import build_producer_map, inline_jit_calls
 
 __all__ = [
     'ControlFlowPolicy',
     'DEFAULT_CONTROL_FLOW_POLICY',
+    'canonicalize_control_flow',
     'if_convert_conds',
+    'unroll_inner_scans',
 ]
 
 
@@ -78,8 +88,12 @@ class ControlFlowPolicy:
         ``NotImplementedError``; ETP primitives inside are excluded with a
         warning).
     scan_unroll_limit : int, optional
-        Reserved for the Phase 2 inner-``scan`` unrolling pass; currently
-        unused. Default ``16``.
+        Maximum static length of an ETP-relevant inner ``scan`` that
+        :func:`unroll_inner_scans` unrolls into flat equations. Longer (or
+        effectful, or ``while``-containing) scans stay opaque with a
+        :attr:`~braintrace.DiagnosticKind.SCAN_UNROLL_SKIPPED` warning, and
+        the existing control-flow restrictions apply. ``0`` (or negative)
+        disables unrolling entirely. Default ``16``.
 
     Notes
     -----
@@ -101,9 +115,11 @@ class ControlFlowPolicy:
       itself (e.g. ``sqrt(where(ok, x, 1.))``) inside the branch.
 
     For branches whose values and Jacobians are finite, the canonicalized
-    jaxpr is exact in both value and derivative. Branches with effects, or
-    containing ``while``/``scan``, are never converted (see
-    :func:`if_convert_conds`).
+    jaxpr is exact in both value and derivative. Branches with effects,
+    containing ``while``, or containing a ``scan`` that
+    :func:`unroll_inner_scans` could not unroll, are never converted (see
+    :func:`if_convert_conds`). Scan unrolling itself has no semantics
+    change: the unrolled equations compute exactly what the loop computed.
 
     Examples
     --------
@@ -150,6 +166,14 @@ def _jaxpr_contains(jaxpr: Jaxpr, pred: Callable[[JaxprEqn], bool]) -> bool:
             if _jaxpr_contains(sub, pred):
                 return True
     return False
+
+
+def _iter_eqns_transitive(jaxpr: Jaxpr) -> Iterable[JaxprEqn]:
+    """Yield every equation in *jaxpr*, descending sub-jaxprs."""
+    for eqn in jaxpr.eqns:
+        yield eqn
+        for sub in _subjaxprs(eqn):
+            yield from _iter_eqns_transitive(sub)
 
 
 def _is_etp_eqn(eqn: JaxprEqn) -> bool:
@@ -207,9 +231,11 @@ def if_convert_conds(
     A ``cond`` equation is converted only when it is *relevant* — any branch
     transitively contains an ETP primitive, or the equation consumes a
     weight/hidden input variable, or produces a hidden output variable — and
-    *safe*: no effects, and no branch transitively contains ``while`` or
-    ``scan`` (inner-``scan`` unrolling lands in Phase 2). A relevant-but-
-    unsafe ``cond`` stays opaque and a
+    *safe*: no effects, no branch transitively contains ``while``, and every
+    ``scan`` transitively inside a branch is eligible for unrolling (static
+    length within ``policy.scan_unroll_limit``, no effects, no inner
+    ``while``) so that :func:`canonicalize_control_flow` can flatten it once
+    it surfaces. A relevant-but-unsafe ``cond`` stays opaque and a
     :attr:`~braintrace.DiagnosticKind.COND_CONVERSION_SKIPPED` warning is
     emitted; the existing control-flow restrictions then apply unchanged.
     Irrelevant ``cond`` equations always stay opaque, at zero cost.
@@ -239,6 +265,7 @@ def if_convert_conds(
             hidden_invars=hidden_invars,
             hidden_outvars=hidden_outvars,
             skip_warned=skip_warned,
+            policy=policy,
         )
         if n_converted == 0:
             return result
@@ -252,6 +279,7 @@ def _convert_conds_once(
     hidden_invars: Container[Var],
     hidden_outvars: Container[Var],
     skip_warned: set,
+    policy: ControlFlowPolicy = DEFAULT_CONTROL_FLOW_POLICY,
 ):
     """One conversion sweep over the top-level equations.
 
@@ -294,11 +322,20 @@ def _convert_conds_once(
                 return 'a branch has effects'
             if _jaxpr_contains(sub, is_while_primitive):
                 return 'a branch contains a while loop'
-            if _jaxpr_contains(sub, is_scan_primitive):
-                return (
-                    'a branch contains an inner scan '
-                    '(scan unrolling is not implemented yet)'
-                )
+            # An inner scan is fine as long as it can itself be unrolled
+            # once conversion surfaces it (canonicalize_control_flow runs
+            # both passes to a fixpoint). Only the identity-free criteria
+            # are checkable here — branch-internal vars cannot be matched
+            # against the outer weight table; the weights-as-xs gate
+            # re-runs with real identities after the scan surfaces.
+            for sub_eqn in _iter_eqns_transitive(sub):
+                if is_scan_primitive(sub_eqn):
+                    bad = _scan_static_ineligibility(sub_eqn, policy)
+                    if bad is not None:
+                        return (
+                            f'a branch contains an inner scan that cannot '
+                            f'be unrolled ({bad})'
+                        )
         return None
 
     def inline_branch(branch_closed, operand_atoms) -> List[Any]:
@@ -429,3 +466,512 @@ def _convert_conds_once(
     )
     result = ClosedJaxpr(new_jaxpr, list(closed_jaxpr.consts) + extra_consts)
     return result, n_converted
+
+
+# ---------------------------------------------------------------------------
+# Phase 2 — inner-scan unrolling
+# ---------------------------------------------------------------------------
+
+def _scan_static_ineligibility(
+    eqn: JaxprEqn,
+    policy: ControlFlowPolicy,
+) -> Optional[str]:
+    """Identity-free reasons a ``scan`` equation cannot be unrolled.
+
+    Checks only criteria that need no Var-identity resolution (so the cond
+    safety gate can consult it for scans buried inside branches): the policy
+    knob, the static length, effects, and inner ``while`` loops. The
+    weights-as-xs gate needs real outer identities and lives in
+    :func:`_unroll_scans_once`. Returns ``None`` when unrollable.
+    """
+    if policy.scan_unroll_limit <= 0:
+        return 'scan unrolling is disabled (scan_unroll_limit <= 0)'
+    length = eqn.params['length']
+    if length == 0:
+        return 'its length is 0'
+    if length > policy.scan_unroll_limit:
+        return (
+            f'its length {length} exceeds '
+            f'scan_unroll_limit={policy.scan_unroll_limit}'
+        )
+    body = eqn.params['jaxpr'].jaxpr
+    if eqn.effects or body.effects:
+        return 'the scan (or its body) has effects'
+    if _jaxpr_contains(body, is_while_primitive):
+        return 'its body contains a while loop'
+    return None
+
+
+def unroll_inner_scans(
+    closed_jaxpr: ClosedJaxpr,
+    *,
+    weight_invars: Container[Var],
+    hidden_invars: Container[Var],
+    hidden_outvars: Container[Var],
+    policy: ControlFlowPolicy = DEFAULT_CONTROL_FLOW_POLICY,
+) -> ClosedJaxpr:
+    """Unroll every ETP-relevant, eligible ``scan`` equation in *closed_jaxpr*.
+
+    Each unrolled ``scan`` is replaced by ``length`` clones of its body with
+    fresh internal variables, the carry threaded from one clone to the next
+    (starting from the outer init operands), per-iteration ``xs`` slices
+    materialized as ``slice`` + ``squeeze`` equations, and — for stacked
+    ``ys`` outputs that are actually consumed — ``broadcast_in_dim`` +
+    ``concatenate`` equations rebuilding the stacked value. The original
+    ``scan`` output variables are re-emitted by these equations, and the
+    jaxpr's ``invars``/``outvars`` are preserved by object identity, so every
+    Var-identity lookup table built from them stays valid. Unrolling is
+    semantically identical: values and all derivatives are exact.
+
+    Parameters
+    ----------
+    closed_jaxpr : ClosedJaxpr
+        The closed jaxpr to canonicalize. ``jit`` equations should already be
+        inlined (the pass re-runs
+        :func:`~braintrace._compiler.jaxpr_graph.inline_jit_calls` after each
+        sweep to flatten ``jit`` bodies surfaced from unrolled scan bodies).
+    weight_invars : Container[Var]
+        Jaxpr input variables of the trainable weights.
+    hidden_invars : Container[Var]
+        Jaxpr input variables of the hidden states.
+    hidden_outvars : Container[Var]
+        Jaxpr output variables of the hidden states.
+    policy : ControlFlowPolicy, optional
+        Canonicalization policy. With ``policy.scan_unroll_limit <= 0`` the
+        input is returned unchanged.
+
+    Returns
+    -------
+    ClosedJaxpr
+        The canonicalized closed jaxpr. When nothing is unrolled, the input
+        object itself is returned unchanged.
+
+    Notes
+    -----
+    A ``scan`` equation is unrolled only when it is *relevant* — its body
+    transitively contains an ETP primitive, or the equation consumes a
+    weight/hidden input variable, or produces a hidden output variable — and
+    *eligible*: static ``length`` in ``[1, policy.scan_unroll_limit]``, no
+    effects, no inner ``while``, and no scanned-over (``xs``) operand that is
+    (or is computed from) a trainable weight. A relevant scan whose ``xs``
+    carry a weight stays opaque with a
+    :attr:`~braintrace.DiagnosticKind.RELATION_EXCLUDED_SLICED_WEIGHT`
+    warning — after unrolling, each iteration would consume a *slice* of the
+    stacked parameter, which the relation pass would mis-attribute to the
+    full parameter (slice-aware relations are future work). Any other
+    ineligible-but-relevant scan warns
+    :attr:`~braintrace.DiagnosticKind.SCAN_UNROLL_SKIPPED`. In both cases
+    the existing control-flow restrictions then apply unchanged. Irrelevant
+    scans always stay opaque, at zero cost — in particular the outer
+    time-step loop of a training harness is never touched.
+    """
+    if policy.scan_unroll_limit <= 0:
+        return closed_jaxpr
+
+    # Fixpoint: unrolling a scan can surface user ``jit`` equations and
+    # nested scans from its body. Each sweep unrolls the visible top-level
+    # scans, then flattens surfaced jits; nesting depth is finite, so this
+    # terminates. ``skip_warned`` carries the equations already reported, so
+    # a relevant-but-ineligible scan warns once, not once per sweep.
+    result = closed_jaxpr
+    skip_warned: set = set()
+    while True:
+        converted, n_unrolled = _unroll_scans_once(
+            result,
+            weight_invars=weight_invars,
+            hidden_invars=hidden_invars,
+            hidden_outvars=hidden_outvars,
+            policy=policy,
+            skip_warned=skip_warned,
+        )
+        if n_unrolled == 0:
+            return result
+        result = inline_jit_calls(converted)
+
+
+def _unroll_scans_once(
+    closed_jaxpr: ClosedJaxpr,
+    *,
+    weight_invars: Container[Var],
+    hidden_invars: Container[Var],
+    hidden_outvars: Container[Var],
+    policy: ControlFlowPolicy,
+    skip_warned: set,
+):
+    """One unrolling sweep over the top-level equations.
+
+    Returns ``(closed_jaxpr, n_unrolled)``; the input object itself when
+    nothing is unrolled.
+    """
+    jaxpr = closed_jaxpr.jaxpr
+    if not any(is_scan_primitive(eqn) for eqn in jaxpr.eqns):
+        return closed_jaxpr, 0
+
+    # Consumption of the original scan outvars, for dead-output elision.
+    # Downstream equations keep referencing the original outvars (they are
+    # re-emitted under the same identity), so the original jaxpr's edges are
+    # exactly the right consumption record.
+    consumed: Set[Var] = set()
+    for eqn in jaxpr.eqns:
+        for iv in eqn.invars:
+            if isinstance(iv, Var):
+                consumed.add(iv)
+    for ov in jaxpr.outvars:
+        if isinstance(ov, Var):
+            consumed.add(ov)
+
+    producers = build_producer_map(jaxpr)
+
+    def reaches_weight(atom: Any) -> bool:
+        """Backward reachability from *atom* to any weight invar."""
+        if not isinstance(atom, Var):
+            return False
+        frontier = [atom]
+        visited: Set[Var] = set()
+        while frontier:
+            v = frontier.pop()
+            if v in visited:
+                continue
+            visited.add(v)
+            if v in weight_invars:
+                return True
+            producer = producers.get(v)
+            if producer is not None:
+                for iv in producer.invars:
+                    if isinstance(iv, Var) and iv not in visited:
+                        frontier.append(iv)
+        return False
+
+    def relevance_reason(eqn: JaxprEqn) -> Optional[str]:
+        for v in eqn.invars:
+            if isinstance(v, Var):
+                if v in weight_invars:
+                    return 'it consumes a weight invar'
+                if v in hidden_invars:
+                    return 'it consumes a hidden-state invar'
+        for v in eqn.outvars:
+            if v in hidden_outvars:
+                return 'it produces a hidden-state outvar'
+        if _jaxpr_contains(eqn.params['jaxpr'].jaxpr, _is_etp_eqn):
+            return 'its body contains an ETP primitive'
+        return None
+
+    extra_constvars: List[Var] = []
+    extra_consts: List[Any] = []
+    new_eqns: List[JaxprEqn] = []
+    n_unrolled = 0
+
+    def fresh_like(v: Var) -> Var:
+        return new_var('', v.aval)
+
+    def unroll_scan(eqn: JaxprEqn) -> None:
+        params = eqn.params
+        body_closed = params['jaxpr']
+        body = body_closed.jaxpr
+        length: int = params['length']
+        num_consts: int = params['num_consts']
+        num_carry: int = params['num_carry']
+        reverse: bool = params['reverse']
+
+        const_atoms = list(eqn.invars[:num_consts])
+        init_atoms = list(eqn.invars[num_consts:num_consts + num_carry])
+        xs_atoms = list(eqn.invars[num_consts + num_carry:])
+        num_ys = len(eqn.outvars) - num_carry
+        source_info = eqn.source_info
+
+        # Body consts are read-only: hoist each ONCE as a fresh outer
+        # constvar shared by every iteration (freshened, not adopted, for
+        # the same reason as in cond inlining).
+        const_subst: Dict[Var, Any] = {}
+        for cv, cval in zip(body.constvars, body_closed.consts):
+            fresh = fresh_like(cv)
+            const_subst[cv] = fresh
+            extra_constvars.append(fresh)
+            extra_consts.append(cval)
+
+        carry_atoms: List[Any] = list(init_atoms)
+        ys_atoms: List[List[Any]] = [[None] * length for _ in range(num_ys)]
+
+        # reverse=True threads the carry from the LAST xs slice to the
+        # first, but the y computed for slice t still lands at ys[t].
+        order = range(length - 1, -1, -1) if reverse else range(length)
+        for t in order:
+            subst: Dict[Var, Any] = dict(const_subst)
+            for iv, atom in zip(body.invars[:num_consts], const_atoms):
+                subst[iv] = atom
+            for iv, atom in zip(
+                body.invars[num_consts:num_consts + num_carry], carry_atoms
+            ):
+                subst[iv] = atom
+
+            # Materialize this iteration's xs slices.
+            for iv, xs_atom in zip(
+                body.invars[num_consts + num_carry:], xs_atoms
+            ):
+                tail = tuple(iv.aval.shape)
+                sliced = new_var('', iv.aval.update(shape=(1,) + tail))
+                new_eqns.append(new_jaxpr_eqn(
+                    [xs_atom],
+                    [sliced],
+                    jax.lax.slice_p,
+                    dict(
+                        start_indices=(t,) + (0,) * len(tail),
+                        limit_indices=(t + 1,) + tail,
+                        strides=None,
+                    ),
+                    set(),
+                    source_info.replace(),
+                ))
+                squeezed = fresh_like(iv)
+                new_eqns.append(new_jaxpr_eqn(
+                    [sliced],
+                    [squeezed],
+                    jax.lax.squeeze_p,
+                    dict(dimensions=(0,)),
+                    set(),
+                    source_info.replace(),
+                ))
+                subst[iv] = squeezed
+
+            def resolve(atom: Any) -> Any:
+                if isinstance(atom, Var):
+                    return subst.get(atom, atom)
+                return atom
+
+            # Clone the body equations with fresh outvars.
+            for body_eqn in body.eqns:
+                fresh_outvars = [fresh_like(v) for v in body_eqn.outvars]
+                for ov, fresh in zip(body_eqn.outvars, fresh_outvars):
+                    subst[ov] = fresh
+                new_eqns.append(body_eqn.replace(
+                    invars=[resolve(v) for v in body_eqn.invars],
+                    outvars=fresh_outvars,
+                ))
+
+            out_atoms = [resolve(v) for v in body.outvars]
+            carry_atoms = out_atoms[:num_carry]
+            for j, y_atom in enumerate(out_atoms[num_carry:]):
+                ys_atoms[j][t] = y_atom
+
+        # Re-emit the original scan outvars. Dead outputs (never consumed —
+        # including DropVars) get no producing equation, which is legal.
+        for ov, final_atom in zip(eqn.outvars[:num_carry], carry_atoms):
+            if ov not in consumed:
+                continue
+            shape = tuple(ov.aval.shape)
+            new_eqns.append(new_jaxpr_eqn(
+                [final_atom],
+                [ov],
+                jax.lax.broadcast_in_dim_p,
+                dict(
+                    shape=shape,
+                    broadcast_dimensions=tuple(range(len(shape))),
+                    sharding=None,
+                ),
+                set(),
+                source_info.replace(),
+            ))
+        for j, ov in enumerate(eqn.outvars[num_carry:]):
+            if ov not in consumed:
+                continue
+            stacked_shape = tuple(ov.aval.shape)
+            slice_shape = stacked_shape[1:]
+            slice_vars = []
+            for y_atom in ys_atoms[j]:
+                sv = new_var('', ov.aval.update(shape=(1,) + slice_shape))
+                new_eqns.append(new_jaxpr_eqn(
+                    [y_atom],
+                    [sv],
+                    jax.lax.broadcast_in_dim_p,
+                    dict(
+                        shape=(1,) + slice_shape,
+                        broadcast_dimensions=tuple(
+                            range(1, 1 + len(slice_shape))
+                        ),
+                        sharding=None,
+                    ),
+                    set(),
+                    source_info.replace(),
+                ))
+                slice_vars.append(sv)
+            new_eqns.append(new_jaxpr_eqn(
+                slice_vars,
+                [ov],
+                jax.lax.concatenate_p,
+                dict(dimension=0),
+                set(),
+                source_info.replace(),
+            ))
+
+    for eqn in jaxpr.eqns:
+        if not (is_scan_primitive(eqn) and 'jaxpr' in eqn.params):
+            new_eqns.append(eqn)
+            continue
+        reason = relevance_reason(eqn)
+        if reason is None:
+            new_eqns.append(eqn)
+            continue
+        bad = _scan_static_ineligibility(eqn, policy)
+        if bad is not None:
+            if id(eqn) not in skip_warned:
+                skip_warned.add(id(eqn))
+                emit(
+                    kind=DiagnosticKind.SCAN_UNROLL_SKIPPED,
+                    level=DiagnosticLevel.WARNING,
+                    message=(
+                        f'An ETP-relevant scan ({reason}) was NOT unrolled '
+                        f'because {bad}; it stays opaque and the existing '
+                        f'control-flow restrictions apply. Raise '
+                        f'ControlFlowPolicy.scan_unroll_limit or restructure '
+                        f'the loop if its weights should learn online.'
+                    ),
+                    context={'reason': bad, 'relevance': reason},
+                )
+            new_eqns.append(eqn)
+            continue
+        num_prefix = eqn.params['num_consts'] + eqn.params['num_carry']
+        sliced_weight = [
+            v for v in eqn.invars[num_prefix:] if reaches_weight(v)
+        ]
+        if sliced_weight:
+            if id(eqn) not in skip_warned:
+                skip_warned.add(id(eqn))
+                emit(
+                    kind=DiagnosticKind.RELATION_EXCLUDED_SLICED_WEIGHT,
+                    level=DiagnosticLevel.WARNING,
+                    message=(
+                        f'An ETP-relevant scan ({reason}) was NOT unrolled '
+                        f'because it scans over a trainable weight (a '
+                        f'stacked parameter passed as xs). Each unrolled '
+                        f'iteration would consume a *slice* of the '
+                        f'parameter, which relation analysis cannot yet '
+                        f'attribute correctly. Pass per-iteration weights '
+                        f'as separate parameters, or keep the loop out of '
+                        f'online learning.'
+                    ),
+                    context={'relevance': reason,
+                             'n_sliced': len(sliced_weight)},
+                )
+            new_eqns.append(eqn)
+            continue
+
+        unroll_scan(eqn)
+        n_unrolled += 1
+        emit(
+            kind=DiagnosticKind.SCAN_UNROLLED,
+            level=DiagnosticLevel.INFO,
+            message=(
+                f'Unrolled a scan of length {eqn.params["length"]} '
+                f'(num_consts={eqn.params["num_consts"]}, '
+                f'num_carry={eqn.params["num_carry"]}, '
+                f'reverse={eqn.params["reverse"]}) into flat equations '
+                f'because {reason}.'
+            ),
+            context={
+                'length': eqn.params['length'],
+                'num_consts': eqn.params['num_consts'],
+                'num_carry': eqn.params['num_carry'],
+                'reverse': eqn.params['reverse'],
+                'reason': reason,
+            },
+        )
+
+    if n_unrolled == 0:
+        return closed_jaxpr, 0
+
+    new_jaxpr = Jaxpr(
+        constvars=list(jaxpr.constvars) + extra_constvars,
+        invars=list(jaxpr.invars),
+        outvars=list(jaxpr.outvars),
+        eqns=new_eqns,
+        effects=jaxpr.effects,
+        debug_info=jaxpr.debug_info,
+    )
+    result = ClosedJaxpr(new_jaxpr, list(closed_jaxpr.consts) + extra_consts)
+    return result, n_unrolled
+
+
+# ---------------------------------------------------------------------------
+# Joint fixpoint driver
+# ---------------------------------------------------------------------------
+
+def canonicalize_control_flow(
+    closed_jaxpr: ClosedJaxpr,
+    *,
+    weight_invars: Container[Var],
+    hidden_invars: Container[Var],
+    hidden_outvars: Container[Var],
+    policy: ControlFlowPolicy = DEFAULT_CONTROL_FLOW_POLICY,
+) -> ClosedJaxpr:
+    """Run every control-flow canonicalization pass to a joint fixpoint.
+
+    Alternates :func:`if_convert_conds`'s conversion sweep and
+    :func:`unroll_inner_scans`'s unrolling sweep (re-inlining surfaced
+    ``jit`` bodies after each) until neither changes the jaxpr. The joint
+    fixpoint handles mutual nesting: a ``cond`` inside a ``scan`` body
+    surfaces once the scan unrolls and is then converted; an eligible
+    ``scan`` inside a ``cond`` branch surfaces once the branch inlines and
+    is then unrolled.
+
+    Parameters
+    ----------
+    closed_jaxpr : ClosedJaxpr
+        The closed jaxpr to canonicalize, with ``jit`` equations already
+        inlined.
+    weight_invars : Container[Var]
+        Jaxpr input variables of the trainable weights.
+    hidden_invars : Container[Var]
+        Jaxpr input variables of the hidden states.
+    hidden_outvars : Container[Var]
+        Jaxpr output variables of the hidden states.
+    policy : ControlFlowPolicy, optional
+        Canonicalization policy; each pass honors its own knob
+        (``policy.cond``, ``policy.scan_unroll_limit``).
+
+    Returns
+    -------
+    ClosedJaxpr
+        The canonicalized closed jaxpr. When nothing changes, the input
+        object itself is returned unchanged.
+
+    Raises
+    ------
+    ValueError
+        If ``policy.cond`` is neither ``'convert'`` nor ``'opaque'``.
+    """
+    if policy.cond not in ('convert', 'opaque'):
+        raise ValueError(
+            f"policy.cond must be 'convert' or 'opaque', got {policy.cond!r}."
+        )
+
+    result = closed_jaxpr
+    cond_skip_warned: set = set()
+    scan_skip_warned: set = set()
+    while True:
+        n_total = 0
+        if policy.cond == 'convert':
+            converted, n = _convert_conds_once(
+                result,
+                weight_invars=weight_invars,
+                hidden_invars=hidden_invars,
+                hidden_outvars=hidden_outvars,
+                skip_warned=cond_skip_warned,
+                policy=policy,
+            )
+            if n:
+                result = inline_jit_calls(converted)
+                n_total += n
+        if policy.scan_unroll_limit > 0:
+            converted, n = _unroll_scans_once(
+                result,
+                weight_invars=weight_invars,
+                hidden_invars=hidden_invars,
+                hidden_outvars=hidden_outvars,
+                policy=policy,
+                skip_warned=scan_skip_warned,
+            )
+            if n:
+                result = inline_jit_calls(converted)
+                n_total += n
+        if n_total == 0:
+            return result

--- a/braintrace/_compiler/canonicalize.py
+++ b/braintrace/_compiler/canonicalize.py
@@ -692,9 +692,34 @@ def _unroll_scans_once(
         carry_atoms: List[Any] = list(init_atoms)
         ys_atoms: List[List[Any]] = [[None] * length for _ in range(num_ys)]
 
+        # For the final processing iteration, produce each ORIGINAL carry
+        # outvar directly from the cloned body equation instead of a fresh
+        # var + identity copy. This matters beyond economy: a body that
+        # returns its new carry as a y output (the for_loop shape) aliases
+        # the two by VALUE, and downstream consumers of the stacked ys must
+        # flow through the hidden outvar for perturbation-based learning
+        # signals (dL/dh) to see them. Positions whose body outvar is a
+        # passthrough invar, a Literal, or a duplicate of an already-mapped
+        # carry fall back to the identity-copy path below.
+        body_produced: Set[Var] = set()
+        for body_eqn in body.eqns:
+            body_produced.update(
+                v for v in body_eqn.outvars if isinstance(v, Var)
+            )
+        final_carry_map: Dict[Var, Var] = {}
+        for bv, ov in zip(body.outvars[:num_carry], eqn.outvars[:num_carry]):
+            if (
+                ov in consumed
+                and isinstance(bv, Var)
+                and bv in body_produced
+                and bv not in final_carry_map
+            ):
+                final_carry_map[bv] = ov
+
         # reverse=True threads the carry from the LAST xs slice to the
         # first, but the y computed for slice t still lands at ys[t].
         order = range(length - 1, -1, -1) if reverse else range(length)
+        final_t = order[-1] if length else None
         for t in order:
             subst: Dict[Var, Any] = dict(const_subst)
             for iv, atom in zip(body.invars[:num_consts], const_atoms):
@@ -738,9 +763,16 @@ def _unroll_scans_once(
                     return subst.get(atom, atom)
                 return atom
 
-            # Clone the body equations with fresh outvars.
+            # Clone the body equations with fresh outvars; on the final
+            # processing iteration, eligible carry outputs write the
+            # original scan outvars directly.
+            outvar_map = final_carry_map if t == final_t else {}
             for body_eqn in body.eqns:
-                fresh_outvars = [fresh_like(v) for v in body_eqn.outvars]
+                fresh_outvars = [
+                    outvar_map.get(v) if isinstance(v, Var) and v in outvar_map
+                    else fresh_like(v)
+                    for v in body_eqn.outvars
+                ]
                 for ov, fresh in zip(body_eqn.outvars, fresh_outvars):
                     subst[ov] = fresh
                 new_eqns.append(body_eqn.replace(
@@ -754,9 +786,10 @@ def _unroll_scans_once(
                 ys_atoms[j][t] = y_atom
 
         # Re-emit the original scan outvars. Dead outputs (never consumed —
-        # including DropVars) get no producing equation, which is legal.
+        # including DropVars) get no producing equation, which is legal;
+        # direct-mapped carries were already written by the final clone.
         for ov, final_atom in zip(eqn.outvars[:num_carry], carry_atoms):
-            if ov not in consumed:
+            if ov not in consumed or final_atom is ov:
                 continue
             shape = tuple(ov.aval.shape)
             new_eqns.append(new_jaxpr_eqn(

--- a/braintrace/_compiler/canonicalize_test.py
+++ b/braintrace/_compiler/canonicalize_test.py
@@ -1057,5 +1057,134 @@ class TestCanonicalizeControlFlow:
         assert 'cond' in names
 
 
+class _InnerLoopCell(brainstate.nn.Module):
+    """Cell whose one-step update runs an inner ``for_loop`` of ``loops``
+    sub-steps, each applying two ETP matmuls to the hidden state."""
+
+    def __init__(self, n_rec: int, loops: int = 3):
+        super().__init__()
+        self.loops = loops
+        self.w = brainstate.ParamState(0.1 * brainstate.random.randn(n_rec, n_rec))
+        self.h = brainstate.HiddenState(jnp.zeros(n_rec))
+
+    def init_state(self, *args, **kwargs):
+        self.h.value = jnp.zeros_like(self.h.value)
+
+    def update(self, x):
+        def step(i):
+            self.h.value = jnp.tanh(
+                braintrace.matmul(x, self.w.value)
+                + braintrace.matmul(self.h.value, self.w.value)
+            )
+            return self.h.value
+
+        outs = brainstate.transform.for_loop(step, jnp.arange(self.loops))
+        return outs[-1]
+
+
+class _UnrolledLoopCell(brainstate.nn.Module):
+    """Hand-flattened twin of :class:`_InnerLoopCell`: the same ``loops``
+    sub-steps written out at trace time (no runtime loop)."""
+
+    def __init__(self, n_rec: int, loops: int = 3):
+        super().__init__()
+        self.loops = loops
+        self.w = brainstate.ParamState(0.1 * brainstate.random.randn(n_rec, n_rec))
+        self.h = brainstate.HiddenState(jnp.zeros(n_rec))
+
+    def init_state(self, *args, **kwargs):
+        self.h.value = jnp.zeros_like(self.h.value)
+
+    def update(self, x):
+        for _ in range(self.loops):
+            self.h.value = jnp.tanh(
+                braintrace.matmul(x, self.w.value)
+                + braintrace.matmul(self.h.value, self.w.value)
+            )
+        return self.h.value
+
+
+class TestScanModelCompilation:
+    """A model with ETP ops inside a `for_loop`/`scan` body must compile
+    identically to the hand-unrolled twin (spec Phase 2)."""
+
+    N_REC, LOOPS = 4, 3
+
+    def _graph_for(self, cell_cls, **compile_kwargs):
+        with brainstate.random.seed_context(42):
+            cell = cell_cls(self.N_REC, self.LOOPS)
+        brainstate.nn.init_all_states(cell)
+        x = jnp.ones(self.N_REC)
+        return braintrace.compile_etrace_graph(cell, x, **compile_kwargs)
+
+    def test_scan_model_compiles_without_scan_eqn(self):
+        graph = self._graph_for(_InnerLoopCell)
+        names = [eqn.primitive.name for eqn in graph.module_info.jaxpr.eqns]
+        assert 'scan' not in names
+        assert names.count('etp_mv') == 2 * self.LOOPS
+
+    def test_relation_parity_with_unrolled_model(self):
+        # Only the LAST sub-step's two ETP calls become relations: earlier
+        # sub-steps reach the hidden outvar exclusively through later ETP
+        # ops (the weight -> weight -> hidden invariant excludes them). The
+        # hand-flattened twin proves 2 is the canonical count.
+        g_scan = self._graph_for(_InnerLoopCell)
+        g_flat = self._graph_for(_UnrolledLoopCell)
+        assert len(g_scan.hidden_param_op_relations) == 2
+        assert len(g_flat.hidden_param_op_relations) == 2
+        assert all(
+            r.trainable_paths['weight'] == ('w',)
+            for r in g_scan.hidden_param_op_relations
+        )
+        scan_prims = sorted(
+            r.primitive.name for r in g_scan.hidden_param_op_relations
+        )
+        flat_prims = sorted(
+            r.primitive.name for r in g_flat.hidden_param_op_relations
+        )
+        assert scan_prims == flat_prims
+
+    def test_unroll_diagnostic_recorded(self):
+        graph = self._graph_for(_InnerLoopCell)
+        records = graph.explain(kind=DiagnosticKind.SCAN_UNROLLED)
+        assert len(records) == 1
+
+    def test_limit_zero_policy_keeps_existing_error(self):
+        with pytest.raises(NotImplementedError, match='scan'):
+            with pytest.warns(UserWarning):
+                self._graph_for(
+                    _InnerLoopCell,
+                    control_flow=ControlFlowPolicy(scan_unroll_limit=0),
+                )
+
+    def test_drtrl_gradient_parity_with_unrolled_model(self):
+        def build_and_grads(cell_cls):
+            with brainstate.random.seed_context(42):
+                model = cell_cls(self.N_REC, self.LOOPS)
+            learner = braintrace.compile(model, braintrace.D_RTRL, jnp.zeros(self.N_REC))
+            weights = model.states(brainstate.ParamState)
+            with brainstate.random.seed_context(7):
+                xs = brainstate.random.randn(6, self.N_REC)
+
+            def total_loss(xs):
+                def step(carry, x):
+                    out = learner(x)
+                    return carry, jnp.mean(jnp.asarray(out) ** 2)
+
+                _, ls = brainstate.transform.scan(step, None, xs)
+                return jnp.sum(ls)
+
+            return brainstate.transform.grad(total_loss, weights)(xs)
+
+        g_scan = build_and_grads(_InnerLoopCell)
+        g_flat = build_and_grads(_UnrolledLoopCell)
+        leaves_scan = jax.tree.leaves(g_scan)
+        leaves_flat = jax.tree.leaves(g_flat)
+        assert leaves_scan and len(leaves_scan) == len(leaves_flat)
+        for a, b in zip(leaves_scan, leaves_flat):
+            assert jnp.allclose(a, b, atol=1e-6), (a - b)
+        assert any(jnp.any(jnp.abs(leaf) > 0) for leaf in leaves_scan)
+
+
 if __name__ == '__main__':
     pytest.main([__file__, '-v'])

--- a/braintrace/_compiler/canonicalize_test.py
+++ b/braintrace/_compiler/canonicalize_test.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 # ==============================================================================
 
+import warnings
+
 import brainstate
 import jax
 import jax.numpy as jnp
@@ -1156,6 +1158,38 @@ class TestScanModelCompilation:
                     _InnerLoopCell,
                     control_flow=ControlFlowPolicy(scan_unroll_limit=0),
                 )
+
+    def test_while_body_model_keeps_existing_error(self):
+        # `while_loop` is out of Phase 2 scope: an ETP-relevant while in the
+        # update must still hard-error, untouched by canonicalization.
+        class WhileCell(brainstate.nn.Module):
+            def __init__(self, n, loops):
+                super().__init__()
+                self.loops = loops
+                self.w = brainstate.ParamState(0.1 * brainstate.random.randn(n, n))
+                self.h = brainstate.HiddenState(jnp.zeros(n))
+
+            def update(self, x):
+                def cond_fn(carry):
+                    i, _ = carry
+                    return i < self.loops
+
+                def body_fn(carry):
+                    i, h = carry
+                    h = jnp.tanh(
+                        braintrace.matmul(x, self.w.value)
+                        + braintrace.matmul(h, self.w.value)
+                    )
+                    return i + 1, h
+
+                _, h = jax.lax.while_loop(cond_fn, body_fn, (0, self.h.value))
+                self.h.value = h
+                return h
+
+        with pytest.raises(NotImplementedError, match='while'):
+            with warnings.catch_warnings():
+                warnings.simplefilter('ignore', UserWarning)
+                self._graph_for(WhileCell)
 
     def test_drtrl_gradient_parity_with_unrolled_model(self):
         def build_and_grads(cell_cls):

--- a/braintrace/_compiler/canonicalize_test.py
+++ b/braintrace/_compiler/canonicalize_test.py
@@ -22,7 +22,9 @@ import braintrace
 from braintrace._compiler.canonicalize import (
     ControlFlowPolicy,
     DEFAULT_CONTROL_FLOW_POLICY,
+    canonicalize_control_flow,
     if_convert_conds,
+    unroll_inner_scans,
 )
 from braintrace._compiler.diagnostics import (
     DiagnosticKind,
@@ -350,10 +352,33 @@ class TestIfConvertConds:
         kinds = [r.kind for r in reporter.records()]
         assert DiagnosticKind.COND_CONVERSION_SKIPPED in kinds
 
-    def test_safety_gate_scan_in_branch(self):
+    def test_safety_gate_unrollable_scan_in_branch_no_longer_skips(self):
+        # Phase 2 gate revision: a branch scan that unroll_inner_scans could
+        # flatten (short, effect-free, while-free) no longer blocks
+        # conversion. if_convert_conds alone leaves the surfaced scan in
+        # place; canonicalize_control_flow flattens it too.
         def f(x, w):
             def true_fn():
                 return jax.lax.scan(lambda c, _: (c * 1.1, None), x, length=3)[0]
+
+            return jax.lax.cond(
+                jnp.sum(x) > 0., true_fn, lambda: braintrace.matmul(x, w)
+            )
+
+        closed = jax.make_jaxpr(f)(jnp.ones(3), jnp.eye(3))
+        conv = _convert(closed)
+        names = _primitive_names(conv)
+        assert 'cond' not in names
+        assert 'scan' in names  # surfaced, not unrolled by this pass alone
+        for xi in (jnp.ones(3), -jnp.ones(3)):
+            assert jnp.allclose(_eval(conv, xi, jnp.eye(3))[0], f(xi, jnp.eye(3)))
+
+    def test_safety_gate_unrollable_scan_gate_with_ineligible_scan(self):
+        # A branch scan the unroller would REFUSE (length > limit) still
+        # blocks conversion, exactly as in Phase 1.
+        def f(x, w):
+            def true_fn():
+                return jax.lax.scan(lambda c, _: (c * 1.1, None), x, length=64)[0]
 
             return jax.lax.cond(
                 jnp.sum(x) > 0., true_fn, lambda: braintrace.matmul(x, w)
@@ -532,6 +557,504 @@ class TestCondModelCompilation:
             assert jnp.allclose(a, b, atol=1e-6), (a - b)
         # Gradients must be nonzero: both branches are exercised by the inputs.
         assert any(jnp.any(jnp.abs(leaf) > 0) for leaf in leaves_cond)
+
+
+def _unroll(closed_jaxpr, weights=(), hiddens_in=(), hiddens_out=(), policy=None):
+    kwargs = dict(
+        weight_invars=set(weights),
+        hidden_invars=set(hiddens_in),
+        hidden_outvars=set(hiddens_out),
+    )
+    if policy is not None:
+        kwargs['policy'] = policy
+    return unroll_inner_scans(closed_jaxpr, **kwargs)
+
+
+class TestUnrollInnerScans:
+    """Unit tests of the scan -> flat unrolled equation sequence rewrite."""
+
+    L = 3
+
+    def _etp_scan_jaxpr(self):
+        def f(w, h0, xs):
+            def body(h, x):
+                h = jnp.tanh(braintrace.matmul(x, w) + braintrace.matmul(h, w))
+                return h, 2.0 * h
+            return jax.lax.scan(body, h0, xs)
+
+        w = jnp.eye(3) * 0.5
+        h0 = jnp.zeros(3)
+        xs = jnp.arange(self.L * 3, dtype=jnp.float32).reshape(self.L, 3) * 0.1
+        closed = jax.make_jaxpr(f)(w, h0, xs)
+        return f, closed, w, h0, xs
+
+    def _unroll_etp(self, closed):
+        return _unroll(
+            closed,
+            weights=[closed.jaxpr.invars[0]],
+            hiddens_in=[closed.jaxpr.invars[1]],
+            hiddens_out=[closed.jaxpr.outvars[0]],
+        )
+
+    def test_etp_scan_is_unrolled(self):
+        f, closed, w, h0, xs = self._etp_scan_jaxpr()
+        with diagnostic_context() as reporter:
+            conv = self._unroll_etp(closed)
+        names = _primitive_names(conv)
+        assert 'scan' not in names
+        assert names.count('etp_mv') == 2 * self.L
+        kinds = [r.kind for r in reporter.records()]
+        assert kinds.count(DiagnosticKind.SCAN_UNROLLED) == 1
+
+    def test_outvars_and_invars_preserved_by_identity(self):
+        f, closed, w, h0, xs = self._etp_scan_jaxpr()
+        conv = self._unroll_etp(closed)
+        assert all(a is b for a, b in zip(conv.jaxpr.invars, closed.jaxpr.invars))
+        assert all(a is b for a, b in zip(conv.jaxpr.outvars, closed.jaxpr.outvars))
+
+    def test_value_equivalence(self):
+        f, closed, w, h0, xs = self._etp_scan_jaxpr()
+        conv = self._unroll_etp(closed)
+        h_ref, ys_ref = f(w, h0, xs)
+        h_got, ys_got = _eval(conv, w, h0, xs)
+        assert jnp.allclose(h_got, h_ref)
+        assert jnp.allclose(ys_got, ys_ref)
+
+    def test_gradient_equivalence(self):
+        f, closed, w, h0, xs = self._etp_scan_jaxpr()
+        conv = self._unroll_etp(closed)
+
+        def loss_ref(w_, h_, xs_):
+            h, ys = f(w_, h_, xs_)
+            return jnp.sum(h ** 2) + jnp.sum(ys ** 2)
+
+        def loss_conv(w_, h_, xs_):
+            h, ys = _eval(conv, w_, h_, xs_)
+            return jnp.sum(h ** 2) + jnp.sum(ys ** 2)
+
+        for argnum in (0, 1, 2):
+            g_ref = jax.grad(loss_ref, argnum)(w, h0, xs)
+            g_conv = jax.grad(loss_conv, argnum)(w, h0, xs)
+            assert jnp.allclose(g_ref, g_conv, atol=1e-6)
+
+    def test_multiple_carries_and_ys(self):
+        def f(w, a0, b0, xs):
+            def body(carry, x):
+                a, b = carry
+                a2 = jnp.tanh(braintrace.matmul(x, w) + a)
+                b2 = b + x
+                return (a2, b2), (a2 * 2.0, b2 - 1.0)
+            return jax.lax.scan(body, (a0, b0), xs)
+
+        w = jnp.eye(3) * 0.3
+        a0, b0 = jnp.zeros(3), jnp.ones(3)
+        xs = jnp.arange(6, dtype=jnp.float32).reshape(2, 3) * 0.1
+        closed = jax.make_jaxpr(f)(w, a0, b0, xs)
+        conv = _unroll(closed, weights=[closed.jaxpr.invars[0]])
+        assert 'scan' not in _primitive_names(conv)
+        ref = f(w, a0, b0, xs)
+        got = _eval(conv, w, a0, b0, xs)
+        for r, g in zip(jax.tree.leaves(ref), got):
+            assert jnp.allclose(g, r)
+
+    def test_zero_xs_length_scan(self):
+        def f(w, h0):
+            def body(h, _):
+                return jnp.tanh(braintrace.matmul(h, w)), h * 2.0
+            return jax.lax.scan(body, h0, None, length=self.L)
+
+        w = jnp.eye(3) * 0.5
+        h0 = jnp.ones(3)
+        closed = jax.make_jaxpr(f)(w, h0)
+        conv = _unroll(closed, weights=[closed.jaxpr.invars[0]])
+        assert 'scan' not in _primitive_names(conv)
+        ref = f(w, h0)
+        got = _eval(conv, w, h0)
+        for r, g in zip(jax.tree.leaves(ref), got):
+            assert jnp.allclose(g, r)
+
+    def test_length_one(self):
+        def f(w, h0, xs):
+            def body(h, x):
+                h = jnp.tanh(braintrace.matmul(x, w) + h)
+                return h, h
+            return jax.lax.scan(body, h0, xs)
+
+        w = jnp.eye(3) * 0.5
+        h0 = jnp.zeros(3)
+        xs = jnp.ones((1, 3))
+        closed = jax.make_jaxpr(f)(w, h0, xs)
+        conv = _unroll(closed, weights=[closed.jaxpr.invars[0]])
+        assert 'scan' not in _primitive_names(conv)
+        ref = f(w, h0, xs)
+        got = _eval(conv, w, h0, xs)
+        for r, g in zip(jax.tree.leaves(ref), got):
+            assert jnp.allclose(g, r)
+
+    def test_reverse_scan(self):
+        def f(w, h0, xs):
+            def body(h, x):
+                h = jnp.tanh(braintrace.matmul(x, w) + h)
+                return h, h * 2.0
+            return jax.lax.scan(body, h0, xs, reverse=True)
+
+        w = jnp.eye(3) * 0.5
+        h0 = jnp.zeros(3)
+        xs = jnp.arange(9, dtype=jnp.float32).reshape(3, 3) * 0.1
+        closed = jax.make_jaxpr(f)(w, h0, xs)
+        conv = _unroll(closed, weights=[closed.jaxpr.invars[0]])
+        assert 'scan' not in _primitive_names(conv)
+        ref = f(w, h0, xs)
+        got = _eval(conv, w, h0, xs)
+        for r, g in zip(jax.tree.leaves(ref), got):
+            assert jnp.allclose(g, r)
+
+    def test_duplicate_body_outvars(self):
+        # A body returning its new carry AS the y output produces the same
+        # Var twice in body.outvars — the natural for_loop shape.
+        def f(w, h0, xs):
+            def body(h, x):
+                h = jnp.tanh(braintrace.matmul(x, w) + h)
+                return h, h
+            return jax.lax.scan(body, h0, xs)
+
+        w = jnp.eye(3) * 0.5
+        h0 = jnp.zeros(3)
+        xs = jnp.arange(9, dtype=jnp.float32).reshape(3, 3) * 0.1
+        closed = jax.make_jaxpr(f)(w, h0, xs)
+        body = [e for e in closed.jaxpr.eqns if e.primitive.name == 'scan'][0]
+        body_outvars = body.params['jaxpr'].jaxpr.outvars
+        assert body_outvars[0] is body_outvars[1]  # fixture really is degenerate
+        conv = _unroll(closed, weights=[closed.jaxpr.invars[0]])
+        assert 'scan' not in _primitive_names(conv)
+        ref = f(w, h0, xs)
+        got = _eval(conv, w, h0, xs)
+        for r, g in zip(jax.tree.leaves(ref), got):
+            assert jnp.allclose(g, r)
+
+    def test_passthrough_carry(self):
+        # The body returns its carry INPUT unchanged: the body outvar is a
+        # body invar, so the final carry resolves to the outer init atom.
+        def f(w, h0, xs):
+            def body(h, x):
+                return h, braintrace.matmul(x, w) + h
+            return jax.lax.scan(body, h0, xs)
+
+        w = jnp.eye(3) * 0.5
+        h0 = jnp.ones(3)
+        xs = jnp.arange(6, dtype=jnp.float32).reshape(2, 3) * 0.1
+        closed = jax.make_jaxpr(f)(w, h0, xs)
+        conv = _unroll(closed, weights=[closed.jaxpr.invars[0]])
+        assert 'scan' not in _primitive_names(conv)
+        ref = f(w, h0, xs)
+        got = _eval(conv, w, h0, xs)
+        for r, g in zip(jax.tree.leaves(ref), got):
+            assert jnp.allclose(g, r)
+
+    def test_unused_ys_not_stacked(self):
+        def f(w, h0, xs):
+            def body(h, x):
+                h = jnp.tanh(braintrace.matmul(x, w) + h)
+                return h, h * 2.0
+            h, _ = jax.lax.scan(body, h0, xs)
+            return h
+
+        w = jnp.eye(3) * 0.5
+        h0 = jnp.zeros(3)
+        xs = jnp.ones((3, 3))
+        closed = jax.make_jaxpr(f)(w, h0, xs)
+        conv = _unroll(closed, weights=[closed.jaxpr.invars[0]])
+        names = _primitive_names(conv)
+        assert 'scan' not in names
+        assert 'concatenate' not in names
+        assert jnp.allclose(_eval(conv, w, h0, xs)[0], f(w, h0, xs))
+
+    def test_relevance_gate_irrelevant_scan_unchanged(self):
+        def f(x):
+            return jax.lax.scan(lambda c, v: (c + v, c), jnp.zeros(()), x)
+
+        closed = jax.make_jaxpr(f)(jnp.ones(4))
+        out = _unroll(closed)
+        assert out is closed
+
+    def test_skip_length_exceeds_limit(self):
+        f, closed, w, h0, xs = self._etp_scan_jaxpr()
+        with diagnostic_context() as reporter:
+            with pytest.warns(UserWarning, match='NOT unrolled'):
+                conv = _unroll(
+                    closed,
+                    weights=[closed.jaxpr.invars[0]],
+                    policy=ControlFlowPolicy(scan_unroll_limit=self.L - 1),
+                )
+        assert 'scan' in _primitive_names(conv)
+        kinds = [r.kind for r in reporter.records()]
+        assert kinds.count(DiagnosticKind.SCAN_UNROLL_SKIPPED) == 1
+
+    def test_skip_effects_in_body(self):
+        def f(w, h0, xs):
+            def body(h, x):
+                jax.debug.print('h0: {}', h[0])
+                return jnp.tanh(braintrace.matmul(x, w) + h), h
+            return jax.lax.scan(body, h0, xs)
+
+        closed = jax.make_jaxpr(f)(jnp.eye(3), jnp.zeros(3), jnp.ones((2, 3)))
+        with diagnostic_context() as reporter:
+            with pytest.warns(UserWarning, match='NOT unrolled'):
+                conv = _unroll(closed, weights=[closed.jaxpr.invars[0]])
+        assert 'scan' in _primitive_names(conv)
+        kinds = [r.kind for r in reporter.records()]
+        assert DiagnosticKind.SCAN_UNROLL_SKIPPED in kinds
+
+    def test_skip_while_in_body(self):
+        def f(w, h0, xs):
+            def body(h, x):
+                h = jax.lax.while_loop(
+                    lambda v: jnp.sum(v) < 1., lambda v: v + 0.5, h
+                )
+                return jnp.tanh(braintrace.matmul(x, w) + h), h
+            return jax.lax.scan(body, h0, xs)
+
+        closed = jax.make_jaxpr(f)(jnp.eye(3), jnp.zeros(3), jnp.ones((2, 3)))
+        with diagnostic_context() as reporter:
+            with pytest.warns(UserWarning, match='NOT unrolled'):
+                conv = _unroll(closed, weights=[closed.jaxpr.invars[0]])
+        assert 'scan' in _primitive_names(conv)
+        kinds = [r.kind for r in reporter.records()]
+        assert DiagnosticKind.SCAN_UNROLL_SKIPPED in kinds
+
+    def test_policy_limit_zero_disables(self):
+        f, closed, w, h0, xs = self._etp_scan_jaxpr()
+        out = _unroll(
+            closed,
+            weights=[closed.jaxpr.invars[0]],
+            policy=ControlFlowPolicy(scan_unroll_limit=0),
+        )
+        assert out is closed
+
+    def test_weights_as_xs_skipped(self):
+        # Scanning over a stacked weight: the xs invar IS a weight invar.
+        def f(ws, h0):
+            def body(h, w_t):
+                return jnp.tanh(braintrace.matmul(h, w_t)), h
+            return jax.lax.scan(body, h0, ws)
+
+        ws = jnp.stack([jnp.eye(3)] * 2) * 0.5
+        h0 = jnp.ones(3)
+        closed = jax.make_jaxpr(f)(ws, h0)
+        with diagnostic_context() as reporter:
+            with pytest.warns(UserWarning, match='scans over a trainable weight'):
+                conv = _unroll(closed, weights=[closed.jaxpr.invars[0]])
+        assert 'scan' in _primitive_names(conv)
+        kinds = [r.kind for r in reporter.records()]
+        assert kinds.count(DiagnosticKind.RELATION_EXCLUDED_SLICED_WEIGHT) == 1
+
+    def test_weight_derived_xs_skipped(self):
+        # The xs value is COMPUTED from a weight before the scan; backward
+        # reachability must still catch it (direct membership would not).
+        def f(w, h0):
+            ws = jnp.stack([w, w * 2.0])
+
+            def body(h, w_t):
+                return jnp.tanh(braintrace.matmul(h, w_t)), h
+            return jax.lax.scan(body, h0, ws)
+
+        closed = jax.make_jaxpr(f)(jnp.eye(3), jnp.ones(3))
+        with diagnostic_context() as reporter:
+            with pytest.warns(UserWarning, match='scans over a trainable weight'):
+                conv = _unroll(closed, weights=[closed.jaxpr.invars[0]])
+        assert 'scan' in _primitive_names(conv)
+        kinds = [r.kind for r in reporter.records()]
+        assert DiagnosticKind.RELATION_EXCLUDED_SLICED_WEIGHT in kinds
+
+    def test_jit_inside_body_inlined(self):
+        @jax.jit
+        def helper(a, b):
+            return a + b
+
+        def f(w, h0, xs):
+            def body(h, x):
+                h = jnp.tanh(helper(braintrace.matmul(x, w), h))
+                return h, h
+            return jax.lax.scan(body, h0, xs)
+
+        w = jnp.eye(3) * 0.5
+        h0 = jnp.zeros(3)
+        xs = jnp.ones((2, 3))
+        closed = jax.make_jaxpr(f)(w, h0, xs)
+        conv = _unroll(closed, weights=[closed.jaxpr.invars[0]])
+        names = _primitive_names(conv)
+        assert 'scan' not in names
+        assert 'jit' not in names and 'pjit' not in names
+        ref = f(w, h0, xs)
+        got = _eval(conv, w, h0, xs)
+        for r, g in zip(jax.tree.leaves(ref), got):
+            assert jnp.allclose(g, r)
+
+    def test_nested_eligible_scans_unrolled(self):
+        def f(w, h0, xs):
+            def outer_body(h, x):
+                def inner_body(g, _):
+                    return jnp.tanh(braintrace.matmul(g, w)), None
+                g, _ = jax.lax.scan(inner_body, h + x, None, length=2)
+                return g, g
+            return jax.lax.scan(outer_body, h0, xs)
+
+        w = jnp.eye(3) * 0.5
+        h0 = jnp.zeros(3)
+        xs = jnp.ones((2, 3)) * 0.1
+        closed = jax.make_jaxpr(f)(w, h0, xs)
+        conv = _unroll(closed, weights=[closed.jaxpr.invars[0]])
+        names = _primitive_names(conv)
+        assert 'scan' not in names
+        assert names.count('etp_mv') == 4  # 2 outer x 2 inner
+        ref = f(w, h0, xs)
+        got = _eval(conv, w, h0, xs)
+        for r, g in zip(jax.tree.leaves(ref), got):
+            assert jnp.allclose(g, r)
+
+    def test_skip_warning_once_across_fixpoint(self):
+        # One eligible + one ineligible scan: the second sweep (triggered by
+        # the first unroll) must not re-warn for the ineligible one.
+        def f(w, h0, xs_short, xs_long):
+            def body(h, x):
+                return jnp.tanh(braintrace.matmul(x, w) + h), h
+            h1, _ = jax.lax.scan(body, h0, xs_short)
+            h2, _ = jax.lax.scan(body, h1, xs_long)
+            return h2
+
+        w = jnp.eye(3) * 0.5
+        h0 = jnp.zeros(3)
+        xs_short = jnp.ones((2, 3))
+        xs_long = jnp.ones((5, 3))
+        closed = jax.make_jaxpr(f)(w, h0, xs_short, xs_long)
+        with diagnostic_context() as reporter:
+            with pytest.warns(UserWarning, match='NOT unrolled'):
+                conv = _unroll(
+                    closed,
+                    weights=[closed.jaxpr.invars[0]],
+                    policy=ControlFlowPolicy(scan_unroll_limit=3),
+                )
+        names = _primitive_names(conv)
+        assert names.count('scan') == 1
+        kinds = [r.kind for r in reporter.records()]
+        assert kinds.count(DiagnosticKind.SCAN_UNROLL_SKIPPED) == 1
+
+    def test_determinism(self):
+        f, closed, w, h0, xs = self._etp_scan_jaxpr()
+        conv1 = self._unroll_etp(closed)
+        conv2 = self._unroll_etp(closed)
+        assert _primitive_names(conv1) == _primitive_names(conv2)
+        assert str(conv1.jaxpr) == str(conv2.jaxpr)
+
+
+class TestCanonicalizeControlFlow:
+    """The joint cond + scan fixpoint driver."""
+
+    def test_cond_inside_scan_body(self):
+        def f(w, h0, xs):
+            def body(h, x):
+                drive = jax.lax.cond(
+                    jnp.sum(x) > 0.,
+                    lambda: braintrace.matmul(x, w),
+                    lambda: x * 2.,
+                )
+                return jnp.tanh(drive + h), h
+            return jax.lax.scan(body, h0, xs)
+
+        w = jnp.eye(3) * 0.5
+        h0 = jnp.zeros(3)
+        xs = jnp.stack([jnp.ones(3), -jnp.ones(3)])
+        closed = jax.make_jaxpr(f)(w, h0, xs)
+        conv = canonicalize_control_flow(
+            closed,
+            weight_invars={closed.jaxpr.invars[0]},
+            hidden_invars=set(),
+            hidden_outvars=set(),
+            policy=DEFAULT_CONTROL_FLOW_POLICY,
+        )
+        names = _primitive_names(conv)
+        assert 'scan' not in names
+        assert 'cond' not in names
+        assert 'select_n' in names
+        ref = f(w, h0, xs)
+        got = _eval(conv, w, h0, xs)
+        for r, g in zip(jax.tree.leaves(ref), got):
+            assert jnp.allclose(g, r)
+
+    def test_eligible_scan_inside_cond_branch(self):
+        def f(x, w, h0):
+            def true_fn():
+                def body(h, _):
+                    return jnp.tanh(braintrace.matmul(h, w)), None
+                h, _ = jax.lax.scan(body, h0, None, length=2)
+                return h
+
+            return jax.lax.cond(jnp.sum(x) > 0., true_fn, lambda: h0 * 2.)
+
+        x = jnp.ones(3)
+        w = jnp.eye(3) * 0.5
+        h0 = jnp.ones(3)
+        closed = jax.make_jaxpr(f)(x, w, h0)
+        conv = canonicalize_control_flow(
+            closed,
+            weight_invars={closed.jaxpr.invars[1]},
+            hidden_invars=set(),
+            hidden_outvars=set(),
+            policy=DEFAULT_CONTROL_FLOW_POLICY,
+        )
+        names = _primitive_names(conv)
+        assert 'cond' not in names
+        assert 'scan' not in names
+        for xi in (x, -x):
+            assert jnp.allclose(_eval(conv, xi, w, h0)[0], f(xi, w, h0))
+
+    def test_ineligible_scan_inside_cond_branch_skips_cond(self):
+        def f(x, w, h0):
+            def true_fn():
+                def body(h, _):
+                    return jnp.tanh(braintrace.matmul(h, w)), None
+                h, _ = jax.lax.scan(body, h0, None, length=64)
+                return h
+
+            return jax.lax.cond(jnp.sum(x) > 0., true_fn, lambda: h0 * 2.)
+
+        closed = jax.make_jaxpr(f)(jnp.ones(3), jnp.eye(3), jnp.ones(3))
+        with diagnostic_context() as reporter:
+            with pytest.warns(UserWarning, match='NOT if-converted'):
+                conv = canonicalize_control_flow(
+                    closed,
+                    weight_invars={closed.jaxpr.invars[1]},
+                    hidden_invars=set(),
+                    hidden_outvars=set(),
+                    policy=DEFAULT_CONTROL_FLOW_POLICY,
+                )
+        assert 'cond' in _primitive_names(conv)
+        kinds = [r.kind for r in reporter.records()]
+        assert DiagnosticKind.COND_CONVERSION_SKIPPED in kinds
+
+    def test_limit_zero_reproduces_phase1_gating(self):
+        # With unrolling disabled, a cond guarding ANY inner scan must stay
+        # opaque, exactly as in Phase 1.
+        def f(x, w, h0):
+            def true_fn():
+                def body(h, _):
+                    return jnp.tanh(braintrace.matmul(h, w)), None
+                h, _ = jax.lax.scan(body, h0, None, length=2)
+                return h
+
+            return jax.lax.cond(jnp.sum(x) > 0., true_fn, lambda: h0 * 2.)
+
+        closed = jax.make_jaxpr(f)(jnp.ones(3), jnp.eye(3), jnp.ones(3))
+        with pytest.warns(UserWarning, match='NOT if-converted'):
+            conv = canonicalize_control_flow(
+                closed,
+                weight_invars={closed.jaxpr.invars[1]},
+                hidden_invars=set(),
+                hidden_outvars=set(),
+                policy=ControlFlowPolicy(scan_unroll_limit=0),
+            )
+        names = _primitive_names(conv)
+        assert 'cond' in names
 
 
 if __name__ == '__main__':

--- a/braintrace/_compiler/diagnostics.py
+++ b/braintrace/_compiler/diagnostics.py
@@ -100,6 +100,9 @@ class DiagnosticKind(str, Enum):
     # Control-flow canonicalization (see _compiler/canonicalize.py)
     COND_IF_CONVERTED = 'cond_if_converted'
     COND_CONVERSION_SKIPPED = 'cond_conversion_skipped'
+    SCAN_UNROLLED = 'scan_unrolled'
+    SCAN_UNROLL_SKIPPED = 'scan_unroll_skipped'
+    RELATION_EXCLUDED_SLICED_WEIGHT = 'relation_excluded_sliced_weight'
 
     # Structural observations (informational / partial)
     PRIMITIVE_INSIDE_NESTED_JIT = 'primitive_inside_nested_jit'

--- a/braintrace/_compiler/module_info.py
+++ b/braintrace/_compiler/module_info.py
@@ -41,7 +41,7 @@ from braintrace._typing import (
     StateVals,
     TempData,
 )
-from .canonicalize import ControlFlowPolicy, DEFAULT_CONTROL_FLOW_POLICY, if_convert_conds
+from .canonicalize import ControlFlowPolicy, DEFAULT_CONTROL_FLOW_POLICY, canonicalize_control_flow
 from .diagnostics import DiagnosticKind, DiagnosticLevel, emit
 from .jaxpr_graph import inline_jit_calls
 
@@ -495,11 +495,12 @@ def extract_module_info(
     *model_args
         The positional arguments of the model.
     control_flow : ControlFlowPolicy or None, optional
-        Policy governing control-flow canonicalization (currently ``cond``
-        if-conversion; see
-        :func:`~braintrace._compiler.canonicalize.if_convert_conds`).
+        Policy governing control-flow canonicalization (``cond``
+        if-conversion and inner-``scan`` unrolling; see
+        :func:`~braintrace._compiler.canonicalize.canonicalize_control_flow`).
         ``None`` (default) uses the default policy, which converts every
-        ETP-relevant ``cond``.
+        ETP-relevant ``cond`` and unrolls every ETP-relevant ``scan`` of
+        static length at most 16.
     **model_kwargs
         The keyword arguments of the model.
 
@@ -641,11 +642,12 @@ def extract_module_info(
 
     weight_invars = brainstate.util.PrettyList(dict.fromkeys(v for vs in weight_path_to_invars.values() for v in vs))
 
-    # Canonicalize ETP-relevant control flow (Phase 1: cond -> select_n).
-    # The pass reuses each converted equation's original outvars and never
-    # touches the jaxpr's invars/outvars, so every Var-identity table built
-    # above stays valid; only the equation list (and consts) change.
-    closed_jaxpr = if_convert_conds(
+    # Canonicalize ETP-relevant control flow (cond -> select_n, inner-scan
+    # unrolling, run to a joint fixpoint). The passes reuse each rewritten
+    # equation's original outvars and never touch the jaxpr's invars/outvars,
+    # so every Var-identity table built above stays valid; only the equation
+    # list (and consts) change.
+    closed_jaxpr = canonicalize_control_flow(
         closed_jaxpr,
         weight_invars=set(weight_invars),
         hidden_invars=set(hidden_path_to_invar.values()),

--- a/braintrace/_compiler/scenario_catalog.py
+++ b/braintrace/_compiler/scenario_catalog.py
@@ -303,9 +303,12 @@ class PartialPathRNN(brainstate.nn.Module):
 def make_scan_body_etp_jaxpr(n_in: int, n_out: int, length: int = 4):
     """Return a jaxpr containing ``braintrace.matmul`` inside ``lax.scan``.
 
-    The compiler's full pipeline rejects ETP inside scan at the
-    ``hidden_group`` stage, so this scenario is exercised by feeding the
-    raw jaxpr to the lower-level ``_scan_jaxpr_for_etp_eqns``.
+    The full pipeline unrolls *eligible* inner scans at extraction time
+    (Phase 2 canonicalization, ``_compiler/canonicalize.py``); only
+    ineligible scans (too long, effectful, while-in-body) still reach the
+    lower layers and are rejected/skipped there. This fixture bypasses the
+    canonicalizer and feeds the raw jaxpr to the lower-level
+    ``_scan_jaxpr_for_etp_eqns`` to exercise the scanner directly.
     """
     w = jnp.zeros((n_in, n_out))
     xs = jnp.zeros((length, n_in))
@@ -347,6 +350,39 @@ class CondBranchRNN(brainstate.nn.Module):
         )
         self.h.value = jnp.tanh(u + 0.9 * self.h.value)
         return self.h.value
+
+
+class ScanBodyRNN(brainstate.nn.Module):
+    """``h <- tanh(mv(x, W) + mv(h, W))`` applied ``loops`` times per step
+    inside ``brainstate.transform.for_loop`` (which lowers to ``lax.scan``).
+
+    ETP primitives inside a ``scan`` body: the full pipeline unrolls the
+    inner scan at extraction time (Phase 2 canonicalization, see
+    ``_compiler/canonicalize.py``). Only the *last* sub-step's ETP ops
+    become relations — earlier sub-steps reach the hidden state through
+    another trainable ETP op and are excluded per the
+    weight->weight->hidden invariant.
+    """
+
+    def __init__(self, n: int, loops: int = 3):
+        super().__init__()
+        self.loops = loops
+        self.w = brainstate.ParamState(0.1 * brainstate.random.randn(n, n))
+        self.h = brainstate.HiddenState(jnp.zeros(n))
+
+    def init_state(self, *args, **kwargs):
+        self.h.value = jnp.zeros_like(self.h.value)
+
+    def update(self, x):
+        def substep(_):
+            self.h.value = jnp.tanh(
+                braintrace.matmul(x, self.w.value)
+                + braintrace.matmul(self.h.value, self.w.value)
+            )
+            return self.h.value
+
+        outs = brainstate.transform.for_loop(substep, jnp.arange(self.loops))
+        return outs[-1]
 
 
 def make_cond_branches_etp_jaxpr(n_in: int, n_out: int):

--- a/braintrace/_compiler/scenario_catalog_test.py
+++ b/braintrace/_compiler/scenario_catalog_test.py
@@ -711,6 +711,7 @@ from braintrace._compiler.scenario_catalog import (
     PartialPathRNN,
     NestedJitRNN,
     CondBranchRNN,
+    ScanBodyRNN,
     make_scan_body_etp_jaxpr,
     make_cond_branches_etp_jaxpr,
     make_while_body_etp_jaxpr,
@@ -942,10 +943,14 @@ class TestCategoryN_ControlFlow:
     surfaces the location for the user.
 
     These tests exercise the *raw scanner* on unprocessed jaxprs. In the
-    full pipeline, ``cond`` never reaches the scanner: ETP-relevant conds
-    are if-converted into inlined branches + ``select_n`` at extraction
-    time (``_compiler/canonicalize.py``), so their weights DO participate
-    as relations — see ``test_cond_branches_full_pipeline_converts``."""
+    full pipeline, ETP-relevant ``cond``/``scan`` equations normally never
+    reach the scanner: conds are if-converted into inlined branches +
+    ``select_n`` and eligible scans are unrolled at extraction time
+    (``_compiler/canonicalize.py``), so their weights DO participate as
+    relations — see ``test_cond_branches_full_pipeline_converts`` and
+    ``test_scan_body_full_pipeline_unrolls``. Only ineligible scans (too
+    long, effectful, while-in-body) and ``while`` still fall through to
+    the scanner."""
 
     def test_cond_branches_full_pipeline_converts(self):
         model = CondBranchRNN(3, 4)
@@ -957,6 +962,22 @@ class TestCategoryN_ControlFlow:
         assert len(graph.hidden_param_op_relations) == 2
         kinds = [r.kind for r in graph.diagnostics]
         assert DiagnosticKind.COND_IF_CONVERTED in kinds
+
+    def test_scan_body_full_pipeline_unrolls(self):
+        model = ScanBodyRNN(4, loops=3)
+        brainstate.nn.init_all_states(model)
+        with warnings.catch_warnings():
+            # Earlier sub-steps' weights are excluded per the
+            # weight->weight->hidden invariant and warn about it.
+            warnings.simplefilter('ignore', UserWarning)
+            graph = compile_etrace_graph(model, jnp.ones(4))
+        names = [eqn.primitive.name for eqn in graph.module_info.jaxpr.eqns]
+        assert 'scan' not in names
+        # Only the final sub-step's two ETP ops are relations; the earlier
+        # sub-steps reach `h` through another trainable ETP op.
+        assert len(graph.hidden_param_op_relations) == 2
+        kinds = [r.kind for r in graph.diagnostics]
+        assert DiagnosticKind.SCAN_UNROLLED in kinds
 
     def test_scan_body_etp_emits_diagnostic(self):
         jaxpr = make_scan_body_etp_jaxpr(3, 4)

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,42 @@
 
 ### Highlights
 
+#### New: inner-`scan` unrolling (compiler canonicalization, Phase 2)
+
+- **ETP operations inside `lax.scan` / `brainstate.transform.for_loop`
+  bodies now participate in online learning.** A new canonicalization pass
+  (`unroll_inner_scans` in `_compiler/canonicalize.py`) runs at extraction
+  time and replaces every ETP-relevant, statically short scan with its
+  unrolled body: one cloned copy per iteration with fresh variables, `xs`
+  sliced per step, consumed `ys` re-stacked via `broadcast_in_dim` +
+  `concatenate`, and `reverse=True` respected. The unrolled program is
+  value- and Jacobian-identical to the scan, so exact algorithms (D-RTRL,
+  full-rank pp_prop, EProp(k=0), OSTLRecurrent) match BPTT element-wise on
+  scan-body models — verified against hand-flattened twins and the BPTT
+  oracle. Cond and scan canonicalization now run as a joint fixpoint
+  (`canonicalize_control_flow`), so a `cond` inside a scan body (and an
+  eligible scan inside a `cond` branch) both flatten.
+- **Relation counts follow the weight→weight→hidden invariant**: in an
+  unrolled inner loop only the *last* sub-step's ETP ops become relations —
+  earlier sub-steps reach the hidden state through another trainable ETP op
+  and are excluded (with the usual no-relation warning).
+- **Eligibility gates**: only scans whose static `length` is ≤
+  `ControlFlowPolicy.scan_unroll_limit` (default 16) and that carry no
+  effects and contain no `while` are unrolled. An ETP-relevant scan that
+  fails a gate emits a `SCAN_UNROLL_SKIPPED` warning and keeps today's
+  hard-error behavior; unrolls are recorded as `SCAN_UNROLLED` INFO
+  diagnostics on `ETraceGraph.diagnostics`. Scans that scan *over* a
+  trainable weight (weights as `xs`) are never unrolled
+  (`RELATION_EXCLUDED_SLICED_WEIGHT` warning) — per-slice trace lineage is
+  deferred.
+- **Cond gate revision**: a branch containing a scan no longer blocks
+  if-conversion when that scan is itself unrollable; `scan_unroll_limit=0`
+  disables unrolling and restores the exact Phase 1 gating.
+- **Tied-weight invariant locked**: one `ParamState` consumed by several
+  ETP call sites (which unrolling multiplies) is keyed per relation
+  instance with per-path gradient accumulation — verified BPTT-exact and
+  now covered by regression tests.
+
 #### New: `cond` if-conversion (compiler canonicalization, Phase 1)
 
 - **ETP operations inside `lax.cond` branches now participate in online


### PR DESCRIPTION
## Summary

Phase 2 of ETP control-flow support: **inner-`scan` unrolling** in the compiler
canonicalization pass, so ETP operations inside `lax.scan` /
`brainstate.transform.for_loop` bodies now participate in online learning.

This continues the control-flow line after Phase 0 (vmap, #124) and Phase 1
(`cond` if-conversion, #125).

## What changed

- **`unroll_inner_scans` (`_compiler/canonicalize.py`)** — a new
  canonicalization pass run at extraction time. It replaces every ETP-relevant,
  statically short scan with its unrolled body: one cloned copy per iteration
  with fresh variables, `xs` sliced per step, consumed `ys` re-stacked via
  `broadcast_in_dim` + `concatenate`, and `reverse=True` respected. The unrolled
  program is value- and Jacobian-identical to the scan.
- **Joint control-flow fixpoint (`canonicalize_control_flow`)** — `cond` and
  `scan` canonicalization now run together to a fixpoint, so a `cond` inside a
  scan body (and an eligible scan inside a `cond` branch) both flatten.
  `extract_module_info` calls this instead of the Phase 1 `if_convert_conds`.
- **Eligibility gates** — only scans whose static `length` ≤
  `ControlFlowPolicy.scan_unroll_limit` (default 16), with no effects and no
  inner `while`, are unrolled. Ineligible ETP-relevant scans emit
  `SCAN_UNROLL_SKIPPED` and keep the pre-existing hard-error behavior; unrolls
  are recorded as `SCAN_UNROLLED` INFO diagnostics. Scans *over* a trainable
  weight (weights as `xs`) are never unrolled (`RELATION_EXCLUDED_SLICED_WEIGHT`).
- **Learning-signal aliasing fix in the unroller** — the final iteration writes
  the original scan carry outvars directly from the cloned body equations, so
  stacked-`ys` broadcasts consume the hidden outvar itself (otherwise per-step
  loss sensitivities vanish onto a dead identity copy).
- **Invariants preserved** — the weight→weight→hidden invariant holds across
  unrolled sub-steps (only the last sub-step's ETP ops become relations); tied
  weights (one `ParamState` across several ETP call sites) are keyed per relation
  instance with per-path gradient accumulation.

## Correctness

`oracle_models.scan_body_rnn` (a tanh RNN whose per-step update is an inner
`for_loop` of ETP sub-steps) is registered in the exact-correctness matrix: all
four exact algorithms (D-RTRL, full-rank pp_prop, EProp(k=0), OSTLRecurrent)
match the BPTT oracle element-wise on the unrolled program. Integration tests
(`TestScanModelCompilation`) verify the scan eqn is gone after extraction,
relation parity with a hand-unrolled twin, the `SCAN_UNROLLED` diagnostic, that
`scan_unroll_limit=0` restores the exact Phase 1 hard error, and D-RTRL gradient
parity between scan and flat models. An ETP-relevant `while_loop` still
hard-errors (untouched by canonicalization).

## Testing

Full suite green on CPU: **1883 passed, 3 skipped, 4 deselected** (~6m51s).

## Scope

Files: `_compiler/{canonicalize,module_info,diagnostics,scenario_catalog,__init__}.py`
(+ tests), `_algorithm/oracle_models.py`, `_algorithm/tests/exact_correctness_test.py`,
`__init___test.py`, `changelog.md`. `while` loops remain unsupported.
