### PR TITLE
while support: weight-free opaque-forward while loops in etrace compilation (Phase 3)

### DIFF
--- a/braintrace/_algorithm/oracle_models.py
+++ b/braintrace/_algorithm/oracle_models.py
@@ -308,3 +308,77 @@ def scan_body_rnn(n_rec: int = 4, loops: int = 3, seed: int = 0) -> ModelSpec:
         return Net()
 
     return ModelSpec(factory=factory, etp_param_keys=(('w',),), plain_param_keys=())
+
+
+def while_settle_rnn(
+    n_in: int = 3, n_rec: int = 4, k: int = 3, decay: float = 0.8, seed: int = 0
+) -> ModelSpec:
+    """Leaky drive followed by a **weight-free** ``lax.while_loop`` settle.
+
+    ``pre = matmul(x, win) + decay * h_prev`` (ETP input weight, plain leak),
+    then ``k`` settle iterations ``h <- h + 0.5 * tanh(pre - h)`` inside a
+    ``lax.while_loop`` starting from ``h_prev``. The loop consumes only
+    weight-*derived* values, so the compiler keeps it as an opaque forward
+    node (Phase 3 ``while_hidden='opaque-fwd'``): hidden Jacobians are
+    extracted in forward mode and the perturbation pass detaches the loop
+    inputs. :func:`while_settle_twin_rnn` with the same ``seed`` builds the
+    mathematically identical model with the loop hand-composed, so the pair
+    isolates the while-specific machinery.
+    """
+
+    def factory():
+        class Net(brainstate.nn.Module):
+            def __init__(self):
+                super().__init__()
+                with brainstate.random.seed_context(seed):
+                    self.win = brainstate.ParamState(
+                        0.1 * brainstate.random.randn(n_in, n_rec)
+                    )
+                self.h = brainstate.HiddenState(jnp.zeros((1, n_rec)))
+
+            def update(self, x):
+                h_prev = self.h.value
+                pre = braintrace.matmul(x.reshape(1, -1), self.win.value) + decay * h_prev
+
+                def body(s):
+                    i, h = s
+                    return i + 1, h + 0.5 * jnp.tanh(pre - h)
+
+                _, h_new = jax.lax.while_loop(lambda s: s[0] < k, body, (0, h_prev))
+                self.h.value = h_new
+                return h_new
+
+        return Net()
+
+    return ModelSpec(factory=factory, etp_param_keys=(('win',),), plain_param_keys=())
+
+
+def while_settle_twin_rnn(
+    n_in: int = 3, n_rec: int = 4, k: int = 3, decay: float = 0.8, seed: int = 0
+) -> ModelSpec:
+    """Hand-composed twin of :func:`while_settle_rnn` (same ``seed`` gives
+    identical weights): the fixed-trip-count while is replaced by its
+    ``k``-fold composition, so reverse-mode oracles (BPTT) apply."""
+
+    def factory():
+        class Net(brainstate.nn.Module):
+            def __init__(self):
+                super().__init__()
+                with brainstate.random.seed_context(seed):
+                    self.win = brainstate.ParamState(
+                        0.1 * brainstate.random.randn(n_in, n_rec)
+                    )
+                self.h = brainstate.HiddenState(jnp.zeros((1, n_rec)))
+
+            def update(self, x):
+                h_prev = self.h.value
+                pre = braintrace.matmul(x.reshape(1, -1), self.win.value) + decay * h_prev
+                h = h_prev
+                for _ in range(k):
+                    h = h + 0.5 * jnp.tanh(pre - h)
+                self.h.value = h
+                return h
+
+        return Net()
+
+    return ModelSpec(factory=factory, etp_param_keys=(('win',),), plain_param_keys=())

--- a/braintrace/_algorithm/tests/exact_correctness_test.py
+++ b/braintrace/_algorithm/tests/exact_correctness_test.py
@@ -37,6 +37,7 @@ from braintrace._algorithm.oracle_models import (
     stacked_tanh_rnn,
     tanh_rnn,
     tied_weight_rnn,
+    while_settle_twin_rnn,
 )
 
 ATOL_BPTT = 1e-4
