### PR TITLE
Rename YW_TO_W ETP rule to DT_TO_T

### DIFF
--- a/braintrace/_algorithm/_common.py
+++ b/braintrace/_algorithm/_common.py
@@ -456,7 +456,7 @@ def _route_grads_by_path(
     """Route per-key gradients from a dict-API rule into per-path pytrees.
 
     Both D-RTRL and ES-D-RTRL share this bookkeeping: for each key in
-    ``per_key_grads`` (returned by ``xy_to_dw`` or ``yw_to_w``), look up the
+    ``per_key_grads`` (returned by ``xy_to_dw`` or ``dt_to_t``), look up the
     owning ``ParamState`` path and the leaf index from ``relation``, accumulate
     into ``per_path``, then wrap with ``_wrap_leaves_as_pytree`` and merge into
     ``target_dict`` via ``_update_dict``.

--- a/braintrace/_algorithm/param_dim_vjp.py
+++ b/braintrace/_algorithm/param_dim_vjp.py
@@ -27,7 +27,7 @@ from braintrace._compiler import HiddenParamOpRelation, HiddenGroup
 from braintrace._op import (
     etp_conv_p,
     etp_elemwise_p,
-    ETP_RULES_YW_TO_W,
+    ETP_RULES_DT_TO_T,
     ETP_RULES_XY_TO_DW,
     ETP_RULES_INIT_DRTRL,
     is_batched_primitive,
@@ -220,12 +220,12 @@ def _update_param_dim_etrace_scan_fn(
             get_instant_drtrl_rule(relation.primitive)
             or ETP_RULES_XY_TO_DW[relation.primitive]
         )
-        yw_to_w_rule = ETP_RULES_YW_TO_W[relation.primitive]
+        dt_to_t_rule = ETP_RULES_DT_TO_T[relation.primitive]
         eqn_params = relation.eqn_params
         is_elemwise = relation.primitive is etp_elemwise_p
         batched = is_batched_primitive(relation.primitive)
         has_bias = eqn_params.get('has_bias', False)
-        # Fast path only applies to primitives with elementwise yw_to_w, and
+        # Fast path only applies to primitives with elementwise dt_to_t, and
         # only when no parameter-transform hook is present (the closed-form
         # kernels drop the f'(W) factor — gated by ``fp.applicable``).
         fp = get_fast_path_rules(relation.primitive)
@@ -239,7 +239,7 @@ def _update_param_dim_etrace_scan_fn(
         def _call_xy_to_dw_dict(x_: Any, df_: Any, weights_: Any, _rule: Any = xy_to_dw_rule, _params: Any = eqn_params) -> Any:
             return _rule(x_, df_, weights_, **_params)
 
-        def _call_yw_to_w_dict(d: Any, trace_: Any, _rule: Any = yw_to_w_rule, _params: Any = eqn_params) -> Any:
+        def _call_dt_to_t_dict(d: Any, trace_: Any, _rule: Any = dt_to_t_rule, _params: Any = eqn_params) -> Any:
             return _rule(d, trace_, **_params)
 
         def comp_dw_with_x(x_: Any, df_: Any, _wdict: Any = weights_dict) -> Any:
@@ -266,14 +266,14 @@ def _update_param_dim_etrace_scan_fn(
             return _inner(df_all)
 
         def _comp_recurrent_legacy(diag_: Any, old_bwg_: Any, num_state_: Any) -> Any:
-            """Legacy nested-vmap yw_to_w + sum path."""
+            """Legacy nested-vmap dt_to_t + sum path."""
 
             # Under ``brainstate.nn.Vmap(vmap_states='new')`` the hidden-state
             # Jacobian (diag) is per-lane and has lost its leading batch axis,
             # while the weight trace (old_bwg) still carries the singleton batch
             # from ``init_drtrl`` (``batch = x_var.shape[0]`` == 1 for a conv whose
             # forward forces a batch axis). Re-insert the matching singleton on
-            # diag so the ``yw_to_w`` rule sees a consistent batch prefix on both
+            # diag so the ``dt_to_t`` rule sees a consistent batch prefix on both
             # the cotangent and the trace (collapsed again by the solve-time sum).
             if batched and x is not None and diag_.ndim == x.ndim + 1:
                 diag_ = diag_[None]
@@ -281,7 +281,7 @@ def _update_param_dim_etrace_scan_fn(
             def fn_bwg_pre(d: Any, _old: Any = old_bwg_) -> Any:
                 return jax.tree.map(
                     lambda arr: _sum_dim(arr, axis=-1),
-                    jax.vmap(_call_yw_to_w_dict, in_axes=-1, out_axes=-1)(d, _old),
+                    jax.vmap(_call_dt_to_t_dict, in_axes=-1, out_axes=-1)(d, _old),
                 )
 
             # num_state == 1 shortcut: squeeze the size-1 alpha axis to skip
@@ -378,7 +378,7 @@ def _solve_param_dim_weight_gradients(
     # summing the unbatched gradient would collapse its leading (in-feature) axis.
     batched_paths: set = set()
     for relation in weight_hidden_relations:
-        yw_to_w_rule = ETP_RULES_YW_TO_W[relation.primitive]
+        dt_to_t_rule = ETP_RULES_DT_TO_T[relation.primitive]
         solve_drtrl_rule = get_solve_drtrl_rule(relation.primitive)
         eqn_params = relation.eqn_params
         batched = is_batched_primitive(relation.primitive)
@@ -395,7 +395,7 @@ def _solve_param_dim_weight_gradients(
             # e.g. LoRA's effective-weight trace): chain the learning signal
             # through the current weights. The rule sees batch-free,
             # num_state-free slices — the vmap scaffolding below is shared
-            # with the legacy ``yw_to_w`` path.
+            # with the legacy ``dt_to_t`` path.
             weights_dict = {
                 key: _extract_leaf(
                     weight_vals[relation.trainable_paths[key]],
@@ -413,12 +413,12 @@ def _solve_param_dim_weight_gradients(
 
             _call_rule_dict = _call_solve_drtrl_dict
         else:
-            def _call_yw_to_w_dict(d: Any, trace_: Any, _rule: Any = yw_to_w_rule, _params: Any = eqn_params) -> Any:
+            def _call_dt_to_t_dict(d: Any, trace_: Any, _rule: Any = dt_to_t_rule, _params: Any = eqn_params) -> Any:
                 return _rule(d, trace_, **_params)
 
-            _call_rule_dict = _call_yw_to_w_dict
+            _call_rule_dict = _call_dt_to_t_dict
 
-        yw_to_w = (
+        dt_to_t = (
             jax.vmap(_call_rule_dict)
             if batched
             else _call_rule_dict
@@ -439,7 +439,7 @@ def _solve_param_dim_weight_gradients(
             # (necessarily conv here — dense/lora/sparse dispatch to their
             # unbatched variants when per-lane) has a per-lane hidden cotangent
             # that lost its leading batch axis, while the weight trace keeps the
-            # singleton batch from ``init_drtrl``. Both the batched ``yw_to_w`` and
+            # singleton batch from ``init_drtrl``. Both the batched ``dt_to_t`` and
             # the closed-form solve map a shared leading batch axis, so re-insert
             # the matching singleton on the cotangent; the trailing solve-time sum
             # (``has_batched`` branch below) collapses it again.
@@ -479,11 +479,11 @@ def _solve_param_dim_weight_gradients(
                 etr_squeezed = jax.tree.map(
                     lambda a: u.math.squeeze(a, axis=-1), etrace_data_unitless
                 )
-                dg_weight_dict = yw_to_w(dg_hid_squeezed, etr_squeezed)
+                dg_weight_dict = dt_to_t(dg_hid_squeezed, etr_squeezed)
             else:
                 dg_weight_dict = jax.tree.map(
                     lambda arr: _sum_dim(arr, axis=-1),
-                    jax.vmap(yw_to_w, in_axes=-1, out_axes=-1)(
+                    jax.vmap(dt_to_t, in_axes=-1, out_axes=-1)(
                         dg_hidden_unitless, etrace_data_unitless
                     ),
                 )

--- a/braintrace/_algorithm/param_dim_vjp_test.py
+++ b/braintrace/_algorithm/param_dim_vjp_test.py
@@ -648,11 +648,11 @@ class TestInstantSolveDrtrlDispatch:
 
     def test_registered_rules_replicating_legacy_are_identical(self):
         """Routing through the new dispatch with rules that replicate the
-        legacy ``xy_to_dw`` / ``yw_to_w`` behavior must reproduce the same
+        legacy ``xy_to_dw`` / ``dt_to_t`` behavior must reproduce the same
         gradients — proving the ``weights_dict`` plumbing and the batch /
         num_state vmap scaffolding are wired consistently."""
         from braintrace._op import (
-            ETP_RULES_XY_TO_DW, ETP_RULES_YW_TO_W, etp_mm_p,
+            ETP_RULES_XY_TO_DW, ETP_RULES_DT_TO_T, etp_mm_p,
         )
         from braintrace._op._registries import (
             ETP_RULES_INSTANT_DRTRL, ETP_RULES_SOLVE_DRTRL,
@@ -663,7 +663,7 @@ class TestInstantSolveDrtrlDispatch:
         inputs = brainstate.random.randn(5, 3).astype('float32')
 
         xy_rule = ETP_RULES_XY_TO_DW[etp_mm_p]
-        yw_rule = ETP_RULES_YW_TO_W[etp_mm_p]
+        yw_rule = ETP_RULES_DT_TO_T[etp_mm_p]
         seen_weight_keys = []
 
         def instant(x, df, weights, **params):

--- a/braintrace/_legacy/_ops.py
+++ b/braintrace/_legacy/_ops.py
@@ -153,7 +153,7 @@ class ETraceOp:
         """
         return self.xw_to_y(inputs, weights)
 
-    def yw_to_w(self, hidden_dim_arr, weight_dim_tree):
+    def dt_to_t(self, hidden_dim_arr, weight_dim_tree):
         raise NotImplementedError
 
     def xy_to_dw(self, input_dim_arr, hidden_dim_arr, weights):

--- a/braintrace/_op/__init__.py
+++ b/braintrace/_op/__init__.py
@@ -44,7 +44,7 @@ from ._registries import (
     ETP_RULES_INIT_PP,
     ETP_RULES_PP_X_REPR,
     ETP_RULES_XY_TO_DW,
-    ETP_RULES_YW_TO_W,
+    ETP_RULES_DT_TO_T,
     ETP_TRAINABLE_INVARS_FNS,
     ETP_X_INVAR_INDICES,
     ETP_Y_OUTVAR_INDICES,
@@ -76,7 +76,7 @@ __all__ = [
 
     # registries + flag helpers
     'ETP_PRIMITIVES',
-    'ETP_RULES_YW_TO_W',
+    'ETP_RULES_DT_TO_T',
     'ETP_RULES_XY_TO_DW',
     'ETP_RULES_INIT_DRTRL',
     'ETP_RULES_INIT_PP',

--- a/braintrace/_op/_primitive.py
+++ b/braintrace/_op/_primitive.py
@@ -16,7 +16,7 @@
 r""":class:`ETPPrimitive` and :func:`register_primitive`.
 
 Each ETP primitive is a JAX :class:`~jax.core.Primitive` subclass with
-four ETP-specific rule slots (``yw_to_w``, ``xy_to_dw``, ``init_drtrl``,
+four ETP-specific rule slots (``dt_to_t``, ``xy_to_dw``, ``init_drtrl``,
 ``init_pp``). All standard JAX rules — ``impl``, ``abstract_eval``,
 MLIR lowering, JVP, transpose, batching — are auto-derived from a single
 implementation function via :func:`register_primitive`.
@@ -42,7 +42,7 @@ from ._registries import (
     ETP_RULES_INIT_PP,
     ETP_RULES_PP_X_REPR,
     ETP_RULES_XY_TO_DW,
-    ETP_RULES_YW_TO_W,
+    ETP_RULES_DT_TO_T,
     ETP_TRAINABLE_INVARS_FNS,
     ETP_X_INVAR_INDICES,
     ETP_Y_OUTVAR_INDICES,
@@ -85,7 +85,7 @@ class ETPPrimitive(Primitive):
         (2, 4)
     """
 
-    def register_yw_to_w(self, fn: Callable[..., Any]) -> None:
+    def register_dt_to_t(self, fn: Callable[..., Any]) -> None:
         """Install a D-RTRL trace propagation rule.
 
         Parameters
@@ -93,7 +93,7 @@ class ETPPrimitive(Primitive):
         fn : Callable
             Rule with signature ``(hidden_dim, trace, **params) -> trace``.
         """
-        ETP_RULES_YW_TO_W[self] = fn
+        ETP_RULES_DT_TO_T[self] = fn
 
     def register_xy_to_dw(self, fn: Callable[..., Any]) -> None:
         """Install a weight-gradient rule.
@@ -130,7 +130,7 @@ class ETPPrimitive(Primitive):
     def register_etp_rules(
         self,
         *,
-        yw_to_w: Callable[..., Any] | None = None,
+        dt_to_t: Callable[..., Any] | None = None,
         xy_to_dw: Callable[..., Any] | None = None,
         init_drtrl: Callable[..., Any] | None = None,
         init_pp: Callable[..., Any] | None = None,
@@ -143,7 +143,7 @@ class ETPPrimitive(Primitive):
 
         Parameters
         ----------
-        yw_to_w : Callable, optional
+        dt_to_t : Callable, optional
             D-RTRL trace propagation rule. Default ``None``.
         xy_to_dw : Callable, optional
             Weight-gradient rule. Default ``None``.
@@ -155,7 +155,7 @@ class ETPPrimitive(Primitive):
             Closed-form param-dim D-RTRL fast-path kernel bundle (instant /
             recurrent / solve kernels plus the ``applicable`` gate). Registered
             into :data:`ETP_FAST_PATH_RULES`. Supplied only by primitives with
-            an elementwise ``yw_to_w`` rule (mm / mv / elemwise); ``None``
+            an elementwise ``dt_to_t`` rule (mm / mv / elemwise); ``None``
             leaves the primitive without a fast path. Default ``None``.
         pp_x_repr : Callable, optional
             IO-dim x-trace representation rule
@@ -165,8 +165,8 @@ class ETPPrimitive(Primitive):
             one-hot encoding of its integer indices); ``None`` leaves the
             IO-dim trace filtering the raw ``x``. Default ``None``.
         """
-        if yw_to_w is not None:
-            ETP_RULES_YW_TO_W[self] = yw_to_w
+        if dt_to_t is not None:
+            ETP_RULES_DT_TO_T[self] = dt_to_t
         if xy_to_dw is not None:
             ETP_RULES_XY_TO_DW[self] = xy_to_dw
         if init_drtrl is not None:

--- a/braintrace/_op/_primitive_test.py
+++ b/braintrace/_op/_primitive_test.py
@@ -21,7 +21,7 @@ batching — are auto-derived from a single Python ``impl_fn``. These
 tests register a fresh primitive per scenario and verify that ``jit``,
 ``grad``, ``vmap``, ``jvp`` all work without any additional plumbing.
 
-The four ETP rule registration helpers (`register_yw_to_w`,
+The four ETP rule registration helpers (`register_dt_to_t`,
 `register_xy_to_dw`, `register_init_drtrl`, `register_init_pp`,
 `register_etp_rules`) are exercised with both the per-rule and bulk
 APIs.
@@ -43,7 +43,7 @@ from braintrace._op import (
     ETP_RULES_INIT_DRTRL,
     ETP_RULES_INIT_PP,
     ETP_RULES_XY_TO_DW,
-    ETP_RULES_YW_TO_W,
+    ETP_RULES_DT_TO_T,
     GRADIENT_ENABLED_PRIMITIVES,
     ETPPrimitive,
     register_primitive,
@@ -274,16 +274,16 @@ class TestVmap:
 
 class TestRegisterPerRuleAPI:
 
-    def test_register_yw_to_w(self):
+    def test_register_dt_to_t(self):
         p = register_primitive(_fresh_name('yw'), lambda x: x)
         marker = object()
 
         def _rule(hidden_dim, trace, **params):
             return marker
 
-        p.register_yw_to_w(_rule)
-        assert ETP_RULES_YW_TO_W[p] is _rule
-        assert ETP_RULES_YW_TO_W[p](None, None) is marker
+        p.register_dt_to_t(_rule)
+        assert ETP_RULES_DT_TO_T[p] is _rule
+        assert ETP_RULES_DT_TO_T[p](None, None) is marker
 
     def test_register_xy_to_dw(self):
         p = register_primitive(_fresh_name('xy'), lambda x: x)
@@ -318,8 +318,8 @@ class TestRegisterEtpRulesBulk:
     def test_register_all_four(self):
         p = register_primitive(_fresh_name('bulk'), lambda x: x)
         a, b, c, d = (lambda *x, **k: i for i in range(4))
-        p.register_etp_rules(yw_to_w=a, xy_to_dw=b, init_drtrl=c, init_pp=d)
-        assert ETP_RULES_YW_TO_W[p] is a
+        p.register_etp_rules(dt_to_t=a, xy_to_dw=b, init_drtrl=c, init_pp=d)
+        assert ETP_RULES_DT_TO_T[p] is a
         assert ETP_RULES_XY_TO_DW[p] is b
         assert ETP_RULES_INIT_DRTRL[p] is c
         assert ETP_RULES_INIT_PP[p] is d
@@ -327,9 +327,9 @@ class TestRegisterEtpRulesBulk:
     def test_register_partial_skips_none(self):
         p = register_primitive(_fresh_name('partial'), lambda x: x)
         rule = lambda hidden_dim, trace, **params: None
-        # Only yw_to_w is supplied — the other three must remain absent.
-        p.register_etp_rules(yw_to_w=rule)
-        assert ETP_RULES_YW_TO_W[p] is rule
+        # Only dt_to_t is supplied — the other three must remain absent.
+        p.register_etp_rules(dt_to_t=rule)
+        assert ETP_RULES_DT_TO_T[p] is rule
         assert p not in ETP_RULES_XY_TO_DW
         assert p not in ETP_RULES_INIT_DRTRL
         assert p not in ETP_RULES_INIT_PP
@@ -340,10 +340,10 @@ class TestRegisterEtpRulesBulk:
         p = register_primitive(_fresh_name('overwrite'), lambda x: x)
         rule_a = lambda *a, **k: 'a'
         rule_b = lambda *a, **k: 'b'
-        p.register_yw_to_w(rule_a)
-        assert ETP_RULES_YW_TO_W[p] is rule_a
-        p.register_yw_to_w(rule_b)
-        assert ETP_RULES_YW_TO_W[p] is rule_b
+        p.register_dt_to_t(rule_a)
+        assert ETP_RULES_DT_TO_T[p] is rule_a
+        p.register_dt_to_t(rule_b)
+        assert ETP_RULES_DT_TO_T[p] is rule_b
 
 
 class TestPrimitiveNameAndRepr:

--- a/braintrace/_op/_registries.py
+++ b/braintrace/_op/_registries.py
@@ -38,13 +38,13 @@ weight / ``x`` / ``y`` variables on an equation. They are populated by
 One further metadata dictionary — :data:`ETP_FAST_PATH_RULES` — holds the
 optional per-primitive closed-form param-dim D-RTRL "fast-path" kernel
 bundle (:class:`FastPathRules`). Only primitives with an elementwise
-``yw_to_w`` rule register one; it is queried through
+``dt_to_t`` rule register one; it is queried through
 :func:`get_fast_path_rules`.
 
 Two further *optional* rule dictionaries —
 :data:`ETP_RULES_INSTANT_DRTRL` and :data:`ETP_RULES_SOLVE_DRTRL` — let a
 primitive override the param-dim D-RTRL algorithm's default use of
-``xy_to_dw`` (instantaneous trace term) and ``yw_to_w`` (solve-time
+``xy_to_dw`` (instantaneous trace term) and ``dt_to_t`` (solve-time
 contraction) when the trace structure it carries differs from its
 parameter structure (e.g. LoRA's effective-weight trace). They are queried
 through :func:`get_instant_drtrl_rule` / :func:`get_solve_drtrl_rule`,
@@ -58,7 +58,7 @@ from braintrace._compatible_imports import Primitive
 
 __all__ = [
     'ETP_PRIMITIVES',
-    'ETP_RULES_YW_TO_W',
+    'ETP_RULES_DT_TO_T',
     'ETP_RULES_XY_TO_DW',
     'ETP_RULES_INIT_DRTRL',
     'ETP_RULES_INIT_PP',
@@ -89,7 +89,7 @@ __all__ = [
 
 ETP_PRIMITIVES: set = set()
 
-ETP_RULES_YW_TO_W: Dict[Primitive, Callable] = {}
+ETP_RULES_DT_TO_T: Dict[Primitive, Callable] = {}
 r"""D-RTRL trace propagation: ``(hidden_dim, trace, **params) -> trace``."""
 
 ETP_RULES_XY_TO_DW: Dict[Primitive, Callable] = {}
@@ -232,7 +232,7 @@ class FastPathRules(NamedTuple):
 
     Bundles the three closed-form einsum kernels that replace the generic
     nested-``vmap`` trace path for primitives with an *elementwise*
-    ``yw_to_w`` rule (currently ``etp_mm_p`` / ``etp_mv_p`` / ``etp_elemwise_p``),
+    ``dt_to_t`` rule (currently ``etp_mm_p`` / ``etp_mv_p`` / ``etp_elemwise_p``),
     together with a gate predicate that decides whether the fast path is
     valid for a given equation.
 
@@ -245,7 +245,7 @@ class FastPathRules(NamedTuple):
         Recurrent term ``D^t · ε^{t-1}``. Signature
         ``(diag, old_bwg, num_state) -> dict``.
     solve : Callable
-        Solve-time contraction ``Σ_alpha diag_like[..., alpha] · yw_to_w(ε[..., alpha])``.
+        Solve-time contraction ``Σ_alpha diag_like[..., alpha] · dt_to_t(ε[..., alpha])``.
         Signature ``(diag_like, etrace_data, *, fold_batch) -> dict``.
     applicable : Callable
         Gate predicate ``(eqn_params) -> bool`` — ``True`` iff the closed-form
@@ -265,7 +265,7 @@ ETP_FAST_PATH_RULES: Dict[Primitive, FastPathRules] = {}
 r"""Closed-form param-dim D-RTRL fast-path bundle per primitive.
 
 Populated by :meth:`ETPPrimitive.register_etp_rules` (via its ``fast_path``
-keyword). Only primitives with an elementwise ``yw_to_w`` rule register one;
+keyword). Only primitives with an elementwise ``dt_to_t`` rule register one;
 conv / sparse / LoRA primitives are absent (they have no closed-form fast
 path). Queried through :func:`get_fast_path_rules`.
 """
@@ -310,10 +310,10 @@ r"""Optional solve-time weight-gradient rule for param-dim D-RTRL.
 returning **param-shaped** gradients keyed by the primitive's trainable
 names. Register it (together with :data:`ETP_RULES_INSTANT_DRTRL`) when the
 trace structure differs from the parameter structure, so the solve step can
-no longer be expressed by ``yw_to_w`` alone. The rule sees **batch-free,
+no longer be expressed by ``dt_to_t`` alone. The rule sees **batch-free,
 num_state-free slices** (the algorithm vmaps over both axes, mirroring the
-legacy ``yw_to_w`` scaffolding). Unregistered primitives fall back to
-:data:`ETP_RULES_YW_TO_W`.
+legacy ``dt_to_t`` scaffolding). Unregistered primitives fall back to
+:data:`ETP_RULES_DT_TO_T`.
 """
 
 
@@ -349,7 +349,7 @@ def get_solve_drtrl_rule(primitive) -> Optional[Callable]:
         Rule ``(dg_hidden, trace_dict, weights_dict, **eqn_params) -> dict``
         producing param-shaped gradients keyed by trainable names, or
         ``None`` if the primitive did not register one (the algorithm then
-        uses ``yw_to_w``).
+        uses ``dt_to_t``).
     """
     return ETP_RULES_SOLVE_DRTRL.get(primitive)
 

--- a/braintrace/_op/_registries_test.py
+++ b/braintrace/_op/_registries_test.py
@@ -30,7 +30,7 @@ from braintrace._op import (
     ETP_RULES_INIT_DRTRL,
     ETP_RULES_INIT_PP,
     ETP_RULES_XY_TO_DW,
-    ETP_RULES_YW_TO_W,
+    ETP_RULES_DT_TO_T,
     GRADIENT_ENABLED_PRIMITIVES,
     etp_conv_p,
     etp_elemwise_p,
@@ -82,9 +82,9 @@ class TestETPPrimitivesMembership:
 class TestRuleDictsPopulated:
     """Every shipped primitive has all four ETP rules registered."""
 
-    def test_yw_to_w_for_every_shipped(self):
+    def test_dt_to_t_for_every_shipped(self):
         for prim in _ALL_SHIPPED:
-            assert prim in ETP_RULES_YW_TO_W, prim.name
+            assert prim in ETP_RULES_DT_TO_T, prim.name
 
     def test_xy_to_dw_for_every_shipped(self):
         for prim in _ALL_SHIPPED:
@@ -161,7 +161,7 @@ class TestRegistriesAreSharedAcrossImports:
 
     def test_shim_and_package_share_rule_dicts(self):
         from braintrace import _op as legacy
-        assert legacy.ETP_RULES_YW_TO_W is ETP_RULES_YW_TO_W
+        assert legacy.ETP_RULES_DT_TO_T is ETP_RULES_DT_TO_T
         assert legacy.ETP_RULES_XY_TO_DW is ETP_RULES_XY_TO_DW
         assert legacy.ETP_RULES_INIT_DRTRL is ETP_RULES_INIT_DRTRL
         assert legacy.ETP_RULES_INIT_PP is ETP_RULES_INIT_PP
@@ -175,7 +175,7 @@ class TestRegistriesAreSharedAcrossImports:
 def test_get_fast_path_rules_none_for_sparse_conv_lora():
     """Primitives without a closed-form fast path return ``None``.
 
-    Only the elementwise-``yw_to_w`` primitives (mm / mv / elemwise) register
+    Only the elementwise-``dt_to_t`` primitives (mm / mv / elemwise) register
     a :class:`FastPathRules` bundle. Conv / sparse / LoRA primitives have
     non-elementwise rules and so must not appear in the fast-path registry.
     """

--- a/braintrace/_op/conv.py
+++ b/braintrace/_op/conv.py
@@ -49,7 +49,7 @@ output element). The conv primitive implements:
   **without** summing over spatial positions (the sum happens at the
   consumer's contraction step).
 
-* ``instant_drtrl`` / ``yw_to_w`` / ``solve_drtrl`` — the param-dim
+* ``instant_drtrl`` / ``dt_to_t`` / ``solve_drtrl`` — the param-dim
   D-RTRL trace machinery. Because the kernel is *spatially shared*
   (every output position reads the same :math:`K`) while the D-RTRL
   discount :math:`\mathbf{D}^t` acts per output element, no kernel-shaped
@@ -71,7 +71,7 @@ output element). The conv primitive implements:
     :math:`(\mathbf{D}_f^t)_{b,\mathbf{s},k}\,\mathrm{patch}^t_{b,\mathbf{s},\mathbf{u},c}`
     for the kernel, and the per-position cotangent (with the ``bias_fn``
     chain) for the bias.
-  - ``yw_to_w`` (recurrence only) multiplies every trace slot by the
+  - ``dt_to_t`` (recurrence only) multiplies every trace slot by the
     per-position factor :math:`D^t_{b,\mathbf{s},k}` — no spatial sums
     anywhere.
   - ``solve_drtrl`` contracts the learning signal with the trace,
@@ -106,7 +106,7 @@ are always taken w.r.t. the **raw** kernel / bias, so the transform
 Jacobian :math:`f'` enters *only* through the instantaneous rules via
 :func:`jax.vjp` (``kernel_fn`` through a kernel VJP — applied per output
 position in ``instant_drtrl`` — ``bias_fn`` as an elementwise per-channel
-diagonal factor). The ``yw_to_w`` / ``solve_drtrl`` rules and the trace
+diagonal factor). The ``dt_to_t`` / ``solve_drtrl`` rules and the trace
 initialisers are transform-free and stay exact (they operate on
 :math:`\partial h / \partial K_{\text{raw}}`).
 
@@ -248,7 +248,7 @@ def _conv_layout(params: dict[str, Any]) -> tuple[int, int, int, int]:
     return n_spatial, channel_axis, batch_axis, kernel_out_axis
 
 
-def _conv_yw_to_w(hidden_dim: Any, trace: dict[str, Any], **params: Any) -> dict[str, Any]:
+def _conv_dt_to_t(hidden_dim: Any, trace: dict[str, Any], **params: Any) -> dict[str, Any]:
     r"""Apply the recurrence factor :math:`D^t = \partial h^t / \partial y`
     to the per-position conv trace — a pure elementwise multiply.
 
@@ -343,7 +343,7 @@ def _conv_xy_to_dw(x: Any, hidden_dim: Any, weights: dict[str, Any], **params: A
     **Bias path.** The bias appears additively with no spatial coupling,
     so its instantaneous Jacobian is the cotangent itself at each
     spatial position. We store this per-position (no spatial sum here);
-    the sum is performed inside :func:`_conv_yw_to_w` during trace
+    the sum is performed inside :func:`_conv_dt_to_t` during trace
     propagation — this keeps the bias-trace shape identical to
     :math:`\partial h / \partial y` so the :math:`\mathbf{D}^t \boldsymbol{\epsilon}^{t-1}`
     recurrence can be applied element-by-element.
@@ -669,7 +669,7 @@ def _conv_init_drtrl(x_var: Any, y_var: Any, weight_vars: dict[str, Any],
     convolutions prefer the IO-dim algorithm (``pp_prop`` /
     ``IODimVjpAlgorithm``), whose conv trace stays output-shaped.
 
-    The bias trace keeps spatial dims so :func:`_conv_yw_to_w` can apply
+    The bias trace keeps spatial dims so :func:`_conv_dt_to_t` can apply
     the per-position :math:`D^t` factor elementwise; the spatial sum
     implementing :math:`\sum_{\mathbf{s}} g_{\mathbf{s}} \partial
     h/\partial b_k` is performed at solve time by
@@ -759,7 +759,7 @@ etp_conv_p = register_primitive(
     x_invar_index=0,
 )
 etp_conv_p.register_etp_rules(
-    yw_to_w=_conv_yw_to_w,
+    dt_to_t=_conv_dt_to_t,
     xy_to_dw=_conv_xy_to_dw,
     init_drtrl=_conv_init_drtrl,
     init_pp=_conv_init_pp,
@@ -767,7 +767,7 @@ etp_conv_p.register_etp_rules(
 # Param-dim D-RTRL overrides: the per-position kernel trace (spatial output
 # axes retained) differs from the parameter structure, so the instantaneous
 # term and the solve-time contraction cannot be expressed by xy_to_dw /
-# yw_to_w alone. IO-dim (ES-D-RTRL) keeps using xy_to_dw.
+# dt_to_t alone. IO-dim (ES-D-RTRL) keeps using xy_to_dw.
 ETP_RULES_INSTANT_DRTRL[etp_conv_p] = _conv_instant_drtrl
 ETP_RULES_SOLVE_DRTRL[etp_conv_p] = _conv_solve_drtrl
 

--- a/braintrace/_op/conv_test.py
+++ b/braintrace/_op/conv_test.py
@@ -44,7 +44,7 @@ from braintrace._op import (
     ETP_RULES_INIT_DRTRL,
     ETP_RULES_INIT_PP,
     ETP_RULES_XY_TO_DW,
-    ETP_RULES_YW_TO_W,
+    ETP_RULES_DT_TO_T,
     conv,
     etp_conv_p,
 )
@@ -203,8 +203,8 @@ class TestJAXRules:
 
 class TestConvEtpRules:
 
-    def test_yw_to_w_broadcasts_hidden_no_bias(self):
-        rule = ETP_RULES_YW_TO_W[etp_conv_p]
+    def test_dt_to_t_broadcasts_hidden_no_bias(self):
+        rule = ETP_RULES_DT_TO_T[etp_conv_p]
         # Simulate the scan/etrace-update (recurrence) call — batch retained.
         # 1-D NHC-HIO conv: kernel (H_k=3, in_ch=4, out_ch=4), output (N, H_out=6, C=4).
         # hidden_dim (the per-position D^t factor) has the full batched output
@@ -225,8 +225,8 @@ class TestConvEtpRules:
         expected = w_trace * hidden[:, :, None, None, :]
         np.testing.assert_allclose(out['weight'], expected)
 
-    def test_yw_to_w_broadcasts_hidden_with_bias(self):
-        rule = ETP_RULES_YW_TO_W[etp_conv_p]
+    def test_dt_to_t_broadcasts_hidden_with_bias(self):
+        rule = ETP_RULES_DT_TO_T[etp_conv_p]
         # Recurrence context for 1-D conv NHC-HIO.
         # hidden_dim = (batch=1, H_out=6, out_ch=4).
         # trace['weight'] = (batch=1, H_out=6, H_k=3, in_ch=4, out_ch=4).
@@ -248,10 +248,10 @@ class TestConvEtpRules:
         assert out['bias'].shape == (1, 6, 4)
         np.testing.assert_allclose(out['bias'], b_trace * hidden)
 
-    def test_yw_to_w_default_nch_layout(self):
+    def test_dt_to_t_default_nch_layout(self):
         """Default (NCH/OIH) layout: hd must be transposed to (batch, s, k)
         and its channel aligned to the kernel's out-channel axis (0 in OIH)."""
-        rule = ETP_RULES_YW_TO_W[etp_conv_p]
+        rule = ETP_RULES_DT_TO_T[etp_conv_p]
         batch, c_out, length = 1, 3, 8
         brainstate.random.seed(2)
         hidden = brainstate.random.randn(batch, c_out, length)      # NCH
@@ -285,7 +285,7 @@ class TestConvEtpRules:
         """xy_to_dw returns both 'weight' and 'bias' gradients when has_bias=True.
 
         The bias 'gradient' is the cotangent (hidden_dim) itself — same shape as y.
-        No spatial summation: that is deferred to _conv_yw_to_w.
+        No spatial summation: that is deferred to _conv_dt_to_t.
         """
         rule = ETP_RULES_XY_TO_DW[etp_conv_p]
         x = jnp.ones((1, 3, 8))

--- a/braintrace/_op/dense.py
+++ b/braintrace/_op/dense.py
@@ -46,7 +46,7 @@ by D-RTRL and ES-D-RTRL (pp-prop). For a primitive producing output
       \boldsymbol{\epsilon}^t \approx \mathbf{D}^t \boldsymbol{\epsilon}^{t-1}
                                      + \operatorname{diag}(\mathbf{D}_f^t) \otimes \mathbf{x}^t
 
-* ``yw_to_w(hidden_dim, trace)`` — multiplies the weight-shaped trace
+* ``dt_to_t(hidden_dim, trace)`` — multiplies the weight-shaped trace
   :math:`\boldsymbol{\epsilon}^{t-1}` elementwise by
   :math:`\partial h / \partial y` (supplied as ``hidden_dim``). This
   realises the :math:`\mathbf{D}^t \boldsymbol{\epsilon}^{t-1}` term
@@ -82,7 +82,7 @@ Both primitives accept two optional elementwise transform hooks in their
 :func:`_mv_xy_to_dw` rules apply them; the eligibility trace and gradient
 are always taken w.r.t. the **raw** weight/bias, so the transform Jacobian
 :math:`f'` enters *only* through ``xy_to_dw`` via :func:`jax.vjp`. The
-``yw_to_w`` rule does **not** apply :math:`f'`.
+``dt_to_t`` rule does **not** apply :math:`f'`.
 
 Both hooks are threaded through ``eqn.params``, which JAX treats as a
 *static* (hashed-by-identity) part of the equation. Two textually identical
@@ -150,10 +150,10 @@ def _mm_trainable_invars(params: dict[str, Any]) -> dict[str, int]:
     return base
 
 
-def _mm_yw_to_w(hidden_dim: Any, trace: dict[str, Any], *, has_bias: bool = False,
+def _mm_dt_to_t(hidden_dim: Any, trace: dict[str, Any], *, has_bias: bool = False,
                 weight_fn: WeightFn | None = None,
                 bias_fn: WeightFn | None = None) -> dict[str, Any]:
-    r"""Batched ``yw_to_w`` — propagate :math:`\partial h / \partial y`
+    r"""Batched ``dt_to_t`` — propagate :math:`\partial h / \partial y`
     through a weight-shaped D-RTRL trace.
 
     **Role in D-RTRL.** Implements the multiplicative step inside
@@ -462,7 +462,7 @@ etp_mm_p = register_primitive(
     x_invar_index=0,
 )
 etp_mm_p.register_etp_rules(
-    yw_to_w=_mm_yw_to_w,
+    dt_to_t=_mm_dt_to_t,
     xy_to_dw=_mm_xy_to_dw,
     init_drtrl=_mm_init_drtrl,
     init_pp=_mm_init_pp,
@@ -482,10 +482,10 @@ def _mv_trainable_invars(params: dict[str, Any]) -> dict[str, int]:
     return base
 
 
-def _mv_yw_to_w(hidden_dim: Any, trace: dict[str, Any], *, has_bias: bool = False,
+def _mv_dt_to_t(hidden_dim: Any, trace: dict[str, Any], *, has_bias: bool = False,
                 weight_fn: WeightFn | None = None,
                 bias_fn: WeightFn | None = None) -> dict[str, Any]:
-    r"""Unbatched ``yw_to_w`` — same algebra as the batched case, no batch axis.
+    r"""Unbatched ``dt_to_t`` — same algebra as the batched case, no batch axis.
 
     **Role in D-RTRL.** Realises the :math:`y \to W` chain factor within
     :math:`\mathbf{D}^t \boldsymbol{\epsilon}^{t-1}`; since
@@ -606,7 +606,7 @@ etp_mv_p = register_primitive(
     x_invar_index=0,
 )
 etp_mv_p.register_etp_rules(
-    yw_to_w=_mv_yw_to_w,
+    dt_to_t=_mv_dt_to_t,
     xy_to_dw=_mv_xy_to_dw,
     init_drtrl=_mv_init_drtrl,
     init_pp=_mv_init_pp,

--- a/braintrace/_op/dense_test.py
+++ b/braintrace/_op/dense_test.py
@@ -25,7 +25,7 @@ Coverage:
 * Bias presence — ``has_bias`` parameter is propagated through ``bind``.
 * brainunit support — quantities, mixed units, unitless inputs.
 * JAX rules — jit, vmap, grad, jvp work with no extra plumbing.
-* Four ETP rules — ``yw_to_w``, ``xy_to_dw``, ``init_drtrl``, ``init_pp``
+* Four ETP rules — ``dt_to_t``, ``xy_to_dw``, ``init_drtrl``, ``init_pp``
   return tensors of the documented shape and value.
 """
 
@@ -44,7 +44,7 @@ from braintrace._op import (
     ETP_RULES_INIT_DRTRL,
     ETP_RULES_INIT_PP,
     ETP_RULES_XY_TO_DW,
-    ETP_RULES_YW_TO_W,
+    ETP_RULES_DT_TO_T,
     etp_mm_p,
     etp_mv_p,
     get_fast_path_rules,
@@ -230,19 +230,19 @@ class TestJAXRules:
 
 
 # ---------------------------------------------------------------------------
-# ETP rules — yw_to_w / xy_to_dw / init_drtrl / init_pp
+# ETP rules — dt_to_t / xy_to_dw / init_drtrl / init_pp
 # ---------------------------------------------------------------------------
 
 class TestMmEtpRules:
 
-    def test_yw_to_w_broadcasts_hidden(self):
-        """``yw_to_w`` multiplies ``trace['weight']`` element-wise by
+    def test_dt_to_t_broadcasts_hidden(self):
+        """``dt_to_t`` multiplies ``trace['weight']`` element-wise by
         ``hidden_dim`` broadcast along the input axis. Trace shape is
         ``(in, out)`` (solve context, batch stripped); ``hidden_dim`` is
         ``(out,)``. ``expand_dims(hidden_dim, axis=-2)`` → ``(1, out)``
         broadcasts against ``(in, out)`` → per-row scaling by ``hidden[o]``.
         Correct for non-square (in != out)."""
-        rule = ETP_RULES_YW_TO_W[etp_mm_p]
+        rule = ETP_RULES_DT_TO_T[etp_mm_p]
         in_dim, out_dim = 5, 3
         hidden = jnp.array([1.0, 2.0, 3.0])  # (out,)
         trace = {'weight': jnp.ones((in_dim, out_dim))}
@@ -254,9 +254,9 @@ class TestMmEtpRules:
             out['weight'], jnp.ones((in_dim, out_dim)) * hidden[None, :]
         )
 
-    def test_yw_to_w_with_bias(self):
-        """When has_bias=True, ``yw_to_w`` also scales ``trace['bias']``."""
-        rule = ETP_RULES_YW_TO_W[etp_mm_p]
+    def test_dt_to_t_with_bias(self):
+        """When has_bias=True, ``dt_to_t`` also scales ``trace['bias']``."""
+        rule = ETP_RULES_DT_TO_T[etp_mm_p]
         in_dim, out_dim = 5, 4
         hidden = jnp.array([1.0, 2.0, 3.0, 4.0])  # (out,)
         trace = {
@@ -325,10 +325,10 @@ class TestMmEtpRules:
 
 class TestMvEtpRules:
 
-    def test_yw_to_w_broadcasts_hidden(self):
-        """``yw_to_w`` multiplies ``trace['weight']`` by ``hidden`` broadcast
+    def test_dt_to_t_broadcasts_hidden(self):
+        """``dt_to_t`` multiplies ``trace['weight']`` by ``hidden`` broadcast
         along the column axis. The rule accepts and returns a dict."""
-        rule = ETP_RULES_YW_TO_W[etp_mv_p]
+        rule = ETP_RULES_DT_TO_T[etp_mv_p]
         hidden = jnp.array([1.0, 2.0, 3.0, 4.0])  # (out,)
         trace = {'weight': jnp.ones((3, 4))}  # (in, out)
         out = rule(hidden, trace)
@@ -337,9 +337,9 @@ class TestMvEtpRules:
         # column j scaled by hidden[j]
         np.testing.assert_allclose(out['weight'], jnp.ones((3, 4)) * hidden[None, :])
 
-    def test_yw_to_w_with_bias(self):
-        """When has_bias=True, ``yw_to_w`` also scales ``trace['bias']``."""
-        rule = ETP_RULES_YW_TO_W[etp_mv_p]
+    def test_dt_to_t_with_bias(self):
+        """When has_bias=True, ``dt_to_t`` also scales ``trace['bias']``."""
+        rule = ETP_RULES_DT_TO_T[etp_mv_p]
         hidden = jnp.array([1.0, 2.0, 3.0, 4.0])
         trace = {'weight': jnp.ones((3, 4)), 'bias': jnp.ones((4,))}
         out = rule(hidden, trace, has_bias=True)
@@ -480,7 +480,7 @@ class TestMMBiasGradient:
 
 
 class TestMMNonSquareWeight:
-    """_mm_yw_to_w must broadcast hidden_dim correctly when in != out.
+    """_mm_dt_to_t must broadcast hidden_dim correctly when in != out.
 
     The latent bug was ``jnp.expand_dims(hidden_dim, axis=1)`` in the
     gradient-solve context where the batch axis is stripped: for
@@ -490,8 +490,8 @@ class TestMMNonSquareWeight:
     in both the batched (trace-update) and unbatched (solve) contexts.
     """
 
-    def test_yw_to_w_non_square_solve_context(self):
-        from braintrace._op.dense import _mm_yw_to_w
+    def test_dt_to_t_non_square_solve_context(self):
+        from braintrace._op.dense import _mm_dt_to_t
         # Gradient-solve shapes (batch axis stripped by outer vmap).
         in_dim, out_dim = 5, 3
         trace_weight = jnp.arange(in_dim * out_dim, dtype=jnp.float32).reshape(
@@ -499,21 +499,21 @@ class TestMMNonSquareWeight:
         )
         hidden_dim = jnp.array([1.0, 2.0, 3.0])  # (out,)
 
-        out = _mm_yw_to_w(hidden_dim, {'weight': trace_weight}, has_bias=False)
+        out = _mm_dt_to_t(hidden_dim, {'weight': trace_weight}, has_bias=False)
 
         # Expected: trace[i, o] * hidden_dim[o] — broadcast across in axis.
         expected = trace_weight * hidden_dim[None, :]
         np.testing.assert_array_equal(out['weight'], expected)
         assert out['weight'].shape == (in_dim, out_dim)
 
-    def test_yw_to_w_non_square_trace_update_context(self):
-        from braintrace._op.dense import _mm_yw_to_w
+    def test_dt_to_t_non_square_trace_update_context(self):
+        from braintrace._op.dense import _mm_dt_to_t
         # Trace-update shapes (batch retained).
         batch, in_dim, out_dim = 2, 5, 3
         trace_weight = jnp.ones((batch, in_dim, out_dim)) * 0.5
         hidden_dim = jnp.ones((batch, out_dim)) * 2.0
 
-        out = _mm_yw_to_w(hidden_dim, {'weight': trace_weight}, has_bias=False)
+        out = _mm_dt_to_t(hidden_dim, {'weight': trace_weight}, has_bias=False)
 
         # Expected: trace[b,i,o] * hidden_dim[b,o].
         expected = trace_weight * hidden_dim[:, None, :]
@@ -635,8 +635,8 @@ class TestWeightFnBiasFn:
         assert_xy_to_dw_matches_vjp(rule=rule, impl=impl, x=x, hidden_dim=hidden,
                                     weights=weights, params=params)
 
-    def test_yw_to_w_tolerates_transform_params(self):
-        rule = ETP_RULES_YW_TO_W[etp_mv_p]
+    def test_dt_to_t_tolerates_transform_params(self):
+        rule = ETP_RULES_DT_TO_T[etp_mv_p]
         hidden = jnp.arange(4.0)
         trace = {'weight': jnp.ones((3, 4))}
         out = rule(hidden, trace, has_bias=False, weight_fn=jnp.tanh, bias_fn=None)
@@ -793,11 +793,11 @@ class TestDenseFastPath:
 
 
 # ---------------------------------------------------------------------------
-# Audit Task 11 (T3): first-principles ``yw_to_w`` from ``jax.jacobian``
+# Audit Task 11 (T3): first-principles ``dt_to_t`` from ``jax.jacobian``
 # ---------------------------------------------------------------------------
 
-class TestYwToWFirstPrinciplesFromJacobian:
-    """Derive ``_mm_yw_to_w`` / ``_mv_yw_to_w`` from ``jax.jacobian`` of the
+class TestDtToTFirstPrinciplesFromJacobian:
+    """Derive ``_mm_dt_to_t`` / ``_mv_dt_to_t`` from ``jax.jacobian`` of the
     primitive's own forward, rather than trusting the rule's own formula.
 
     ``y = x @ w`` has ``partial y_o / partial w_{i, o'} = delta(o, o') x_i`` —
@@ -806,15 +806,15 @@ class TestYwToWFirstPrinciplesFromJacobian:
     (``in != out``, so a wrong-axis broadcast would not silently line up).
     Because the Jacobian is diagonal, the general chain-rule contraction of a
     cotangent ``g`` against the full Jacobian collapses to an elementwise
-    broadcast-multiply — exactly what ``yw_to_w`` implements. Each test
+    broadcast-multiply — exactly what ``dt_to_t`` implements. Each test
     builds the "general" contraction via an explicit ``jnp.einsum`` over the
     *raw* Jacobian tensor (never the rule's own broadcast code) and compares
     it, for a random (never all-ones) cotangent and random incoming trace,
     against the rule's actual output.
     """
 
-    def test_mm_yw_to_w_weight_and_bias_match_jacobian_contraction(self):
-        from braintrace._op.dense import _mm_yw_to_w
+    def test_mm_dt_to_t_weight_and_bias_match_jacobian_contraction(self):
+        from braintrace._op.dense import _mm_dt_to_t
         brainstate.random.seed(301)
         batch, n_in, n_out = 2, 3, 5  # non-square: exercises axis=-2 broadcast
         x = brainstate.random.randn(batch, n_in)
@@ -855,12 +855,12 @@ class TestYwToWFirstPrinciplesFromJacobian:
         ref_w = jnp.einsum('bo,bio->bio', g, trace_w)
         ref_b = jnp.einsum('bo,bo->bo', g, trace_b)
 
-        out = _mm_yw_to_w(g, {'weight': trace_w, 'bias': trace_b}, has_bias=True)
+        out = _mm_dt_to_t(g, {'weight': trace_w, 'bias': trace_b}, has_bias=True)
         np.testing.assert_allclose(out['weight'], ref_w, atol=1e-10)
         np.testing.assert_allclose(out['bias'], ref_b, atol=1e-10)
 
-    def test_mv_yw_to_w_weight_and_bias_match_jacobian_contraction(self):
-        from braintrace._op.dense import _mv_yw_to_w
+    def test_mv_dt_to_t_weight_and_bias_match_jacobian_contraction(self):
+        from braintrace._op.dense import _mv_dt_to_t
         brainstate.random.seed(302)
         n_in, n_out = 3, 5  # non-square
         x = brainstate.random.randn(n_in)
@@ -884,6 +884,6 @@ class TestYwToWFirstPrinciplesFromJacobian:
         ref_w = jnp.einsum('o,io->io', g, trace_w)
         ref_b = jnp.einsum('o,o->o', g, trace_b)
 
-        out = _mv_yw_to_w(g, {'weight': trace_w, 'bias': trace_b}, has_bias=True)
+        out = _mv_dt_to_t(g, {'weight': trace_w, 'bias': trace_b}, has_bias=True)
         np.testing.assert_allclose(out['weight'], ref_w, atol=1e-10)
         np.testing.assert_allclose(out['bias'], ref_b, atol=1e-10)

--- a/braintrace/_op/einsum.py
+++ b/braintrace/_op/einsum.py
@@ -152,7 +152,7 @@ etp_einsum_p = register_primitive(
 )
 
 
-def _einsum_yw_to_w(hidden_dim: Any, trace: dict[str, Any], *, equation: str,
+def _einsum_dt_to_t(hidden_dim: Any, trace: dict[str, Any], *, equation: str,
                     weight_fn: WeightFn | None = None) -> dict[str, Any]:
     r"""Propagate ``∂h/∂y`` through the weight-shaped trace, mechanically.
 
@@ -228,7 +228,7 @@ def _einsum_init_pp(x_var: Any, y_var: Any, weight_vars: dict[str, Any],
 
 
 etp_einsum_p.register_etp_rules(
-    yw_to_w=_einsum_yw_to_w,
+    dt_to_t=_einsum_dt_to_t,
     xy_to_dw=_einsum_xy_to_dw,
     init_drtrl=_einsum_init_drtrl,
     init_pp=_einsum_init_pp,

--- a/braintrace/_op/einsum_test.py
+++ b/braintrace/_op/einsum_test.py
@@ -153,7 +153,7 @@ from braintrace._op import (
     ETP_RULES_INIT_DRTRL,
     ETP_RULES_INIT_PP,
     ETP_RULES_XY_TO_DW,
-    ETP_RULES_YW_TO_W,
+    ETP_RULES_DT_TO_T,
 )
 from braintrace._op.dense import etp_mm_p
 from braintrace._op.grouped import etp_gmm_p
@@ -162,45 +162,45 @@ from braintrace._op.op_rule_oracle import assert_xy_to_dw_matches_vjp
 
 class TestEinsumEtpRules:
 
-    def test_yw_to_w_matches_dense_rule(self):
+    def test_dt_to_t_matches_dense_rule(self):
         brainstate.random.seed(10)
         hd = brainstate.random.randn(5, 4)
         tr = {'weight': brainstate.random.randn(5, 3, 4)}
-        got = ETP_RULES_YW_TO_W[etp_einsum_p](hd, tr, equation='bk,kn->bn')
-        want = ETP_RULES_YW_TO_W[etp_mm_p](hd, dict(tr), has_bias=False)
+        got = ETP_RULES_DT_TO_T[etp_einsum_p](hd, tr, equation='bk,kn->bn')
+        want = ETP_RULES_DT_TO_T[etp_mm_p](hd, dict(tr), has_bias=False)
         np.testing.assert_allclose(got['weight'], want['weight'], atol=1e-6)
 
-    def test_yw_to_w_matches_grouped_rule(self):
+    def test_dt_to_t_matches_grouped_rule(self):
         brainstate.random.seed(11)
         hd = brainstate.random.randn(5, 2, 4)
         tr = {'weight': brainstate.random.randn(5, 2, 3, 4)}
-        got = ETP_RULES_YW_TO_W[etp_einsum_p](hd, tr, equation='bgk,gkn->bgn')
-        want = ETP_RULES_YW_TO_W[etp_gmm_p](hd, dict(tr), has_bias=False)
+        got = ETP_RULES_DT_TO_T[etp_einsum_p](hd, tr, equation='bgk,gkn->bgn')
+        want = ETP_RULES_DT_TO_T[etp_gmm_p](hd, dict(tr), has_bias=False)
         np.testing.assert_allclose(got['weight'], want['weight'], atol=1e-6)
 
-    def test_yw_to_w_grad_context_batch_stripped(self):
+    def test_dt_to_t_grad_context_batch_stripped(self):
         brainstate.random.seed(12)
         hd = brainstate.random.randn(4)                    # (n,) — batch stripped
         tr = {'weight': brainstate.random.randn(3, 4)}     # (k, n)
-        got = ETP_RULES_YW_TO_W[etp_einsum_p](hd, tr, equation='bk,kn->bn')
+        got = ETP_RULES_DT_TO_T[etp_einsum_p](hd, tr, equation='bk,kn->bn')
         np.testing.assert_allclose(got['weight'], tr['weight'] * hd[None, :], atol=1e-6)
 
-    def test_yw_to_w_per_head_diagonal_axes(self):
+    def test_dt_to_t_per_head_diagonal_axes(self):
         brainstate.random.seed(13)
         hd = brainstate.random.randn(5, 2, 4)              # (b, h, e)
         tr = {'weight': brainstate.random.randn(5, 2, 3, 4)}  # (b, h, d, e)
-        got = ETP_RULES_YW_TO_W[etp_einsum_p](hd, tr, equation='bhd,hde->bhe')
+        got = ETP_RULES_DT_TO_T[etp_einsum_p](hd, tr, equation='bhd,hde->bhe')
         want = tr['weight'] * hd[:, :, None, :]
         np.testing.assert_allclose(got['weight'], want, atol=1e-6)
 
-    def test_yw_to_w_shared_axis_sums_hidden(self):
+    def test_dt_to_t_shared_axis_sums_hidden(self):
         """Rule-level contract for shared axes: hd is summed over 't' then
         broadcast — oracle-proven exact when the hidden state carries the
         shared axes (see TestSharedAxisOracle)."""
         brainstate.random.seed(14)
         hd = brainstate.random.randn(5, 2, 4)              # (b, t, n)
         tr = {'weight': brainstate.random.randn(5, 3, 4)}  # (b, k, n)
-        got = ETP_RULES_YW_TO_W[etp_einsum_p](hd, tr, equation='btk,kn->btn')
+        got = ETP_RULES_DT_TO_T[etp_einsum_p](hd, tr, equation='btk,kn->btn')
         want = tr['weight'] * hd.sum(axis=1)[:, None, :]
         np.testing.assert_allclose(got['weight'], want, atol=1e-5)
 

--- a/braintrace/_op/elemwise.py
+++ b/braintrace/_op/elemwise.py
@@ -49,7 +49,7 @@ primitive when composing Jacobians).
   instantaneous :math:`\operatorname{diag}(\mathbf{D}_f^t)\otimes 1` for
   D-RTRL (no :math:`x` factor since the op has no separate input).
 
-* ``yw_to_w(hidden_dim, trace)`` — elementwise product
+* ``dt_to_t(hidden_dim, trace)`` — elementwise product
   :math:`\epsilon^t = (\partial h/\partial y) \odot \epsilon^{t-1}`.
   The primitive is *diagonal*, so broadcasting is trivial: both trace
   and ``hidden_dim`` share the same shape.
@@ -68,7 +68,7 @@ The primitive accepts a single optional elementwise transform hook,
 is no ``x`` input and no bias for this op). The eligibility trace and
 gradient are taken w.r.t. the **raw** weight, so the transform Jacobian
 :math:`f'` enters *only* through :func:`_elemwise_xy_to_dw` via
-:func:`jax.vjp`; the ``yw_to_w`` rule does **not** apply :math:`f'`.
+:func:`jax.vjp`; the ``dt_to_t`` rule does **not** apply :math:`f'`.
 
 **Fast path**
 
@@ -105,7 +105,7 @@ def _elem_trainable_invars(params: dict[str, Any]) -> dict[str, int]:
     return {'weight': 0}
 
 
-def _elemwise_yw_to_w(hidden_dim: Any, trace: dict[str, Any], *,
+def _elemwise_dt_to_t(hidden_dim: Any, trace: dict[str, Any], *,
                       weight_fn: WeightFn | None = None) -> dict[str, Any]:
     r"""Diagonal trace propagation for an identity-like op.
 
@@ -373,7 +373,7 @@ etp_elemwise_p = register_primitive(
     x_invar_index=None,
 )
 etp_elemwise_p.register_etp_rules(
-    yw_to_w=_elemwise_yw_to_w,
+    dt_to_t=_elemwise_dt_to_t,
     xy_to_dw=_elemwise_xy_to_dw,
     init_drtrl=_elemwise_init_drtrl,
     init_pp=_elemwise_init_pp,

--- a/braintrace/_op/elemwise_test.py
+++ b/braintrace/_op/elemwise_test.py
@@ -44,7 +44,7 @@ from braintrace._op import (
     ETP_RULES_INIT_DRTRL,
     ETP_RULES_INIT_PP,
     ETP_RULES_XY_TO_DW,
-    ETP_RULES_YW_TO_W,
+    ETP_RULES_DT_TO_T,
     GRADIENT_ENABLED_PRIMITIVES,
     element_wise,
     etp_elemwise_p,
@@ -179,8 +179,8 @@ class TestJAXRules:
 
 class TestEtpRules:
 
-    def test_yw_to_w_is_elementwise_multiply(self):
-        rule = ETP_RULES_YW_TO_W[etp_elemwise_p]
+    def test_dt_to_t_is_elementwise_multiply(self):
+        rule = ETP_RULES_DT_TO_T[etp_elemwise_p]
         hidden = jnp.array([1.0, 2.0, 3.0])
         trace = {'weight': jnp.array([10.0, 20.0, 30.0])}
         out = rule(hidden, trace)
@@ -236,10 +236,10 @@ class TestElemwiseDictRules:
         assert set(out.keys()) == {'weight'}
         assert out['weight'].shape == (3, 4)
 
-    def test_yw_to_w_returns_dict(self):
+    def test_dt_to_t_returns_dict(self):
         hidden_dim = jnp.full((3, 4), 2.0)
         trace = {'weight': jnp.full((3, 4), 5.0)}
-        out = ETP_RULES_YW_TO_W[etp_elemwise_p](hidden_dim, trace)
+        out = ETP_RULES_DT_TO_T[etp_elemwise_p](hidden_dim, trace)
         assert isinstance(out, dict)
         assert out['weight'].shape == (3, 4)
         # 5 * 2 = 10
@@ -401,24 +401,24 @@ class TestElemwiseFastPath:
 
 
 # ---------------------------------------------------------------------------
-# Audit Task 11 (T3): first-principles ``yw_to_w`` from ``jax.jacobian``
+# Audit Task 11 (T3): first-principles ``dt_to_t`` from ``jax.jacobian``
 # ---------------------------------------------------------------------------
 
-class TestYwToWFirstPrinciplesFromJacobian:
-    """Derive ``_elemwise_yw_to_w`` from ``jax.jacobian`` of the primitive's
+class TestDtToTFirstPrinciplesFromJacobian:
+    """Derive ``_elemwise_dt_to_t`` from ``jax.jacobian`` of the primitive's
     own (``weight_fn=None``) forward, rather than trusting its formula.
 
     With ``weight_fn=None``, ``y = w`` elementwise, so
     ``partial y_j / partial w_k = delta(j, k)`` — the identity matrix. A
     general chain-rule contraction of a cotangent ``g`` against that
     Jacobian, applied to an arbitrary weight-shaped trace, degenerates to a
-    plain elementwise product ``g * trace`` — exactly what ``_elemwise_yw_to_w``
+    plain elementwise product ``g * trace`` — exactly what ``_elemwise_dt_to_t``
     computes. This is verified with a random (never all-ones) cotangent and
     a random trace, independent of the rule's own code.
     """
 
-    def test_yw_to_w_matches_identity_jacobian_contraction(self):
-        from braintrace._op.elemwise import _elemwise_yw_to_w
+    def test_dt_to_t_matches_identity_jacobian_contraction(self):
+        from braintrace._op.elemwise import _elemwise_dt_to_t
         brainstate.random.seed(401)
         n = 5
         w0 = brainstate.random.randn(n)
@@ -437,16 +437,16 @@ class TestYwToWFirstPrinciplesFromJacobian:
         propagated = jnp.einsum('jk,k->j', J, trace)
         ref = g * propagated
 
-        out = _elemwise_yw_to_w(g, {'weight': trace})
+        out = _elemwise_dt_to_t(g, {'weight': trace})
         np.testing.assert_allclose(out['weight'], ref, atol=1e-10)
 
-    def test_yw_to_w_matches_identity_jacobian_contraction_batched(self):
-        from braintrace._op.elemwise import _elemwise_yw_to_w
+    def test_dt_to_t_matches_identity_jacobian_contraction_batched(self):
+        from braintrace._op.elemwise import _elemwise_dt_to_t
         brainstate.random.seed(402)
         batch, n = 3, 5
         g = brainstate.random.randn(batch, n)
         trace = brainstate.random.randn(batch, n)
 
         ref = g * trace
-        out = _elemwise_yw_to_w(g, {'weight': trace})
+        out = _elemwise_dt_to_t(g, {'weight': trace})
         np.testing.assert_allclose(out['weight'], ref, atol=1e-10)

--- a/braintrace/_op/embedding.py
+++ b/braintrace/_op/embedding.py
@@ -24,7 +24,7 @@ r"""Embedding (trainable gather) ETP primitives.
 
 has :math:`\partial y_{bd} / \partial T_{v d'} = \delta_{dd'}\,
 \delta_{v,\mathrm{idx}_b}` — diagonal in the feature axis, one-hot in the
-vocabulary axis. ``yw_to_w`` is therefore the dense broadcast over the
+vocabulary axis. ``dt_to_t`` is therefore the dense broadcast over the
 vocabulary axis, and ``xy_to_dw`` is the scatter-add VJP of the gather.
 
 The indices are the primitive's ``x`` input and are **never
@@ -71,7 +71,7 @@ def _emb_trainable_invars(params: dict[str, Any]) -> dict[str, int]:
     return {'weight': 1}
 
 
-def _emb_yw_to_w(hidden_dim: Any, trace: dict[str, Any], *,
+def _emb_dt_to_t(hidden_dim: Any, trace: dict[str, Any], *,
                  weight_fn: WeightFn | None = None) -> dict[str, Any]:
     r"""Propagate ``∂h/∂y`` through the table-shaped trace.
 
@@ -177,14 +177,14 @@ etp_emb_v_p = register_primitive(
 register_batched_counterpart(etp_emb_v_p, etp_emb_p)
 
 etp_emb_p.register_etp_rules(
-    yw_to_w=_emb_yw_to_w,
+    dt_to_t=_emb_dt_to_t,
     xy_to_dw=_emb_xy_to_dw,
     init_drtrl=_emb_init_drtrl,
     init_pp=_emb_init_pp,
     pp_x_repr=_emb_pp_x_repr,
 )
 etp_emb_v_p.register_etp_rules(
-    yw_to_w=_emb_yw_to_w,
+    dt_to_t=_emb_dt_to_t,
     xy_to_dw=_emb_xy_to_dw,
     init_drtrl=_emb_v_init_drtrl,
     init_pp=_emb_init_pp,

--- a/braintrace/_op/embedding_test.py
+++ b/braintrace/_op/embedding_test.py
@@ -129,7 +129,7 @@ from braintrace._op import (
     ETP_RULES_INIT_DRTRL,
     ETP_RULES_INIT_PP,
     ETP_RULES_XY_TO_DW,
-    ETP_RULES_YW_TO_W,
+    ETP_RULES_DT_TO_T,
 )
 from braintrace._op.op_rule_oracle import assert_xy_to_dw_matches_vjp
 
@@ -137,18 +137,18 @@ from braintrace._op.op_rule_oracle import assert_xy_to_dw_matches_vjp
 class TestEmbEtpRules:
     B, V, D, A = 3, 5, 4, 2
 
-    def test_yw_to_w_broadcasts_over_vocab(self):
+    def test_dt_to_t_broadcasts_over_vocab(self):
         brainstate.random.seed(40)
         hd = brainstate.random.randn(self.B, self.D)
         tr = {'weight': brainstate.random.randn(self.B, self.V, self.D)}
-        out = ETP_RULES_YW_TO_W[etp_emb_p](hd, tr)
+        out = ETP_RULES_DT_TO_T[etp_emb_p](hd, tr)
         np.testing.assert_allclose(out['weight'], tr['weight'] * hd[:, None, :], atol=1e-6)
 
-    def test_yw_to_w_grad_context(self):
+    def test_dt_to_t_grad_context(self):
         brainstate.random.seed(41)
         hd = brainstate.random.randn(self.D)
         tr = {'weight': brainstate.random.randn(self.V, self.D)}
-        out = ETP_RULES_YW_TO_W[etp_emb_p](hd, tr)
+        out = ETP_RULES_DT_TO_T[etp_emb_p](hd, tr)
         np.testing.assert_allclose(out['weight'], tr['weight'] * hd[None, :], atol=1e-6)
 
     def test_xy_to_dw_matches_vjp_scatter_add(self):
@@ -192,7 +192,7 @@ class TestEmbEtpRules:
         brainstate.random.seed(44)
         hd = brainstate.random.randn(self.D)
         tr = {'weight': brainstate.random.randn(self.V, self.D)}
-        out = ETP_RULES_YW_TO_W[etp_emb_v_p](hd, tr)
+        out = ETP_RULES_DT_TO_T[etp_emb_v_p](hd, tr)
         np.testing.assert_allclose(out['weight'], tr['weight'] * hd[None, :], atol=1e-6)
 
         idx = jnp.int32(2)

--- a/braintrace/_op/grouped.py
+++ b/braintrace/_op/grouped.py
@@ -26,7 +26,7 @@ blocks:
 
 Each weight entry touches exactly one output component per example
 (:math:`\partial y_{\dots gn} / \partial W_{g'kn'} = \delta_{gg'}\delta_{nn'}
-x_{\dots gk}`), the same diagonal structure as dense matmul — so ``yw_to_w``
+x_{\dots gk}`), the same diagonal structure as dense matmul — so ``dt_to_t``
 is the dense broadcast generalized by one leading group axis, and the same
 closed-form fast path applies.
 
@@ -81,15 +81,15 @@ def _gmm_trainable_invars(params: dict[str, Any]) -> dict[str, int]:
     return base
 
 
-def _gmm_yw_to_w(hidden_dim: Any, trace: dict[str, Any], *, has_bias: bool = False,
+def _gmm_dt_to_t(hidden_dim: Any, trace: dict[str, Any], *, has_bias: bool = False,
                  weight_fn: WeightFn | None = None,
                  bias_fn: WeightFn | None = None) -> dict[str, Any]:
-    r"""Batched ``yw_to_w`` — the dense broadcast with one extra group axis.
+    r"""Batched ``dt_to_t`` — the dense broadcast with one extra group axis.
 
     ``∂y[b,g,n]/∂W[g',k,n'] = δ_gg' δ_nn' x[b,g,k]``, so the y→W chain
     factor is ``1`` on the matching ``(g, n)`` slot and ``hidden_dim`` is
     broadcast over the ``in`` axis (``axis=-2``), exactly as in dense
-    ``_mm_yw_to_w``. Contexts: scan ``(B,G,N)/(B,G,K,N)``; grad ``(G,N)/(G,K,N)``.
+    ``_mm_dt_to_t``. Contexts: scan ``(B,G,N)/(B,G,K,N)``; grad ``(G,N)/(G,K,N)``.
     """
     out = {'weight': trace['weight'] * jnp.expand_dims(hidden_dim, axis=-2)}
     if has_bias:
@@ -229,7 +229,7 @@ etp_gmm_p = register_primitive(
     x_invar_index=0,
 )
 etp_gmm_p.register_etp_rules(
-    yw_to_w=_gmm_yw_to_w,
+    dt_to_t=_gmm_dt_to_t,
     xy_to_dw=_gmm_xy_to_dw,
     init_drtrl=_gmm_init_drtrl,
     init_pp=_gmm_init_pp,
@@ -249,10 +249,10 @@ def _gmv_trainable_invars(params: dict[str, Any]) -> dict[str, int]:
     return base
 
 
-def _gmv_yw_to_w(hidden_dim: Any, trace: dict[str, Any], *, has_bias: bool = False,
+def _gmv_dt_to_t(hidden_dim: Any, trace: dict[str, Any], *, has_bias: bool = False,
                  weight_fn: WeightFn | None = None,
                  bias_fn: WeightFn | None = None) -> dict[str, Any]:
-    r"""Unbatched ``yw_to_w`` — shapes ``hd (G,N)``, ``trace['weight'] (G,K,N)``."""
+    r"""Unbatched ``dt_to_t`` — shapes ``hd (G,N)``, ``trace['weight'] (G,K,N)``."""
     out = {'weight': trace['weight'] * jnp.expand_dims(hidden_dim, axis=-2)}
     if has_bias:
         out['bias'] = trace['bias'] * hidden_dim
@@ -316,7 +316,7 @@ etp_gmv_p = register_primitive(
     x_invar_index=0,
 )
 etp_gmv_p.register_etp_rules(
-    yw_to_w=_gmv_yw_to_w,
+    dt_to_t=_gmv_dt_to_t,
     xy_to_dw=_gmv_xy_to_dw,
     init_drtrl=_gmv_init_drtrl,
     init_pp=_gmv_init_pp,

--- a/braintrace/_op/grouped_test.py
+++ b/braintrace/_op/grouped_test.py
@@ -152,7 +152,7 @@ from braintrace._op import (
     ETP_RULES_INIT_DRTRL,
     ETP_RULES_INIT_PP,
     ETP_RULES_XY_TO_DW,
-    ETP_RULES_YW_TO_W,
+    ETP_RULES_DT_TO_T,
 )
 from braintrace._op.op_rule_oracle import assert_xy_to_dw_matches_vjp
 
@@ -160,20 +160,20 @@ from braintrace._op.op_rule_oracle import assert_xy_to_dw_matches_vjp
 class TestGmmEtpRules:
     B, G, K, N, A = 5, 2, 3, 4, 2   # batch, groups, in, out, n_state
 
-    def test_yw_to_w_broadcasts_hidden_over_in_axis(self):
+    def test_dt_to_t_broadcasts_hidden_over_in_axis(self):
         brainstate.random.seed(10)
         hd = brainstate.random.randn(self.B, self.G, self.N)
         tr = {'weight': brainstate.random.randn(self.B, self.G, self.K, self.N),
               'bias': brainstate.random.randn(self.B, self.G, self.N)}
-        out = ETP_RULES_YW_TO_W[etp_gmm_p](hd, tr, has_bias=True)
+        out = ETP_RULES_DT_TO_T[etp_gmm_p](hd, tr, has_bias=True)
         np.testing.assert_allclose(out['weight'], tr['weight'] * hd[:, :, None, :], atol=1e-6)
         np.testing.assert_allclose(out['bias'], tr['bias'] * hd, atol=1e-6)
 
-    def test_yw_to_w_grad_context_batch_stripped(self):
+    def test_dt_to_t_grad_context_batch_stripped(self):
         brainstate.random.seed(11)
         hd = brainstate.random.randn(self.G, self.N)
         tr = {'weight': brainstate.random.randn(self.G, self.K, self.N)}
-        out = ETP_RULES_YW_TO_W[etp_gmm_p](hd, tr, has_bias=False)
+        out = ETP_RULES_DT_TO_T[etp_gmm_p](hd, tr, has_bias=False)
         np.testing.assert_allclose(out['weight'], tr['weight'] * hd[:, None, :], atol=1e-6)
 
     def test_xy_to_dw_matches_vjp_plain(self):
@@ -238,12 +238,12 @@ class TestGmmEtpRules:
 class TestGmvEtpRules:
     G, K, N, A = 2, 3, 4, 2
 
-    def test_yw_to_w(self):
+    def test_dt_to_t(self):
         brainstate.random.seed(20)
         hd = brainstate.random.randn(self.G, self.N)
         tr = {'weight': brainstate.random.randn(self.G, self.K, self.N),
               'bias': brainstate.random.randn(self.G, self.N)}
-        out = ETP_RULES_YW_TO_W[etp_gmv_p](hd, tr, has_bias=True)
+        out = ETP_RULES_DT_TO_T[etp_gmv_p](hd, tr, has_bias=True)
         np.testing.assert_allclose(out['weight'], tr['weight'] * hd[:, None, :], atol=1e-6)
         np.testing.assert_allclose(out['bias'], tr['bias'] * hd, atol=1e-6)
 

--- a/braintrace/_op/lora.py
+++ b/braintrace/_op/lora.py
@@ -52,7 +52,7 @@ Let :math:`g = \partial h / \partial y`. The chain rule yields
   three pullbacks from a single ``jax.vjp`` call. This **param-shaped**
   rule is what the IO-dim (ES-D-RTRL) algorithm applies at solve time.
 
-* ``instant_drtrl`` / ``yw_to_w`` / ``solve_drtrl`` — the param-dim
+* ``instant_drtrl`` / ``dt_to_t`` / ``solve_drtrl`` — the param-dim
   D-RTRL trace machinery. No :math:`B`-shaped ``(in, rank)`` trace can
   be exact: the hidden-to-hidden discount :math:`\mathbf{D}^t` acts on
   the *output* axis, which :math:`B`'s shape lacks (:math:`\partial h /
@@ -65,7 +65,7 @@ Let :math:`g = \partial h / \partial y`. The chain rule yields
     :math:`\boldsymbol{\epsilon}_{W}` (the exact dense instantaneous
     term for :math:`y = x\,W_{\text{eff}}`), while the :math:`A` and
     bias entries reuse the exact ``xy_to_dw`` pullbacks.
-  - ``yw_to_w`` scales *every* trace along the output axis by
+  - ``dt_to_t`` scales *every* trace along the output axis by
     :math:`g = \partial h / \partial y` (the dense :math:`y \to W`
     link) — including the :math:`W_{\text{eff}}` trace.
   - ``solve_drtrl`` contracts the learning signal with each trace and
@@ -115,7 +115,7 @@ param-dim D-RTRL path, ``a_fn'`` and ``bias_fn'`` enter through
 the :math:`A` / bias trace entries), while ``b_fn'`` enters at solve time
 through :func:`_lora_solve_drtrl` via :func:`jax.vjp` (the effective-weight
 trace itself is transform-free). In the IO-dim path all three Jacobians
-enter through ``xy_to_dw``'s single fused VJP. The ``yw_to_w`` rule and the
+enter through ``xy_to_dw``'s single fused VJP. The ``dt_to_t`` rule and the
 trace initialisers are transform-free.
 
 These primitives have **no fast path** — they always use the generic rule
@@ -168,10 +168,10 @@ def _lora_trainable_invars(params: dict[str, Any]) -> dict[str, int]:
     return base
 
 
-def _lora_mm_yw_to_w(hidden_dim: Any, trace: dict[str, Any], *, alpha: float = 1.0,
+def _lora_mm_dt_to_t(hidden_dim: Any, trace: dict[str, Any], *, alpha: float = 1.0,
                      has_bias: bool = False, b_fn: WeightFn | None = None,
                      a_fn: WeightFn | None = None, bias_fn: WeightFn | None = None) -> dict[str, Any]:
-    r"""Batched LoRA ``yw_to_w`` — propagate :math:`\partial h / \partial y`
+    r"""Batched LoRA ``dt_to_t`` — propagate :math:`\partial h / \partial y`
     through every trace along the output axis.
 
     **Role in D-RTRL.** Realises the :math:`y \to` chain factor of
@@ -222,10 +222,10 @@ def _lora_mm_yw_to_w(hidden_dim: Any, trace: dict[str, Any], *, alpha: float = 1
     return out
 
 
-def _lora_mv_yw_to_w(hidden_dim: Any, trace: dict[str, Any], *, alpha: float = 1.0,
+def _lora_mv_dt_to_t(hidden_dim: Any, trace: dict[str, Any], *, alpha: float = 1.0,
                      has_bias: bool = False, b_fn: WeightFn | None = None,
                      a_fn: WeightFn | None = None, bias_fn: WeightFn | None = None) -> dict[str, Any]:
-    r"""Unbatched LoRA ``yw_to_w`` — identical algebra with no batch axis.
+    r"""Unbatched LoRA ``dt_to_t`` — identical algebra with no batch axis.
 
     Trace shapes (recurrence context, after the ``n_state``-vmap):
         ``trace['lora_b'] : (in, out)``    — :math:`\boldsymbol{\epsilon}_W`, scaled by :math:`g`
@@ -235,7 +235,7 @@ def _lora_mv_yw_to_w(hidden_dim: Any, trace: dict[str, Any], *, alpha: float = 1
     ``jnp.expand_dims(hidden_dim, axis=-2)`` turns ``(out,) → (1, out)``
     so it broadcasts against both the ``(in, out)`` effective-weight
     trace and the ``(rank, out)`` :math:`A` trace. See
-    :func:`_lora_mm_yw_to_w` for the algebra.
+    :func:`_lora_mm_dt_to_t` for the algebra.
     """
     g = jnp.expand_dims(hidden_dim, axis=-2)
     out = {'lora_b': trace['lora_b'] * g, 'lora_a': trace['lora_a'] * g}
@@ -333,7 +333,7 @@ def _lora_instant_drtrl(x: Any, hidden_dim: Any, weights: dict[str, Any], *,
     * ``'lora_a'`` and ``'bias'`` reuse the exact param-shaped
       :func:`_lora_xy_to_dw` pullbacks (which thread ``a_fn'`` /
       ``bias_fn'`` through the fused VJP); their per-factor traces are
-      already exact under the dense-style ``yw_to_w`` recurrence. The
+      already exact under the dense-style ``dt_to_t`` recurrence. The
       VJP's unused ``'lora_b'`` pullback is dead code eliminated under
       ``jit``.
 
@@ -377,7 +377,7 @@ def _lora_solve_drtrl(dg_hidden: Any, trace: dict[str, Any], weights: dict[str, 
       parameters held fixed over the gradient window.
 
     * ``'lora_a'`` / ``'bias'`` — the same contraction the generic
-      ``yw_to_w`` solve path produced (it was exact): broadcast-multiply
+      ``dt_to_t`` solve path produced (it was exact): broadcast-multiply
       the signal along the output axis. ``a_fn'`` / ``bias_fn'`` are
       **not** re-applied here — they already entered the traces through
       :func:`_lora_instant_drtrl`.
@@ -539,7 +539,7 @@ etp_lora_mm_p = register_primitive(
     x_invar_index=0,
 )
 etp_lora_mm_p.register_etp_rules(
-    yw_to_w=_lora_mm_yw_to_w,
+    dt_to_t=_lora_mm_dt_to_t,
     xy_to_dw=_lora_xy_to_dw,
     init_drtrl=_lora_mm_init_drtrl,
     init_pp=_lora_mm_init_pp,
@@ -547,7 +547,7 @@ etp_lora_mm_p.register_etp_rules(
 # Param-dim D-RTRL overrides: the trace structure ('lora_b' holds the
 # effective-weight trace) differs from the parameter structure, so the
 # instantaneous term and the solve-time contraction cannot be expressed by
-# xy_to_dw / yw_to_w alone. IO-dim (ES-D-RTRL) keeps using xy_to_dw.
+# xy_to_dw / dt_to_t alone. IO-dim (ES-D-RTRL) keeps using xy_to_dw.
 ETP_RULES_INSTANT_DRTRL[etp_lora_mm_p] = _lora_instant_drtrl
 ETP_RULES_SOLVE_DRTRL[etp_lora_mm_p] = _lora_solve_drtrl
 
@@ -559,7 +559,7 @@ etp_lora_mv_p = register_primitive(
     x_invar_index=0,
 )
 etp_lora_mv_p.register_etp_rules(
-    yw_to_w=_lora_mv_yw_to_w,
+    dt_to_t=_lora_mv_dt_to_t,
     xy_to_dw=_lora_xy_to_dw,
     init_drtrl=_lora_mv_init_drtrl,
     init_pp=_lora_mv_init_pp,

--- a/braintrace/_op/lora_test.py
+++ b/braintrace/_op/lora_test.py
@@ -43,7 +43,7 @@ from braintrace._op import (
     ETP_RULES_INIT_DRTRL,
     ETP_RULES_INIT_PP,
     ETP_RULES_XY_TO_DW,
-    ETP_RULES_YW_TO_W,
+    ETP_RULES_DT_TO_T,
     etp_lora_mm_p,
     etp_lora_mv_p,
     lora_matmul,
@@ -237,8 +237,8 @@ class TestJAXRules:
 
 class TestLoraMmEtpRules:
 
-    def test_yw_to_w_pytree_structure(self):
-        """``yw_to_w`` broadcasts ``hidden`` across the leading matrix axis of
+    def test_dt_to_t_pytree_structure(self):
+        """``dt_to_t`` broadcasts ``hidden`` across the leading matrix axis of
         BOTH traces via ``expand_dims(hidden, axis=-2)``: the ``'lora_b'``
         entry is the effective-weight trace ``(in, out)`` (dense-style
         recurrence), the ``'lora_a'`` entry the factor trace ``(rank, out)``.
@@ -247,7 +247,7 @@ class TestLoraMmEtpRules:
           * ``(out,)`` — per-slice context (batch stripped by the algorithm's vmap)
           * ``(batch, out)`` — as called from ``_update_param_dim_etrace_scan_fn``
         """
-        rule = ETP_RULES_YW_TO_W[etp_lora_mm_p]
+        rule = ETP_RULES_DT_TO_T[etp_lora_mm_p]
 
         # Test 1: slice context — hidden=(out=4,)
         hidden = jnp.array([1.0, 2.0, 3.0, 4.0])  # (out=4,)
@@ -330,11 +330,11 @@ class TestLoraMmEtpRules:
 
 class TestLoraMvEtpRules:
 
-    def test_yw_to_w_pytree_structure(self):
+    def test_dt_to_t_pytree_structure(self):
         """mv-variant: ``expand_dims(hidden, axis=-2)`` broadcasts ``hidden``
         along the output axis of BOTH the effective-weight trace ``(in, out)``
         and the ``(rank, out)`` A-trace."""
-        rule = ETP_RULES_YW_TO_W[etp_lora_mv_p]
+        rule = ETP_RULES_DT_TO_T[etp_lora_mv_p]
         hidden = jnp.array([1.0, 2.0, 3.0, 4.0])  # (out=4,)
         trace_W = jnp.ones((3, 4))  # effective-weight trace (in=3, out=4)
         trace_A = jnp.ones((2, 4))  # (rank=2, out=4)
@@ -485,7 +485,7 @@ class TestLoRAOnlineLearningExact:
     and every parameter gradient must match a BPTT oracle element-wise
     (``rel < 1e-10`` in float64). This covers the audit finding that
     ``lora_b`` gradients were wrong even at T=1 (rel err ~4) because the
-    B-factor trace was propagated unchanged through ``yw_to_w``.
+    B-factor trace was propagated unchanged through ``dt_to_t``.
     """
 
     LEAK = 0.5
@@ -645,7 +645,7 @@ class TestInstantSolveDrtrlFirstPrinciplesFromJacobian:
     instantaneous term — those are chained back only at solve time). Since
     ``y = x @ W_eff`` is exactly the dense-matmul forward, its Jacobian
     ``dy_o/dW_eff[i, o']`` is diagonal in the two "out" indices — the same
-    structural fact exploited by :mod:`dense`'s ``yw_to_w``. This test
+    structural fact exploited by :mod:`dense`'s ``dt_to_t``. This test
     builds that Jacobian via ``jax.jacobian`` on the *unscaled, untransformed*
     effective weight, confirms the diagonal structure, and checks the
     rule's ``'lora_b'`` output against the raw-Jacobian contraction for a

--- a/braintrace/_op/op_rule_oracle_test.py
+++ b/braintrace/_op/op_rule_oracle_test.py
@@ -29,7 +29,7 @@ from braintrace._op import (
     ETP_RULES_INIT_DRTRL,
     ETP_RULES_INIT_PP,
     ETP_RULES_XY_TO_DW,
-    ETP_RULES_YW_TO_W,
+    ETP_RULES_DT_TO_T,
 )
 from braintrace._op.dense import etp_mm_p, _etp_matmul_impl
 from braintrace._op.conv import etp_conv_p, _etp_conv_impl
@@ -124,14 +124,14 @@ def test_lora_xy_to_dw_matches_vjp():
     )
 
 
-def test_lora_yw_to_w_scales_both_traces_along_output_axis():
-    """yw_to_w applies the dense ``y -> W`` link to BOTH traces: the
+def test_lora_dt_to_t_scales_both_traces_along_output_axis():
+    """dt_to_t applies the dense ``y -> W`` link to BOTH traces: the
     ``'lora_b'`` entry is the effective-weight trace ``(in, out)`` for
     ``W_eff = alpha * b_fn(B) @ a_fn(A)`` and follows the same recurrence as
     the dense ``mm`` rule (a raw B-shaped trace cannot be discounted along
     the output axis it lacks — the old pass-through made ``lora_b``
     gradients wrong even at T=1)."""
-    rule = ETP_RULES_YW_TO_W[etp_lora_mm_p]
+    rule = ETP_RULES_DT_TO_T[etp_lora_mm_p]
     in_dim, rank, out_dim = 6, 3, 4
     hidden = jnp.arange(1.0, out_dim + 1.0)            # (out,)
     trace = {'lora_b': jnp.ones((in_dim, out_dim)), 'lora_a': jnp.ones((rank, out_dim))}

--- a/braintrace/_op/sparse.py
+++ b/braintrace/_op/sparse.py
@@ -47,7 +47,7 @@ frozen.
   :math:`\operatorname{diag}(\mathbf{D}_f^t)\otimes \mathbf{x}^t` term
   for D-RTRL, projected onto the sparse support.
 
-* ``yw_to_w(hidden_dim, trace)`` — propagation of
+* ``dt_to_t(hidden_dim, trace)`` — propagation of
   :math:`\mathbf{D}^t \boldsymbol{\epsilon}^{t-1}`. For the weight data,
   delegates to ``sparse_mat.yw_to_w_transposed``: this contracts
   ``hidden_dim`` along ``out`` and restricts to the sparse pattern in a
@@ -85,7 +85,7 @@ and ``bias_fn`` (adds ``bias_fn(b)``). The forward impl and
 :func:`_sp_xy_to_dw` apply them; the eligibility trace and gradient are
 always taken w.r.t. the **raw** weight data / bias, so the transform
 Jacobian :math:`f'` enters *only* through ``xy_to_dw`` via :func:`jax.vjp`.
-The ``yw_to_w`` rule and the trace initialisers are transform-free and stay
+The ``dt_to_t`` rule and the trace initialisers are transform-free and stay
 exact (they operate on :math:`\partial h / \partial w_{\text{raw}}`).
 
 These primitives have **no fast path** — they always use the generic rule
@@ -147,7 +147,7 @@ def _unwrap_sparse_mat(sparse_mat: Any) -> Any:
     ``sparse_matmul`` binds a ``_HashableSparseMat`` wrapper (see above) so the
     equation parameter is hashable. Every consumer of ``params['sparse_mat']``
     (the forward impl -- and therefore also the auto-derived abstract-eval,
-    lowering, JVP and batching rules -- plus the ``yw_to_w``/``xy_to_dw`` ETP
+    lowering, JVP and batching rules -- plus the ``dt_to_t``/``xy_to_dw`` ETP
     rules) must unwrap it before calling the sparse-matrix protocol methods.
 
     Direct (non-``sparse_matmul``) call sites -- e.g. the rule-level unit
@@ -195,11 +195,11 @@ def _sp_trainable_invars(params: dict[str, Any]) -> dict[str, int]:
 # etp_sp_mm_p — batched
 # ---------------------------------------------------------------------------
 
-def _sp_mm_yw_to_w(hidden_dim: Any, trace: dict[str, Any], *,
+def _sp_mm_dt_to_t(hidden_dim: Any, trace: dict[str, Any], *,
                    sparse_mat: brainevent.DataRepresentation | None = None,
                    has_bias: bool = False, weight_fn: WeightFn | None = None,
                    bias_fn: WeightFn | None = None) -> dict[str, Any]:
-    r"""Batched sparse ``yw_to_w`` — propagate :math:`\partial h / \partial y`
+    r"""Batched sparse ``dt_to_t`` — propagate :math:`\partial h / \partial y`
     through the nnz-shaped D-RTRL trace.
 
     **Role in D-RTRL.** Implements the :math:`y \to w_{\text{data}}` chain
@@ -354,11 +354,11 @@ def _sp_mm_init_pp(x_var: Any, y_var: Any, weight_vars: dict[str, Any],
 # etp_sp_mv_p — unbatched
 # ---------------------------------------------------------------------------
 
-def _sp_mv_yw_to_w(hidden_dim: Any, trace: dict[str, Any], *,
+def _sp_mv_dt_to_t(hidden_dim: Any, trace: dict[str, Any], *,
                    sparse_mat: brainevent.DataRepresentation | None = None,
                    has_bias: bool = False, weight_fn: WeightFn | None = None,
                    bias_fn: WeightFn | None = None) -> dict[str, Any]:
-    r"""Unbatched sparse ``yw_to_w`` — identical algebra to the batched case
+    r"""Unbatched sparse ``dt_to_t`` — identical algebra to the batched case
     with no batch axis.
 
     Propagates :math:`\partial h / \partial y` through the sparse pattern:
@@ -434,7 +434,7 @@ etp_sp_mm_p = register_primitive(
     x_invar_index=0,
 )
 etp_sp_mm_p.register_etp_rules(
-    yw_to_w=_sp_mm_yw_to_w,
+    dt_to_t=_sp_mm_dt_to_t,
     xy_to_dw=_sp_xy_to_dw,
     init_drtrl=_sp_mm_init_drtrl,
     init_pp=_sp_mm_init_pp,
@@ -448,7 +448,7 @@ etp_sp_mv_p = register_primitive(
     x_invar_index=0,
 )
 etp_sp_mv_p.register_etp_rules(
-    yw_to_w=_sp_mv_yw_to_w,
+    dt_to_t=_sp_mv_dt_to_t,
     xy_to_dw=_sp_xy_to_dw,
     init_drtrl=_sp_mv_init_drtrl,
     init_pp=_sp_mv_init_pp,

--- a/braintrace/_op/sparse_test.py
+++ b/braintrace/_op/sparse_test.py
@@ -49,7 +49,7 @@ from braintrace._op import (
     ETP_RULES_INIT_DRTRL,
     ETP_RULES_INIT_PP,
     ETP_RULES_XY_TO_DW,
-    ETP_RULES_YW_TO_W,
+    ETP_RULES_DT_TO_T,
     etp_sp_mm_p,
     etp_sp_mv_p,
     sparse_matmul,
@@ -217,13 +217,13 @@ class TestBrainunit:
 
 
 # ---------------------------------------------------------------------------
-# ETP rules — yw_to_w / xy_to_dw / init_*
+# ETP rules — dt_to_t / xy_to_dw / init_*
 # ---------------------------------------------------------------------------
 
 class TestSpMmEtpRules:
 
-    def test_yw_to_w_via_stub(self):
-        rule = ETP_RULES_YW_TO_W[etp_sp_mm_p]
+    def test_dt_to_t_via_stub(self):
+        rule = ETP_RULES_DT_TO_T[etp_sp_mm_p]
         stub = _StubSparseMat(jnp.zeros((3, 4)))
         hidden = jnp.array([1.0, 2.0, 3.0, 4.0])
         # trace is now a dict {'weight': ...}
@@ -232,8 +232,8 @@ class TestSpMmEtpRules:
         # stub.yw_to_w_transposed broadcasts hidden over rows.
         np.testing.assert_allclose(out['weight'], jnp.ones((3, 4)) * hidden[None, :])
 
-    def test_yw_to_w_with_bias(self):
-        rule = ETP_RULES_YW_TO_W[etp_sp_mm_p]
+    def test_dt_to_t_with_bias(self):
+        rule = ETP_RULES_DT_TO_T[etp_sp_mm_p]
         stub = _StubSparseMat(jnp.zeros((3, 4)))
         hidden = jnp.array([1.0, 2.0, 3.0, 4.0])
         trace = {'weight': jnp.ones((3, 4)), 'bias': jnp.ones(4)}
@@ -303,8 +303,8 @@ class TestSpMmEtpRules:
 
 class TestSpMvEtpRules:
 
-    def test_yw_to_w_via_stub(self):
-        rule = ETP_RULES_YW_TO_W[etp_sp_mv_p]
+    def test_dt_to_t_via_stub(self):
+        rule = ETP_RULES_DT_TO_T[etp_sp_mv_p]
         stub = _StubSparseMat(jnp.zeros((3, 4)))
         hidden = jnp.array([1.0, 2.0, 3.0, 4.0])
         # trace is now a dict {'weight': ...}
@@ -312,8 +312,8 @@ class TestSpMvEtpRules:
         out = rule(hidden, trace, sparse_mat=stub)
         np.testing.assert_allclose(out['weight'], jnp.ones((3, 4)) * hidden[None, :])
 
-    def test_yw_to_w_with_bias(self):
-        rule = ETP_RULES_YW_TO_W[etp_sp_mv_p]
+    def test_dt_to_t_with_bias(self):
+        rule = ETP_RULES_DT_TO_T[etp_sp_mv_p]
         stub = _StubSparseMat(jnp.zeros((3, 4)))
         hidden = jnp.array([1.0, 2.0, 3.0, 4.0])
         trace = {'weight': jnp.ones((3, 4)), 'bias': jnp.ones(4)}
@@ -686,7 +686,7 @@ class TestStockCSRHashable:
 
 
 class TestBatchedSparseDRTRLOracle:
-    """C3: ``_sp_mm_yw_to_w`` (the ``etp_sp_mm_p`` D-RTRL trace-recurrence rule)
+    """C3: ``_sp_mm_dt_to_t`` (the ``etp_sp_mm_p`` D-RTRL trace-recurrence rule)
     is handed a leading batch axis -- ``hidden_dim: (batch, out)``,
     ``trace['weight']: (batch, nnz)`` -- straight from the online-trace update.
     ``brainevent``'s ``yw_to_w_transposed`` kernel only accepts 1-D operands, so
@@ -755,7 +755,7 @@ class TestBatchedSparseDRTRLOracle:
 
 
 # ---------------------------------------------------------------------------
-# Audit Task 11 (T3): first-principles ``yw_to_w`` from ``jax.jacobian``
+# Audit Task 11 (T3): first-principles ``dt_to_t`` from ``jax.jacobian``
 # ---------------------------------------------------------------------------
 
 def _sparse_row_col_of_nnz(csr):
@@ -779,8 +779,8 @@ def _random_masked_csr(mask: np.ndarray, seed: int):
     return brainevent.CSR.fromdense(dense)
 
 
-class TestYwToWFirstPrinciplesFromJacobian:
-    """Derive ``_sp_mv_yw_to_w`` / ``_sp_mm_yw_to_w`` from ``jax.jacobian`` of
+class TestDtToTFirstPrinciplesFromJacobian:
+    """Derive ``_sp_mv_dt_to_t`` / ``_sp_mm_dt_to_t`` from ``jax.jacobian`` of
     the primitive's own forward on a real, non-diagonal :class:`brainevent.CSR`.
 
     For ``y = x @ W`` with ``W`` sparse, ``partial y_o / partial data_k`` is
@@ -803,8 +803,8 @@ class TestYwToWFirstPrinciplesFromJacobian:
             [1, 1, 0, 0],
         ], dtype=bool)  # (in=3, out=4), deliberately non-diagonal/non-square
 
-    def test_mv_yw_to_w_matches_jacobian_contraction(self):
-        from braintrace._op.sparse import _sp_mv_yw_to_w
+    def test_mv_dt_to_t_matches_jacobian_contraction(self):
+        from braintrace._op.sparse import _sp_mv_dt_to_t
         csr = self._random_masked_csr_mv()
         n_in, n_out = csr.shape
         row_of_nnz, col_of_nnz = _sparse_row_col_of_nnz(csr)
@@ -836,14 +836,14 @@ class TestYwToWFirstPrinciplesFromJacobian:
         ref_w = trace_w * g[col_of_nnz]
         ref_b = trace_b * g
 
-        out = _sp_mv_yw_to_w(
+        out = _sp_mv_dt_to_t(
             g, {'weight': trace_w, 'bias': trace_b}, sparse_mat=csr, has_bias=True,
         )
         np.testing.assert_allclose(out['weight'], ref_w, atol=1e-10)
         np.testing.assert_allclose(out['bias'], ref_b, atol=1e-10)
 
-    def test_mm_yw_to_w_matches_jacobian_contraction(self):
-        from braintrace._op.sparse import _sp_mm_yw_to_w
+    def test_mm_dt_to_t_matches_jacobian_contraction(self):
+        from braintrace._op.sparse import _sp_mm_dt_to_t
         csr = self._random_masked_csr_mm()
         n_in, n_out = csr.shape
         row_of_nnz, col_of_nnz = _sparse_row_col_of_nnz(csr)
@@ -873,7 +873,7 @@ class TestYwToWFirstPrinciplesFromJacobian:
         ref_w = trace_w * g[:, col_of_nnz]
         ref_b = trace_b * g
 
-        out = _sp_mm_yw_to_w(
+        out = _sp_mm_dt_to_t(
             g, {'weight': trace_w, 'bias': trace_b}, sparse_mat=csr, has_bias=True,
         )
         np.testing.assert_allclose(out['weight'], ref_w, atol=1e-10)

--- a/changelog.md
+++ b/changelog.md
@@ -196,7 +196,7 @@ input contract. Two public APIs are renamed and one operand type is now required
 
 - **Correct `weight_fn` / `bias_fn` gradients on the fast path.** The
   transform Jacobian `f'(W)` is now applied on the param-dim D-RTRL closed-form
-  fast path (it lives solely in `xy_to_dw`; `yw_to_w` stays transform-free), so
+  fast path (it lives solely in `xy_to_dw`; `dt_to_t` stays transform-free), so
   transformed-parameter gradients match the slow path. Also fixes an
   `element_wise` slow-path batched-cotangent crash (#120).
 - **Operator-layer fast-path kernels.** The closed-form fast-path kernels
@@ -421,7 +421,7 @@ hardens the package with PEP 561 typing and a BPTT-oracle-backed test suite.
   **bias gradient support**, each verified element-wise against a BPTT oracle.
 - **Fixed layout-aware axis handling in conv** primitives (1D/2D, NHWC/NCHW,
   OIHW/HWIO kernel layouts) that previously corrupted gradients on non-default
-  layouts, and **fixed non-square dense weight broadcasting** in `_mm_yw_to_w`.
+  layouts, and **fixed non-square dense weight broadcasting** in `_mm_dt_to_t`.
 - Eligibility traces are now stored as per-key dicts; the transitional
   legacy-array adapter has been fully removed.
 

--- a/docs/apis/primitives.rst
+++ b/docs/apis/primitives.rst
@@ -38,7 +38,7 @@ compiler:
 * ``y_outvar_index`` — position of the output ``y`` in ``eqn.outvars``.
 
 The call populates the four global rule registries
-(:data:`ETP_RULES_YW_TO_W`, :data:`ETP_RULES_XY_TO_DW`,
+(:data:`ETP_RULES_DT_TO_T`, :data:`ETP_RULES_XY_TO_DW`,
 :data:`ETP_RULES_INIT_DRTRL`, :data:`ETP_RULES_INIT_PP`) and returns a
 fully-functional :class:`ETPPrimitive`.
 
@@ -78,7 +78,7 @@ algorithms look up the rule for a primitive at compile time.
    * - Registry
      - Signature
      - Purpose
-   * - ``ETP_RULES_YW_TO_W``
+   * - ``ETP_RULES_DT_TO_T``
      - ``(hidden_dim, trace, **params) -> trace``
      - D-RTRL trace propagation: combine an upstream hidden-state Jacobian
        factor with the trace through the current weight.
@@ -120,8 +120,8 @@ Registration example
    )
 
    # Rules can be registered one-by-one, or in a single call via
-   # ``register_etp_rules(yw_to_w=..., xy_to_dw=..., ...)``.
-   my_p.register_yw_to_w(
+   # ``register_etp_rules(dt_to_t=..., xy_to_dw=..., ...)``.
+   my_p.register_dt_to_t(
        lambda hidden, trace, **params: trace * hidden[None, :]
    )
    my_p.register_xy_to_dw(

--- a/docs/tutorials/drtrl.md
+++ b/docs/tutorials/drtrl.md
@@ -28,7 +28,7 @@ Compared with BPTT, D-RTRL:
 - **ETP primitive**: `matmul`, `sparse_matmul`, `lora_matmul`, `conv`,
   `element_wise`. Plain `x @ w` is **excluded** — use it to freeze.
 - **compile_graph**: one jaxpr walk discovers ETP uses, builds the trace graph.
-- **Jacobian rules**: per-primitive `yw_to_w`, `xy_to_dw`, `init_drtrl`.
+- **Jacobian rules**: per-primitive `dt_to_t`, `xy_to_dw`, `init_drtrl`.
 
 ## 3. Minimal example — integrator
 

--- a/examples/drtrl/11-knob-fast-solve.py
+++ b/examples/drtrl/11-knob-fast-solve.py
@@ -6,7 +6,7 @@ Demonstrates:
   * wall-clock speedup from the einsum fast path
 
 The fast path applies when every ETP primitive in the graph has an
-elementwise ``yw_to_w`` rule (matmul, mv, element_wise). For this example
+elementwise ``dt_to_t`` rule (matmul, mv, element_wise). For this example
 (ValinaRNN + Linear) all primitives qualify.
 """
 

--- a/examples/pp_prop/10-operator-lora.py
+++ b/examples/pp_prop/10-operator-lora.py
@@ -3,7 +3,7 @@
 
 Parameterise the recurrent matrix as W = alpha * B @ A with rank r << n_rec.
 pp_prop dispatches to the LoRA ETP primitive etp_lora_mm_p, which registers
-its own xy_to_dw / yw_to_w rules so the eligibility trace propagates through
+its own xy_to_dw / dt_to_t rules so the eligibility trace propagates through
 the low-rank factors rather than a dense W.
 """
 


### PR DESCRIPTION
## Summary
- Renames the `YW_TO_W` ETP rule (registry, functions, docstrings, tests, docs) to `DT_TO_T`, matching what it actually computes: the D^t·epsilon^{t-1} recurrent trace-propagation term in the D-RTRL update rule.
- `brainevent`'s external `DataRepresentation` protocol methods (`yw_to_w` / `yw_to_w_transposed`), which are outside braintrace's control, are left unchanged; call sites in `sparse.py` and the matching test stubs still target them correctly.

## Test plan
- [x] `python -m pytest braintrace/` — 2059 passed, 3 skipped, 4 deselected (pre-existing, unrelated)