@@ -101,6 +102,10 @@ _EXACT_MULTISTEP_ALGOS = {
 # scan_body exercises the Phase 2 inner-scan unrolling: ETP matmuls inside a
 # `for_loop` body must stay BPTT-exact after the scan is unrolled at
 # extraction time.
+# while_twin anchors the Phase 3 while-hidden equivalence to ground truth: it
+# is the hand-composed (no-while) twin of while_settle_rnn, so proving
+# twin == BPTT here plus while == twin (while_support_test.py, single-step)
+# chains the while model to the oracle.
 _EXACT_CASES = (
     [('tanh_rnn', a) for a in _EXACT_MULTISTEP_ALGOS]
     + [('stacked_tanh_rnn', a) for a in _EXACT_MULTISTEP_ALGOS]
@@ -108,6 +113,7 @@ _EXACT_CASES = (
     + [('scan_body', a) for a in _EXACT_MULTISTEP_ALGOS]
     + [('leaky_linear', 'D_RTRL')]
     + [('cond_gate', 'D_RTRL')]
+    + [('while_twin', 'D_RTRL'), ('while_twin', 'pp_prop_full')]
 )
 
 
@@ -124,6 +130,8 @@ def _model_spec(name):
         return tied_weight_rnn(n_rec=3, seed=0)
     if name == 'scan_body':
         return scan_body_rnn(n_rec=3, loops=3, seed=0)
+    if name == 'while_twin':
+        return while_settle_twin_rnn(n_in=3, n_rec=4, seed=0)
     raise KeyError(name)
 
 

--- a/braintrace/_algorithm/tests/while_support_test.py
+++ b/braintrace/_algorithm/tests/while_support_test.py
@@ -1,0 +1,179 @@
+# Copyright 2026 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Phase 3 while-hidden support: algorithm-level equivalence + negative pins.
+
+**Primary equivalence.** ``while_settle_rnn`` and ``while_settle_twin_rnn``
+(same seed) are the same math — the only differences are the compiler
+machinery Phase 3 added for the while path: forward-mode instead of
+reverse-mode hidden-Jacobian extraction, and the ``stop_gradient`` detach of
+the loop inputs in the perturbed jaxpr. D_RTRL with the default single-step
+VJP must therefore produce element-wise identical gradients on the pair over
+a T=6 sequence; any mismatch is a Phase 3 bug, not an approximation.
+
+**Ground-truth anchor.** The twin (no while, plain unrolled composition) is
+registered in ``exact_correctness_test.py``'s ``_EXACT_CASES`` so its
+multi-step D_RTRL / pp_prop_full gradients are checked against the BPTT
+oracle. That anchors the primary assertion above to ground truth.
+
+**Negative pins.**
+
+- A weight used *through an ETP primitive* inside a while body is a hard
+  compile error (``WEIGHT_IN_WHILE``).
+- An ETP primitive inside a while body without a tracked weight invar is
+  rejected by the relation-pass hardening under the default policy
+  (``etp_in_control_flow='error'``).
+- ``vjp_method='multi-step'`` on the while model hits JAX's structural
+  reverse-through-``while_loop`` ``ValueError`` — the documented limitation;
+  the single-step path is the supported one (its learning signal comes
+  exclusively from the perturbation cotangents, which the detach keeps
+  exact).
+"""
+
+import brainstate
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+import braintrace
+from braintrace._algorithm.oracle import (
+    assert_param_gradients_close,
+    online_param_gradients,
+    online_param_gradients_singlestep_naive,
+)
+from braintrace._algorithm.oracle_models import (
+    while_settle_rnn,
+    while_settle_twin_rnn,
+)
+
+ATOL_EQUIV = 1e-5
+
+
+def _inputs(T, n_in, seed=42):
+    return jnp.asarray(np.random.RandomState(seed).randn(T, n_in).astype('float32'))
+
+
+# --- twin contract -------------------------------------------------------------
+
+def test_while_and_twin_share_weights_and_forward_values():
+    """Same seed => identical weights, and the two updates produce identical
+    hidden trajectories (the twin really is the same model minus the while)."""
+    m_while = while_settle_rnn(seed=0).factory()
+    m_twin = while_settle_twin_rnn(seed=0).factory()
+    brainstate.nn.init_all_states(m_while, batch_size=1)
+    brainstate.nn.init_all_states(m_twin, batch_size=1)
+    assert bool(jnp.array_equal(m_while.win.value, m_twin.win.value))
+
+    inputs = _inputs(4, 3)
+    out_w = brainstate.transform.for_loop(m_while.update, inputs)
+    out_t = brainstate.transform.for_loop(m_twin.update, inputs)
+    np.testing.assert_allclose(np.asarray(out_w), np.asarray(out_t), atol=1e-6)
+
+
+# --- primary: single-step D_RTRL while == twin ----------------------------------
+
+def test_d_rtrl_singlestep_while_equals_twin():
+    """D_RTRL (default single-step VJP) total gradient over T=6 on the while
+    model equals the twin element-wise. Isolates the Phase 3 machinery:
+    jacfwd-vs-jacrev extraction and the perturbation detach must be
+    gradient-neutral."""
+    inputs = _inputs(6, 3)
+    g_while = online_param_gradients_singlestep_naive(
+        while_settle_rnn(seed=0).factory, inputs, algo_factory=braintrace.D_RTRL
+    )
+    g_twin = online_param_gradients_singlestep_naive(
+        while_settle_twin_rnn(seed=0).factory, inputs, algo_factory=braintrace.D_RTRL
+    )
+    assert_param_gradients_close(g_while, g_twin, atol=ATOL_EQUIV)
+
+
+# --- negative: weight-in-while is a hard compile error --------------------------
+
+class _WeightInWhileNet(brainstate.nn.Module):
+    """Recurrent ETP matmul INSIDE the while body — must be rejected."""
+
+    def __init__(self, n_rec: int = 4):
+        super().__init__()
+        with brainstate.random.seed_context(0):
+            self.w = brainstate.ParamState(0.1 * brainstate.random.randn(n_rec, n_rec))
+        self.h = brainstate.HiddenState(jnp.zeros((1, n_rec)))
+
+    def update(self, x):
+        def body(s):
+            i, h = s
+            return i + 1, jnp.tanh(braintrace.matmul(h, self.w.value))
+
+        _, h_new = jax.lax.while_loop(lambda s: s[0] < 3, body, (0, self.h.value))
+        self.h.value = h_new
+        return h_new
+
+
+def test_weight_in_while_raises_at_compile():
+    model = _WeightInWhileNet()
+    brainstate.nn.init_all_states(model, batch_size=1)
+    with pytest.raises(NotImplementedError, match='while'):
+        braintrace.compile_etrace_graph(model, jnp.ones((3,), dtype='float32'))
+
+
+# --- negative: ETP primitive in while without a weight invar --------------------
+
+class _EtpConstInWhileNet(brainstate.nn.Module):
+    """ETP matmul applied to a plain CONSTANT matrix inside the while body: no
+    tracked weight invar enters the loop (so ``WEIGHT_IN_WHILE`` cannot fire),
+    but the un-flattened ETP primitive must still be rejected by the
+    relation-pass hardening under the default policy."""
+
+    def __init__(self, n_rec: int = 4):
+        super().__init__()
+        with brainstate.random.seed_context(1):
+            self.win = brainstate.ParamState(0.1 * brainstate.random.randn(3, n_rec))
+        self.h = brainstate.HiddenState(jnp.zeros((1, n_rec)))
+        self._const_w = 0.1 * jnp.ones((n_rec, n_rec))
+
+    def update(self, x):
+        pre = braintrace.matmul(x.reshape(1, -1), self.win.value)
+        const_w = self._const_w
+
+        def body(s):
+            i, h = s
+            return i + 1, jnp.tanh(pre + braintrace.matmul(h, const_w))
+
+        _, h_new = jax.lax.while_loop(lambda s: s[0] < 3, body, (0, self.h.value))
+        self.h.value = h_new
+        return h_new
+
+
+def test_etp_primitive_in_while_raises_under_default_policy():
+    model = _EtpConstInWhileNet()
+    brainstate.nn.init_all_states(model, batch_size=1)
+    with pytest.raises(NotImplementedError, match='could not flatten'):
+        braintrace.compile_etrace_graph(model, jnp.ones((3,), dtype='float32'))
+
+
+# --- negative: multi-step VJP hits reverse-through-while (documented limit) -----
+
+def test_multistep_vjp_on_while_model_raises_reverse_through_while():
+    """Pin the current failure mode: the multi-step VJP path differentiates in
+    reverse through the step function, and JAX structurally rejects
+    reverse-mode through ``lax.while_loop``. The single-step path is the
+    supported one for while-hidden models."""
+    spec = while_settle_rnn(seed=0)
+    inputs = _inputs(6, 3)
+    with pytest.raises(ValueError, match='while_loop'):
+        online_param_gradients(
+            spec.factory, inputs,
+            algo_factory=lambda m: braintrace.D_RTRL(m, vjp_method='multi-step'),
+        )

--- a/braintrace/_algorithm/tests/while_support_test.py
+++ b/braintrace/_algorithm/tests/while_support_test.py
@@ -37,10 +37,19 @@ oracle. That anchors the primary assertion above to ground truth.
   (``etp_in_control_flow='error'``).
 - ``vjp_method='multi-step'`` on the while model hits JAX's structural
   reverse-through-``while_loop`` ``ValueError`` — the documented limitation;
-  the single-step path is the supported one (its learning signal comes
-  exclusively from the perturbation cotangents, which the detach keeps
-  exact).
+  the single-step path is the supported one (the loop's own hidden group's
+  learning signal comes exclusively from the perturbation cotangents, which
+  the detach keeps exact).
+- **Detach scope limitation (pinned as documented behavior):** the detach
+  zeroes every same-step reverse path *through* the loop, so an upstream
+  trainable layer whose only path to the loss crosses a while-hidden layer
+  receives an exactly-zero learning signal — its gradient is zero while the
+  twin's is not. Stacking trainable layers behind a while-hidden layer is
+  therefore unsupported for upstream credit; the compile emits a
+  WARNING-level ``CONTROL_FLOW_OPAQUE_FWD`` diagnostic for each detach.
 """
+
+import warnings
 
 import brainstate
 import jax
@@ -177,3 +186,71 @@ def test_multistep_vjp_on_while_model_raises_reverse_through_while():
             spec.factory, inputs,
             algo_factory=lambda m: braintrace.D_RTRL(m, vjp_method='multi-step'),
         )
+
+
+# --- documented limitation: upstream layer behind a while-hidden layer ----------
+
+class _StackedWhileNet(brainstate.nn.Module):
+    """Layer 1: tanh RNN (ETP ``w1``) feeding layer 2: while-settle (ETP
+    ``w2``). ``while_layer=False`` replaces the loop with its hand-composed
+    ``k``-fold twin; the same seed gives both variants identical weights."""
+
+    def __init__(self, n_in: int = 3, n_rec: int = 4, k: int = 3,
+                 decay: float = 0.8, while_layer: bool = True):
+        super().__init__()
+        self.k = k
+        self.decay = decay
+        self.while_layer = while_layer
+        with brainstate.random.seed_context(2):
+            self.w1 = brainstate.ParamState(0.1 * brainstate.random.randn(n_in, n_rec))
+            self.w2 = brainstate.ParamState(0.1 * brainstate.random.randn(n_rec, n_rec))
+        self.h1 = brainstate.HiddenState(jnp.zeros((1, n_rec)))
+        self.h2 = brainstate.HiddenState(jnp.zeros((1, n_rec)))
+
+    def update(self, x):
+        x_row = x.reshape(1, -1)
+        self.h1.value = jnp.tanh(
+            braintrace.matmul(x_row, self.w1.value) + 0.5 * self.h1.value
+        )
+        pre = braintrace.matmul(self.h1.value, self.w2.value) + self.decay * self.h2.value
+        h_prev = self.h2.value
+        if self.while_layer:
+            def body(s):
+                i, h = s
+                return i + 1, h + 0.5 * jnp.tanh(pre - h)
+
+            _, h_new = jax.lax.while_loop(lambda s: s[0] < self.k, body, (0, h_prev))
+        else:
+            h_new = h_prev
+            for _ in range(self.k):
+                h_new = h_new + 0.5 * jnp.tanh(pre - h_new)
+        self.h2.value = h_new
+        return h_new
+
+
+def test_upstream_layer_gradient_is_zero_behind_while_DOCUMENTED_LIMITATION():
+    """The perturbation detach zeroes every same-step reverse path THROUGH the
+    loop: the upstream layer's weight ``w1`` (whose only path to the loss
+    crosses the while) gets an exactly-zero gradient, while the twin's is
+    substantially nonzero. The while layer's own weight ``w2`` still matches
+    the twin exactly. This is the documented while-hidden limitation, not an
+    approximation — a WARNING-level CONTROL_FLOW_OPAQUE_FWD diagnostic is
+    emitted at compile time for each detach."""
+    inputs = _inputs(6, 3)
+
+    def grads(while_layer):
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', UserWarning)
+            return online_param_gradients_singlestep_naive(
+                lambda: _StackedWhileNet(while_layer=while_layer),
+                inputs,
+                algo_factory=braintrace.D_RTRL,
+            )
+
+    g_while = grads(True)
+    g_twin = grads(False)
+    # the while layer's own weight: exact match with the twin
+    assert_param_gradients_close(g_while, g_twin, atol=ATOL_EQUIV, keys=[('w2',)])
+    # the upstream weight: exactly zero under the while model, nonzero in the twin
+    assert bool(jnp.all(jnp.asarray(g_while[('w1',)]) == 0))
+    assert float(jnp.max(jnp.abs(jnp.asarray(g_twin[('w1',)])))) > 1e-4

--- a/braintrace/_compatible_imports.py
+++ b/braintrace/_compatible_imports.py
@@ -43,10 +43,16 @@ try:
 except ImportError:  # future JAX relocation: recover the primitive by tracing
     import jax.numpy as _jnp
 
-    stop_gradient_p = jax.make_jaxpr(jax.lax.stop_gradient)(
-        _jnp.zeros((1,))
-    ).jaxpr.eqns[0].primitive
-    assert stop_gradient_p.name == 'stop_gradient'
+    _probe_eqns = jax.make_jaxpr(jax.lax.stop_gradient)(_jnp.zeros((1,))).jaxpr.eqns
+    if len(_probe_eqns) != 1 or _probe_eqns[0].primitive.name != 'stop_gradient':
+        raise ImportError(
+            'Could not locate the stop_gradient primitive: jax._src.ad_util no '
+            'longer exposes stop_gradient_p and tracing jax.lax.stop_gradient '
+            f'produced {[e.primitive.name for e in _probe_eqns]} instead of a '
+            'single stop_gradient equation. Update braintrace._compatible_imports '
+            'for this JAX version.'
+        )
+    stop_gradient_p = _probe_eqns[0].primitive
 
 
 def new_var(suffix, aval):

--- a/braintrace/_compatible_imports.py
+++ b/braintrace/_compatible_imports.py
@@ -24,6 +24,7 @@ __all__ = [
     'Literal',
     'new_var',
     'new_jaxpr_eqn',
+    'stop_gradient_p',
     'is_jit_primitive',
     'is_scan_primitive',
     'is_while_primitive',
@@ -36,6 +37,16 @@ try:
     from jax.extend.core import new_jaxpr_eqn
 except ImportError:  # older JAX exposes it on jax.core only
     from jax.core import new_jaxpr_eqn
+
+try:
+    from jax._src.ad_util import stop_gradient_p
+except ImportError:  # future JAX relocation: recover the primitive by tracing
+    import jax.numpy as _jnp
+
+    stop_gradient_p = jax.make_jaxpr(jax.lax.stop_gradient)(
+        _jnp.zeros((1,))
+    ).jaxpr.eqns[0].primitive
+    assert stop_gradient_p.name == 'stop_gradient'
 
 
 def new_var(suffix, aval):

--- a/braintrace/_compiler/base.py
+++ b/braintrace/_compiler/base.py
@@ -28,6 +28,7 @@ from braintrace._op import (
     is_etp_enable_gradient_primitive,
 )
 from braintrace._typing import Path
+from .canonicalize import ControlFlowPolicy, DEFAULT_CONTROL_FLOW_POLICY
 from .diagnostics import DiagnosticKind, DiagnosticLevel, emit
 
 __all__ = [
@@ -102,7 +103,10 @@ def check_unsupported_op(
     Parameters
     ----------
     self : JaxprEvaluation
-        The instance of the class containing this method.
+        The instance of the class containing this method. Its optional
+        ``control_flow`` attribute (a :class:`ControlFlowPolicy`) governs
+        the hidden-state branch; instances without the attribute behave as
+        the default policy.
     eqn : JaxprEqn
         The JAX equation to be checked.
     op_name : str
@@ -111,15 +115,45 @@ def check_unsupported_op(
     Raises
     ------
     NotImplementedError
-        If the equation uses weight variables or computes hidden state variables
-        in an unsupported manner.
+        If the equation uses weight variables, or computes hidden state
+        variables in an unsupported manner (``jit`` regions always; opaque
+        control flow when ``control_flow.while_hidden == 'error'``).
+    ValueError
+        If ``control_flow.while_hidden`` is not ``'opaque-fwd'`` or
+        ``'error'``.
     """
+    policy = getattr(self, 'control_flow', DEFAULT_CONTROL_FLOW_POLICY)
+
     # checking whether the weight variables are used in the equation
     # Note: user ``jax.jit`` boundaries are inlined at extraction time
     # (see ``jaxpr_graph.inline_jit_calls``), so reaching this check means
     # a weight is used inside a genuinely opaque region (scan/while/cond).
     invar = find_element_exist_in_the_set(eqn.invars, self.weight_invars)
     if invar is not None:
+        if op_name == 'while':
+            # A while body has no fixed trip count, so there is no
+            # per-iteration hoisting that could connect the weight to the
+            # hidden states — always a hard error with its own kind.
+            guidance = (
+                'Weight state used inside a while loop; while bodies cannot '
+                'participate in online learning (a data-dependent trip count '
+                'admits no fixed per-iteration decomposition). Restructure '
+                'the loop, use a fixed-length scan/for_loop (which the '
+                'compiler unrolls), or apply the weight through a plain '
+                '(non-ETP) op to exclude it from ETP.'
+            )
+            emit(
+                kind=DiagnosticKind.WEIGHT_IN_WHILE,
+                level=DiagnosticLevel.ERROR,
+                message=guidance,
+                context={'op_name': op_name, 'invar': invar},
+            )
+            raise NotImplementedError(
+                f'{guidance} \n\n'
+                f'The weight state variable is: {invar}. \n'
+                f'The Jaxpr of the while function is: \n\n'
+                f'{eqn} \n\n'
+            )
         emit(
             kind=DiagnosticKind.WEIGHT_IN_CONTROL_FLOW,
             level=DiagnosticLevel.ERROR,
@@ -140,6 +174,33 @@ def check_unsupported_op(
     # checking whether the hidden variables are computed in the equation
     outvar = find_element_exist_in_the_set(eqn.outvars, self.hidden_outvars)
     if outvar is not None:
+        if op_name in ('scan', 'while', 'cond'):
+            if policy.while_hidden == 'opaque-fwd':
+                # Weight-free control flow producing a hidden state is kept
+                # as an opaque forward node: the transition embeds the whole
+                # equation and its Jacobian is extracted in forward mode.
+                emit(
+                    kind=DiagnosticKind.CONTROL_FLOW_OPAQUE_FWD,
+                    level=DiagnosticLevel.INFO,
+                    message=(
+                        f'Hidden state {self.outvar_to_hidden_path[outvar]} is '
+                        f'produced by an opaque {op_name} with no weight inside; '
+                        f'treating it as an opaque forward node (forward-mode '
+                        f'Jacobians; reverse-mode signals through it are detached '
+                        f'in the perturbed jaxpr for while).'
+                    ),
+                    context={
+                        'op_name': op_name,
+                        'evaluator': type(self).__name__,
+                        'hidden_path': self.outvar_to_hidden_path[outvar],
+                    },
+                )
+                return
+            if policy.while_hidden != 'error':
+                raise ValueError(
+                    f"policy.while_hidden must be 'opaque-fwd' or 'error', "
+                    f'got {policy.while_hidden!r}.'
+                )
         raise NotImplementedError(
             f'Currently, we do not support the hidden states are computed within a {op_name} function. \n'
             f'Please remove your {op_name} on the intermediate steps. \n\n'
@@ -172,6 +233,10 @@ class JaxprEvaluation(object):
         Mapping from input variables to their paths in the hidden state hierarchy.
     outvar_to_hidden_path : Dict[Var, Path]
         Mapping from output variables to their paths in the hidden state hierarchy.
+    control_flow : ControlFlowPolicy, optional
+        Policy governing opaque control-flow handling (see
+        :class:`~braintrace.ControlFlowPolicy`). Keyword-only. Defaults to
+        the package default policy.
 
     Attributes
     ----------
@@ -185,6 +250,8 @@ class JaxprEvaluation(object):
         Stored mapping from input variables to hidden paths.
     outvar_to_hidden_path : Dict[Var, Path]
         Stored mapping from output variables to hidden paths.
+    control_flow : ControlFlowPolicy
+        Stored control-flow policy.
     """
     __module__ = 'braintrace'
 
@@ -195,12 +262,15 @@ class JaxprEvaluation(object):
         hidden_outvars: Set[Var],
         invar_to_hidden_path: Dict[Var, Path],
         outvar_to_hidden_path: Dict[Var, Path],
+        *,
+        control_flow: ControlFlowPolicy = DEFAULT_CONTROL_FLOW_POLICY,
     ):
         self.weight_invars = weight_invars
         self.hidden_invars = hidden_invars
         self.hidden_outvars = hidden_outvars
         self.invar_to_hidden_path = invar_to_hidden_path
         self.outvar_to_hidden_path = outvar_to_hidden_path
+        self.control_flow = control_flow
 
     def _eval_jaxpr(self, jaxpr) -> None:
         """

--- a/braintrace/_compiler/base.py
+++ b/braintrace/_compiler/base.py
@@ -137,10 +137,14 @@ def check_unsupported_op(
             guidance = (
                 'Weight state used inside a while loop; while bodies cannot '
                 'participate in online learning (a data-dependent trip count '
-                'admits no fixed per-iteration decomposition). Restructure '
-                'the loop, use a fixed-length scan/for_loop (which the '
-                'compiler unrolls), or apply the weight through a plain '
-                '(non-ETP) op to exclude it from ETP.'
+                'admits no fixed per-iteration decomposition). Move the '
+                'weight application outside the loop so the loop consumes '
+                'only its result, or use a fixed-length scan/for_loop (which '
+                'the compiler unrolls). Note that a hidden-producing while '
+                'drops same-step reverse-mode credit through its inputs: a '
+                'parameter whose only same-step path to the loss crosses the '
+                'loop receives a zero learning signal (see the while-hidden '
+                'limitation in the changelog).'
             )
             emit(
                 kind=DiagnosticKind.WEIGHT_IN_WHILE,

--- a/braintrace/_compiler/base_test.py
+++ b/braintrace/_compiler/base_test.py
@@ -34,6 +34,12 @@ from braintrace._compiler.base import (
     check_unsupported_op,
     JaxprEvaluation,
 )
+from braintrace._compiler.canonicalize import ControlFlowPolicy
+from braintrace._compiler.diagnostics import (
+    DiagnosticKind,
+    DiagnosticLevel,
+    diagnostic_context,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -245,6 +251,8 @@ class TestCheckUnsupportedOp(unittest.TestCase):
         self.assertIn('weight states', str(ctx.exception))
 
     def test_hidden_var_in_outvars_raises(self):
+        """With ``while_hidden='error'`` (the pre-Phase-3 behaviour), a hidden
+        state produced by an opaque control-flow equation still raises."""
         v_in = _make_var(0)
         h_out = _make_var(1)
         eqn = _make_eqn([v_in], [h_out])
@@ -252,6 +260,7 @@ class TestCheckUnsupportedOp(unittest.TestCase):
             hidden_outvars={h_out},
             outvar_to_hidden_path={h_out: ('layer', 'hidden')},
         )
+        obj.control_flow = ControlFlowPolicy(while_hidden='error')
         with self.assertRaises(NotImplementedError) as ctx:
             check_unsupported_op(obj, eqn, 'while')
         self.assertIn('while', str(ctx.exception))
@@ -311,6 +320,120 @@ class TestCheckUnsupportedOp(unittest.TestCase):
         check_unsupported_op(obj, eqn, 'scan')
 
 
+class TestCheckUnsupportedOpPhase3(unittest.TestCase):
+    """Phase 3 control-flow policy: while-specific weight error, and the
+    opaque-forward relaxation for weight-free hidden-producing control flow."""
+
+    def _hidden_obj(self, h_out, **overrides):
+        return _make_evaluator(
+            hidden_outvars={h_out},
+            outvar_to_hidden_path={h_out: ('layer', 'hidden')},
+            **overrides,
+        )
+
+    def test_weight_in_while_raises_actionable_error(self):
+        """A weight consumed by a ``while`` raises with guidance (mentions
+        'while' and the fixed-length-scan alternative) and emits the
+        dedicated ``WEIGHT_IN_WHILE`` kind, not the generic one."""
+        w = _make_var(0)
+        eqn = _make_while_eqn([w], [_make_var(1)])
+        obj = _make_evaluator(weight_invars={w})
+        with diagnostic_context() as reporter:
+            with self.assertRaises(NotImplementedError) as ctx:
+                check_unsupported_op(obj, eqn, 'while')
+        msg = str(ctx.exception)
+        self.assertIn('while', msg)
+        self.assertIn('fixed-length', msg)
+        kinds = [r.kind for r in reporter.records()]
+        self.assertIn(DiagnosticKind.WEIGHT_IN_WHILE, kinds)
+        self.assertNotIn(DiagnosticKind.WEIGHT_IN_CONTROL_FLOW, kinds)
+        record = reporter.records()[0]
+        self.assertIs(record.level, DiagnosticLevel.ERROR)
+
+    def test_weight_in_scan_keeps_generic_kind(self):
+        """Weight-in-scan/cond keeps the pre-existing generic diagnostic."""
+        w = _make_var(0)
+        for factory, op_name in [(_make_scan_eqn, 'scan'), (_make_cond_eqn, 'cond')]:
+            eqn = factory([w], [_make_var(1)])
+            obj = _make_evaluator(weight_invars={w})
+            with diagnostic_context() as reporter:
+                with self.assertRaises(NotImplementedError):
+                    check_unsupported_op(obj, eqn, op_name)
+            kinds = [r.kind for r in reporter.records()]
+            self.assertIn(DiagnosticKind.WEIGHT_IN_CONTROL_FLOW, kinds)
+            self.assertNotIn(DiagnosticKind.WEIGHT_IN_WHILE, kinds)
+
+    def test_hidden_from_control_flow_default_policy_is_opaque_fwd(self):
+        """Under the default policy, a weight-free while/scan/cond producing a
+        hidden state does NOT raise; an INFO ``CONTROL_FLOW_OPAQUE_FWD``
+        record is emitted instead."""
+        for factory, op_name in [
+            (_make_while_eqn, 'while'),
+            (_make_scan_eqn, 'scan'),
+            (_make_cond_eqn, 'cond'),
+        ]:
+            h_out = _make_var(1)
+            eqn = factory([_make_var(0)], [h_out])
+            obj = self._hidden_obj(h_out)
+            with diagnostic_context() as reporter:
+                check_unsupported_op(obj, eqn, op_name)  # must not raise
+            records = [
+                r for r in reporter.records()
+                if r.kind is DiagnosticKind.CONTROL_FLOW_OPAQUE_FWD
+            ]
+            self.assertEqual(len(records), 1, f'op={op_name}')
+            self.assertIs(records[0].level, DiagnosticLevel.INFO)
+            self.assertEqual(records[0].context['op_name'], op_name)
+            self.assertEqual(records[0].context['hidden_path'], ('layer', 'hidden'))
+
+    def test_hidden_from_while_error_policy_raises(self):
+        """``while_hidden='error'`` restores the pre-Phase-3 hard error."""
+        h_out = _make_var(1)
+        eqn = _make_while_eqn([_make_var(0)], [h_out])
+        obj = self._hidden_obj(
+            h_out, control_flow=ControlFlowPolicy(while_hidden='error')
+        )
+        with self.assertRaises(NotImplementedError) as ctx:
+            check_unsupported_op(obj, eqn, 'while')
+        self.assertIn('hidden states', str(ctx.exception))
+
+    def test_hidden_from_jit_still_raises(self):
+        """The opaque-forward relaxation applies only to scan/while/cond; a
+        hidden state produced by an opaque jit region still raises."""
+        h_out = _make_var(1)
+        eqn = _make_jit_eqn([_make_var(0)], [h_out])
+        obj = self._hidden_obj(h_out)
+        with self.assertRaises(NotImplementedError):
+            check_unsupported_op(obj, eqn, 'jit')
+
+    def test_bogus_while_hidden_raises_value_error(self):
+        """An invalid ``while_hidden`` value is a use-site ``ValueError``."""
+        h_out = _make_var(1)
+        eqn = _make_while_eqn([_make_var(0)], [h_out])
+        obj = self._hidden_obj(
+            h_out, control_flow=ControlFlowPolicy(while_hidden='bogus')
+        )
+        with self.assertRaises(ValueError) as ctx:
+            check_unsupported_op(obj, eqn, 'while')
+        self.assertIn('while_hidden', str(ctx.exception))
+
+    def test_object_without_control_flow_attr_uses_default(self):
+        """Callers that never set ``control_flow`` (e.g. hand-rolled mock
+        objects) behave as the default policy."""
+
+        class Bare:
+            weight_invars = set()
+            hidden_outvars = None
+            outvar_to_hidden_path = None
+
+        h_out = _make_var(1)
+        obj = Bare()
+        obj.hidden_outvars = {h_out}
+        obj.outvar_to_hidden_path = {h_out: ('h',)}
+        eqn = _make_while_eqn([_make_var(0)], [h_out])
+        check_unsupported_op(obj, eqn, 'while')  # must not raise
+
+
 # ===========================================================================
 # Tests for JaxprEvaluation
 # ===========================================================================
@@ -344,6 +467,16 @@ class TestJaxprEvaluationInit(unittest.TestCase):
         self.assertEqual(evaluator.hidden_outvars, set())
         self.assertEqual(evaluator.invar_to_hidden_path, {})
         self.assertEqual(evaluator.outvar_to_hidden_path, {})
+
+    def test_default_control_flow_policy_stored(self):
+        from braintrace._compiler.canonicalize import DEFAULT_CONTROL_FLOW_POLICY
+        evaluator = _make_evaluator()
+        self.assertIs(evaluator.control_flow, DEFAULT_CONTROL_FLOW_POLICY)
+
+    def test_custom_control_flow_policy_stored(self):
+        policy = ControlFlowPolicy(while_hidden='error')
+        evaluator = _make_evaluator(control_flow=policy)
+        self.assertIs(evaluator.control_flow, policy)
 
 
 class TestJaxprEvaluationEvalEqn(unittest.TestCase):
@@ -544,11 +677,25 @@ class TestJaxprEvaluationEvalScan(unittest.TestCase):
             evaluator._eval_scan(eqn)
         self.assertIn('scan', str(ctx.exception))
 
-    def test_scan_with_hidden_outvar_raises(self):
+    def test_scan_with_hidden_outvar_default_policy_evaluates(self):
+        """Default policy: a weight-free hidden-producing scan is kept as an
+        opaque forward node and still dispatched to ``_eval_eqn``."""
         h = _make_var(1)
         evaluator = _make_concrete_evaluator(
             hidden_outvars={h},
             outvar_to_hidden_path={h: ('h',)},
+        )
+        eqn = _make_scan_eqn([_make_var(0)], [h])
+
+        evaluator._eval_scan(eqn)
+        self.assertEqual(len(evaluator.evaluated_eqns), 1)
+
+    def test_scan_with_hidden_outvar_error_policy_raises(self):
+        h = _make_var(1)
+        evaluator = _make_concrete_evaluator(
+            hidden_outvars={h},
+            outvar_to_hidden_path={h: ('h',)},
+            control_flow=ControlFlowPolicy(while_hidden='error'),
         )
         eqn = _make_scan_eqn([_make_var(0)], [h])
 
@@ -579,11 +726,25 @@ class TestJaxprEvaluationEvalWhile(unittest.TestCase):
             evaluator._eval_while(eqn)
         self.assertIn('while', str(ctx.exception))
 
-    def test_while_with_hidden_outvar_raises(self):
+    def test_while_with_hidden_outvar_default_policy_evaluates(self):
+        """Default policy: a weight-free hidden-producing while is kept as an
+        opaque forward node and still dispatched to ``_eval_eqn``."""
         h = _make_var(1)
         evaluator = _make_concrete_evaluator(
             hidden_outvars={h},
             outvar_to_hidden_path={h: ('h',)},
+        )
+        eqn = _make_while_eqn([_make_var(0)], [h])
+
+        evaluator._eval_while(eqn)
+        self.assertEqual(len(evaluator.evaluated_eqns), 1)
+
+    def test_while_with_hidden_outvar_error_policy_raises(self):
+        h = _make_var(1)
+        evaluator = _make_concrete_evaluator(
+            hidden_outvars={h},
+            outvar_to_hidden_path={h: ('h',)},
+            control_flow=ControlFlowPolicy(while_hidden='error'),
         )
         eqn = _make_while_eqn([_make_var(0)], [h])
 
@@ -614,11 +775,25 @@ class TestJaxprEvaluationEvalCond(unittest.TestCase):
             evaluator._eval_cond(eqn)
         self.assertIn('cond', str(ctx.exception))
 
-    def test_cond_with_hidden_outvar_raises(self):
+    def test_cond_with_hidden_outvar_default_policy_evaluates(self):
+        """Default policy: a weight-free hidden-producing cond is kept as an
+        opaque forward node and still dispatched to ``_eval_eqn``."""
         h = _make_var(1)
         evaluator = _make_concrete_evaluator(
             hidden_outvars={h},
             outvar_to_hidden_path={h: ('h',)},
+        )
+        eqn = _make_cond_eqn([_make_var(0)], [h])
+
+        evaluator._eval_cond(eqn)
+        self.assertEqual(len(evaluator.evaluated_eqns), 1)
+
+    def test_cond_with_hidden_outvar_error_policy_raises(self):
+        h = _make_var(1)
+        evaluator = _make_concrete_evaluator(
+            hidden_outvars={h},
+            outvar_to_hidden_path={h: ('h',)},
+            control_flow=ControlFlowPolicy(while_hidden='error'),
         )
         eqn = _make_cond_eqn([_make_var(0)], [h])
 

--- a/braintrace/_compiler/canonicalize.py
+++ b/braintrace/_compiler/canonicalize.py
@@ -94,6 +94,25 @@ class ControlFlowPolicy:
         :attr:`~braintrace.DiagnosticKind.SCAN_UNROLL_SKIPPED` warning, and
         the existing control-flow restrictions apply. ``0`` (or negative)
         disables unrolling entirely. Default ``16``.
+    while_hidden : str, optional
+        How an *opaque* control-flow equation (``while``, or a ``scan``/
+        ``cond`` the canonicalizer left opaque) that produces a hidden-state
+        output **without consuming any weight invar** is handled.
+        ``'opaque-fwd'`` (default) keeps it as an opaque forward node: the
+        whole equation is embedded in the hidden-to-hidden transition and
+        its Jacobian is extracted in forward mode (``while`` has no
+        reverse-mode rule), recorded as a
+        :attr:`~braintrace.DiagnosticKind.CONTROL_FLOW_OPAQUE_FWD` INFO
+        diagnostic. ``'error'`` restores the pre-opaque-forward behaviour of
+        raising ``NotImplementedError``.
+    etp_in_control_flow : str, optional
+        How an ETP primitive found *inside* a remaining opaque control-flow
+        body is handled during relation discovery. ``'error'`` (default)
+        raises ``NotImplementedError`` — that weight would otherwise
+        silently drop out of online learning. ``'exclude'`` restores the
+        previous behaviour of a loud warning
+        (:attr:`~braintrace.DiagnosticKind.PRIMITIVE_INSIDE_CONTROL_FLOW`)
+        plus exclusion of the weight from ETP relations.
 
     Notes
     -----
@@ -133,6 +152,8 @@ class ControlFlowPolicy:
 
     cond: str = 'convert'
     scan_unroll_limit: int = 16
+    while_hidden: str = 'opaque-fwd'
+    etp_in_control_flow: str = 'error'
 
 
 DEFAULT_CONTROL_FLOW_POLICY = ControlFlowPolicy()

--- a/braintrace/_compiler/canonicalize_test.py
+++ b/braintrace/_compiler/canonicalize_test.py
@@ -57,6 +57,8 @@ class TestControlFlowPolicy:
     def test_defaults(self):
         assert DEFAULT_CONTROL_FLOW_POLICY.cond == 'convert'
         assert DEFAULT_CONTROL_FLOW_POLICY.scan_unroll_limit == 16
+        assert DEFAULT_CONTROL_FLOW_POLICY.while_hidden == 'opaque-fwd'
+        assert DEFAULT_CONTROL_FLOW_POLICY.etp_in_control_flow == 'error'
 
     def test_opaque_returns_input_unchanged(self):
         def f(x, w):

--- a/braintrace/_compiler/diagnostics.py
+++ b/braintrace/_compiler/diagnostics.py
@@ -104,6 +104,23 @@ class DiagnosticKind(str, Enum):
     SCAN_UNROLL_SKIPPED = 'scan_unroll_skipped'
     RELATION_EXCLUDED_SLICED_WEIGHT = 'relation_excluded_sliced_weight'
 
+    # Opaque control flow touching weights / hidden states (Phase 3)
+    #
+    # ``WEIGHT_IN_WHILE``: a tracked weight invar is consumed by a ``while``
+    # equation — always an ERROR (a data-dependent trip count admits no fixed
+    # per-iteration hoisting, so the weight cannot participate in online
+    # learning).
+    # ``CONTROL_FLOW_OPAQUE_FWD``: a weight-free opaque ``scan``/``while``/
+    # ``cond`` produces a hidden state and is kept as an opaque forward node
+    # (INFO; see ``ControlFlowPolicy.while_hidden``).
+    # ``CONTROL_FLOW_RECURRENT_MIXING``: an opaque control-flow body applies a
+    # recurrent weight-mixing primitive to the carried hidden state, so the
+    # equation is excluded from the hidden-to-hidden transition in the default
+    # ("without recurrence") grouping mode (WARNING).
+    WEIGHT_IN_WHILE = 'weight_in_while'
+    CONTROL_FLOW_OPAQUE_FWD = 'control_flow_opaque_fwd'
+    CONTROL_FLOW_RECURRENT_MIXING = 'control_flow_recurrent_mixing'
+
     # Structural observations (informational / partial)
     PRIMITIVE_INSIDE_NESTED_JIT = 'primitive_inside_nested_jit'
     PRIMITIVE_INSIDE_CONTROL_FLOW = 'primitive_inside_control_flow'

--- a/braintrace/_compiler/diagnostics_test.py
+++ b/braintrace/_compiler/diagnostics_test.py
@@ -43,6 +43,16 @@ from braintrace._op import etp_mm_p, etp_mv_p
 
 class TestDiagnosticsBasics:
 
+    def test_phase3_control_flow_kinds_exist(self):
+        """The Phase 3 while/opaque-forward decisions each have a dedicated
+        machine-readable kind, so tests and users can assert on
+        ``CompilationRecord.kind`` instead of parsing messages."""
+        assert DiagnosticKind.WEIGHT_IN_WHILE.value == 'weight_in_while'
+        assert (DiagnosticKind.CONTROL_FLOW_OPAQUE_FWD.value
+                == 'control_flow_opaque_fwd')
+        assert (DiagnosticKind.CONTROL_FLOW_RECURRENT_MIXING.value
+                == 'control_flow_recurrent_mixing')
+
     def test_graph_has_diagnostics_field(self):
         """``ETraceGraph`` carries a ``diagnostics`` field populated by the
         compiler. Each entry is a :class:`CompilationRecord`."""

--- a/braintrace/_compiler/graph.py
+++ b/braintrace/_compiler/graph.py
@@ -314,13 +314,31 @@ def compile_etrace_graph(
         Jacobian is extracted (RTRL-exact temporal credit, e.g. for
         :class:`~braintrace.OSTLRecurrent` / :class:`~braintrace.OSTTP`).
     control_flow : ControlFlowPolicy or None, optional
-        Policy governing control-flow canonicalization, forwarded to
-        :func:`~braintrace.extract_module_info`. ``None`` (default) uses the
-        default policy, which if-converts every ETP-relevant ``cond`` into
-        inlined branches + ``select_n`` (both branches then execute every
-        step). Pass ``ControlFlowPolicy(cond='opaque')`` to restore the
-        previous behavior (weights inside ``cond`` raise
-        ``NotImplementedError``).
+        Policy governing control-flow canonicalization and downstream
+        handling, forwarded to :func:`~braintrace.extract_module_info` and
+        (via ``ModuleInfo.control_flow``) to every later compiler pass.
+        ``None`` (default) uses the default policy, which:
+
+        - if-converts every ETP-relevant ``cond`` into inlined branches +
+          ``select_n`` (both branches then execute every step); pass
+          ``ControlFlowPolicy(cond='opaque')`` to restore the previous
+          behavior (weights inside ``cond`` raise ``NotImplementedError``);
+        - unrolls every ETP-relevant ``scan`` of static length at most
+          ``scan_unroll_limit`` (default 16);
+        - keeps a **weight-free** ``while`` that reads/updates hidden state
+          as an opaque forward node (``while_hidden='opaque-fwd'``):
+          hidden-to-hidden Jacobians for groups whose transition crosses the
+          loop are extracted in forward mode, and the perturbation pass
+          detaches the loop's inputs with ``stop_gradient`` so the perturbed
+          jaxpr stays reverse-traceable. Pass
+          ``ControlFlowPolicy(while_hidden='error')`` to reject such loops
+          instead. A weight *used through an ETP primitive* inside a
+          ``while`` is always a hard error;
+        - raises on ETP primitives left inside a control-flow body the
+          canonicalizer could not flatten
+          (``etp_in_control_flow='error'``); pass
+          ``ControlFlowPolicy(etp_in_control_flow='exclude')`` to restore
+          the warn-and-exclude behavior.
 
     Returns
     -------

--- a/braintrace/_compiler/hid_param_op.py
+++ b/braintrace/_compiler/hid_param_op.py
@@ -678,6 +678,9 @@ def _scan_jaxpr_for_etp_eqns(
     for eqn in jaxpr.eqns:
         if is_etp_primitive(eqn.primitive):
             if inside_control_flow:
+                # Use-site validation (project precedent): a bogus knob value
+                # only surfaces when an ETP eqn is actually found inside
+                # control flow — models without such eqns never read it.
                 if policy.etp_in_control_flow not in ('error', 'exclude'):
                     raise ValueError(
                         f"policy.etp_in_control_flow must be 'error' or "

--- a/braintrace/_compiler/hid_param_op.py
+++ b/braintrace/_compiler/hid_param_op.py
@@ -70,6 +70,7 @@ from braintrace._op import (
     is_etp_enable_gradient_primitive,
 )
 from braintrace._misc import git_issue_addr
+from .canonicalize import ControlFlowPolicy, DEFAULT_CONTROL_FLOW_POLICY
 from braintrace._typing import (
     Path,
     HiddenOutVar,
@@ -660,20 +661,48 @@ def _scan_jaxpr_for_etp_eqns(
     jaxpr: Jaxpr,
     *,
     inside_control_flow: bool = False,
+    policy: ControlFlowPolicy = DEFAULT_CONTROL_FLOW_POLICY,
 ) -> List[JaxprEqn]:
     """Walk the Jaxpr and return all equations whose primitive is ETP.
 
-    Descends into ``jit``/``pjit`` (transparently) and emits diagnostics
-    when ETP primitives are found inside control-flow primitives
-    (``scan``/``while``/``cond``). Control-flow ETP primitives are *not*
+    Descends into ``jit``/``pjit`` (transparently). ETP primitives found
+    inside control-flow primitives (``scan``/``while``/``cond``) are *not*
     returned to the main relation pass — their semantics (carry vars,
-    branch unification) are not yet fully supported and a structured
-    diagnostic is emitted so users can locate them.
+    branch unification) are not supported. Under the default policy
+    (``etp_in_control_flow='error'``) they raise ``NotImplementedError``
+    after an ERROR-level record, because the weight would otherwise
+    silently drop out of online learning; ``'exclude'`` restores the loud
+    WARNING + exclusion.
     """
     etp_eqns: List[JaxprEqn] = []
     for eqn in jaxpr.eqns:
         if is_etp_primitive(eqn.primitive):
             if inside_control_flow:
+                if policy.etp_in_control_flow not in ('error', 'exclude'):
+                    raise ValueError(
+                        f"policy.etp_in_control_flow must be 'error' or "
+                        f"'exclude', got {policy.etp_in_control_flow!r}."
+                    )
+                if policy.etp_in_control_flow == 'error':
+                    message = (
+                        f'ETP primitive {eqn.primitive.name} found inside a '
+                        f'scan/while/cond body that the compiler could not '
+                        f'flatten. Its weight would silently drop out of '
+                        f'online learning. Restructure the loop, use a '
+                        f'fixed-length scan/for_loop within the unroll '
+                        f'limit, use a plain (non-ETP) op to exclude the '
+                        f'weight, or set '
+                        f"ControlFlowPolicy(etp_in_control_flow='exclude') "
+                        f'to restore the warning-and-exclude behavior.'
+                    )
+                    emit(
+                        kind=DiagnosticKind.PRIMITIVE_INSIDE_CONTROL_FLOW,
+                        level=DiagnosticLevel.ERROR,
+                        also_warn=False,
+                        message=message,
+                        primitive=eqn.primitive,
+                    )
+                    raise NotImplementedError(message)
                 emit(
                     kind=DiagnosticKind.PRIMITIVE_INSIDE_CONTROL_FLOW,
                     level=DiagnosticLevel.WARNING,
@@ -694,6 +723,7 @@ def _scan_jaxpr_for_etp_eqns(
             inner_jaxpr = eqn.params['jaxpr'].jaxpr
             inner_etp = _scan_jaxpr_for_etp_eqns(
                 inner_jaxpr, inside_control_flow=inside_control_flow,
+                policy=policy,
             )
             if inner_etp:
                 emit(
@@ -717,7 +747,7 @@ def _scan_jaxpr_for_etp_eqns(
         elif is_scan_primitive(eqn) or is_while_primitive(eqn) or is_cond_primitive(eqn):
             for sub_jaxpr in _control_flow_subjaxprs(eqn):
                 _scan_jaxpr_for_etp_eqns(
-                    sub_jaxpr, inside_control_flow=True,
+                    sub_jaxpr, inside_control_flow=True, policy=policy,
                 )
     return etp_eqns
 
@@ -751,6 +781,7 @@ def find_hidden_param_op_relations_from_jaxpr(
     outvar_to_hidden_path: Dict[HiddenOutVar, Path],
     hid_path_to_group: Dict[Path, HiddenGroup],
     weight_path_to_invars: Optional[Dict[Path, List[Var]]] = None,
+    control_flow: ControlFlowPolicy = DEFAULT_CONTROL_FLOW_POLICY,
     **_ignored,
 ) -> Sequence[HiddenParamOpRelation]:
     """Find all ETP-primitive-to-hidden-state relations in *jaxpr*."""
@@ -786,7 +817,7 @@ def find_hidden_param_op_relations_from_jaxpr(
         for ov, p in outvar_to_hidden_path.items()
     }
 
-    etp_eqns = _scan_jaxpr_for_etp_eqns(jaxpr)
+    etp_eqns = _scan_jaxpr_for_etp_eqns(jaxpr, policy=control_flow)
     relations: List[HiddenParamOpRelation] = []
 
     for eqn in etp_eqns:
@@ -1090,6 +1121,7 @@ def find_hidden_param_op_relations_from_minfo(
         outvar_to_hidden_path=minfo.outvar_to_hidden_path,
         hid_path_to_group=hid_path_to_group,
         weight_path_to_invars=weight_path_to_invars,
+        control_flow=minfo.control_flow,
     )
 
 

--- a/braintrace/_compiler/hidden_group.py
+++ b/braintrace/_compiler/hidden_group.py
@@ -53,7 +53,15 @@ import jax.core
 import numpy as np
 from brainstate import HiddenGroupState
 
-from braintrace._compatible_imports import Var, Literal, JaxprEqn, Jaxpr
+from braintrace._compatible_imports import (
+    Var,
+    Literal,
+    JaxprEqn,
+    Jaxpr,
+    is_scan_primitive,
+    is_while_primitive,
+    is_cond_primitive,
+)
 from braintrace._op import is_etp_primitive, is_etp_enable_gradient_primitive
 from braintrace._misc import NotSupportedError
 from braintrace._typing import (
@@ -63,6 +71,7 @@ from braintrace._typing import (
     Path,
 )
 from .base import JaxprEvaluation, find_matched_vars
+from .canonicalize import ControlFlowPolicy, DEFAULT_CONTROL_FLOW_POLICY
 from .diagnostics import DiagnosticKind, DiagnosticLevel, emit
 from .module_info import extract_module_info, ModuleInfo
 
@@ -276,12 +285,21 @@ class HiddenGroup(NamedTuple):
         cross-position terms -- inflating every entry and driving the eligibility
         trace to overflow -- so the true block diagonal is extracted directly via
         :func:`block_diagonal_last_dim`.
+
+        When the transition contains a ``while`` equation (an opaque forward
+        node), reverse-mode differentiation is unavailable (JAX has no
+        transpose rule for ``while``), so the Jacobian is extracted in
+        forward mode instead (:func:`jacfwd_last_dim`, or
+        :func:`block_diagonal_last_dim` with ``use_forward_mode=True``) --
+        same values, different derivative mode.
         """
         fn = lambda hid: self.concat_hidden(self.transition(self.split_hidden(hid), input_vals))
         concat_hid = self.concat_hidden(hidden_vals)
+        needs_fwd = _transition_contains_while(self.transition_jaxpr)
         if self.is_diagonal_recurrence:
-            return jacrev_last_dim(fn, concat_hid)
-        return block_diagonal_last_dim(fn, concat_hid)
+            extract = jacfwd_last_dim if needs_fwd else jacrev_last_dim
+            return extract(fn, concat_hid)
+        return block_diagonal_last_dim(fn, concat_hid, use_forward_mode=needs_fwd)
 
     def concat_hidden(self, splitted_hid_vals: Sequence[jax.Array]):
         """Concatenate split hidden-state values into a single array.
@@ -394,9 +412,53 @@ def jacrev_last_dim(
     return jac[0]
 
 
+def jacfwd_last_dim(
+    fn: Callable[..., jax.Array],
+    hid_vals: jax.Array,
+) -> jax.Array:
+    """Forward-mode counterpart of :func:`jacrev_last_dim`.
+
+    Computes the same ``(*varshape, num_state, num_state)`` last-dimension
+    Jacobian, but by pushing ``num_state`` one-hot tangents through
+    :func:`jax.jvp` instead of pulling cotangents through ``vjp``. Valid on
+    the same position-diagonal maps as :func:`jacrev_last_dim`, and — unlike
+    it — usable when ``fn`` contains a ``while`` loop (JAX supports
+    forward-mode but not reverse-mode differentiation of ``while``).
+
+    Parameters
+    ----------
+    fn : Callable[[jax.Array], jax.Array]
+        A shape-preserving map on ``(*varshape, num_state)`` arrays.
+    hid_vals : jax.Array
+        The point at which to linearize, shape ``(*varshape, num_state)``.
+
+    Returns
+    -------
+    jax.Array
+        The Jacobian with shape ``(*varshape, num_state, num_state)``; entry
+        ``[p, a, b]`` is ``d fn(hid)[p, a] / d hid[p, b]``.
+
+    Raises
+    ------
+    AssertionError
+        If the number of input and output states are not the same.
+    """
+    num_state = hid_vals.shape[-1]
+    varshape = hid_vals.shape[:-1]
+    basis = u.math.broadcast_to(u.math.eye(num_state), (*varshape, num_state, num_state))
+
+    def _push(tangent):
+        out, tang = jax.jvp(fn, (hid_vals,), (tangent,))
+        assert out.shape[-1] == num_state, 'Error: the number of input/output states should be the same.'
+        return tang
+
+    return jax.vmap(_push, in_axes=-2, out_axes=-1)(basis)
+
+
 def block_diagonal_last_dim(
     fn: Callable[..., jax.Array],
     hid_vals: jax.Array,
+    use_forward_mode: bool = False,
 ) -> jax.Array:
     """Compute the per-position block diagonal of ``fn``'s Jacobian.
 
@@ -414,6 +476,11 @@ def block_diagonal_last_dim(
         A shape-preserving map on ``(*varshape, num_state)`` arrays.
     hid_vals : jax.Array
         The point at which to linearize, shape ``(*varshape, num_state)``.
+    use_forward_mode : bool, optional
+        Materialize the full Jacobian with :func:`jax.jacfwd` instead of
+        :func:`jax.jacrev`. Required when ``fn`` contains a ``while`` loop
+        (no reverse-mode rule); the extracted blocks are identical.
+        Default ``False``.
 
     Returns
     -------
@@ -431,12 +498,133 @@ def block_diagonal_last_dim(
     num_state = hid_vals.shape[-1]
     varshape = hid_vals.shape[:-1]
     num_pos = int(np.prod(varshape)) if varshape else 1
-    full_jac = jax.jacrev(fn)(hid_vals)  # (*varshape, num_state, *varshape, num_state)
+    jac_fn = jax.jacfwd if use_forward_mode else jax.jacrev
+    full_jac = jac_fn(fn)(hid_vals)  # (*varshape, num_state, *varshape, num_state)
     full_jac = u.math.reshape(full_jac, (num_pos, num_state, num_pos, num_state))
     # take the per-position block: block[p] = full_jac[p, :, p, :]
     block = u.math.diagonal(full_jac, axis1=0, axis2=2)  # (num_state, num_state, num_pos)
     block = u.math.moveaxis(block, -1, 0)  # (num_pos, num_state, num_state)
     return u.math.reshape(block, (*varshape, num_state, num_state))
+
+
+def _transition_contains_while(jaxpr: Jaxpr) -> bool:
+    """Whether *jaxpr* (descending sub-jaxprs) contains a ``while`` equation.
+
+    Used by :meth:`HiddenGroup.diagonal_jacobian` to switch Jacobian
+    extraction to forward mode: ``while`` has no reverse-mode rule.
+    """
+    for eqn in jaxpr.eqns:
+        if is_while_primitive(eqn):
+            return True
+        for key in ('jaxpr', 'cond_jaxpr', 'body_jaxpr', 'call_jaxpr'):
+            sub = eqn.params.get(key)
+            if sub is not None and _transition_contains_while(getattr(sub, 'jaxpr', sub)):
+                return True
+        branches = eqn.params.get('branches')
+        if branches is not None:
+            for b in branches:
+                if _transition_contains_while(getattr(b, 'jaxpr', b)):
+                    return True
+    return False
+
+
+def _map_positions_to_subjaxpr_seeds(
+    eqn: JaxprEqn,
+    positions: Sequence[int],
+) -> List[Tuple[Jaxpr, List[Var], Dict[Var, Var]]]:
+    """Map hidden-derived invar *positions* of a control-flow equation to the
+    corresponding body-jaxpr variables.
+
+    Returns ``(sub_jaxpr, seed_vars, carry_feedback)`` triples, one per body
+    to inspect. ``carry_feedback`` maps a body outvar at carry position ``c``
+    to the body invar receiving it on the next iteration, so reachability can
+    be closed over loop-carried values.
+
+    Layouts (JAX): ``while`` invars are ``[*cond_consts, *body_consts,
+    *carry]`` with ``body.invars = [*body_consts, *carry]`` (cond consts only
+    steer the trip count and are skipped); ``scan`` invars are ``[*consts,
+    *carry, *xs]`` positionally identical to ``body.invars``; ``cond`` invars
+    are ``[pred, *operands]`` with each branch taking the operands.
+    """
+    name = eqn.primitive.name
+    results: List[Tuple[Jaxpr, List[Var], Dict[Var, Var]]] = []
+    if name == 'while':
+        cn = eqn.params['cond_nconsts']
+        bn = eqn.params['body_nconsts']
+        body = eqn.params['body_jaxpr'].jaxpr
+        n_carry = len(eqn.invars) - cn - bn
+        seeds = []
+        for j in positions:
+            if j < cn:
+                continue  # cond consts influence the trip count, not carried values
+            seeds.append(body.invars[j - cn])
+        feedback: Dict[Var, Var] = {}
+        for c in range(n_carry):
+            ov = body.outvars[c]
+            if isinstance(ov, Var):
+                feedback[ov] = body.invars[bn + c]
+        if seeds:
+            results.append((body, seeds, feedback))
+    elif name == 'scan':
+        body = eqn.params['jaxpr'].jaxpr
+        num_consts = eqn.params['num_consts']
+        num_carry = eqn.params['num_carry']
+        seeds = [body.invars[j] for j in positions]
+        feedback = {}
+        for c in range(num_carry):
+            ov = body.outvars[c]
+            if isinstance(ov, Var):
+                feedback[ov] = body.invars[num_consts + c]
+        if seeds:
+            results.append((body, seeds, feedback))
+    elif name == 'cond':
+        for branch in eqn.params['branches']:
+            b = getattr(branch, 'jaxpr', branch)
+            seeds = [b.invars[j - 1] for j in positions if j >= 1]
+            if seeds:
+                results.append((b, seeds, {}))
+    return results
+
+
+def _jaxpr_mixes_from(
+    jaxpr: Jaxpr,
+    seeds: Sequence[Var],
+    carry_feedback: Dict[Var, Var],
+) -> bool:
+    """Whether a recurrent weight-mixing primitive in *jaxpr* consumes a
+    value forward-reachable from *seeds*.
+
+    Runs a forward reachability sweep from the seed variables, returning
+    ``True`` as soon as a ``_RECURRENT_WEIGHT_MIXING_PRIMITIVES`` equation
+    consumes a reachable value; nested control flow is descended with the
+    same position mapping. The sweep is repeated until the carry feedback
+    (loop outvar fed back as next-iteration invar) adds no new seeds, so
+    mixing that only appears after the first loop iteration is still found.
+    """
+    seed_set = set(seeds)
+    while True:
+        reachable = set(seed_set)
+        for eqn in jaxpr.eqns:
+            hit = [
+                j for j, v in enumerate(eqn.invars)
+                if isinstance(v, Var) and v in reachable
+            ]
+            if not hit:
+                continue
+            if eqn.primitive.name in _RECURRENT_WEIGHT_MIXING_PRIMITIVES:
+                return True
+            if is_scan_primitive(eqn) or is_while_primitive(eqn) or is_cond_primitive(eqn):
+                for sub, sub_seeds, sub_fb in _map_positions_to_subjaxpr_seeds(eqn, hit):
+                    if _jaxpr_mixes_from(sub, sub_seeds, sub_fb):
+                        return True
+            reachable.update(v for v in eqn.outvars if isinstance(v, Var))
+        new_seeds = set(seed_set)
+        for outvar, invar in carry_feedback.items():
+            if outvar in reachable:
+                new_seeds.add(invar)
+        if new_seeds == seed_set:
+            return False
+        seed_set = new_seeds
 
 
 class HiddenToHiddenGroupTracer(NamedTuple):
@@ -687,6 +875,8 @@ class JaxprEvalForHiddenGroup(JaxprEvaluation):
         invar_to_hidden_path: The mapping from the weight input variable to the hidden state path.
         outvar_to_hidden_path: The mapping from the hidden output variable to the hidden state path.
         path_to_state: The mapping from the hidden state path to the state.
+        control_flow: The :class:`~braintrace.ControlFlowPolicy` governing
+            opaque control-flow handling (see ``base.check_unsupported_op``).
     """
     __module__ = 'braintrace'
 
@@ -699,6 +889,7 @@ class JaxprEvalForHiddenGroup(JaxprEvaluation):
         outvar_to_hidden_path: Dict[HiddenOutVar, Path],
         path_to_state: Dict[Path, brainstate.HiddenState],
         include_recurrent_mixing: bool = False,
+        control_flow: ControlFlowPolicy = DEFAULT_CONTROL_FLOW_POLICY,
     ):
         # the jaxpr of the original model, assuming that the model is well-defined,
         # see the doc for the model which can be online learning compiled.
@@ -725,7 +916,8 @@ class JaxprEvalForHiddenGroup(JaxprEvaluation):
             hidden_invars=hidden_invars,
             hidden_outvars=hidden_outvars,
             invar_to_hidden_path=invar_to_hidden_path,
-            outvar_to_hidden_path=outvar_to_hidden_path
+            outvar_to_hidden_path=outvar_to_hidden_path,
+            control_flow=control_flow,
         )
 
     def compile(self) -> Tuple[
@@ -792,6 +984,32 @@ class JaxprEvalForHiddenGroup(JaxprEvaluation):
             and eqn.primitive.name in _RECURRENT_WEIGHT_MIXING_PRIMITIVES
             and self._eqn_consumes_hidden(eqn)
         ):
+            return
+
+        # An opaque control-flow equation (while, or a scan/cond the
+        # canonicalizer left opaque) whose *body* applies a recurrent
+        # weight-mixing primitive to the carried hidden state couples the
+        # positions exactly like a top-level recurrent matmul -- so in the
+        # default mode it is likewise a boundary. Bodies that only mix
+        # loop constants (an input projection ``x @ W_in``) are kept.
+        if (
+            not self.include_recurrent_mixing
+            and (is_scan_primitive(eqn) or is_while_primitive(eqn) or is_cond_primitive(eqn))
+            and self._control_flow_mixes_hidden(eqn)
+        ):
+            emit(
+                kind=DiagnosticKind.CONTROL_FLOW_RECURRENT_MIXING,
+                level=DiagnosticLevel.WARNING,
+                message=(
+                    f'An opaque {eqn.primitive.name} whose body applies a '
+                    f'recurrent weight-mixing primitive to the carried hidden '
+                    f'state was excluded from the hidden-to-hidden transition '
+                    f'(default "without recurrence" mode). Its temporal credit '
+                    f'falls back to the zero-recurrence (e-prop) approximation; '
+                    f'pass include_recurrent_mixing=True to trace through it.'
+                ),
+                context={'op_name': eqn.primitive.name},
+            )
             return
 
         # check whether the invars have one of the hidden states.
@@ -878,6 +1096,37 @@ class JaxprEvalForHiddenGroup(JaxprEvaluation):
             if find_matched_vars(eqn.invars, tracer.invar_needed_in_oth_eqns):
                 return True
         return False
+
+    def _hidden_derived_invar_positions(self, eqn: JaxprEqn) -> List[int]:
+        """Positions of ``eqn.invars`` carrying a hidden-derived value.
+
+        A position qualifies when the invar is a previous hidden state
+        (:attr:`hidden_invars`) or transitively derived from one (tracked by
+        an active tracer's ``invar_needed_in_oth_eqns``).
+        """
+        positions = []
+        for j, invar in enumerate(eqn.invars):
+            if not isinstance(invar, Var):
+                continue
+            if invar in self.hidden_invars:
+                positions.append(j)
+                continue
+            for tracer in self.active_tracers.values():
+                if invar in tracer.invar_needed_in_oth_eqns:
+                    positions.append(j)
+                    break
+        return positions
+
+    def _control_flow_mixes_hidden(self, eqn: JaxprEqn) -> bool:
+        """Whether a control-flow equation's body applies a recurrent
+        weight-mixing primitive to a hidden-derived input."""
+        positions = self._hidden_derived_invar_positions(eqn)
+        if not positions:
+            return False
+        return any(
+            _jaxpr_mixes_from(sub, seeds, feedback)
+            for sub, seeds, feedback in _map_positions_to_subjaxpr_seeds(eqn, positions)
+        )
 
     def _post_check(self) -> Tuple[
         Sequence[HiddenGroup],
@@ -1284,6 +1533,7 @@ def find_hidden_groups_from_jaxpr(
     outvar_to_hidden_path: Dict[HiddenOutVar, Path],
     path_to_state: Dict[Path, brainstate.State],
     include_recurrent_mixing: bool = False,
+    control_flow: ControlFlowPolicy = DEFAULT_CONTROL_FLOW_POLICY,
 ) -> Tuple[Sequence[HiddenGroup], brainstate.util.PrettyDict]:
     """
     Find hidden groups from the jaxpr.
@@ -1310,6 +1560,10 @@ def find_hidden_groups_from_jaxpr(
               coupling. The resulting (coupled) Jacobian is extracted per
               position via :func:`block_diagonal_last_dim` (selected automatically
               by :attr:`HiddenGroup.is_diagonal_recurrence`).
+        control_flow: The :class:`~braintrace.ControlFlowPolicy` governing how
+            opaque control-flow equations touching hidden states are handled
+            (``'opaque-fwd'`` keeps a weight-free while/scan/cond as an opaque
+            forward node; ``'error'`` raises as before Phase 3).
 
     Returns:
         A tuple containing:
@@ -1328,6 +1582,7 @@ def find_hidden_groups_from_jaxpr(
         # brainstate is currently untyped (both collapse to Any).
         path_to_state=cast(Dict[Path, brainstate.HiddenState], path_to_state),  # type: ignore[redundant-cast]
         include_recurrent_mixing=include_recurrent_mixing,
+        control_flow=control_flow,
     )
     hidden_groups, hid_path_to_group = evaluator.compile()
     return hidden_groups, brainstate.util.PrettyDict(hid_path_to_group)
@@ -1369,6 +1624,7 @@ def find_hidden_groups_from_minfo(
         outvar_to_hidden_path=minfo.outvar_to_hidden_path,
         path_to_state=minfo.retrieved_model_states,
         include_recurrent_mixing=include_recurrent_mixing,
+        control_flow=minfo.control_flow,
     )
     return hidden_groups, hid_path_to_group
 

--- a/braintrace/_compiler/hidden_group.py
+++ b/braintrace/_compiler/hidden_group.py
@@ -507,6 +507,18 @@ def block_diagonal_last_dim(
     return u.math.reshape(block, (*varshape, num_state, num_state))
 
 
+def _param_subjaxprs(eqn: JaxprEqn) -> List[Jaxpr]:
+    """Every jaxpr-valued param of an equation (ClosedJaxpr unwrapped;
+    tuple/list params such as cond ``branches`` flattened)."""
+    found: List[Jaxpr] = []
+    for val in eqn.params.values():
+        for item in (val if isinstance(val, (tuple, list)) else (val,)):
+            sub = getattr(item, 'jaxpr', item)
+            if isinstance(sub, Jaxpr):
+                found.append(sub)
+    return found
+
+
 def _transition_contains_while(jaxpr: Jaxpr) -> bool:
     """Whether *jaxpr* (descending sub-jaxprs) contains a ``while`` equation.
 
@@ -516,15 +528,9 @@ def _transition_contains_while(jaxpr: Jaxpr) -> bool:
     for eqn in jaxpr.eqns:
         if is_while_primitive(eqn):
             return True
-        for key in ('jaxpr', 'cond_jaxpr', 'body_jaxpr', 'call_jaxpr'):
-            sub = eqn.params.get(key)
-            if sub is not None and _transition_contains_while(getattr(sub, 'jaxpr', sub)):
+        for sub in _param_subjaxprs(eqn):
+            if _transition_contains_while(sub):
                 return True
-        branches = eqn.params.get('branches')
-        if branches is not None:
-            for b in branches:
-                if _transition_contains_while(getattr(b, 'jaxpr', b)):
-                    return True
     return False
 
 
@@ -546,9 +552,8 @@ def _map_positions_to_subjaxpr_seeds(
     *carry, *xs]`` positionally identical to ``body.invars``; ``cond`` invars
     are ``[pred, *operands]`` with each branch taking the operands.
     """
-    name = eqn.primitive.name
     results: List[Tuple[Jaxpr, List[Var], Dict[Var, Var]]] = []
-    if name == 'while':
+    if is_while_primitive(eqn):
         cn = eqn.params['cond_nconsts']
         bn = eqn.params['body_nconsts']
         body = eqn.params['body_jaxpr'].jaxpr
@@ -565,7 +570,7 @@ def _map_positions_to_subjaxpr_seeds(
                 feedback[ov] = body.invars[bn + c]
         if seeds:
             results.append((body, seeds, feedback))
-    elif name == 'scan':
+    elif is_scan_primitive(eqn):
         body = eqn.params['jaxpr'].jaxpr
         num_consts = eqn.params['num_consts']
         num_carry = eqn.params['num_carry']
@@ -577,7 +582,7 @@ def _map_positions_to_subjaxpr_seeds(
                 feedback[ov] = body.invars[num_consts + c]
         if seeds:
             results.append((body, seeds, feedback))
-    elif name == 'cond':
+    elif is_cond_primitive(eqn):
         for branch in eqn.params['branches']:
             b = getattr(branch, 'jaxpr', branch)
             seeds = [b.invars[j - 1] for j in positions if j >= 1]
@@ -597,9 +602,15 @@ def _jaxpr_mixes_from(
     Runs a forward reachability sweep from the seed variables, returning
     ``True`` as soon as a ``_RECURRENT_WEIGHT_MIXING_PRIMITIVES`` equation
     consumes a reachable value; nested control flow is descended with the
-    same position mapping. The sweep is repeated until the carry feedback
-    (loop outvar fed back as next-iteration invar) adds no new seeds, so
-    mixing that only appears after the first loop iteration is still found.
+    same position mapping. Call-like equations (``jit``/``pjit``, ``remat``,
+    ``custom_jvp_call``/``custom_vjp_call``) are descended positionally, so a
+    ``jax.jit``-wrapped helper inside a loop body cannot hide mixing; any
+    other equation carrying a body jaxpr whose arity does not match is
+    conservatively reported as mixing (degrading to the zero-recurrence
+    fallback plus a warning, never to a silently wrong Jacobian). The sweep
+    is repeated until the carry feedback (loop outvar fed back as
+    next-iteration invar) adds no new seeds, so mixing that only appears
+    after the first loop iteration is still found.
     """
     seed_set = set(seeds)
     while True:
@@ -616,6 +627,13 @@ def _jaxpr_mixes_from(
             if is_scan_primitive(eqn) or is_while_primitive(eqn) or is_cond_primitive(eqn):
                 for sub, sub_seeds, sub_fb in _map_positions_to_subjaxpr_seeds(eqn, hit):
                     if _jaxpr_mixes_from(sub, sub_seeds, sub_fb):
+                        return True
+            else:
+                for sub in _param_subjaxprs(eqn):
+                    if len(sub.invars) != len(eqn.invars):
+                        return True  # unknown invar mapping: assume mixing
+                    sub_seeds = [sub.invars[j] for j in hit]
+                    if _jaxpr_mixes_from(sub, sub_seeds, {}):
                         return True
             reachable.update(v for v in eqn.outvars if isinstance(v, Var))
         new_seeds = set(seed_set)

--- a/braintrace/_compiler/hidden_group_test.py
+++ b/braintrace/_compiler/hidden_group_test.py
@@ -15,6 +15,7 @@
 
 
 import unittest
+import warnings
 from pprint import pprint
 
 import brainstate
@@ -1202,3 +1203,341 @@ class TestGroupOrderingAndDiagnostics:
         )
         with pytest.raises(NotSupportedError):
             group.check_consistent_varshape()
+
+
+# ---------------------------------------------------------------------------
+# Phase 3: weight-free while loops as opaque forward nodes
+# ---------------------------------------------------------------------------
+
+import jax.numpy as jnp
+
+from braintrace import DiagnosticKind, DiagnosticLevel
+from braintrace._compiler.diagnostics import diagnostic_context
+from braintrace._compiler.hidden_group import (
+    _transition_contains_while,
+    block_diagonal_last_dim,
+    find_hidden_groups_from_minfo,
+    jacfwd_last_dim,
+    jacrev_last_dim,
+)
+
+_WHILE_K = 3
+
+
+def _settle_step(h, x):
+    return h + 0.5 * jnp.tanh(x - h)
+
+
+def _settle_twin(h, x):
+    """Hand-composed K-step equivalent of the while fixture (no while eqn,
+    so reverse-mode oracles work on it)."""
+    for _ in range(_WHILE_K):
+        h = _settle_step(h, x)
+    return h
+
+
+class WhileSettleCell(brainstate.nn.Module):
+    """Weight-free ``lax.while_loop`` reading and updating the hidden state.
+
+    Runs exactly ``_WHILE_K`` iterations of the element-wise settle step, so
+    ``_settle_twin`` is its exact hand-composed equivalent.
+    """
+
+    def __init__(self, n, k=_WHILE_K):
+        super().__init__()
+        self.k = k
+        self.h = brainstate.HiddenState(jnp.zeros(n))
+
+    def init_state(self, *args, **kwargs):
+        self.h.value = jnp.zeros_like(self.h.value)
+
+    def update(self, x):
+        h_prev = self.h.value
+
+        def cond_fn(s):
+            return s[0] < self.k
+
+        def body_fn(s):
+            i, h = s
+            return i + 1, _settle_step(h, x)
+
+        _, h_new = jax.lax.while_loop(cond_fn, body_fn, (0, h_prev))
+        self.h.value = h_new
+        return h_new
+
+
+class WhileMixingCell(brainstate.nn.Module):
+    """While body applying a (constant) recurrent matrix to the carried
+    hidden state — cross-position coupling inside the loop."""
+
+    def __init__(self, n, k=2):
+        super().__init__()
+        self.k = k
+        self.R = 0.1 * brainstate.random.randn(n, n)
+        self.h = brainstate.HiddenState(jnp.zeros(n))
+
+    def init_state(self, *args, **kwargs):
+        self.h.value = jnp.zeros_like(self.h.value)
+
+    def update(self, x):
+        h_prev = self.h.value
+
+        def cond_fn(s):
+            return s[0] < self.k
+
+        def body_fn(s):
+            i, h = s
+            return i + 1, jnp.tanh(h @ self.R + x)
+
+        _, h_new = jax.lax.while_loop(cond_fn, body_fn, (0, h_prev))
+        self.h.value = h_new
+        return h_new
+
+
+class WhileInputProjCell(brainstate.nn.Module):
+    """While body whose ``dot_general`` consumes only loop constants
+    (``x @ W``) — no cross-position coupling of the carried hidden."""
+
+    def __init__(self, n, k=2):
+        super().__init__()
+        self.k = k
+        self.W = 0.1 * brainstate.random.randn(n, n)
+        self.h = brainstate.HiddenState(jnp.zeros(n))
+
+    def init_state(self, *args, **kwargs):
+        self.h.value = jnp.zeros_like(self.h.value)
+
+    def update(self, x):
+        h_prev = self.h.value
+
+        def cond_fn(s):
+            return s[0] < self.k
+
+        def body_fn(s):
+            i, h = s
+            return i + 1, h + 0.5 * jnp.tanh(x @ self.W - h)
+
+        _, h_new = jax.lax.while_loop(cond_fn, body_fn, (0, h_prev))
+        self.h.value = h_new
+        return h_new
+
+
+def _constvals_for(group, x):
+    """Values for ``group.transition_jaxpr_constvars``: the float vector
+    matching ``x``'s shape gets ``x``; every other constvar (e.g. the loop
+    counter's initial value) gets zeros of its aval."""
+    vals = []
+    for v in group.transition_jaxpr_constvars:
+        aval = v.aval
+        if aval.shape == x.shape and jnp.issubdtype(aval.dtype, jnp.floating):
+            vals.append(x)
+        else:
+            vals.append(jnp.zeros(aval.shape, aval.dtype))
+    return vals
+
+
+class TestJacfwdLastDim:
+    """Forward-mode last-dim Jacobian extraction (`while` has no
+    reverse-mode rule, so opaque-forward transitions need these)."""
+
+    def test_matches_jacrev_on_position_diagonal_map(self):
+        h = brainstate.random.rand(5, 2)
+
+        def fn(hid):
+            a, b = hid[..., 0], hid[..., 1]
+            return jnp.stack([jnp.tanh(a) * b, a + jnp.sin(b)], axis=-1)
+
+        fwd = jacfwd_last_dim(fn, h)
+        rev = jacrev_last_dim(fn, h)
+        assert fwd.shape == rev.shape == (5, 2, 2)
+        assert u.math.allclose(fwd, rev, atol=1e-6)
+
+    def test_block_diagonal_forward_mode_matches_reverse(self):
+        h = brainstate.random.rand(4, 2)
+        R = brainstate.random.rand(4, 4)
+
+        def fn(hid):
+            return jnp.tanh(jnp.einsum('ps,pq->qs', hid, R))
+
+        fwd = block_diagonal_last_dim(fn, h, use_forward_mode=True)
+        rev = block_diagonal_last_dim(fn, h)
+        assert fwd.shape == rev.shape == (4, 2, 2)
+        assert u.math.allclose(fwd, rev, atol=1e-6)
+
+    def test_jacfwd_through_while_matches_twin(self):
+        x = brainstate.random.rand(5)
+
+        def fn_while(hid):
+            def cond_fn(s):
+                return s[0] < _WHILE_K
+
+            def body_fn(s):
+                i, h = s
+                return i + 1, _settle_step(h, x)
+
+            _, h_final = jax.lax.while_loop(cond_fn, body_fn, (0, hid[..., 0]))
+            return h_final[..., None]
+
+        def fn_twin(hid):
+            return _settle_twin(hid[..., 0], x)[..., None]
+
+        h = brainstate.random.rand(5, 1)
+        fwd = jacfwd_last_dim(fn_while, h)
+        rev = jacrev_last_dim(fn_twin, h)
+        assert fwd.shape == (5, 1, 1)
+        assert u.math.allclose(fwd, rev, atol=1e-6)
+
+    def test_transition_contains_while_helper(self):
+        x = brainstate.random.rand(3)
+
+        def with_while(h):
+            def body_fn(s):
+                i, hh = s
+                return i + 1, _settle_step(hh, x)
+
+            return jax.lax.while_loop(lambda s: s[0] < 2, body_fn, (0, h))[1]
+
+        jaxpr_w = jax.make_jaxpr(with_while)(x).jaxpr
+        jaxpr_plain = jax.make_jaxpr(lambda h: jnp.tanh(h))(x).jaxpr
+        assert _transition_contains_while(jaxpr_w)
+        assert not _transition_contains_while(jaxpr_plain)
+
+
+class TestWhileOpaqueForwardGroups:
+    """A weight-free while reading/updating the hidden state becomes an
+    opaque forward node in the hidden-to-hidden transition."""
+
+    def _compile_settle(self, n=4):
+        cell = WhileSettleCell(n)
+        brainstate.nn.init_all_states(cell)
+        x = brainstate.random.rand(n)
+        with diagnostic_context() as reporter:
+            groups, path_to_group = find_hidden_groups_from_module(cell, x)
+        return cell, x, groups, path_to_group, reporter
+
+    def test_one_group_with_while_in_transition(self):
+        _, _, groups, _, reporter = self._compile_settle()
+        assert len(groups) == 1
+        names = [e.primitive.name for e in groups[0].transition_jaxpr.eqns]
+        assert 'while' in names
+        kinds = [r.kind for r in reporter.records()]
+        assert DiagnosticKind.CONTROL_FLOW_OPAQUE_FWD in kinds
+
+    def test_transition_evaluates_and_matches_twin(self):
+        _, x, groups, _, _ = self._compile_settle()
+        group = groups[0]
+        h0 = brainstate.random.rand(*group.hidden_invars[0].aval.shape)
+        out = group.transition([h0], _constvals_for(group, x))
+        expect = _settle_twin(h0, x)
+        assert u.math.allclose(out[0], expect, atol=1e-6)
+
+    def test_diagonal_jacobian_matches_twin(self):
+        _, x, groups, _, _ = self._compile_settle()
+        group = groups[0]
+        n = group.hidden_invars[0].aval.shape[0]
+        h0 = brainstate.random.rand(n)
+
+        diag = group.diagonal_jacobian([h0], _constvals_for(group, x))
+
+        twin_full = jax.jacrev(lambda h: _settle_twin(h, x))(h0)
+        expect = jnp.diagonal(twin_full)[..., None, None]
+        assert diag.shape == (n, 1, 1)
+        assert u.math.allclose(diag, expect, atol=1e-5)
+
+    def test_while_hidden_error_policy_raises_in_group_pass(self):
+        """``find_hidden_groups_from_minfo`` must consult the policy the
+        canonicalizer ran with (threaded through ``ModuleInfo``)."""
+        cell = WhileSettleCell(4)
+        brainstate.nn.init_all_states(cell)
+        x = brainstate.random.rand(4)
+        policy = braintrace.ControlFlowPolicy(while_hidden='error')
+        minfo = braintrace.extract_module_info(cell, x, control_flow=policy)
+        with pytest.raises(NotImplementedError):
+            find_hidden_groups_from_minfo(minfo)
+
+
+class TestWhileRecurrentMixingGuard:
+    """A while body applying a recurrent weight-mixing primitive to the
+    carried hidden state is a boundary in the default ("without
+    recurrence") grouping mode."""
+
+    def _compile_mixing(self, include_recurrent_mixing=False, n=4):
+        cell = WhileMixingCell(n)
+        brainstate.nn.init_all_states(cell)
+        x = brainstate.random.rand(n)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', UserWarning)
+            with diagnostic_context() as reporter:
+                groups, path_to_group = find_hidden_groups_from_module(
+                    cell, x, include_recurrent_mixing=include_recurrent_mixing,
+                )
+        return cell, x, groups, reporter
+
+    def test_default_mode_falls_back_to_zero_recurrence(self):
+        _, x, groups, reporter = self._compile_mixing()
+        assert len(groups) == 1
+        group = groups[0]
+        # zero-recurrence fallback: empty transition, D == 0
+        assert list(group.transition_jaxpr.eqns) == []
+        h0 = brainstate.random.rand(*group.hidden_invars[0].aval.shape)
+        const_vals = [
+            brainstate.random.rand(*v.aval.shape)
+            for v in group.transition_jaxpr_constvars
+        ]
+        diag = group.diagonal_jacobian([h0], const_vals)
+        assert u.math.allclose(diag, jnp.zeros_like(diag))
+        kinds = [r.kind for r in reporter.records()]
+        assert DiagnosticKind.CONTROL_FLOW_RECURRENT_MIXING in kinds
+        record = next(
+            r for r in reporter.records()
+            if r.kind is DiagnosticKind.CONTROL_FLOW_RECURRENT_MIXING
+        )
+        assert record.level is DiagnosticLevel.WARNING
+
+    def test_include_recurrent_mixing_traces_through_while(self):
+        cell, x, groups, reporter = self._compile_mixing(include_recurrent_mixing=True)
+        assert len(groups) == 1
+        group = groups[0]
+        names = [e.primitive.name for e in group.transition_jaxpr.eqns]
+        assert 'while' in names
+        assert group.is_diagonal_recurrence is False
+        kinds = [r.kind for r in reporter.records()]
+        assert DiagnosticKind.CONTROL_FLOW_RECURRENT_MIXING not in kinds
+
+        # forward-mode block diagonal equals the hand-composed twin's blocks.
+        # The mixing cell's constvars are the counter init (int) plus two
+        # float arrays distinguishable by shape: x (n,) and R (n, n).
+        n = group.hidden_invars[0].aval.shape[0]
+        h0 = brainstate.random.rand(n)
+        const_vals = []
+        for v in group.transition_jaxpr_constvars:
+            aval = v.aval
+            if aval.shape == x.shape and jnp.issubdtype(aval.dtype, jnp.floating):
+                const_vals.append(x)
+            elif aval.shape == cell.R.shape and jnp.issubdtype(aval.dtype, jnp.floating):
+                const_vals.append(jnp.asarray(cell.R))
+            else:
+                const_vals.append(jnp.zeros(aval.shape, aval.dtype))
+        diag = group.diagonal_jacobian([h0], const_vals)
+
+        def twin(h):
+            for _i in range(cell.k):
+                h = jnp.tanh(h @ cell.R + x)
+            return h
+
+        full = jax.jacrev(twin)(h0)
+        expect = jnp.diagonal(full)[..., None, None]
+        assert diag.shape == (n, 1, 1)
+        assert u.math.allclose(diag, expect, atol=1e-5)
+
+    def test_input_projection_in_body_is_not_a_boundary(self):
+        cell = WhileInputProjCell(4)
+        brainstate.nn.init_all_states(cell)
+        x = brainstate.random.rand(4)
+        with diagnostic_context() as reporter:
+            groups, _pg = find_hidden_groups_from_module(cell, x)
+        assert len(groups) == 1
+        names = [e.primitive.name for e in groups[0].transition_jaxpr.eqns]
+        assert 'while' in names
+        kinds = [r.kind for r in reporter.records()]
+        assert DiagnosticKind.CONTROL_FLOW_RECURRENT_MIXING not in kinds

--- a/braintrace/_compiler/hidden_group_test.py
+++ b/braintrace/_compiler/hidden_group_test.py
@@ -1322,6 +1322,37 @@ class WhileInputProjCell(brainstate.nn.Module):
         return h_new
 
 
+class WhileJitMixingCell(brainstate.nn.Module):
+    """Same recurrent mixing as ``WhileMixingCell`` but hidden behind a
+    ``jax.jit``-wrapped helper inside the while body: the guard must descend
+    the call-like sub-jaxpr, or the mixing would silently survive as a
+    "diagonal" transition with wrong per-position Jacobians."""
+
+    def __init__(self, n, k=2):
+        super().__init__()
+        self.k = k
+        self.R = 0.1 * brainstate.random.randn(n, n)
+        self.h = brainstate.HiddenState(jnp.zeros(n))
+
+    def init_state(self, *args, **kwargs):
+        self.h.value = jnp.zeros_like(self.h.value)
+
+    def update(self, x):
+        h_prev = self.h.value
+        mix = jax.jit(lambda h: jnp.tanh(h @ self.R + x))
+
+        def cond_fn(s):
+            return s[0] < self.k
+
+        def body_fn(s):
+            i, h = s
+            return i + 1, mix(h)
+
+        _, h_new = jax.lax.while_loop(cond_fn, body_fn, (0, h_prev))
+        self.h.value = h_new
+        return h_new
+
+
 def _constvals_for(group, x):
     """Values for ``group.transition_jaxpr_constvars``: the float vector
     matching ``x``'s shape gets ``x``; every other constvar (e.g. the loop
@@ -1541,3 +1572,22 @@ class TestWhileRecurrentMixingGuard:
         assert 'while' in names
         kinds = [r.kind for r in reporter.records()]
         assert DiagnosticKind.CONTROL_FLOW_RECURRENT_MIXING not in kinds
+
+    def test_jit_wrapped_mixing_in_body_is_still_a_boundary(self):
+        """Regression: mixing behind a ``jax.jit`` call inside the while body
+        must not evade the guard (a missed boundary means the transition is
+        kept as position-diagonal and ``diagonal_jacobian`` silently returns
+        Jacobian row sums instead of the true diagonal)."""
+        cell = WhileJitMixingCell(4)
+        brainstate.nn.init_all_states(cell)
+        x = brainstate.random.rand(4)
+        with warnings.catch_warnings():
+            warnings.simplefilter('ignore', UserWarning)
+            with diagnostic_context() as reporter:
+                groups, _pg = find_hidden_groups_from_module(cell, x)
+        assert len(groups) == 1
+        group = groups[0]
+        # zero-recurrence fallback, exactly like the un-jitted mixing cell
+        assert list(group.transition_jaxpr.eqns) == []
+        kinds = [r.kind for r in reporter.records()]
+        assert DiagnosticKind.CONTROL_FLOW_RECURRENT_MIXING in kinds

--- a/braintrace/_compiler/hidden_pertubation.py
+++ b/braintrace/_compiler/hidden_pertubation.py
@@ -237,11 +237,16 @@ class JaxprEvalForHiddenPerturbation(JaxprEvaluation):
         perturbed jaxpr (JAX has no transpose rule for ``while``, so an
         undetached loop would make the VJP of the perturbed step
         untraceable). The perturbation add ``h = fresh + p`` stays *outside*
-        the detach, so per-step learning signals ``dL/dp`` are exact.
-        Consequence: any *reverse-mode* path through the loop body within
-        the same step contributes zero — temporal credit through the loop
-        is carried instead by the forward-computed hidden-to-hidden
-        Jacobian ``D^t`` (see ``hidden_group.jacfwd_last_dim``).
+        the detach, so the loop's *own* hidden group keeps an exact per-step
+        learning signal ``dL/dp``. Consequence: any *reverse-mode* path
+        through the loop body within the same step contributes zero — the
+        loop's temporal credit is carried instead by the forward-computed
+        hidden-to-hidden Jacobian ``D^t`` (see
+        ``hidden_group.jacfwd_last_dim``), but a parameter or *other* hidden
+        group whose only same-step path to the loss crosses the loop (e.g.
+        an upstream layer feeding the loop) receives a ZERO learning signal.
+        A WARNING-level ``CONTROL_FLOW_OPAQUE_FWD`` diagnostic
+        (``site='perturbation'``) records every detach.
     """
     __module__ = 'braintrace'
 
@@ -418,12 +423,19 @@ class JaxprEvalForHiddenPerturbation(JaxprEvaluation):
             n_detached += 1
         emit(
             kind=DiagnosticKind.CONTROL_FLOW_OPAQUE_FWD,
-            level=DiagnosticLevel.INFO,
+            level=DiagnosticLevel.WARNING,
             message=(
                 'Detached the inputs of a hidden-producing while loop in the '
-                'perturbed jaxpr: reverse-mode signals THROUGH the loop are '
-                'zero there (temporal credit flows via the forward-computed '
-                'hidden-to-hidden Jacobian instead).'
+                'perturbed jaxpr: same-step reverse-mode signals THROUGH the '
+                'loop are zero there. The loop\'s own hidden-state learning '
+                'signal stays exact and its temporal credit flows via the '
+                'forward-computed hidden-to-hidden Jacobian, but any '
+                'parameter or other hidden group whose only same-step path '
+                'to the loss crosses this loop receives a ZERO learning '
+                'signal (e.g. the weights of an upstream layer feeding the '
+                'loop). Move such parameters\' influence out of the loop '
+                'inputs, or avoid stacking trainable layers behind a '
+                'while-hidden layer.'
             ),
             context={'site': 'perturbation', 'n_detached': n_detached},
         )

--- a/braintrace/_compiler/hidden_pertubation.py
+++ b/braintrace/_compiler/hidden_pertubation.py
@@ -27,6 +27,7 @@ from braintrace._compatible_imports import (
     ClosedJaxpr,
     new_var,
     new_jaxpr_eqn,
+    stop_gradient_p,
 )
 from braintrace._misc import (
     git_issue_addr,
@@ -38,7 +39,10 @@ from braintrace._typing import (
 )
 from .base import (
     JaxprEvaluation,
+    check_unsupported_op,
 )
+from .canonicalize import ControlFlowPolicy, DEFAULT_CONTROL_FLOW_POLICY
+from .diagnostics import DiagnosticKind, DiagnosticLevel, emit
 from .hidden_group import (
     HiddenGroup,
 )
@@ -221,10 +225,23 @@ class JaxprEvalForHiddenPerturbation(JaxprEvaluation):
         hidden_outvar_to_invar: The mapping from the hidden output variable to the hidden input variable.
         weight_invars: The weight input variables.
         invar_to_hidden_path: The mapping from the weight input variable to the hidden state path.
+        control_flow: The :class:`~braintrace.ControlFlowPolicy` governing
+            opaque control-flow handling.
 
     Returns:
         The revised closed jaxpr with the perturbations.
 
+    Notes:
+        A hidden-producing ``while`` equation gets special treatment: every
+        ``Var`` input of the loop is detached with ``stop_gradient`` in the
+        perturbed jaxpr (JAX has no transpose rule for ``while``, so an
+        undetached loop would make the VJP of the perturbed step
+        untraceable). The perturbation add ``h = fresh + p`` stays *outside*
+        the detach, so per-step learning signals ``dL/dp`` are exact.
+        Consequence: any *reverse-mode* path through the loop body within
+        the same step contributes zero — temporal credit through the loop
+        is carried instead by the forward-computed hidden-to-hidden
+        Jacobian ``D^t`` (see ``hidden_group.jacfwd_last_dim``).
     """
     __module__ = 'braintrace'
 
@@ -236,6 +253,7 @@ class JaxprEvalForHiddenPerturbation(JaxprEvaluation):
         invar_to_hidden_path: Dict[HiddenInVar, Path],
         outvar_to_hidden_path: Dict[Var, Path],
         path_to_state: Dict[Path, brainstate.HiddenState],
+        control_flow: ControlFlowPolicy = DEFAULT_CONTROL_FLOW_POLICY,
     ):
         # necessary data structures
         self.closed_jaxpr = closed_jaxpr
@@ -250,7 +268,8 @@ class JaxprEvalForHiddenPerturbation(JaxprEvaluation):
             hidden_invars=set(hidden_invars_ordered),
             hidden_outvars=set(hidden_outvars_ordered),
             invar_to_hidden_path=invar_to_hidden_path,
-            outvar_to_hidden_path=outvar_to_hidden_path
+            outvar_to_hidden_path=outvar_to_hidden_path,
+            control_flow=control_flow,
         )
         # Keep an ordered version for deterministic iteration in compile()
         self._hidden_outvars_ordered = hidden_outvars_ordered
@@ -356,6 +375,60 @@ class JaxprEvalForHiddenPerturbation(JaxprEvaluation):
         """
         self._eval_eqn(eqn)
 
+    def _eval_while(self, eqn: JaxprEqn) -> None:
+        """Evaluate a ``while`` equation, detaching its inputs when it
+        produces a hidden state.
+
+        JAX cannot transpose ``while``, so a hidden-producing loop left
+        as-is would make ``jax.vjp`` of the perturbed step untraceable.
+        Every ``Var`` input of the loop is therefore routed through a
+        ``stop_gradient`` equation first; the perturbation add stays
+        outside the detach (see the class Notes).
+        """
+        check_unsupported_op(self, eqn, 'while')
+        if any(ov in self.hidden_jaxvars_to_remove for ov in eqn.outvars):
+            eqn = self._detach_invars(eqn)
+        self._eval_eqn(eqn)
+
+    def _detach_invars(self, eqn: JaxprEqn) -> JaxprEqn:
+        """Route every ``Var`` input of *eqn* through ``stop_gradient``.
+
+        Emits the ``stop_gradient`` equations into ``revised_eqns`` and
+        returns a copy of *eqn* consuming the detached variables. Literal
+        inputs are left untouched.
+        """
+        new_invars = []
+        n_detached = 0
+        for iv in eqn.invars:
+            if not isinstance(iv, Var):
+                new_invars.append(iv)
+                continue
+            fresh = new_var('', iv.aval)
+            self.revised_eqns.append(
+                new_jaxpr_eqn(
+                    [iv],
+                    [fresh],
+                    stop_gradient_p,
+                    {},
+                    set(),
+                    eqn.source_info.replace(),
+                )
+            )
+            new_invars.append(fresh)
+            n_detached += 1
+        emit(
+            kind=DiagnosticKind.CONTROL_FLOW_OPAQUE_FWD,
+            level=DiagnosticLevel.INFO,
+            message=(
+                'Detached the inputs of a hidden-producing while loop in the '
+                'perturbed jaxpr: reverse-mode signals THROUGH the loop are '
+                'zero there (temporal credit flows via the forward-computed '
+                'hidden-to-hidden Jacobian instead).'
+            ),
+            context={'site': 'perturbation', 'n_detached': n_detached},
+        )
+        return eqn.replace(invars=new_invars)
+
     def _eval_eqn(self, eqn: JaxprEqn):
         # ------------------------------------------------
         #
@@ -410,6 +483,7 @@ def add_hidden_perturbation_in_jaxpr(
     invar_to_hidden_path: Dict[HiddenInVar, Path],
     outvar_to_hidden_path: Dict[Var, Path],
     path_to_state: Dict[Path, brainstate.HiddenState],
+    control_flow: ControlFlowPolicy = DEFAULT_CONTROL_FLOW_POLICY,
 ) -> HiddenPerturbation:
     """
     Adding perturbations to the hidden states in the jaxpr, and replacing the hidden states with the perturbed states.
@@ -421,6 +495,11 @@ def add_hidden_perturbation_in_jaxpr(
         weight_invars: The weight input variables.
         invar_to_hidden_path: The mapping from the weight input variable to the hidden state path.
         path_to_state: The mapping from the hidden state path to the state.
+        control_flow: The :class:`~braintrace.ControlFlowPolicy` governing
+            opaque control-flow handling. Under the default policy a
+            hidden-producing ``while`` is kept and its inputs are detached
+            in the perturbed jaxpr (see
+            :class:`JaxprEvalForHiddenPerturbation`).
 
     Returns:
         The revised closed jaxpr with the perturbations.
@@ -432,6 +511,7 @@ def add_hidden_perturbation_in_jaxpr(
         invar_to_hidden_path=invar_to_hidden_path,
         outvar_to_hidden_path=outvar_to_hidden_path,
         path_to_state=path_to_state,
+        control_flow=control_flow,
     ).compile()
 
 
@@ -464,6 +544,7 @@ def add_hidden_perturbation_from_minfo(
         invar_to_hidden_path=minfo.invar_to_hidden_path,
         outvar_to_hidden_path=minfo.outvar_to_hidden_path,
         path_to_state=minfo.retrieved_model_states,
+        control_flow=minfo.control_flow,
     )
 
 

--- a/braintrace/_compiler/hidden_pertubation_test.py
+++ b/braintrace/_compiler/hidden_pertubation_test.py
@@ -249,3 +249,198 @@ class TestPerturbationRobustness:
         ).compile()
 
         assert perturb.perturb_jaxpr.jaxpr.effects == closed.jaxpr.effects
+
+
+class TestWhileDetach:
+    """Phase 3: the perturbation pass detaches (``stop_gradient``) every Var
+    input of a hidden-producing ``while`` equation, so the perturbed jaxpr
+    stays reverse-mode traceable (JAX cannot transpose ``while``). Temporal
+    credit through the loop flows via the forward-computed hidden-to-hidden
+    Jacobian instead; the perturbation add remains outside the detach."""
+
+    def _make_while_fixture(self, n=4, k=3):
+        import jax
+        import jax.numpy as jnp
+
+        def f(h_prev, x):
+            def body(s):
+                i, h = s
+                return i + 1, h + 0.5 * jnp.tanh(x - h)
+
+            _, h_new = jax.lax.while_loop(lambda s: s[0] < k, body, (0, h_prev))
+            return h_new, jnp.sum(h_new)
+
+        h0 = jnp.zeros(n)
+        x = jnp.linspace(0.1, 0.4, n)
+        closed = jax.make_jaxpr(f)(h0, x)
+        h_in = closed.jaxpr.invars[0]
+        h_out = closed.jaxpr.outvars[0]
+        return closed, h_in, h_out, h0, x
+
+    def _perturb(self, closed, h_in, h_out):
+        from braintrace._compiler.hidden_pertubation import (
+            JaxprEvalForHiddenPerturbation,
+        )
+        return JaxprEvalForHiddenPerturbation(
+            closed_jaxpr=closed,
+            hidden_outvar_to_invar={h_out: h_in},
+            weight_invars=set(),
+            invar_to_hidden_path={h_in: ('h',)},
+            outvar_to_hidden_path={h_out: ('h',)},
+            path_to_state={('h',): None},
+        ).compile()
+
+    def test_structure_stop_gradient_per_var_invar(self):
+        from braintrace._compatible_imports import Var
+
+        closed, h_in, h_out, _h0, _x = self._make_while_fixture()
+        (while_eqn,) = [e for e in closed.jaxpr.eqns if e.primitive.name == 'while']
+        n_var_invars = sum(isinstance(v, Var) for v in while_eqn.invars)
+
+        perturb = self._perturb(closed, h_in, h_out)
+        eqns = perturb.perturb_jaxpr.jaxpr.eqns
+        names = [e.primitive.name for e in eqns]
+
+        # one stop_gradient per Var invar, all before the while
+        assert names.count('stop_gradient') == n_var_invars
+        sg_outs = {
+            e.outvars[0] for e in eqns if e.primitive.name == 'stop_gradient'
+        }
+        (new_while,) = [e for e in eqns if e.primitive.name == 'while']
+        var_invars = [v for v in new_while.invars if isinstance(v, Var)]
+        assert all(v in sg_outs for v in var_invars), (
+            'the while must consume ONLY detached copies of its Var inputs'
+        )
+
+        # the hidden slot is redirected to a fresh var, and an add re-defines
+        # the ORIGINAL hidden outvar (so downstream eqns keep their reference)
+        assert h_out not in new_while.outvars
+        (add_eqn,) = [
+            e for e in eqns
+            if e.primitive.name == 'add' and e.outvars[0] is h_out
+        ]
+        assert add_eqn.invars[0] in set(new_while.outvars)
+        assert add_eqn.invars[1] in set(perturb.perturb_vars)
+
+        # downstream consumer (reduce_sum) still consumes the original var
+        (sum_eqn,) = [e for e in eqns if e.primitive.name == 'reduce_sum']
+        assert h_out in sum_eqn.invars
+
+    def test_perturbed_jaxpr_is_reverse_traceable(self):
+        import jax
+        import jax.numpy as jnp
+        import numpy as np
+
+        closed, h_in, h_out, h0, x = self._make_while_fixture()
+        perturb = self._perturb(closed, h_in, h_out)
+
+        def eval_loss(h0_val, p_val):
+            outs = perturb.eval_jaxpr([h0_val, x], [p_val])
+            return outs[1]
+
+        p0 = jnp.zeros_like(h0)
+        _, f_vjp = jax.vjp(eval_loss, h0, p0)
+        # the load-bearing property: tracing f_vjp must not hit
+        # "Reverse-mode differentiation does not work for lax.while_loop"
+        jax.make_jaxpr(f_vjp)(jnp.ones(()))
+
+        dh0, dp = f_vjp(jnp.ones(()))
+        # L = sum(while(...) + p): dL/dp is exactly ones
+        np.testing.assert_allclose(np.asarray(dp), np.ones_like(h0), rtol=1e-6)
+        # the loop inputs are detached, so the reverse signal into h0 is zero
+        # (temporal credit flows via the forward-computed D^t instead)
+        np.testing.assert_allclose(np.asarray(dh0), np.zeros_like(h0))
+
+    def test_perturbed_values_unchanged_by_detach(self):
+        import jax
+        import jax.numpy as jnp
+        import numpy as np
+
+        closed, h_in, h_out, h0, x = self._make_while_fixture()
+        perturb = self._perturb(closed, h_in, h_out)
+
+        base_h, base_loss = jax.core.eval_jaxpr(
+            closed.jaxpr, closed.consts, h0, x
+        )
+        p = jnp.full_like(h0, 0.25)
+        out_h, out_loss = perturb.eval_jaxpr([h0, x], [p])
+        np.testing.assert_allclose(np.asarray(out_h), np.asarray(base_h) + 0.25, rtol=1e-6)
+        np.testing.assert_allclose(
+            np.asarray(out_loss), np.asarray(base_loss) + 0.25 * h0.size, rtol=1e-6
+        )
+
+    def test_non_hidden_while_untouched(self):
+        import jax
+        import jax.numpy as jnp
+        from braintrace._compiler.hidden_pertubation import (
+            JaxprEvalForHiddenPerturbation,
+        )
+
+        def f(h_prev, x):
+            # the while computes an auxiliary value; the hidden state is
+            # produced by a plain tanh equation
+            def body(s):
+                i, v = s
+                return i + 1, v * 0.5
+
+            _, aux = jax.lax.while_loop(lambda s: s[0] < 2, body, (0, x))
+            h_new = jnp.tanh(h_prev + aux)
+            return h_new
+
+        h0 = jnp.zeros(3)
+        x = jnp.ones(3)
+        closed = jax.make_jaxpr(f)(h0, x)
+        h_in = closed.jaxpr.invars[0]
+        h_out = closed.jaxpr.outvars[0]
+
+        perturb = JaxprEvalForHiddenPerturbation(
+            closed_jaxpr=closed,
+            hidden_outvar_to_invar={h_out: h_in},
+            weight_invars=set(),
+            invar_to_hidden_path={h_in: ('h',)},
+            outvar_to_hidden_path={h_out: ('h',)},
+            path_to_state={('h',): None},
+        ).compile()
+
+        eqns = perturb.perturb_jaxpr.jaxpr.eqns
+        names = [e.primitive.name for e in eqns]
+        assert 'stop_gradient' not in names
+        (orig_while,) = [e for e in closed.jaxpr.eqns if e.primitive.name == 'while']
+        (new_while,) = [e for e in eqns if e.primitive.name == 'while']
+        assert list(new_while.invars) == list(orig_while.invars)
+
+    def test_while_hidden_error_policy_raises(self):
+        import jax.numpy as jnp
+        from braintrace._compiler.hidden_pertubation import (
+            add_hidden_perturbation_from_minfo,
+        )
+
+        class _WhileCell(brainstate.nn.Module):
+            def __init__(self, n, k=3):
+                super().__init__()
+                self.k = k
+                self.h = brainstate.HiddenState(jnp.zeros(n))
+
+            def init_state(self, *args, **kwargs):
+                self.h.value = jnp.zeros_like(self.h.value)
+
+            def update(self, x):
+                import jax
+
+                def body(s):
+                    i, h = s
+                    return i + 1, h + 0.5 * jnp.tanh(x - h)
+
+                _, h_new = jax.lax.while_loop(
+                    lambda s: s[0] < self.k, body, (0, self.h.value)
+                )
+                self.h.value = h_new
+                return h_new
+
+        cell = _WhileCell(4)
+        brainstate.nn.init_all_states(cell)
+        x = brainstate.random.rand(4)
+        policy = braintrace.ControlFlowPolicy(while_hidden='error')
+        minfo = braintrace.extract_module_info(cell, x, control_flow=policy)
+        with pytest.raises(NotImplementedError):
+            add_hidden_perturbation_from_minfo(minfo)

--- a/braintrace/_compiler/module_info.py
+++ b/braintrace/_compiler/module_info.py
@@ -247,6 +247,11 @@ class ModuleInfo(NamedTuple):
         Number of original output variables.
     num_var_state : int
         Number of state-variable outputs.
+    control_flow : ControlFlowPolicy
+        The control-flow policy the canonicalizer ran with. Downstream
+        passes (hidden-group discovery, relation discovery, hidden
+        perturbation) consult this same policy so opaque control-flow
+        handling is consistent across the whole compilation.
 
     See Also
     --------
@@ -293,6 +298,9 @@ class ModuleInfo(NamedTuple):
     # output
     num_var_out: int  # number of original output variables
     num_var_state: int  # number of state variable outputs
+
+    # control-flow policy the canonicalizer ran with
+    control_flow: ControlFlowPolicy = DEFAULT_CONTROL_FLOW_POLICY
 
     @property
     def jaxpr(self) -> Jaxpr:
@@ -647,12 +655,13 @@ def extract_module_info(
     # equation's original outvars and never touch the jaxpr's invars/outvars,
     # so every Var-identity table built above stays valid; only the equation
     # list (and consts) change.
+    policy = control_flow if control_flow is not None else DEFAULT_CONTROL_FLOW_POLICY
     closed_jaxpr = canonicalize_control_flow(
         closed_jaxpr,
         weight_invars=set(weight_invars),
         hidden_invars=set(hidden_path_to_invar.values()),
         hidden_outvars=set(hidden_path_to_outvar.values()),
-        policy=control_flow if control_flow is not None else DEFAULT_CONTROL_FLOW_POLICY,
+        policy=policy,
     )
 
     return ModuleInfo(
@@ -684,4 +693,7 @@ def extract_module_info(
         # output parameters
         num_var_out=num_out,
         num_var_state=len(jaxpr.outvars[num_out:]),
+
+        # control-flow policy
+        control_flow=policy,
     )

--- a/braintrace/_compiler/module_info.py
+++ b/braintrace/_compiler/module_info.py
@@ -505,10 +505,16 @@ def extract_module_info(
     control_flow : ControlFlowPolicy or None, optional
         Policy governing control-flow canonicalization (``cond``
         if-conversion and inner-``scan`` unrolling; see
-        :func:`~braintrace._compiler.canonicalize.canonicalize_control_flow`).
-        ``None`` (default) uses the default policy, which converts every
-        ETP-relevant ``cond`` and unrolls every ETP-relevant ``scan`` of
-        static length at most 16.
+        :func:`~braintrace._compiler.canonicalize.canonicalize_control_flow`)
+        and downstream handling of un-flattened control flow. ``None``
+        (default) uses the default policy, which converts every ETP-relevant
+        ``cond``, unrolls every ETP-relevant ``scan`` of static length at
+        most 16, keeps weight-free ``while`` loops that touch hidden state as
+        opaque forward nodes (``while_hidden='opaque-fwd'``), and raises on
+        ETP primitives left inside a control-flow body
+        (``etp_in_control_flow='error'``). The policy is stored on the
+        returned :class:`ModuleInfo` (``minfo.control_flow``) so later
+        compiler passes apply the same rules.
     **model_kwargs
         The keyword arguments of the model.
 

--- a/braintrace/_compiler/module_info_test.py
+++ b/braintrace/_compiler/module_info_test.py
@@ -34,6 +34,35 @@ from braintrace._etrace_model_test import (
 )
 
 
+class TestControlFlowPolicyThreading:
+    """``extract_module_info`` resolves the control-flow policy once and the
+    returned ``ModuleInfo`` carries it, so downstream passes (hidden groups,
+    relations, perturbation) consult the same policy the canonicalizer used."""
+
+    def _minfo(self, **kwargs):
+        gru = braintrace.nn.GRUCell(3, 4)
+        brainstate.nn.init_all_states(gru)
+        inputs = brainstate.random.rand(3)
+        return braintrace.extract_module_info(gru, inputs, **kwargs)
+
+    def test_default_policy_stored(self):
+        from braintrace._compiler import DEFAULT_CONTROL_FLOW_POLICY
+        minfo = self._minfo()
+        assert minfo.control_flow is DEFAULT_CONTROL_FLOW_POLICY
+
+    def test_custom_policy_round_trips(self):
+        policy = braintrace.ControlFlowPolicy(
+            cond='opaque', while_hidden='error', etp_in_control_flow='exclude',
+        )
+        minfo = self._minfo(control_flow=policy)
+        assert minfo.control_flow is policy
+
+    def test_add_jaxpr_outs_preserves_policy(self):
+        policy = braintrace.ControlFlowPolicy(while_hidden='error')
+        minfo = self._minfo(control_flow=policy)
+        assert minfo.add_jaxpr_outs([]).control_flow is policy
+
+
 class Test_extract_model_info:
     @pytest.mark.parametrize(
         "cls",

--- a/braintrace/_compiler/scenario_catalog.py
+++ b/braintrace/_compiler/scenario_catalog.py
@@ -424,6 +424,91 @@ def make_while_body_etp_jaxpr(n_in: int, n_out: int, n_iter: int = 3):
     return jax.make_jaxpr(f)(w, x).jaxpr
 
 
+def make_while_hidden_weightfree_jaxpr(n: int, n_iter: int = 3):
+    """Return a jaxpr whose output is produced by a **weight-free**
+    ``lax.while_loop`` reading the first argument (a hidden-state stand-in)."""
+    h = jnp.zeros(n)
+    x = jnp.zeros(n)
+
+    def f(h, x):
+        def body_fn(state):
+            i, hh = state
+            return i + 1, hh + 0.5 * jnp.tanh(x - hh)
+
+        return jax.lax.while_loop(lambda s: s[0] < n_iter, body_fn, (0, h))[1]
+
+    return jax.make_jaxpr(f)(h, x).jaxpr
+
+
+# ---------------------------------------------------------------------------
+# While-hidden — weight-free while loop reading/updating the hidden state
+# ---------------------------------------------------------------------------
+
+class WhileSettleRNN(brainstate.nn.Module):
+    """``pre = etp_matmul(x, W_in) + decay * h_prev``, then a **weight-free**
+    ``lax.while_loop`` running exactly ``k`` settle iterations
+    ``h <- h + 0.5 * tanh(pre - h)`` from ``h_prev``.
+
+    The while consumes only weight-*derived* values (``pre``) and the carried
+    hidden state — no weight invar — so under the default policy it is kept
+    as an opaque forward node: the compiler registers the single ``W_in``
+    relation whose ``y``-to-hidden tail crosses the while, extracts the
+    hidden-to-hidden Jacobian in forward mode, and detaches the loop inputs
+    in the perturbed jaxpr. :class:`WhileSettleTwinRNN` is its exact
+    hand-composed equivalent (fixed trip count).
+    """
+
+    def __init__(self, n_in: int, n_rec: int, k: int = 3, decay: float = 0.8):
+        super().__init__()
+        self.k = k
+        self.decay = decay
+        self.win = brainstate.ParamState(0.3 * brainstate.random.randn(n_in, n_rec))
+        self.h = brainstate.HiddenState(jnp.zeros(n_rec))
+
+    def init_state(self, *args, **kwargs):
+        self.h.value = jnp.zeros_like(self.h.value)
+
+    def update(self, x):
+        h_prev = self.h.value
+        pre = braintrace.matmul(x, self.win.value) + self.decay * h_prev
+
+        def cond_fn(s):
+            return s[0] < self.k
+
+        def body_fn(s):
+            i, h = s
+            return i + 1, h + 0.5 * jnp.tanh(pre - h)
+
+        _, h_new = jax.lax.while_loop(cond_fn, body_fn, (0, h_prev))
+        self.h.value = h_new
+        return h_new
+
+
+class WhileSettleTwinRNN(brainstate.nn.Module):
+    """Hand-composed twin of :class:`WhileSettleRNN`: identical ``update()``
+    with the fixed-trip-count while replaced by its ``k``-fold composition,
+    so reverse-mode oracles (BPTT) work on it."""
+
+    def __init__(self, n_in: int, n_rec: int, k: int = 3, decay: float = 0.8):
+        super().__init__()
+        self.k = k
+        self.decay = decay
+        self.win = brainstate.ParamState(0.3 * brainstate.random.randn(n_in, n_rec))
+        self.h = brainstate.HiddenState(jnp.zeros(n_rec))
+
+    def init_state(self, *args, **kwargs):
+        self.h.value = jnp.zeros_like(self.h.value)
+
+    def update(self, x):
+        h_prev = self.h.value
+        pre = braintrace.matmul(x, self.win.value) + self.decay * h_prev
+        h = h_prev
+        for _ in range(self.k):
+            h = h + 0.5 * jnp.tanh(pre - h)
+        self.h.value = h
+        return h
+
+
 # ---------------------------------------------------------------------------
 # Nested jit — ETP primitive inside a user ``jax.jit`` boundary
 # ---------------------------------------------------------------------------

--- a/braintrace/_compiler/scenario_catalog_test.py
+++ b/braintrace/_compiler/scenario_catalog_test.py
@@ -38,10 +38,12 @@ import warnings
 
 import brainstate
 import jax.numpy as jnp
+import pytest
 
 import braintrace
 from braintrace import (
     DiagnosticKind,
+    DiagnosticLevel,
     compile_etrace_graph,
 )
 from braintrace._op import (
@@ -979,25 +981,54 @@ class TestCategoryN_ControlFlow:
         kinds = [r.kind for r in graph.diagnostics]
         assert DiagnosticKind.SCAN_UNROLLED in kinds
 
-    def test_scan_body_etp_emits_diagnostic(self):
+    def test_scan_body_etp_default_policy_raises(self):
+        """Default policy (``etp_in_control_flow='error'``): an ETP primitive
+        inside an unflattened scan body is a hard error — its weight would
+        otherwise silently drop out of online learning. An ERROR-level
+        record is emitted before raising."""
         jaxpr = make_scan_body_etp_jaxpr(3, 4)
 
+        with diagnostic_context() as reporter:
+            with pytest.raises(NotImplementedError) as exc_info:
+                _scan_jaxpr_for_etp_eqns(jaxpr)
+
+        msg = str(exc_info.value)
+        assert 'scan/while/cond' in msg
+        assert "etp_in_control_flow='exclude'" in msg
+        records = [
+            r for r in reporter.records()
+            if r.kind is DiagnosticKind.PRIMITIVE_INSIDE_CONTROL_FLOW
+        ]
+        assert len(records) == 1
+        assert records[0].level is DiagnosticLevel.ERROR
+
+    def test_scan_body_etp_exclude_policy_warns_and_drops(self):
+        """``etp_in_control_flow='exclude'`` pins the pre-Phase-3 behavior:
+        a WARNING record and exclusion (no bubbling up), no raise."""
+        jaxpr = make_scan_body_etp_jaxpr(3, 4)
+        policy = braintrace.ControlFlowPolicy(etp_in_control_flow='exclude')
+
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', UserWarning)
             with diagnostic_context() as reporter:
-                top = _scan_jaxpr_for_etp_eqns(jaxpr)
+                top = _scan_jaxpr_for_etp_eqns(jaxpr, policy=policy)
 
         assert top == [], 'ETP inside scan body must NOT bubble up'
-        kinds = [r.kind for r in reporter.records()]
-        assert DiagnosticKind.PRIMITIVE_INSIDE_CONTROL_FLOW in kinds
+        records = [
+            r for r in reporter.records()
+            if r.kind is DiagnosticKind.PRIMITIVE_INSIDE_CONTROL_FLOW
+        ]
+        assert len(records) == 1
+        assert records[0].level is DiagnosticLevel.WARNING
 
-    def test_cond_branches_etp_emits_diagnostic_per_branch(self):
+    def test_cond_branches_etp_exclude_policy_diagnostic_per_branch(self):
         jaxpr = make_cond_branches_etp_jaxpr(3, 4)
+        policy = braintrace.ControlFlowPolicy(etp_in_control_flow='exclude')
 
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', UserWarning)
             with diagnostic_context() as reporter:
-                top = _scan_jaxpr_for_etp_eqns(jaxpr)
+                top = _scan_jaxpr_for_etp_eqns(jaxpr, policy=policy)
 
         assert top == []
         n_cf = sum(
@@ -1009,17 +1040,48 @@ class TestCategoryN_ControlFlow:
             f'got {n_cf}'
         )
 
-    def test_while_body_etp_emits_diagnostic(self):
+    def test_cond_branches_etp_default_policy_raises(self):
+        jaxpr = make_cond_branches_etp_jaxpr(3, 4)
+        with diagnostic_context():
+            with pytest.raises(NotImplementedError):
+                _scan_jaxpr_for_etp_eqns(jaxpr)
+
+    def test_while_body_etp_default_policy_raises(self):
+        """The weight of an ETP op inside a while body reaches the loop as an
+        already-processed value (not a tracked weight invar), so
+        ``check_unsupported_op`` cannot catch it — the relation scanner is
+        the last line of defence and must raise by default."""
         jaxpr = make_while_body_etp_jaxpr(4, 4)
+
+        with diagnostic_context() as reporter:
+            with pytest.raises(NotImplementedError):
+                _scan_jaxpr_for_etp_eqns(jaxpr)
+
+        records = [
+            r for r in reporter.records()
+            if r.kind is DiagnosticKind.PRIMITIVE_INSIDE_CONTROL_FLOW
+        ]
+        assert len(records) == 1
+        assert records[0].level is DiagnosticLevel.ERROR
+
+    def test_while_body_etp_exclude_policy_warns_and_drops(self):
+        jaxpr = make_while_body_etp_jaxpr(4, 4)
+        policy = braintrace.ControlFlowPolicy(etp_in_control_flow='exclude')
 
         with warnings.catch_warnings():
             warnings.simplefilter('ignore', UserWarning)
             with diagnostic_context() as reporter:
-                top = _scan_jaxpr_for_etp_eqns(jaxpr)
+                top = _scan_jaxpr_for_etp_eqns(jaxpr, policy=policy)
 
         assert top == []
         kinds = [r.kind for r in reporter.records()]
         assert DiagnosticKind.PRIMITIVE_INSIDE_CONTROL_FLOW in kinds
+
+    def test_bogus_etp_in_control_flow_raises_value_error(self):
+        jaxpr = make_while_body_etp_jaxpr(4, 4)
+        policy = braintrace.ControlFlowPolicy(etp_in_control_flow='bogus')
+        with pytest.raises(ValueError, match='etp_in_control_flow'):
+            _scan_jaxpr_for_etp_eqns(jaxpr, policy=policy)
 
 
 # ---------------------------------------------------------------------------

--- a/braintrace/_compiler/scenario_catalog_test.py
+++ b/braintrace/_compiler/scenario_catalog_test.py
@@ -1396,8 +1396,11 @@ class TestCategoryS_WhileHiddenOpaqueFwd:
     (``dg_hid_perturb_or_dl2h``) as the learning signal; the residual
     hidden-input cotangent (``dg_last_hiddens``) is consumed only by the
     multi-step branch. Detaching the while's inputs in the perturbed jaxpr
-    therefore does not alter the single-step learning signal — ``dL/dε``
-    stays exact because the ``h = fresh + ε`` add sits outside the detach.
+    therefore keeps the loop's OWN hidden group's single-step signal exact —
+    ``dL/dε`` is unaffected because the ``h = fresh + ε`` add sits outside
+    the detach. Scope caveat: a parameter or *other* hidden group whose only
+    same-step path to the loss crosses the loop gets a zero signal (pinned
+    in ``_algorithm/tests/while_support_test.py``).
     """
 
     def _build(self, **compile_kwargs):

--- a/braintrace/_compiler/scenario_catalog_test.py
+++ b/braintrace/_compiler/scenario_catalog_test.py
@@ -37,6 +37,7 @@ The scenarios target the three core principles stated in ``CLAUDE.md``:
 import warnings
 
 import brainstate
+import jax
 import jax.numpy as jnp
 import pytest
 
@@ -1369,3 +1370,98 @@ class TestCategoryR_ComplexModuleGraphs:
                 ]
 
             assert build() == build()
+
+
+# ---------------------------------------------------------------------------
+# Category S — While-hidden opaque forward (Phase 3)
+# ---------------------------------------------------------------------------
+
+from braintrace._compiler.scenario_catalog import (
+    WhileSettleRNN,
+    WhileSettleTwinRNN,
+)
+
+
+class TestCategoryS_WhileHiddenOpaqueFwd:
+    """A **weight-free** ``lax.while_loop`` reads and updates the hidden
+    state (``WhileSettleRNN``). Under the default policy
+    (``while_hidden='opaque-fwd'``) the compiler keeps the loop as an opaque
+    forward node: the ``win`` relation is registered with the while on its
+    ``y``-to-hidden tail, hidden-to-hidden Jacobians switch to forward mode,
+    and the perturbation pass detaches the loop's inputs with
+    ``stop_gradient`` so the perturbed jaxpr stays reverse-traceable.
+
+    Learning-signal correctness note (recorded from ``vjp_base.py``): the
+    single-step VJP path consumes ONLY the perturbation cotangents
+    (``dg_hid_perturb_or_dl2h``) as the learning signal; the residual
+    hidden-input cotangent (``dg_last_hiddens``) is consumed only by the
+    multi-step branch. Detaching the while's inputs in the perturbed jaxpr
+    therefore does not alter the single-step learning signal — ``dL/dε``
+    stays exact because the ``h = fresh + ε`` add sits outside the detach.
+    """
+
+    def _build(self, **compile_kwargs):
+        model = WhileSettleRNN(3, 4)
+        brainstate.nn.init_all_states(model)
+        x = brainstate.random.rand(3)
+        graph = compile_etrace_graph(model, x, **compile_kwargs)
+        return model, x, graph
+
+    def test_compiles_with_single_relation_through_while(self):
+        model, x, graph = self._build()
+        assert _relation_set(graph) == {(('win',), ('h',))}
+        rel = graph.hidden_param_op_relations[0]
+        assert rel.primitive is etp_mv_p
+        prim_names = {
+            eqn.primitive.name
+            for jaxpr in rel.y_to_hidden_group_jaxprs
+            for eqn in jaxpr.eqns
+        }
+        assert 'while' in prim_names
+
+    def test_opaque_fwd_diagnostic_emitted(self):
+        _, _, graph = self._build()
+        kinds = [r.kind for r in graph.diagnostics]
+        assert DiagnosticKind.CONTROL_FLOW_OPAQUE_FWD in kinds
+
+    def test_perturbed_jaxpr_detaches_while_inputs(self):
+        _, _, graph = self._build()
+        assert graph.hidden_perturb is not None
+        names = [
+            eqn.primitive.name
+            for eqn in graph.hidden_perturb.perturb_jaxpr.jaxpr.eqns
+        ]
+        assert 'while' in names
+        assert 'stop_gradient' in names
+
+    def test_error_policy_escape_hatch(self):
+        model = WhileSettleRNN(3, 4)
+        brainstate.nn.init_all_states(model)
+        x = brainstate.random.rand(3)
+        with pytest.raises(NotImplementedError):
+            compile_etrace_graph(
+                model, x,
+                control_flow=braintrace.ControlFlowPolicy(while_hidden='error'),
+            )
+
+    def test_compiled_values_match_hand_composed_twin(self):
+        model, x, graph = self._build()
+        twin = WhileSettleTwinRNN(3, 4)
+        brainstate.nn.init_all_states(twin)
+        twin.win.value = model.win.value
+
+        out, _, _, _ = graph.module_info.jaxpr_call(x)
+        expected = twin.update(x)
+        out_leaves = jax.tree.leaves(out)
+        assert len(out_leaves) == 1
+        assert jnp.allclose(out_leaves[0], expected, atol=1e-6)
+
+    def test_compile_is_deterministic(self):
+        def build():
+            _, _, g = self._build()
+            return [
+                (r.path, tuple(r.connected_hidden_paths))
+                for r in g.hidden_param_op_relations
+            ]
+
+        assert build() == build()

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,46 @@
 
 ### Highlights
 
+#### New: `while`-loop policy — weight-free opaque-forward support (Phase 3)
+
+- **Weight-free `lax.while_loop`s that read/update hidden state now
+  compile.** Under the new default policy knob
+  `ControlFlowPolicy(while_hidden='opaque-fwd')`, a `while` whose inputs
+  carry no trainable ETP weight is kept as an *opaque forward node*: the
+  compiler registers relations whose `y`→hidden tail crosses the loop,
+  emits a `CONTROL_FLOW_OPAQUE_FWD` INFO diagnostic, and extracts
+  hidden-to-hidden Jacobians for any hidden group whose transition contains
+  a `while` in **forward mode** (`jax.jvp`-based `jacfwd_last_dim` /
+  `jacfwd` block extraction) — reverse mode through `while_loop` is
+  structurally unsupported by JAX. Set
+  `ControlFlowPolicy(while_hidden='error')` to reject such loops instead.
+- **Perturbation detach keeps the VJP reverse-traceable.** The hidden
+  perturbation pass rewires every hidden-producing `while` to consume
+  `stop_gradient` copies of its inputs in the *perturbed jaxpr only*; the
+  `h = fresh + ε` add stays outside the detach, so the single-step learning
+  signal (taken exclusively from the perturbation cotangents) is exact.
+  Verified: D-RTRL single-step gradients on a while-settle model match its
+  hand-composed no-`while` twin element-wise, and the twin matches the BPTT
+  oracle. `vjp_method='multi-step'` on a `while`-hidden model still raises
+  JAX's reverse-through-`while_loop` `ValueError` (documented limitation —
+  use the default single-step path).
+- **A weight used through an ETP primitive inside a `while` is now a hard,
+  actionable error** (`WEIGHT_IN_WHILE` ERROR diagnostic +
+  `NotImplementedError`): restructure the loop, use a fixed-length
+  scan/`for_loop` (which the compiler unrolls), or apply the weight through
+  a plain (non-ETP) op to exclude it from ETP.
+- **Breaking: ETP primitives left inside an un-flattened `scan`/`while`/
+  `cond` body now raise** instead of being silently warned-and-excluded
+  (`etp_in_control_flow='error'`, the new default). Pass
+  `ControlFlowPolicy(etp_in_control_flow='exclude')` to restore the old
+  warn-and-exclude behavior.
+- **Position-mixing guard**: a `while`/opaque control-flow body that applies
+  `dot_general`/`conv_general_dilated` to hidden-derived values (recurrent
+  weight mixing inside the loop) cannot be expressed as a per-position
+  Jacobian; the compiler treats it as a boundary, emits a
+  `CONTROL_FLOW_RECURRENT_MIXING` WARNING, and falls back to the
+  zero-recurrence (e-prop-style) group.
+
 #### New: inner-`scan` unrolling (compiler canonicalization, Phase 2)
 
 - **ETP operations inside `lax.scan` / `brainstate.transform.for_loop`

--- a/changelog.md
+++ b/changelog.md
@@ -22,17 +22,24 @@
   perturbation pass rewires every hidden-producing `while` to consume
   `stop_gradient` copies of its inputs in the *perturbed jaxpr only*; the
   `h = fresh + ε` add stays outside the detach, so the single-step learning
-  signal (taken exclusively from the perturbation cotangents) is exact.
-  Verified: D-RTRL single-step gradients on a while-settle model match its
-  hand-composed no-`while` twin element-wise, and the twin matches the BPTT
-  oracle. `vjp_method='multi-step'` on a `while`-hidden model still raises
-  JAX's reverse-through-`while_loop` `ValueError` (documented limitation —
-  use the default single-step path).
-- **A weight used through an ETP primitive inside a `while` is now a hard,
-  actionable error** (`WEIGHT_IN_WHILE` ERROR diagnostic +
-  `NotImplementedError`): restructure the loop, use a fixed-length
-  scan/`for_loop` (which the compiler unrolls), or apply the weight through
-  a plain (non-ETP) op to exclude it from ETP.
+  signal of the loop's **own** hidden group (taken exclusively from the
+  perturbation cotangents) is exact. Verified: D-RTRL single-step gradients
+  on a while-settle model match its hand-composed no-`while` twin
+  element-wise, and the twin matches the BPTT oracle.
+  **Limitation:** the detach zeroes every same-step reverse path *through*
+  the loop, so a parameter or other hidden group whose only same-step path
+  to the loss crosses the loop — e.g. the weights of an upstream layer
+  feeding a while-hidden layer — receives a **zero** learning signal (a
+  WARNING-level `CONTROL_FLOW_OPAQUE_FWD` diagnostic records each detach;
+  the zero-upstream-gradient behavior is pinned by test).
+  `vjp_method='multi-step'` on a `while`-hidden model still raises JAX's
+  reverse-through-`while_loop` `ValueError` (documented limitation — use
+  the default single-step path).
+- **A weight used inside a `while` is now a hard, actionable error**
+  (`WEIGHT_IN_WHILE` ERROR diagnostic + `NotImplementedError`): move the
+  weight application outside the loop so the loop consumes only its result
+  (subject to the same-step limitation above), or use a fixed-length
+  scan/`for_loop` (which the compiler unrolls).
 - **Breaking: ETP primitives left inside an un-flattened `scan`/`while`/
   `cond` body now raise** instead of being silently warned-and-excluded
   (`etp_in_control_flow='error'`, the new default). Pass


### PR DESCRIPTION
## Summary

Phase 3 of the control-flow support spec: `lax.while_loop` policy for the ETP compiler.

- **Weight-free `while` loops that read/update hidden state now compile** under the new default `ControlFlowPolicy(while_hidden='opaque-fwd')`: the loop is kept as an opaque forward node, hidden-to-hidden Jacobians for transitions crossing a `while` are extracted in forward mode (`jacfwd_last_dim` / `jacfwd` block extraction — JAX has no reverse rule for `while`), and the hidden-perturbation pass detaches the loop inputs with `stop_gradient` so the perturbed jaxpr stays reverse-traceable. `while_hidden='error'` restores the old rejection.
- **A weight used inside a `while` is a hard actionable error** (`WEIGHT_IN_WHILE`).
- **Breaking:** ETP primitives left inside an un-flattened `scan`/`while`/`cond` body now raise instead of warn-and-exclude (`etp_in_control_flow='error'`; `'exclude'` is the escape hatch).
- **Recurrent-mixing guard:** `dot_general`/`conv` applied to hidden-derived values inside an opaque loop body (including behind `jit`/`remat`/custom-derivative calls) is detected and degrades to the zero-recurrence fallback with a WARNING — never a silently wrong per-position Jacobian.
- **Documented limitation (pinned by test):** the detach zeroes same-step reverse credit *through* the loop, so parameters upstream of a while-hidden layer get a zero learning signal; a WARNING diagnostic records each detach. `vjp_method='multi-step'` on while-hidden models raises JAX's reverse-through-while `ValueError`.

## Verification

- Full CPU suite: **1934 passed, 3 skipped**.
- Oracle chain: D-RTRL single-step gradients on the while-settle model ≡ hand-composed no-while twin element-wise (maxdiff ~9.5e-7 float32); twin ≡ BPTT (maxdiff 0.0, also for full-rank pp_prop).
- Whole-branch fresh-agent review: 1 Critical (jit-hidden mixing evading the guard) reproduced and fixed with regression test; 2 Important (diagnostic severity/doc honesty, misleading error guidance) fixed; 3 Minor fixed.