### PR TITLE
scan support: structured scan descent for long inner scans (Phase 4)

### DIFF
--- a/braintrace/__init___test.py
+++ b/braintrace/__init___test.py
@@ -153,7 +153,9 @@ def test_weight_used_inside_scan_raises_not_implemented():
     Since Phase 2 canonicalization, statically short scans are unrolled at
     extraction time instead of erroring, so this uses a length above
     ``ControlFlowPolicy.scan_unroll_limit`` to reach the unsupported-op path
-    (after a SCAN_UNROLL_SKIPPED warning)."""
+    (after a SCAN_UNROLL_SKIPPED warning). Since Phase 4, structured scan
+    descent handles over-limit ETP scans by default, so this pins the
+    opt-out path via ``ControlFlowPolicy(scan_descent='off')``."""
 
     class ScanModel(brainstate.nn.Module):
         def __init__(self):
@@ -171,7 +173,8 @@ def test_weight_used_inside_scan_raises_not_implemented():
 
     model = ScanModel()
     brainstate.nn.init_all_states(model, batch_size=1)
-    algo = braintrace.D_RTRL(model)
+    algo = braintrace.D_RTRL(
+        model, control_flow=braintrace.ControlFlowPolicy(scan_descent='off'))
     with pytest.raises(NotImplementedError):
         with pytest.warns(UserWarning, match='NOT unrolled'):
             algo.compile_graph(jnp.ones((1, 4), dtype='float32'))

--- a/braintrace/_algorithm/base.py
+++ b/braintrace/_algorithm/base.py
@@ -273,22 +273,32 @@ class ETraceAlgorithm(brainstate.nn.Module):
             self.graph_executor.compile_graph(*args)
 
             # Structured scan descent (Phase 4): relations discovered inside
-            # a descended scan body need a per-substep trace fold that only
-            # algorithms declaring ``_supports_scan_descent = True`` provide.
-            # Gate here — after the graph is built, before any trace state is
-            # initialized against it.
+            # a descended scan body need a per-substep trace fold, and
+            # hidden groups descended from a scan body carry a leading
+            # substep axis on their Jacobians — both only handled by
+            # algorithms declaring ``_supports_scan_descent = True``. A
+            # descended *group* can exist without any descended relation
+            # (all body weights routed through plain ops), so check both.
+            # Gate here — after the graph is built, before any trace state
+            # is initialized against it.
             if (
-                any(
-                    r.control_flow_context is not None
-                    for r in self.graph.hidden_param_op_relations
+                (
+                    any(
+                        r.control_flow_context is not None
+                        for r in self.graph.hidden_param_op_relations
+                    )
+                    or any(
+                        g.descent is not None
+                        for g in self.graph.hidden_groups
+                    )
                 )
                 and not getattr(self, '_supports_scan_descent', False)
             ):
                 raise NotImplementedError(
                     f'{type(self).__name__} does not support structured scan '
-                    f'descent yet (an ETP relation was discovered inside a '
-                    f'scan body). Use an algorithm that supports scan '
-                    f'descent, or set '
+                    f'descent yet (an ETP relation or hidden group was '
+                    f'discovered inside a scan body). Use an algorithm that '
+                    f'supports scan descent, or set '
                     f"ControlFlowPolicy(scan_descent='off')."
                 )
 

--- a/braintrace/_algorithm/base.py
+++ b/braintrace/_algorithm/base.py
@@ -272,6 +272,26 @@ class ETraceAlgorithm(brainstate.nn.Module):
             # --- the model etrace graph -- #
             self.graph_executor.compile_graph(*args)
 
+            # Structured scan descent (Phase 4): relations discovered inside
+            # a descended scan body need a per-substep trace fold that only
+            # algorithms declaring ``_supports_scan_descent = True`` provide.
+            # Gate here — after the graph is built, before any trace state is
+            # initialized against it.
+            if (
+                any(
+                    r.control_flow_context is not None
+                    for r in self.graph.hidden_param_op_relations
+                )
+                and not getattr(self, '_supports_scan_descent', False)
+            ):
+                raise NotImplementedError(
+                    f'{type(self).__name__} does not support structured scan '
+                    f'descent yet (an ETP relation was discovered inside a '
+                    f'scan body). Use an algorithm that supports scan '
+                    f'descent, or set '
+                    f"ControlFlowPolicy(scan_descent='off')."
+                )
+
             # --- the initialization of the states --- #
             self.init_etrace_state(*args)
 

--- a/braintrace/_algorithm/graph_executor.py
+++ b/braintrace/_algorithm/graph_executor.py
@@ -41,7 +41,7 @@ from typing import Dict, Any, Optional
 
 import brainstate
 
-from braintrace._compiler import ETraceGraph, compile_etrace_graph
+from braintrace._compiler import ControlFlowPolicy, ETraceGraph, compile_etrace_graph
 from .._input_data import get_single_step_data
 from .._typing import Path
 
@@ -65,6 +65,14 @@ class ETraceGraphExecutor:
     ----------
     model: brainstate.nn.Module
         The model to build the eligibility trace graph. The models should only define the one-step behavior.
+    include_recurrent_mixing: bool, optional
+        Hidden-group grouping mode for the hidden-to-hidden transition; see
+        ``compile_etrace_graph(..., include_recurrent_mixing=...)``.
+    control_flow: ControlFlowPolicy, optional
+        Policy governing control-flow canonicalization (cond if-conversion,
+        scan unrolling, structured scan descent, ...) during graph
+        compilation. ``None`` (default) uses
+        :data:`~braintrace.DEFAULT_CONTROL_FLOW_POLICY`.
     """
     __module__ = 'braintrace'
 
@@ -72,6 +80,7 @@ class ETraceGraphExecutor:
         self,
         model: brainstate.nn.Module,
         include_recurrent_mixing: bool = False,
+        control_flow: Optional[ControlFlowPolicy] = None,
     ) -> None:
         # The original model
         if not isinstance(model, brainstate.nn.Module):
@@ -85,6 +94,9 @@ class ETraceGraphExecutor:
         # hidden-group grouping mode for the hidden-to-hidden transition; see
         # ``compile_etrace_graph(..., include_recurrent_mixing=...)``.
         self.include_recurrent_mixing = include_recurrent_mixing
+
+        # control-flow canonicalization policy; None -> compiler default
+        self.control_flow = control_flow
 
         # the compiled graph
         self._compiled_graph: Optional[ETraceGraph] = None
@@ -185,6 +197,7 @@ class ETraceGraphExecutor:
         self._compiled_graph = compile_etrace_graph(
             self.model, *args,
             include_recurrent_mixing=self.include_recurrent_mixing,
+            control_flow=self.control_flow,
         )
 
     def show_graph(

--- a/braintrace/_algorithm/graph_executor_test.py
+++ b/braintrace/_algorithm/graph_executor_test.py
@@ -65,3 +65,24 @@ class TestShowGraph(unittest.TestCase):
         graph = braintrace.ETraceGraphExecutor(net)
         graph.compile_graph(brainstate.random.rand(n_in))
         graph.show_graph()
+
+
+class TestControlFlowThreading(unittest.TestCase):
+    def test_control_flow_policy_reaches_compiled_module_info(self):
+        class Net(brainstate.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.w = brainstate.ParamState(jnp.ones((3, 3)) * 0.1)
+                self.h = brainstate.HiddenState(jnp.zeros((1, 3)))
+
+            def update(self, x):
+                self.h.value = 0.9 * self.h.value + braintrace.matmul(
+                    x.reshape(1, -1), self.w.value)
+                return self.h.value
+
+        policy = braintrace.ControlFlowPolicy(scan_unroll_limit=5)
+        model = Net()
+        brainstate.nn.init_all_states(model, batch_size=1)
+        algo = braintrace.D_RTRL(model, control_flow=policy)
+        algo.compile_graph(jnp.ones((3,), dtype='float32'))
+        assert algo.graph.module_info.control_flow is policy

--- a/braintrace/_algorithm/io_dim_vjp.py
+++ b/braintrace/_algorithm/io_dim_vjp.py
@@ -34,7 +34,7 @@ import jax
 import jax.numpy as jnp
 import brainunit as u
 
-from braintrace._compiler import HiddenGroup, HiddenParamOpRelation
+from braintrace._compiler import ControlFlowPolicy, HiddenGroup, HiddenParamOpRelation
 from braintrace._op import (
     etp_elemwise_p,
     ETP_RULES_XY_TO_DW,
@@ -567,6 +567,11 @@ class IODimVjpAlgorithm(ETraceVjpAlgorithm):
         - ``"multi-step"``: the VJP is computed at multiple time steps, i.e.,
           :math:`\partial L^t/\partial h^{t-k}`, where :math:`k` is determined by
           the data input.
+    control_flow : ControlFlowPolicy, optional
+        Policy governing control-flow canonicalization (cond if-conversion,
+        scan unrolling, structured scan descent, ...) during graph
+        compilation. ``None`` (default) uses
+        :data:`~braintrace.DEFAULT_CONTROL_FLOW_POLICY`.
     name : str, optional
         The name of the etrace algorithm.
     mode : braintrace.mixin.Mode, optional
@@ -667,8 +672,10 @@ class IODimVjpAlgorithm(ETraceVjpAlgorithm):
         name: Optional[str] = None,
         vjp_method: str = 'single-step',
         fast_solve: bool = True,
+        control_flow: Optional[ControlFlowPolicy] = None,
     ) -> None:
-        super().__init__(model, name=name, vjp_method=vjp_method)
+        super().__init__(model, name=name, vjp_method=vjp_method,
+                         control_flow=control_flow)
         self.decay, num_rank = _format_decay_and_rank(decay_or_rank)
         self.fast_solve = fast_solve
 

--- a/braintrace/_algorithm/oracle.py
+++ b/braintrace/_algorithm/oracle.py
@@ -113,6 +113,60 @@ def online_param_gradients(
     )(inputs)
 
 
+def chunked_online_param_gradients(
+    model_factory: Callable[[], brainstate.nn.Module],
+    inputs,
+    *,
+    algo_factory: Callable[[brainstate.nn.Module], braintrace.ETraceAlgorithm],
+    chunk_size: int,
+):
+    """Total sequence gradient accumulated over multi-step chunks.
+
+    Splits ``inputs`` into consecutive chunks of ``chunk_size`` steps, calls
+    the algorithm once per chunk (hidden and eligibility-trace state persist
+    across calls), and sums the per-chunk parameter gradients. Unlike
+    :func:`online_param_gradients` (one whole-sequence call, where the
+    within-call gradient is exact reverse-mode and the trace only enters at
+    the sequence boundary), chunking makes the total depend on the
+    eligibility trace at every chunk boundary — this is the oracle that
+    actually validates trace correctness.
+
+    Parameters
+    ----------
+    model_factory : Callable[[], brainstate.nn.Module]
+        Zero-arg factory returning an uninitialized model.
+    inputs : jax.Array
+        ``(T, ...)`` input sequence.
+    algo_factory : Callable[[brainstate.nn.Module], braintrace.ETraceAlgorithm]
+        Builds the online algorithm; must accept ``MultiStepData``.
+    chunk_size : int
+        Steps per chunk; the last chunk may be shorter.
+
+    Returns
+    -------
+    dict
+        Path-keyed total gradients for every ``ParamState``.
+    """
+    model = model_factory()
+    brainstate.nn.init_all_states(model, batch_size=1)
+    algo = algo_factory(model)
+    algo.compile_graph(inputs[0])
+    algo.init_etrace_state()
+    params = model.states(brainstate.ParamState)
+
+    total = None
+    # test-support chunk loop (few iterations), not a model step driver
+    for start in range(0, inputs.shape[0], chunk_size):
+        chunk = inputs[start:start + chunk_size]
+        g = brainstate.transform.grad(
+            lambda seq: (algo(braintrace.MultiStepData(seq)) ** 2).sum(),
+            params,
+        )(chunk)
+        total = g if total is None else jax.tree.map(
+            lambda a, b: a + b, total, g)
+    return total
+
+
 def online_param_gradients_singlestep_naive(
     model_factory: Callable[[], brainstate.nn.Module],
     inputs,

--- a/braintrace/_algorithm/oracle_models.py
+++ b/braintrace/_algorithm/oracle_models.py
@@ -310,6 +310,89 @@ def scan_body_rnn(n_rec: int = 4, loops: int = 3, seed: int = 0) -> ModelSpec:
     return ModelSpec(factory=factory, etp_param_keys=(('w',),), plain_param_keys=())
 
 
+def snn_scan_rnn(n_rec: int = 4, loops: int = 40, decay: float = 0.9,
+                 seed: int = 0) -> ModelSpec:
+    """Leaky unit whose per-step update runs ``loops`` inner sub-steps
+    ``h <- decay * h + tanh(matmul(x, w))`` in a ``for_loop``.
+
+    The body's hidden-to-hidden path is the plain elementwise leak, so the
+    per-substep Jacobian is exactly ``decay * I`` and structured scan
+    descent (Phase 4) is exact: descended == unrolled == BPTT, including
+    under chunked (online) gradient accumulation. This is the flagship
+    diagonal-recurrence model for the descent oracle; with the default
+    ``scan_unroll_limit`` a ``loops=40`` instance descends while ``loops=8``
+    can be unrolled, so one factory serves both compile paths.
+    """
+
+    def factory():
+        class Net(brainstate.nn.Module):
+            def __init__(self):
+                super().__init__()
+                with brainstate.random.seed_context(seed):
+                    self.w = brainstate.ParamState(
+                        0.1 * brainstate.random.randn(n_rec, n_rec))
+                self.h = brainstate.HiddenState(jnp.zeros((1, n_rec)))
+
+            def update(self, x):
+                x_row = x.reshape(1, -1)
+
+                def substep(_):
+                    self.h.value = decay * self.h.value + jax.nn.tanh(
+                        braintrace.matmul(x_row, self.w.value))
+                    return self.h.value
+
+                outs = brainstate.transform.for_loop(
+                    substep, jnp.arange(loops))
+                return outs[-1]
+
+        return Net()
+
+    return ModelSpec(factory=factory, etp_param_keys=(('w',),),
+                     plain_param_keys=())
+
+
+def snn_scan_two_state_rnn(n_rec: int = 3, loops: int = 40,
+                           seed: int = 0) -> ModelSpec:
+    """Two coupled hidden states (v, a) updated inside a ``for_loop`` —
+    the descended analogue of :func:`two_state_rnn`.
+
+    ``v <- 0.9 v + matmul(x, w) - 0.1 a``; ``a <- 0.95 a + v`` per sub-step.
+    The compiler groups (v, a) into ONE descended HiddenGroup with
+    ``num_state == 2``; the per-substep Jacobian is a per-position 2x2
+    block, exercising the trailing learning-signal axis through the
+    substep fold. Diagonal-recurrence class: D_RTRL descent is exact.
+    """
+
+    def factory():
+        class Net(brainstate.nn.Module):
+            def __init__(self):
+                super().__init__()
+                with brainstate.random.seed_context(seed):
+                    self.w = brainstate.ParamState(
+                        0.1 * brainstate.random.randn(n_rec, n_rec))
+                self.v = brainstate.HiddenState(jnp.zeros((1, n_rec)))
+                self.a = brainstate.HiddenState(jnp.zeros((1, n_rec)))
+
+            def update(self, x):
+                x_row = x.reshape(1, -1)
+
+                def substep(_):
+                    v, a = self.v.value, self.a.value
+                    self.v.value = 0.9 * v + braintrace.matmul(
+                        x_row, self.w.value) - 0.1 * a
+                    self.a.value = 0.95 * a + v
+                    return self.v.value
+
+                outs = brainstate.transform.for_loop(
+                    substep, jnp.arange(loops))
+                return outs[-1]
+
+        return Net()
+
+    return ModelSpec(factory=factory, etp_param_keys=(('w',),),
+                     plain_param_keys=())
+
+
 def while_settle_rnn(
     n_in: int = 3, n_rec: int = 4, k: int = 3, decay: float = 0.8, seed: int = 0
 ) -> ModelSpec:

--- a/braintrace/_algorithm/otpe.py
+++ b/braintrace/_algorithm/otpe.py
@@ -37,6 +37,7 @@ import jax.numpy as jnp
 from braintrace._op import etp_mm_p, etp_mv_p, is_batched_primitive
 from braintrace._misc import etrace_df_key
 from ._common import _route_grads_by_path, _update_dict
+from braintrace._compiler import ControlFlowPolicy
 from .vjp_base import ETraceVjpAlgorithm
 
 __all__ = ['OTPE']
@@ -121,6 +122,11 @@ class OTPE(ETraceVjpAlgorithm):
         :class:`ValueError` at construction; multi-step *inputs* (i.e. calling
         the compiled learner with :class:`~braintrace.MultiStepData`) raise
         :class:`NotImplementedError` instead, at call time.
+    control_flow : ControlFlowPolicy, optional
+        Policy governing control-flow canonicalization (cond if-conversion,
+        scan unrolling, structured scan descent, ...) during graph
+        compilation. ``None`` (default) uses
+        :data:`~braintrace.DEFAULT_CONTROL_FLOW_POLICY`.
 
     Limitations
     -----------
@@ -215,6 +221,7 @@ class OTPE(ETraceVjpAlgorithm):
         name: Optional[str] = None,
         vjp_method: str = 'single-step',
         trace_clip_abs: Optional[float] = None,
+        control_flow: Optional[ControlFlowPolicy] = None,
     ) -> None:
         if mode not in ('full', 'approx'):
             raise ValueError(f"mode must be 'full' or 'approx'; got {mode!r}")
@@ -227,7 +234,8 @@ class OTPE(ETraceVjpAlgorithm):
                 f"a time and have no multi-step form; got "
                 f"vjp_method={vjp_method!r}."
             )
-        super().__init__(model, name=name, vjp_method=vjp_method)
+        super().__init__(model, name=name, vjp_method=vjp_method,
+                         control_flow=control_flow)
         self.mode = mode
         self.leak = float(leak)
         self.trace_clip_abs = trace_clip_abs

--- a/braintrace/_algorithm/ottt.py
+++ b/braintrace/_algorithm/ottt.py
@@ -34,6 +34,7 @@ import jax.numpy as jnp
 
 from braintrace._op import etp_mm_p, etp_mv_p, is_batched_primitive
 from ._common import PresynapticTrace, _route_grads_by_path, _update_dict
+from braintrace._compiler import ControlFlowPolicy
 from .vjp_base import ETraceVjpAlgorithm
 
 __all__ = ['OTTT']
@@ -111,6 +112,11 @@ class OTTT(ETraceVjpAlgorithm):
         :class:`ValueError` at construction; multi-step *inputs* (i.e. calling
         the compiled learner with :class:`~braintrace.MultiStepData`) raise
         :class:`NotImplementedError` instead, at call time.
+    control_flow : ControlFlowPolicy, optional
+        Policy governing control-flow canonicalization (cond if-conversion,
+        scan unrolling, structured scan descent, ...) during graph
+        compilation. ``None`` (default) uses
+        :data:`~braintrace.DEFAULT_CONTROL_FLOW_POLICY`.
 
     Limitations
     -----------
@@ -189,6 +195,7 @@ class OTTT(ETraceVjpAlgorithm):
         leak: float,
         name: Optional[str] = None,
         vjp_method: str = 'single-step',
+        control_flow: Optional[ControlFlowPolicy] = None,
     ) -> None:
         if mode not in ('A', 'O'):
             raise ValueError(f"mode must be 'A' or 'O'; got {mode!r}")
@@ -201,7 +208,8 @@ class OTTT(ETraceVjpAlgorithm):
                 f"a time and have no multi-step form; got "
                 f"vjp_method={vjp_method!r}."
             )
-        super().__init__(model, name=name, vjp_method=vjp_method)
+        super().__init__(model, name=name, vjp_method=vjp_method,
+                         control_flow=control_flow)
         self.mode = mode
         self.leak = float(leak)
         self._pre_traces: Dict[int, PresynapticTrace] = {}

--- a/braintrace/_algorithm/param_dim_vjp.py
+++ b/braintrace/_algorithm/param_dim_vjp.py
@@ -23,7 +23,7 @@ import jax
 import jax.numpy as jnp
 import brainunit as u
 
-from braintrace._compiler import HiddenParamOpRelation, HiddenGroup
+from braintrace._compiler import ControlFlowPolicy, HiddenParamOpRelation, HiddenGroup
 from braintrace._op import (
     etp_conv_p,
     etp_elemwise_p,
@@ -587,6 +587,11 @@ class ParamDimVjpAlgorithm(ETraceVjpAlgorithm):
         - ``"multi-step"``: the VJP is computed at multiple time steps, i.e.,
           :math:`\partial L^t/\partial h^{t-k}`, where :math:`k` is determined by
           the data input.
+    control_flow : ControlFlowPolicy, optional
+        Policy governing control-flow canonicalization (cond if-conversion,
+        scan unrolling, structured scan descent, ...) during graph
+        compilation. ``None`` (default) uses
+        :data:`~braintrace.DEFAULT_CONTROL_FLOW_POLICY`.
     name : str, optional
         The name of the etrace algorithm.
     mode : braintrace.mixin.Mode, optional
@@ -691,8 +696,10 @@ class ParamDimVjpAlgorithm(ETraceVjpAlgorithm):
         vjp_method: str = 'single-step',
         fast_solve: bool = True,
         trace_dtype: Optional[DTypeLike] = None,
+        control_flow: Optional[ControlFlowPolicy] = None,
     ) -> None:
-        super().__init__(model, name=name, vjp_method=vjp_method)
+        super().__init__(model, name=name, vjp_method=vjp_method,
+                         control_flow=control_flow)
         # ``fast_solve=True`` enables closed-form einsum kernels for
         # mm/mv/elemwise primitives, replacing the nested-vmap legacy path.
         # Conv / sparse / LoRA primitives always use the legacy path.

--- a/braintrace/_algorithm/param_dim_vjp.py
+++ b/braintrace/_algorithm/param_dim_vjp.py
@@ -37,7 +37,7 @@ from braintrace._op._registries import (
     get_instant_drtrl_rule,
     get_solve_drtrl_rule,
 )
-from braintrace._misc import etrace_df_key
+from braintrace._misc import etrace_df_key, etrace_x_key
 from braintrace._typing import (
     PyTree,
     WeightID,
@@ -195,13 +195,106 @@ def _update_param_dim_etrace_scan_fn(
     #
     hid_group_jacobians: Sequence[jax.Array] = jacobians[2]
 
+    # --- partition: flat relations vs descended relations (by owning scan) --- #
+    #
+    # Descended relations (structured scan descent, Phase 4) carry stacked
+    # per-substep Jacobians with a leading axis ``L``; their trace update is
+    # folded over that axis with an inner ``jax.lax.scan``. Flat relations
+    # take the historical single-application path unchanged.
+    regular = [r for r in hidden_param_op_relations
+               if r.control_flow_context is None]
+    by_scan: Dict[int, list] = {}
+    for r in hidden_param_op_relations:
+        if r.control_flow_context is not None:
+            by_scan.setdefault(id(r.control_flow_context.scan), []).append(r)
+
     # The etrace weight gradients at the current time step.
     # i.e., The "hist_etrace_vals" at the next time step
     #
-    new_etrace_bwg = dict()
+    new_etrace_bwg = dict(hist_etrace_vals)
+
+    if regular:
+        new_etrace_bwg.update(_apply_relation_step(
+            hist_etrace_vals, etrace_xs_at_t, etrace_ys_at_t,
+            hid_group_jacobians, regular, weight_path_to_vals,
+            fast_solve, trace_dtype,
+        ))
+
+    for rels in by_scan.values():
+        trace_keys = [(id(r.y_var), g.index)
+                      for r in rels for g in r.hidden_groups]
+        x_keys = [etrace_x_key(r.x_var) for r in rels if r.x_var is not None]
+        df_keys = [etrace_df_key(r.y_var, g.index)
+                   for r in rels for g in r.hidden_groups]
+        g_idx = sorted({g.index for r in rels for g in r.hidden_groups})
+
+        sub_carry = {k: hist_etrace_vals[k] for k in trace_keys}
+        sub_xs = (
+            {k: etrace_xs_at_t[k] for k in x_keys},      # (L, ...)
+            {k: etrace_ys_at_t[k] for k in df_keys},     # (L, ...)
+            {i: hid_group_jacobians[i] for i in g_idx},  # (L, ...)
+        )
+
+        def _substep(carry, sliced, _rels=rels):
+            xs_t, dfs_t, diags_t = sliced
+            carry = {**carry, **_apply_relation_step(
+                carry, xs_t, dfs_t, diags_t, _rels,
+                weight_path_to_vals, fast_solve, trace_dtype)}
+            return carry, None
+
+        sub_carry, _ = jax.lax.scan(_substep, sub_carry, sub_xs)
+        new_etrace_bwg.update(sub_carry)
+
+    return new_etrace_bwg, None
+
+
+def _apply_relation_step(
+    hist_etrace_vals: Dict[ETraceWG_Key, jax.Array],
+    etrace_xs_at_t: Dict[ETraceX_Key, jax.Array],
+    etrace_ys_at_t: Dict[ETraceDF_Key, jax.Array],
+    hid_group_jacobians: Any,
+    relations: Any,
+    weight_path_to_vals: Dict[Path, PyTree],
+    fast_solve: bool = True,
+    trace_dtype: Optional[DTypeLike] = None,
+) -> Dict[ETraceWG_Key, jax.Array]:
+    """One trace-update application over ``relations`` (a subset is fine).
+
+    The body of the historical per-relation loop of
+    :func:`_update_param_dim_etrace_scan_fn`, extracted verbatim so the
+    descended-scan substep fold can reuse it per substep.
+
+    Parameters
+    ----------
+    hist_etrace_vals : dict
+        Previous trace values; only the keys touched by ``relations`` are
+        read.
+    etrace_xs_at_t : dict
+        Weight-x values keyed by :func:`~braintrace._misc.etrace_x_key`.
+    etrace_ys_at_t : dict
+        Weight-df values keyed by :func:`~braintrace._misc.etrace_df_key`.
+    hid_group_jacobians : sequence or dict
+        The hidden-group Jacobians; may be the executor's list (indexed by
+        ``group.index``) or an int-keyed dict holding only the indices these
+        relations touch — both support ``[group.index]``.
+    relations : sequence of HiddenParamOpRelation
+        The relations to apply (a subset of the graph's relations is fine).
+    weight_path_to_vals : dict
+        Mapping from weight paths to their PyTree values.
+    fast_solve : bool, default True
+        Whether closed-form fast-path kernels may be used.
+    trace_dtype : dtype-like, optional
+        Reduced trace precision (fast path only).
+
+    Returns
+    -------
+    dict
+        ONLY the updated trace keys (``(id(y_var), group.index)``).
+    """
+    new_etrace_bwg: Dict[ETraceWG_Key, jax.Array] = dict()
 
     relation: HiddenParamOpRelation
-    for relation in hidden_param_op_relations:
+    for relation in relations:
 
         # Build the weights dict the rules consume.
         weights_dict = {
@@ -333,7 +426,7 @@ def _update_param_dim_etrace_scan_fn(
             )
             new_etrace_bwg[w_key] = new_bwg
 
-    return new_etrace_bwg, None
+    return new_etrace_bwg
 
 
 def _solve_param_dim_weight_gradients(
@@ -688,6 +781,11 @@ class ParamDimVjpAlgorithm(ETraceVjpAlgorithm):
 
     # batch of weight gradients
     etrace_bwg: Dict[ETraceWG_Key, brainstate.State]
+
+    _supports_scan_descent = True
+    """Structured scan descent (Phase 4): the param-dim trace update folds
+    per-substep injections with an inner scan; see
+    ``braintrace._compiler.scan_descent``."""
 
     def __init__(
         self,

--- a/braintrace/_algorithm/tests/scan_descent_support_test.py
+++ b/braintrace/_algorithm/tests/scan_descent_support_test.py
@@ -139,6 +139,72 @@ class TestSubstepFold:
         with pytest.raises(NotImplementedError, match='scan descent'):
             algo.compile_graph(jnp.ones((4,), dtype='float32'))
 
+    def test_orphan_descended_group_still_gated(self):
+        """A body whose only weight is used through plain ops descends with
+        a hidden group but ZERO relations; the group's Jacobians still carry
+        the substep axis, so non-supporting algorithms must be gated on
+        groups too, not just relations."""
+
+        class Net(brainstate.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.w = brainstate.ParamState(jnp.ones((4, 4)) * 0.1)
+                self.h = brainstate.HiddenState(jnp.zeros((1, 4)))
+
+            def update(self, x):
+                x_row = x.reshape(1, -1)
+
+                def substep(_):
+                    # plain matmul: no ETP relation is produced
+                    self.h.value = 0.9 * self.h.value + jnp.tanh(
+                        x_row @ self.w.value)
+                    return self.h.value
+
+                return brainstate.transform.for_loop(
+                    substep, jnp.arange(40))[-1]
+
+        net = Net()
+        brainstate.nn.init_all_states(net, batch_size=1)
+        algo = braintrace.pp_prop(net, decay_or_rank=16,
+                                  vjp_method='multi-step',
+                                  control_flow=DESCEND())
+        with pytest.warns(UserWarning, match='no ETP relation'):
+            with pytest.raises(NotImplementedError, match='scan descent'):
+                algo.compile_graph(jnp.ones((4,), dtype='float32'))
+
+    def test_orphan_descended_group_runs_under_d_rtrl(self):
+        """Same plain-op-weight body under a supporting algorithm: compiles
+        (with the exclusion warning), holds no traces for the excluded
+        weight, and a forward update executes despite the substep axis on
+        the orphan group's Jacobians."""
+
+        class Net(brainstate.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.w = brainstate.ParamState(jnp.ones((4, 4)) * 0.1)
+                self.h = brainstate.HiddenState(jnp.zeros((1, 4)))
+
+            def update(self, x):
+                x_row = x.reshape(1, -1)
+
+                def substep(_):
+                    self.h.value = 0.9 * self.h.value + jnp.tanh(
+                        x_row @ self.w.value)
+                    return self.h.value
+
+                return brainstate.transform.for_loop(
+                    substep, jnp.arange(40))[-1]
+
+        net = Net()
+        brainstate.nn.init_all_states(net, batch_size=1)
+        algo = braintrace.D_RTRL(net, vjp_method='multi-step',
+                                 control_flow=DESCEND())
+        with pytest.warns(UserWarning, match='no ETP relation'):
+            algo.compile_graph(jnp.ones((4,), dtype='float32'))
+        assert len(algo.etrace_bwg) == 0
+        out = algo.update(jnp.ones((4,), dtype='float32'))
+        assert jnp.shape(out) == (1, 4)
+
 
 from braintrace._algorithm.oracle import (
     assert_param_gradients_close,

--- a/braintrace/_algorithm/tests/scan_descent_support_test.py
+++ b/braintrace/_algorithm/tests/scan_descent_support_test.py
@@ -276,3 +276,12 @@ class TestDescentCorrectness:
         np.testing.assert_allclose(np.asarray(g_ys[('w',)]), 0.0, atol=0.0)
         g_carry = self._one_step_grads(DESCEND(), carry_readout=True)
         assert float(np.linalg.norm(np.asarray(g_carry[('w',)]))) > 1.0
+
+
+def test_default_policy_descends_long_scans():
+    """Phase 4 default: an over-limit ETP scan compiles without any policy."""
+    net = make_snn_scan_net(loops=40)
+    algo = braintrace.D_RTRL(net, vjp_method='multi-step')
+    algo.compile_graph(jnp.ones((4,), dtype='float32'))
+    assert any(r.control_flow_context is not None
+               for r in algo.graph.hidden_param_op_relations)

--- a/braintrace/_algorithm/tests/scan_descent_support_test.py
+++ b/braintrace/_algorithm/tests/scan_descent_support_test.py
@@ -1,0 +1,110 @@
+# Copyright 2026 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Phase 4 structured-scan-descent correctness: stacked executor Jacobians,
+substep trace fold, descended == unrolled == BPTT on diagonal-recurrence
+bodies, and gating/diagnostic pins."""
+
+import brainstate
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+import braintrace
+from braintrace import ControlFlowPolicy
+
+DESCEND = lambda: ControlFlowPolicy(scan_unroll_limit=4, scan_descent='auto')
+UNROLL = lambda: ControlFlowPolicy(scan_unroll_limit=16, scan_descent='off')
+
+
+def make_snn_scan_net(loops, n_rec=4, decay=0.9, seed=0):
+    class Net(brainstate.nn.Module):
+        def __init__(self):
+            super().__init__()
+            with brainstate.random.seed_context(seed):
+                self.w = brainstate.ParamState(
+                    0.1 * brainstate.random.randn(n_rec, n_rec))
+            self.h = brainstate.HiddenState(jnp.zeros((1, n_rec)))
+
+        def update(self, x):
+            x_row = x.reshape(1, -1)
+
+            def substep(_):
+                self.h.value = decay * self.h.value + jnp.tanh(
+                    braintrace.matmul(x_row, self.w.value))
+                return self.h.value
+
+            return brainstate.transform.for_loop(substep, jnp.arange(loops))[-1]
+
+    net = Net()
+    brainstate.nn.init_all_states(net, batch_size=1)
+    return net
+
+
+def _compiled_algo(net, policy, **kw):
+    algo = braintrace.D_RTRL(net, vjp_method='multi-step',
+                             control_flow=policy, **kw)
+    algo.compile_graph(jnp.ones((4,), dtype='float32'))
+    algo.init_etrace_state()
+    return algo
+
+
+@pytest.fixture
+def allow_descent(monkeypatch):
+    """Task-9 shim: bypass the Part-1 algorithm gate until the param-dim
+    substep fold lands (Task 10 sets ``_supports_scan_descent = True`` for
+    real and this fixture becomes a no-op)."""
+    monkeypatch.setattr(braintrace.D_RTRL, '_supports_scan_descent', True,
+                        raising=False)
+
+
+class TestStackedJacobians:
+    def test_descended_diag_is_decay_identity_per_substep(self, allow_descent):
+        L, decay = 8, 0.9
+        algo = _compiled_algo(make_snn_scan_net(loops=L, decay=decay), DESCEND())
+        executor = algo.graph_executor
+        # drive one real step through the executor plumbing to get temps
+        (_, _, _, hid2w, hid2h, _) = executor.solve_h2w_h2h_jacobian(
+            jnp.ones((4,), dtype='float32'))
+        g = next(gr for gr in algo.graph.hidden_groups if gr.descent is not None)
+        diag = hid2h[g.index]
+        assert diag.shape == (L, 1, 4, 1, 1)
+        # body h-path is `decay * h` -> D_tau == decay exactly, every substep
+        np.testing.assert_allclose(np.asarray(diag), decay, atol=1e-6)
+
+    def test_descended_df_matches_manual_tanh_prime(self, allow_descent):
+        L = 8
+        net = make_snn_scan_net(loops=L)
+        algo = _compiled_algo(net, DESCEND())
+        executor = algo.graph_executor
+        (_, _, _, (xs, dfs), _, _) = executor.solve_h2w_h2h_jacobian(
+            jnp.ones((4,), dtype='float32'))
+        rel = next(r for r in algo.graph.hidden_param_op_relations
+                   if r.control_flow_context is not None)
+        from braintrace._misc import etrace_x_key, etrace_df_key
+        x_stack = xs[etrace_x_key(rel.x_var)]
+        assert x_stack.shape == (L, 1, 4)
+        g = rel.hidden_groups[0]
+        df_stack = dfs[etrace_df_key(rel.y_var, g.index)]
+        assert df_stack.shape == (L, 1, 4, 1)
+        # y_tau identical every substep here (x@w is substep-invariant), so
+        # df must equal tanh'(y) with y = x_row @ w
+        y = jnp.ones((1, 4)) @ np.asarray(net.w.value)
+        expect = 1.0 - jnp.tanh(y) ** 2
+        np.testing.assert_allclose(
+            np.asarray(df_stack[0, ..., 0]), np.asarray(expect), atol=1e-5)
+        np.testing.assert_allclose(
+            np.asarray(df_stack[-1, ..., 0]), np.asarray(expect), atol=1e-5)

--- a/braintrace/_algorithm/tests/scan_descent_support_test.py
+++ b/braintrace/_algorithm/tests/scan_descent_support_test.py
@@ -30,7 +30,13 @@ DESCEND = lambda: ControlFlowPolicy(scan_unroll_limit=4, scan_descent='auto')
 UNROLL = lambda: ControlFlowPolicy(scan_unroll_limit=16, scan_descent='off')
 
 
-def make_snn_scan_net(loops, n_rec=4, decay=0.9, seed=0):
+def make_snn_scan_net(loops, n_rec=4, decay=0.9, seed=0, carry_readout=False):
+    """``carry_readout=True`` returns ``self.h.value`` after the loop (the
+    scan's carry outvar) instead of the stacked ys slice ``outs[-1]``. The
+    two are numerically identical, but in single-step (perturbation) mode
+    only the carry readout routes the same-step loss through the per-step
+    hidden perturbation of a *descended* scan — see
+    ``test_single_step_ys_readout_drops_same_step_signal``."""
     class Net(brainstate.nn.Module):
         def __init__(self):
             super().__init__()
@@ -47,7 +53,8 @@ def make_snn_scan_net(loops, n_rec=4, decay=0.9, seed=0):
                     braintrace.matmul(x_row, self.w.value))
                 return self.h.value
 
-            return brainstate.transform.for_loop(substep, jnp.arange(loops))[-1]
+            outs = brainstate.transform.for_loop(substep, jnp.arange(loops))
+            return self.h.value if carry_readout else outs[-1]
 
     net = Net()
     brainstate.nn.init_all_states(net, batch_size=1)
@@ -131,3 +138,141 @@ class TestSubstepFold:
                                   control_flow=DESCEND())
         with pytest.raises(NotImplementedError, match='scan descent'):
             algo.compile_graph(jnp.ones((4,), dtype='float32'))
+
+
+from braintrace._algorithm.oracle import (
+    assert_param_gradients_close,
+    bptt_param_gradients,
+    chunked_online_param_gradients,
+    online_param_gradients,
+)
+from braintrace._algorithm.oracle_models import (
+    scan_body_rnn,
+    snn_scan_rnn,
+    snn_scan_two_state_rnn,
+)
+
+ATOL_BPTT = 1e-4
+# float32 accumulation-order noise between the folded (inner-scan) and the
+# unrolled (flat-relation) trace paths; the design probes measured <=2e-5.
+ATOL_EQUIV = 3e-5
+
+
+def _inputs(T, n, seed=42):
+    return jnp.asarray(np.random.RandomState(seed).randn(T, n).astype('float32'))
+
+
+def _drtrl_descend(m):
+    return braintrace.D_RTRL(m, vjp_method='multi-step', control_flow=DESCEND())
+
+
+def _drtrl_unroll(m):
+    return braintrace.D_RTRL(m, vjp_method='multi-step', control_flow=UNROLL())
+
+
+class TestDescentCorrectness:
+    def test_wholeseq_descended_matches_bptt_diagonal_body(self):
+        spec = snn_scan_rnn(n_rec=4, loops=8, seed=0)
+        inputs = _inputs(6, 4)
+        g_bptt = bptt_param_gradients(spec.factory, inputs)
+        g_onl = online_param_gradients(spec.factory, inputs,
+                                       algo_factory=_drtrl_descend)
+        assert_param_gradients_close(g_onl, g_bptt, atol=ATOL_BPTT)
+
+    @pytest.mark.parametrize('chunk_size', [3, 1])
+    def test_chunked_descended_matches_bptt(self, chunk_size):
+        """THE trace oracle: chunk boundaries make the gradient depend on the
+        folded eligibility trace (boundary term dL/dh0 . eps0)."""
+        spec = snn_scan_rnn(n_rec=4, loops=8, seed=0)
+        inputs = _inputs(6, 4)
+        g_bptt = bptt_param_gradients(spec.factory, inputs)
+        g_chunk = chunked_online_param_gradients(
+            spec.factory, inputs, algo_factory=_drtrl_descend,
+            chunk_size=chunk_size)
+        assert_param_gradients_close(g_chunk, g_bptt, atol=ATOL_BPTT)
+
+    def test_descended_equals_unrolled_gradients(self):
+        spec = snn_scan_rnn(n_rec=4, loops=8, seed=0)
+        inputs = _inputs(6, 4)
+        g_d = chunked_online_param_gradients(
+            spec.factory, inputs, algo_factory=_drtrl_descend, chunk_size=3)
+        g_u = chunked_online_param_gradients(
+            spec.factory, inputs, algo_factory=_drtrl_unroll, chunk_size=3)
+        assert_param_gradients_close(g_d, g_u, atol=ATOL_EQUIV)
+
+    def test_two_state_group_descended_chunked_matches_bptt(self):
+        """num_state == 2 through the fold (SNN learning-signal axis pin)."""
+        spec = snn_scan_two_state_rnn(n_rec=3, loops=8, seed=0)
+        inputs = _inputs(6, 3)
+        g_bptt = bptt_param_gradients(spec.factory, inputs)
+        g_chunk = chunked_online_param_gradients(
+            spec.factory, inputs, algo_factory=_drtrl_descend, chunk_size=3)
+        assert_param_gradients_close(g_chunk, g_bptt, atol=ATOL_BPTT)
+
+    def test_long_scan_L100_compiles_lean_and_matches_bptt_wholeseq(self):
+        spec = snn_scan_rnn(n_rec=4, loops=100, seed=0)
+        inputs = _inputs(4, 4)
+        g_bptt = bptt_param_gradients(spec.factory, inputs)
+        # default-limit policy: L=100 must descend, not unroll
+        policy = ControlFlowPolicy(scan_descent='auto')
+        algo_factory = lambda m: braintrace.D_RTRL(
+            m, vjp_method='multi-step', control_flow=policy)
+        g = online_param_gradients(spec.factory, inputs,
+                                   algo_factory=algo_factory)
+        assert_param_gradients_close(g, g_bptt, atol=ATOL_BPTT)
+        # no unroll blowup
+        model = spec.factory()
+        brainstate.nn.init_all_states(model, batch_size=1)
+        algo = algo_factory(model)
+        algo.compile_graph(inputs[0])
+        assert len(algo.graph.module_info.jaxpr.eqns) < 60
+
+    def test_mixing_body_descended_wholeseq_matches_bptt(self):
+        """scan_body_rnn's body mixes h through an ETP matmul: whole-sequence
+        multi-step is trace-independent, so descent must still be
+        BPTT-exact. Chunked equality is NOT asserted (both compile paths
+        approximate cross-substep credit there; documented divergence)."""
+        spec = scan_body_rnn(n_rec=3, loops=8, seed=0)
+        inputs = _inputs(6, 3)
+        g_bptt = bptt_param_gradients(spec.factory, inputs)
+        g = online_param_gradients(spec.factory, inputs,
+                                   algo_factory=_drtrl_descend)
+        assert_param_gradients_close(g, g_bptt, atol=ATOL_BPTT)
+
+    @staticmethod
+    def _one_step_grads(policy, carry_readout):
+        x = jnp.ones((4,), dtype='float32')
+        net = make_snn_scan_net(loops=8, seed=0, carry_readout=carry_readout)
+        algo = braintrace.D_RTRL(net, vjp_method='single-step',
+                                 control_flow=policy)
+        algo.compile_graph(x)
+        algo.init_etrace_state()
+        params = net.states(brainstate.ParamState)
+        return brainstate.transform.grad(
+            lambda x_: (algo(x_) ** 2).sum(), params)(x)
+
+    def test_single_step_vjp_descended_equals_unrolled_one_step(self):
+        """Perturbation path through the descended compile (single-step mode
+        reverse-differentiates THROUGH the scan; weights detached). The model
+        must read the hidden state from the carry (``self.h.value`` after the
+        loop) for the same-step learning signal to cross the perturbation —
+        see the limitation pin below."""
+        g_d = self._one_step_grads(DESCEND(), carry_readout=True)
+        g_u = self._one_step_grads(UNROLL(), carry_readout=True)
+        assert_param_gradients_close(g_d, g_u, atol=ATOL_EQUIV)
+
+    def test_single_step_ys_readout_drops_same_step_signal(self):
+        """v1 limitation pin: when the loss reads the hidden state through
+        the descended scan's stacked ys output (``for_loop(...)[-1]``)
+        instead of the carry, the same-step loss path bypasses the per-step
+        hidden perturbation (which is added to the scan's *carry* outvar),
+        so the single-step learning signal — and hence the one-step ETP
+        gradient — is zero. This parallels the documented Phase-3
+        while-hidden same-step limitation. Multi-step vjp is unaffected
+        (``test_wholeseq_descended_matches_bptt_diagonal_body`` uses the ys
+        readout). Fix at the model level: return ``self.h.value`` after the
+        loop."""
+        g_ys = self._one_step_grads(DESCEND(), carry_readout=False)
+        np.testing.assert_allclose(np.asarray(g_ys[('w',)]), 0.0, atol=0.0)
+        g_carry = self._one_step_grads(DESCEND(), carry_readout=True)
+        assert float(np.linalg.norm(np.asarray(g_carry[('w',)]))) > 1.0

--- a/braintrace/_algorithm/tests/scan_descent_support_test.py
+++ b/braintrace/_algorithm/tests/scan_descent_support_test.py
@@ -62,17 +62,8 @@ def _compiled_algo(net, policy, **kw):
     return algo
 
 
-@pytest.fixture
-def allow_descent(monkeypatch):
-    """Task-9 shim: bypass the Part-1 algorithm gate until the param-dim
-    substep fold lands (Task 10 sets ``_supports_scan_descent = True`` for
-    real and this fixture becomes a no-op)."""
-    monkeypatch.setattr(braintrace.D_RTRL, '_supports_scan_descent', True,
-                        raising=False)
-
-
 class TestStackedJacobians:
-    def test_descended_diag_is_decay_identity_per_substep(self, allow_descent):
+    def test_descended_diag_is_decay_identity_per_substep(self):
         L, decay = 8, 0.9
         algo = _compiled_algo(make_snn_scan_net(loops=L, decay=decay), DESCEND())
         executor = algo.graph_executor
@@ -85,7 +76,7 @@ class TestStackedJacobians:
         # body h-path is `decay * h` -> D_tau == decay exactly, every substep
         np.testing.assert_allclose(np.asarray(diag), decay, atol=1e-6)
 
-    def test_descended_df_matches_manual_tanh_prime(self, allow_descent):
+    def test_descended_df_matches_manual_tanh_prime(self):
         L = 8
         net = make_snn_scan_net(loops=L)
         algo = _compiled_algo(net, DESCEND())
@@ -108,3 +99,35 @@ class TestStackedJacobians:
             np.asarray(df_stack[0, ..., 0]), np.asarray(expect), atol=1e-5)
         np.testing.assert_allclose(
             np.asarray(df_stack[-1, ..., 0]), np.asarray(expect), atol=1e-5)
+
+
+class TestSubstepFold:
+    def test_descended_trace_equals_sum_of_unrolled_traces(self):
+        """Replay == unroll-in-time: after identical multi-step drives, the
+        descended model's single trace equals the elementwise SUM of the
+        unrolled twin's per-substep-relation traces (diagonal body, L=8)."""
+        L = 8
+        inputs = jnp.asarray(
+            np.random.RandomState(7).randn(3, 4).astype('float32'))
+
+        algo_d = _compiled_algo(make_snn_scan_net(loops=L, seed=0), DESCEND())
+        algo_u = _compiled_algo(make_snn_scan_net(loops=L, seed=0), UNROLL())
+        for algo in (algo_d, algo_u):
+            algo(braintrace.MultiStepData(inputs))
+
+        d_entries = list(algo_d.etrace_bwg.values())
+        u_entries = list(algo_u.etrace_bwg.values())
+        assert len(d_entries) == 1 and len(u_entries) == L
+
+        d_val = d_entries[0].value['weight']
+        u_sum = sum(e.value['weight'] for e in u_entries)
+        np.testing.assert_allclose(
+            np.asarray(d_val), np.asarray(u_sum), atol=1e-6)
+
+    def test_io_dim_algorithm_still_gated(self):
+        net = make_snn_scan_net(loops=40)
+        algo = braintrace.pp_prop(net, decay_or_rank=16,
+                                  vjp_method='multi-step',
+                                  control_flow=DESCEND())
+        with pytest.raises(NotImplementedError, match='scan descent'):
+            algo.compile_graph(jnp.ones((4,), dtype='float32'))

--- a/braintrace/_algorithm/vjp_base.py
+++ b/braintrace/_algorithm/vjp_base.py
@@ -40,6 +40,7 @@ from braintrace._typing import (
     dG_Hidden,
     dG_State,
 )
+from braintrace._compiler import ControlFlowPolicy
 from .base import ETraceAlgorithm
 from .vjp_graph_executor import ETraceVjpGraphExecutor
 
@@ -79,6 +80,11 @@ class ETraceVjpAlgorithm(ETraceAlgorithm):
         - ``"multi-step"``: The VJP is computed at multiple time steps, i.e.,
           :math:`\partial L^t/\partial h^{t-k}`, where :math:`k` is determined by the
           data input.
+    control_flow : ControlFlowPolicy, optional
+        Policy governing control-flow canonicalization (cond if-conversion,
+        scan unrolling, structured scan descent, ...) during graph
+        compilation. ``None`` (default) uses
+        :data:`~braintrace.DEFAULT_CONTROL_FLOW_POLICY`.
 
     Notes
     -----
@@ -115,7 +121,8 @@ class ETraceVjpAlgorithm(ETraceAlgorithm):
         self,
         model: brainstate.nn.Module,
         name: Optional[str] = None,
-        vjp_method: str = 'single-step'
+        vjp_method: str = 'single-step',
+        control_flow: Optional[ControlFlowPolicy] = None,
     ):
 
         # the VJP method
@@ -130,6 +137,7 @@ class ETraceVjpAlgorithm(ETraceAlgorithm):
             model,
             vjp_method=vjp_method,
             include_recurrent_mixing=self._include_recurrent_mixing,
+            control_flow=control_flow,
         )
 
         # super initialization

--- a/braintrace/_algorithm/vjp_graph_executor.py
+++ b/braintrace/_algorithm/vjp_graph_executor.py
@@ -278,12 +278,49 @@ class ETraceVjpGraphExecutor(ETraceGraphExecutor):
         xs = {}
         for relation in self.graph.hidden_param_op_relations:
             if relation.x_var is not None:
+                ctx = relation.control_flow_context
                 x = etrace_x_key(relation.x_var)
-                xs[x] = intermediate_values[relation.x_var]
+                if ctx is not None:
+                    # descended relation: ``x_var`` is body-scoped; its
+                    # runtime value is the stacked ys output (leading substep
+                    # axis L) hoisted by the scan-descent pass.
+                    xs[x] = intermediate_values[
+                        ctx.scan.stacked_var_map[relation.x_var]]
+                else:
+                    xs[x] = intermediate_values[relation.x_var]
 
         # the weight df
         dfs = {}
         for relation in self.graph.hidden_param_op_relations:
+            ctx = relation.control_flow_context
+            if ctx is not None:
+                # Descended relation (structured scan descent, Phase 4): the
+                # ``y -> hidden group`` map and its constvars are body-scoped
+                # per-substep values; read them through the stacked ys
+                # (leading axis L) and vmap the same all-ones-tangent jvp the
+                # flat path uses over the substep axis. Downstream, the
+                # algorithm's substep fold consumes the extra leading axis.
+                m = ctx.scan.stacked_var_map
+                y_stack = intermediate_values[m[relation.y_var]]
+                cvars = list(dict.fromkeys(
+                    v for j in relation.y_to_hidden_group_jaxprs
+                    for v in j.constvars))
+                c_stacks = tuple(intermediate_values[m[v]] for v in cvars)
+
+                def _one_substep(y_t, c_ts, _rel=relation, _cvars=cvars):
+                    env = dict(zip(_cvars, c_ts))
+
+                    def _y2h(y_val):
+                        return _rel.y_to_hidden_groups(
+                            y_val, env, concat_hidden_vals=True)
+
+                    _, tans = jax.jvp(_y2h, (y_t,), (u.math.ones_like(y_t),))
+                    return tuple(tans)
+
+                tangents = jax.vmap(_one_substep)(y_stack, c_stacks)
+                for tangent, group in zip(tangents, relation.hidden_groups):
+                    dfs[etrace_df_key(relation.y_var, group.index)] = tangent
+                continue
             y = intermediate_values[relation.y_var]
 
             #
@@ -342,6 +379,27 @@ class ETraceVjpGraphExecutor(ETraceGraphExecutor):
         hid2hid_jacobian = []
         group: HiddenGroup
         for group in self.graph.hidden_groups:
+
+            if group.descent is not None:
+                # Descended group (structured scan descent, Phase 4): the
+                # transition jaxpr is body-scoped (one substep); its inputs
+                # are the stacked substep-entry hidden values and transition
+                # constants (leading axis L). vmap the per-substep diagonal
+                # Jacobian; result carries a leading substep axis consumed by
+                # the algorithm's fold.
+                m = group.descent.scan.stacked_var_map
+                h_stacks = tuple(
+                    intermediate_values[m[v]]
+                    for v in group.descent.body_hidden_invars)
+                c_stacks = tuple(
+                    intermediate_values[m[v]]
+                    for v in group.transition_jaxpr_constvars)
+
+                def _one_substep(h_ts, c_ts, _g=group):
+                    return _g.diagonal_jacobian(list(h_ts), list(c_ts))
+
+                hid2hid_jacobian.append(jax.vmap(_one_substep)(h_stacks, c_stacks))
+                continue
 
             # data for jacobian computation
             hidden_vals = [intermediate_values[v] for v in group.hidden_invars]

--- a/braintrace/_algorithm/vjp_graph_executor.py
+++ b/braintrace/_algorithm/vjp_graph_executor.py
@@ -51,7 +51,7 @@ from jax.interpreters import partial_eval as pe
 from jax.tree_util import register_pytree_node_class
 
 from braintrace._compatible_imports import Var
-from braintrace._compiler import compile_etrace_graph, HiddenGroup
+from braintrace._compiler import ControlFlowPolicy, compile_etrace_graph, HiddenGroup
 from braintrace._input_data import (
     get_single_step_data,
     split_input_data_types,
@@ -153,6 +153,13 @@ class ETraceVjpGraphExecutor(ETraceGraphExecutor):
         - ``"multi-step"``: The VJP is computed at multiple time steps, i.e.,
           :math:`\partial L^t/\partial h^{t-k}`, where :math:`k` is determined by the
           data input.
+    include_recurrent_mixing : bool, optional
+        Hidden-group grouping mode for the hidden-to-hidden transition; see
+        ``compile_etrace_graph(..., include_recurrent_mixing=...)``.
+    control_flow : ControlFlowPolicy, optional
+        Policy governing control-flow canonicalization during graph
+        compilation. ``None`` (default) uses
+        :data:`~braintrace.DEFAULT_CONTROL_FLOW_POLICY`.
     """
     __module__ = 'braintrace'
 
@@ -161,8 +168,13 @@ class ETraceVjpGraphExecutor(ETraceGraphExecutor):
         model: brainstate.nn.Module,
         vjp_method: str = 'single-step',
         include_recurrent_mixing: bool = False,
+        control_flow: Optional[ControlFlowPolicy] = None,
     ):
-        super().__init__(model, include_recurrent_mixing=include_recurrent_mixing)
+        super().__init__(
+            model,
+            include_recurrent_mixing=include_recurrent_mixing,
+            control_flow=control_flow,
+        )
 
         # the VJP method
         assert vjp_method in ('single-step', 'multi-step'), (
@@ -217,6 +229,7 @@ class ETraceVjpGraphExecutor(ETraceGraphExecutor):
             self.model, *args,
             include_hidden_perturb=self.is_single_step_vjp,
             include_recurrent_mixing=self.include_recurrent_mixing,
+            control_flow=self.control_flow,
         )
 
     def _compute_hid2weight_jacobian(

--- a/braintrace/_compiler/base.py
+++ b/braintrace/_compiler/base.py
@@ -124,6 +124,13 @@ def check_unsupported_op(
     """
     policy = getattr(self, 'control_flow', DEFAULT_CONTROL_FLOW_POLICY)
 
+    # Structured scan descent (Phase 4): a scan equation rewritten by
+    # ``scan_descent.apply_scan_descent`` is exempt from both checks — its
+    # body relations and hidden groups were registered separately, so the
+    # weight usage and hidden-state production inside it are accounted for.
+    if op_name == 'scan' and id(eqn) in getattr(self, 'descended_scan_eqn_ids', ()):
+        return
+
     # checking whether the weight variables are used in the equation
     # Note: user ``jax.jit`` boundaries are inlined at extraction time
     # (see ``jaxpr_graph.inline_jit_calls``), so reaching this check means

--- a/braintrace/_compiler/canonicalize.py
+++ b/braintrace/_compiler/canonicalize.py
@@ -113,6 +113,14 @@ class ControlFlowPolicy:
         previous behaviour of a loud warning
         (:attr:`~braintrace.DiagnosticKind.PRIMITIVE_INSIDE_CONTROL_FLOW`)
         plus exclusion of the weight from ETP relations.
+    scan_descent : str, optional
+        How ETP-relevant scans too long to unroll are handled. ``'auto'``
+        rewrites the scan for structured descent: relations and hidden
+        groups are discovered inside the body and the eligibility trace is
+        folded over the substep axis (see
+        ``braintrace._compiler.scan_descent``). ``'off'`` (default)
+        preserves the pre-Phase-4 behavior: the scan stays opaque and
+        compilation fails on the existing control-flow restrictions.
 
     Notes
     -----
@@ -154,6 +162,14 @@ class ControlFlowPolicy:
     scan_unroll_limit: int = 16
     while_hidden: str = 'opaque-fwd'
     etp_in_control_flow: str = 'error'
+    scan_descent: str = 'off'
+
+    def __post_init__(self):
+        if self.scan_descent not in ('auto', 'off'):
+            raise ValueError(
+                f"ControlFlowPolicy.scan_descent must be 'auto' or 'off', "
+                f"got {self.scan_descent!r}."
+            )
 
 
 DEFAULT_CONTROL_FLOW_POLICY = ControlFlowPolicy()

--- a/braintrace/_compiler/canonicalize.py
+++ b/braintrace/_compiler/canonicalize.py
@@ -885,10 +885,11 @@ def _unroll_scans_once(
         if bad is not None:
             if id(eqn) not in skip_warned:
                 skip_warned.add(id(eqn))
-                over_limit = (
-                    policy.scan_unroll_limit > 0
-                    and eqn.params['length'] > policy.scan_unroll_limit
-                )
+                # Matches the descent-eligibility rule in
+                # ``scan_descent._descent_blockers``: any positive-length
+                # scan beyond the limit descends, including when unrolling
+                # is disabled entirely (limit <= 0).
+                over_limit = eqn.params['length'] > policy.scan_unroll_limit
                 if over_limit and policy.scan_descent == 'auto':
                     # An over-limit scan is no longer a dead end: the
                     # scan-descent pass (Phase 4) picks it up downstream.

--- a/braintrace/_compiler/canonicalize.py
+++ b/braintrace/_compiler/canonicalize.py
@@ -115,12 +115,12 @@ class ControlFlowPolicy:
         plus exclusion of the weight from ETP relations.
     scan_descent : str, optional
         How ETP-relevant scans too long to unroll are handled. ``'auto'``
-        rewrites the scan for structured descent: relations and hidden
-        groups are discovered inside the body and the eligibility trace is
-        folded over the substep axis (see
-        ``braintrace._compiler.scan_descent``). ``'off'`` (default)
-        preserves the pre-Phase-4 behavior: the scan stays opaque and
-        compilation fails on the existing control-flow restrictions.
+        (default) rewrites the scan for structured descent: relations and
+        hidden groups are discovered inside the body and the eligibility
+        trace is folded over the substep axis (see
+        ``braintrace._compiler.scan_descent``). ``'off'`` preserves the
+        pre-Phase-4 behavior: the scan stays opaque and compilation fails
+        on the existing control-flow restrictions.
 
     Notes
     -----
@@ -162,7 +162,7 @@ class ControlFlowPolicy:
     scan_unroll_limit: int = 16
     while_hidden: str = 'opaque-fwd'
     etp_in_control_flow: str = 'error'
-    scan_descent: str = 'off'
+    scan_descent: str = 'auto'
 
     def __post_init__(self):
         if self.scan_descent not in ('auto', 'off'):
@@ -885,18 +885,38 @@ def _unroll_scans_once(
         if bad is not None:
             if id(eqn) not in skip_warned:
                 skip_warned.add(id(eqn))
-                emit(
-                    kind=DiagnosticKind.SCAN_UNROLL_SKIPPED,
-                    level=DiagnosticLevel.WARNING,
-                    message=(
-                        f'An ETP-relevant scan ({reason}) was NOT unrolled '
-                        f'because {bad}; it stays opaque and the existing '
-                        f'control-flow restrictions apply. Raise '
-                        f'ControlFlowPolicy.scan_unroll_limit or restructure '
-                        f'the loop if its weights should learn online.'
-                    ),
-                    context={'reason': bad, 'relevance': reason},
+                over_limit = (
+                    policy.scan_unroll_limit > 0
+                    and eqn.params['length'] > policy.scan_unroll_limit
                 )
+                if over_limit and policy.scan_descent == 'auto':
+                    # An over-limit scan is no longer a dead end: the
+                    # scan-descent pass (Phase 4) picks it up downstream.
+                    emit(
+                        kind=DiagnosticKind.SCAN_UNROLL_SKIPPED,
+                        level=DiagnosticLevel.INFO,
+                        message=(
+                            f'An ETP-relevant scan ({reason}) was NOT '
+                            f'unrolled because {bad}; structured scan '
+                            f'descent will handle it (see '
+                            f'ControlFlowPolicy.scan_descent).'
+                        ),
+                        context={'reason': bad, 'relevance': reason},
+                    )
+                else:
+                    emit(
+                        kind=DiagnosticKind.SCAN_UNROLL_SKIPPED,
+                        level=DiagnosticLevel.WARNING,
+                        message=(
+                            f'An ETP-relevant scan ({reason}) was NOT '
+                            f'unrolled because {bad}; it stays opaque and '
+                            f'the existing control-flow restrictions apply. '
+                            f'Raise ControlFlowPolicy.scan_unroll_limit or '
+                            f'restructure the loop if its weights should '
+                            f'learn online.'
+                        ),
+                        context={'reason': bad, 'relevance': reason},
+                    )
             new_eqns.append(eqn)
             continue
         num_prefix = eqn.params['num_consts'] + eqn.params['num_carry']

--- a/braintrace/_compiler/canonicalize_test.py
+++ b/braintrace/_compiler/canonicalize_test.py
@@ -77,6 +77,16 @@ class TestControlFlowPolicy:
         with pytest.raises(ValueError, match='cond'):
             _convert(closed, policy=ControlFlowPolicy(cond='bogus'))
 
+    def test_scan_descent_default_off(self):
+        assert DEFAULT_CONTROL_FLOW_POLICY.scan_descent == 'off'
+
+    def test_scan_descent_accepts_auto(self):
+        assert ControlFlowPolicy(scan_descent='auto').scan_descent == 'auto'
+
+    def test_scan_descent_rejects_unknown_value(self):
+        with pytest.raises(ValueError, match='scan_descent'):
+            ControlFlowPolicy(scan_descent='yes-please')
+
 
 class TestIfConvertConds:
     """Unit tests of the cond -> inlined branches + select_n rewrite."""

--- a/braintrace/_compiler/canonicalize_test.py
+++ b/braintrace/_compiler/canonicalize_test.py
@@ -30,6 +30,7 @@ from braintrace._compiler.canonicalize import (
 )
 from braintrace._compiler.diagnostics import (
     DiagnosticKind,
+    DiagnosticLevel,
     diagnostic_context,
 )
 
@@ -77,8 +78,8 @@ class TestControlFlowPolicy:
         with pytest.raises(ValueError, match='cond'):
             _convert(closed, policy=ControlFlowPolicy(cond='bogus'))
 
-    def test_scan_descent_default_off(self):
-        assert DEFAULT_CONTROL_FLOW_POLICY.scan_descent == 'off'
+    def test_scan_descent_default_auto(self):
+        assert DEFAULT_CONTROL_FLOW_POLICY.scan_descent == 'auto'
 
     def test_scan_descent_accepts_auto(self):
         assert ControlFlowPolicy(scan_descent='auto').scan_descent == 'auto'
@@ -792,17 +793,41 @@ class TestUnrollInnerScans:
         assert out is closed
 
     def test_skip_length_exceeds_limit(self):
+        # scan_descent='off' pins the pre-Phase-4 WARNING; under the default
+        # ('auto') an over-limit skip is INFO (descent handles the scan).
         f, closed, w, h0, xs = self._etp_scan_jaxpr()
         with diagnostic_context() as reporter:
             with pytest.warns(UserWarning, match='NOT unrolled'):
                 conv = _unroll(
                     closed,
                     weights=[closed.jaxpr.invars[0]],
-                    policy=ControlFlowPolicy(scan_unroll_limit=self.L - 1),
+                    policy=ControlFlowPolicy(scan_unroll_limit=self.L - 1,
+                                             scan_descent='off'),
                 )
         assert 'scan' in _primitive_names(conv)
         kinds = [r.kind for r in reporter.records()]
         assert kinds.count(DiagnosticKind.SCAN_UNROLL_SKIPPED) == 1
+
+    def test_skip_length_exceeds_limit_info_under_descent_auto(self):
+        # Phase 4: with scan_descent='auto' an over-limit scan is no longer a
+        # dead end, so the skip record downgrades to INFO (no UserWarning)
+        # and points at the descent path.
+        f, closed, w, h0, xs = self._etp_scan_jaxpr()
+        with diagnostic_context() as reporter:
+            with warnings.catch_warnings():
+                warnings.simplefilter('error')
+                conv = _unroll(
+                    closed,
+                    weights=[closed.jaxpr.invars[0]],
+                    policy=ControlFlowPolicy(scan_unroll_limit=self.L - 1,
+                                             scan_descent='auto'),
+                )
+        assert 'scan' in _primitive_names(conv)
+        recs = [r for r in reporter.records()
+                if r.kind is DiagnosticKind.SCAN_UNROLL_SKIPPED]
+        assert len(recs) == 1
+        assert recs[0].level is DiagnosticLevel.INFO
+        assert 'descent' in recs[0].message
 
     def test_skip_effects_in_body(self):
         def f(w, h0, xs):
@@ -946,7 +971,8 @@ class TestUnrollInnerScans:
                 conv = _unroll(
                     closed,
                     weights=[closed.jaxpr.invars[0]],
-                    policy=ControlFlowPolicy(scan_unroll_limit=3),
+                    policy=ControlFlowPolicy(scan_unroll_limit=3,
+                                             scan_descent='off'),
                 )
         names = _primitive_names(conv)
         assert names.count('scan') == 1
@@ -1164,11 +1190,15 @@ class TestScanModelCompilation:
         assert len(records) == 1
 
     def test_limit_zero_policy_keeps_existing_error(self):
+        # scan_descent='off' pins the pre-Phase-4 dead end; with the default
+        # ('auto') a limit-0 policy no longer errors — descent picks the
+        # scan up instead.
         with pytest.raises(NotImplementedError, match='scan'):
             with pytest.warns(UserWarning):
                 self._graph_for(
                     _InnerLoopCell,
-                    control_flow=ControlFlowPolicy(scan_unroll_limit=0),
+                    control_flow=ControlFlowPolicy(scan_unroll_limit=0,
+                                                   scan_descent='off'),
                 )
 
     def test_while_body_model_keeps_existing_error(self):

--- a/braintrace/_compiler/diagnostics.py
+++ b/braintrace/_compiler/diagnostics.py
@@ -104,6 +104,17 @@ class DiagnosticKind(str, Enum):
     SCAN_UNROLL_SKIPPED = 'scan_unroll_skipped'
     RELATION_EXCLUDED_SLICED_WEIGHT = 'relation_excluded_sliced_weight'
 
+    # Structured scan descent (Phase 4; see _compiler/scan_descent.py)
+    #
+    # ``SCAN_DESCENT_APPLIED``: an ETP-relevant scan too long to unroll was
+    # rewritten for structured descent — relations/hidden groups discovered
+    # inside its body, stacked per-substep values emitted as extra ys (INFO).
+    # ``SCAN_DESCENT_SKIPPED``: descent was requested (policy ``'auto'``) but
+    # a v1 restriction blocked it; the existing control-flow restrictions
+    # apply (WARNING).
+    SCAN_DESCENT_APPLIED = 'scan_descent_applied'
+    SCAN_DESCENT_SKIPPED = 'scan_descent_skipped'
+
     # Opaque control flow touching weights / hidden states (Phase 3)
     #
     # ``WEIGHT_IN_WHILE``: a tracked weight invar is consumed by a ``while``

--- a/braintrace/_compiler/diagnostics.py
+++ b/braintrace/_compiler/diagnostics.py
@@ -112,8 +112,13 @@ class DiagnosticKind(str, Enum):
     # ``SCAN_DESCENT_SKIPPED``: descent was requested (policy ``'auto'``) but
     # a v1 restriction blocked it; the existing control-flow restrictions
     # apply (WARNING).
+    # ``SCAN_DESCENT_NO_RELATIONS``: a descended scan consumes weight
+    # state(s) that produce no ETP relation (plain-op usage inside the
+    # body), so those weights do not learn online. Pre-descent this scan
+    # was a hard error, so the exclusion is surfaced loudly (WARNING).
     SCAN_DESCENT_APPLIED = 'scan_descent_applied'
     SCAN_DESCENT_SKIPPED = 'scan_descent_skipped'
+    SCAN_DESCENT_NO_RELATIONS = 'scan_descent_no_relations'
 
     # Opaque control flow touching weights / hidden states (Phase 3)
     #

--- a/braintrace/_compiler/graph.py
+++ b/braintrace/_compiler/graph.py
@@ -326,6 +326,14 @@ def compile_etrace_graph(
           behavior (weights inside ``cond`` raise ``NotImplementedError``);
         - unrolls every ETP-relevant ``scan`` of static length at most
           ``scan_unroll_limit`` (default 16);
+        - applies **structured scan descent** (``scan_descent='auto'``) to
+          ETP-relevant scans *above* the unroll limit: relations and hidden
+          groups are discovered inside the scan body, the equation is
+          rewritten to emit stacked per-substep values as extra ys, and the
+          eligibility trace is folded over the substep axis at runtime —
+          compile size stays independent of the scan length. Pass
+          ``ControlFlowPolicy(scan_descent='off')`` to restore the
+          pre-Phase-4 error. See :mod:`braintrace._compiler.scan_descent`;
         - keeps a **weight-free** ``while`` that reads/updates hidden state
           as an opaque forward node (``while_hidden='opaque-fwd'``):
           hidden-to-hidden Jacobians for groups whose transition crosses the

--- a/braintrace/_compiler/graph.py
+++ b/braintrace/_compiler/graph.py
@@ -43,6 +43,7 @@ from .hidden_pertubation import (
     add_hidden_perturbation_from_minfo,
     HiddenPerturbation,
 )
+from .scan_descent import apply_scan_descent
 from .module_info import (
     extract_module_info,
     ModuleInfo,
@@ -375,18 +376,71 @@ def compile_etrace_graph(
         assert isinstance(model_args, tuple)
         minfo = extract_module_info(model, *model_args, control_flow=control_flow)
 
+        # ---   structured scan descent (Phase 4): analyze eligible scans   --- #
+        #
+        # Each descended scan is rewritten to emit stacked per-substep values
+        # as extra ys; its body-discovered hidden groups / relations are
+        # merged below, and the rewritten equations are exempted (by
+        # ``id(eqn)``) from the flat walkers.
+        minfo, descent_bundles = apply_scan_descent(minfo)
+        descended_eqn_ids = frozenset(
+            b.info.scan_eqn_id for b in descent_bundles
+        )
+        descended_paths = frozenset(
+            p for b in descent_bundles for g in b.groups for p in g.hidden_paths
+        )
+
         # ---       evaluating the relationship for hidden-to-hidden        --- #
         hidden_groups, hid_path_to_group = find_hidden_groups_from_minfo(
-            minfo, include_recurrent_mixing=include_recurrent_mixing
+            minfo, include_recurrent_mixing=include_recurrent_mixing,
+            descended_scan_eqn_ids=descended_eqn_ids,
+            descended_hidden_paths=descended_paths,
         )
+
+        # merge the descended groups after the flat ones, re-indexing them to
+        # their final positions, and re-point the bundle relations at the
+        # re-indexed group objects (relations reference groups by identity).
+        hidden_groups = list(hidden_groups)
+        descended_relations = []
+        for bundle in descent_bundles:
+            group_remap = {}
+            for g in bundle.groups:
+                final_group = g._replace(index=len(hidden_groups))
+                group_remap[id(g)] = final_group
+                hidden_groups.append(final_group)
+                for path in final_group.hidden_paths:
+                    hid_path_to_group[path] = final_group
+            for r in bundle.relations:
+                descended_relations.append(r._replace(
+                    hidden_groups=[
+                        group_remap.get(id(g), g) for g in r.hidden_groups
+                    ],
+                ))
         order_hidden_group_index(hidden_groups)
 
         # ---       evaluating the jaxpr for (hidden, param, op) relationships      --- #
 
-        hidden_param_op_relations = find_hidden_param_op_relations_from_minfo(
+        hidden_param_op_relations = list(find_hidden_param_op_relations_from_minfo(
             minfo=minfo,
             hid_path_to_group=hid_path_to_group,
-        )
+            descended_scan_eqn_ids=descended_eqn_ids,
+        ))
+
+        # v1 restriction: an *outer* relation may not target a hidden state
+        # whose group lives inside a descended scan — the per-substep trace
+        # fold has no slot for a once-per-outer-step injection.
+        for relation in hidden_param_op_relations:
+            blocked = [g for g in relation.hidden_groups if g.descent is not None]
+            if blocked:
+                blocked_paths = [p for g in blocked for p in g.hidden_paths]
+                raise NotImplementedError(
+                    f'An ETP relation outside a descended scan targets hidden '
+                    f'state(s) {blocked_paths} carried by that scan. This is '
+                    f'not supported by structured scan descent (v1): move the '
+                    f'operation inside the scan body, restructure the model, '
+                    f"or set ControlFlowPolicy(scan_descent='off')."
+                )
+        hidden_param_op_relations += descended_relations
 
         # ---      Rewrite the jaxpr for computing the needed variables      --- #
 
@@ -399,15 +453,22 @@ def compile_etrace_graph(
         #   5. the hidden-hidden transition variables   ===>  for computing the hidden-hidden jacobian
         #
 
+        # Descended relations/groups reference *body*-scoped vars; their
+        # runtime values arrive through the scan's stacked ys instead, so
+        # they are excluded from the flat hoisting lists below.
+
         # all weight x (deduplicate while preserving insertion order)
         out_wx_jaxvars = list(dict.fromkeys(
             relation.x_var for relation in hidden_param_op_relations
             if relation.x_var is not None
+            and relation.control_flow_context is None
         ))
 
         # all y-to-hidden vars (deduplicate while preserving insertion order)
         out_wy2hid_jaxvars_dict: dict = dict()
         for relation in hidden_param_op_relations:
+            if relation.control_flow_context is not None:
+                continue
             for hpo_jaxpr in relation.y_to_hidden_group_jaxprs:
                 for v in hpo_jaxpr.invars + hpo_jaxpr.constvars:
                     out_wy2hid_jaxvars_dict[v] = None
@@ -416,6 +477,8 @@ def compile_etrace_graph(
         # hidden-hidden transition vars (deduplicate while preserving insertion order)
         hid2hid_jaxvars_dict: dict = dict()
         for group in hidden_groups:
+            if group.descent is not None:
+                continue
             for v in group.hidden_invars:
                 hid2hid_jaxvars_dict[v] = None
             for v in group.transition_jaxpr_constvars:
@@ -428,7 +491,9 @@ def compile_etrace_graph(
             minfo.jaxpr.outvars[minfo.num_var_out:] +  # all state variables
             out_wx_jaxvars +  # all weight x
             out_wy2hid_jaxvars +  # all y-to-hidden invars
-            hid2hid_jaxvars  # all hidden-hidden transition vars
+            hid2hid_jaxvars +  # all hidden-hidden transition vars
+            # stacked per-substep values of every descended scan
+            [v for b in descent_bundles for v in b.stacked_outer_vars]
         )
         temp_outvars = list(dict.fromkeys(
             v for v in all_vars if v not in original_outvars
@@ -440,7 +505,11 @@ def compile_etrace_graph(
         # ---               add perturbations to the hidden states                  --- #
         # --- new jaxpr with hidden state perturbations for computing the residuals --- #
 
-        hidden_perturb = add_hidden_perturbation_from_minfo(minfo) if include_hidden_perturb else None
+        hidden_perturb = (
+            add_hidden_perturbation_from_minfo(
+                minfo, descended_scan_eqn_ids=descended_eqn_ids)
+            if include_hidden_perturb else None
+        )
 
         # ---              return the compiled graph               --- #
 

--- a/braintrace/_compiler/hid_param_op.py
+++ b/braintrace/_compiler/hid_param_op.py
@@ -41,6 +41,7 @@ from typing import TYPE_CHECKING
 from typing import (
     Any,
     Dict,
+    FrozenSet,
     Iterable,
     List,
     NamedTuple,
@@ -676,6 +677,7 @@ def _scan_jaxpr_for_etp_eqns(
     *,
     inside_control_flow: bool = False,
     policy: ControlFlowPolicy = DEFAULT_CONTROL_FLOW_POLICY,
+    descended_scan_eqn_ids: FrozenSet[int] = frozenset(),
 ) -> List[JaxprEqn]:
     """Walk the Jaxpr and return all equations whose primitive is ETP.
 
@@ -686,7 +688,10 @@ def _scan_jaxpr_for_etp_eqns(
     (``etp_in_control_flow='error'``) they raise ``NotImplementedError``
     after an ERROR-level record, because the weight would otherwise
     silently drop out of online learning; ``'exclude'`` restores the loud
-    WARNING + exclusion.
+    WARNING + exclusion. Scan equations whose ``id()`` is in
+    ``descended_scan_eqn_ids`` were rewritten by structured scan descent
+    (Phase 4); their bodies are analyzed separately and are skipped here
+    without any diagnostic.
     """
     etp_eqns: List[JaxprEqn] = []
     for eqn in jaxpr.eqns:
@@ -741,6 +746,7 @@ def _scan_jaxpr_for_etp_eqns(
             inner_etp = _scan_jaxpr_for_etp_eqns(
                 inner_jaxpr, inside_control_flow=inside_control_flow,
                 policy=policy,
+                descended_scan_eqn_ids=descended_scan_eqn_ids,
             )
             if inner_etp:
                 emit(
@@ -762,6 +768,11 @@ def _scan_jaxpr_for_etp_eqns(
                     )},
                 )
         elif is_scan_primitive(eqn) or is_while_primitive(eqn) or is_cond_primitive(eqn):
+            # A descended scan's body relations are registered by the
+            # scan-descent pass; do not re-flag its ETP eqns as
+            # PRIMITIVE_INSIDE_CONTROL_FLOW.
+            if id(eqn) in descended_scan_eqn_ids:
+                continue
             for sub_jaxpr in _control_flow_subjaxprs(eqn):
                 _scan_jaxpr_for_etp_eqns(
                     sub_jaxpr, inside_control_flow=True, policy=policy,
@@ -799,6 +810,7 @@ def find_hidden_param_op_relations_from_jaxpr(
     hid_path_to_group: Dict[Path, HiddenGroup],
     weight_path_to_invars: Optional[Dict[Path, List[Var]]] = None,
     control_flow: ControlFlowPolicy = DEFAULT_CONTROL_FLOW_POLICY,
+    descended_scan_eqn_ids: FrozenSet[int] = frozenset(),
     **_ignored,
 ) -> Sequence[HiddenParamOpRelation]:
     """Find all ETP-primitive-to-hidden-state relations in *jaxpr*."""
@@ -834,7 +846,10 @@ def find_hidden_param_op_relations_from_jaxpr(
         for ov, p in outvar_to_hidden_path.items()
     }
 
-    etp_eqns = _scan_jaxpr_for_etp_eqns(jaxpr, policy=control_flow)
+    etp_eqns = _scan_jaxpr_for_etp_eqns(
+        jaxpr, policy=control_flow,
+        descended_scan_eqn_ids=descended_scan_eqn_ids,
+    )
     relations: List[HiddenParamOpRelation] = []
 
     for eqn in etp_eqns:
@@ -1092,6 +1107,7 @@ def _emit_no_relation_diag(
 def find_hidden_param_op_relations_from_minfo(
     minfo: ModuleInfo,
     hid_path_to_group: Dict[Path, HiddenGroup],
+    descended_scan_eqn_ids: FrozenSet[int] = frozenset(),
 ) -> Sequence[HiddenParamOpRelation]:
     """Find ETP relations from a ``ModuleInfo``.
 
@@ -1104,6 +1120,10 @@ def find_hidden_param_op_relations_from_minfo(
         The model information.
     hid_path_to_group : dict
         Mapping from each hidden-state path to its :class:`HiddenGroup`.
+    descended_scan_eqn_ids : frozenset of int, default ``frozenset()``
+        ``id()`` values of scan equations rewritten by structured scan descent
+        (Phase 4); those equations are skipped by the relation walker (their
+        body relations are registered by the scan-descent pass).
 
     Returns
     -------
@@ -1139,6 +1159,7 @@ def find_hidden_param_op_relations_from_minfo(
         hid_path_to_group=hid_path_to_group,
         weight_path_to_invars=weight_path_to_invars,
         control_flow=minfo.control_flow,
+        descended_scan_eqn_ids=descended_scan_eqn_ids,
     )
 
 

--- a/braintrace/_compiler/hid_param_op.py
+++ b/braintrace/_compiler/hid_param_op.py
@@ -37,6 +37,7 @@ runs of the same model.
 """
 
 from collections import deque
+from typing import TYPE_CHECKING
 from typing import (
     Any,
     Dict,
@@ -90,6 +91,9 @@ __all__ = [
     'find_hidden_param_op_relations_from_minfo',
     'find_hidden_param_op_relations_from_module',
 ]
+
+if TYPE_CHECKING:
+    from .scan_descent import RelationDescent  # noqa: F401
 
 
 # ---------------------------------------------------------------------------
@@ -170,6 +174,9 @@ class HiddenParamOpRelation(NamedTuple):
         Per-key dict mapping each key to the backward-trace processing chain
         (primitives traversed from the trainable invar back to the originating
         ``ParamState`` invar).
+    control_flow_context : RelationDescent or None
+        Descent context when this relation lives inside a descended scan body
+        (Phase 4 structured scan descent); ``None`` for flat relations.
 
     Notes
     -----
@@ -192,6 +199,13 @@ class HiddenParamOpRelation(NamedTuple):
     trainable_leaf_indices: Dict[str, int] = {}
     trainable_param_states: Dict[str, brainstate.ParamState] = {}
     trainable_processing_chains: Dict[str, Tuple[Primitive, ...]] = {}
+
+    control_flow_context: Optional['RelationDescent'] = None
+    """Set when this relation lives inside a descended scan body (Phase 4
+    structured scan descent): ``x_var`` / ``y_var`` /
+    ``y_to_hidden_group_jaxprs`` are body-scoped, and the executor must read
+    their runtime values through ``control_flow_context.scan.stacked_var_map``
+    (stacked over the substep axis). ``None`` for ordinary flat relations."""
 
     # backward compat aliases
     @property

--- a/braintrace/_compiler/hidden_group.py
+++ b/braintrace/_compiler/hidden_group.py
@@ -46,7 +46,7 @@
 
 from itertools import combinations
 from typing import TYPE_CHECKING
-from typing import List, Dict, Sequence, Tuple, Set, Optional, Callable, NamedTuple, Any, cast
+from typing import List, Dict, FrozenSet, Sequence, Tuple, Set, Optional, Callable, NamedTuple, Any, cast
 
 import brainstate
 import brainunit as u
@@ -913,6 +913,10 @@ class JaxprEvalForHiddenGroup(JaxprEvaluation):
         path_to_state: The mapping from the hidden state path to the state.
         control_flow: The :class:`~braintrace.ControlFlowPolicy` governing
             opaque control-flow handling (see ``base.check_unsupported_op``).
+        descended_scan_eqn_ids: ``id()`` values of scan equations rewritten by
+            structured scan descent; those equations are skipped by this walker.
+        descended_hidden_paths: Hidden-state paths covered by descended scan
+            bodies; excluded from the zero-recurrence fallback grouping.
     """
     __module__ = 'braintrace'
 
@@ -926,10 +930,20 @@ class JaxprEvalForHiddenGroup(JaxprEvaluation):
         path_to_state: Dict[Path, brainstate.HiddenState],
         include_recurrent_mixing: bool = False,
         control_flow: ControlFlowPolicy = DEFAULT_CONTROL_FLOW_POLICY,
+        descended_scan_eqn_ids: FrozenSet[int] = frozenset(),
+        descended_hidden_paths: FrozenSet[Path] = frozenset(),
     ):
         # the jaxpr of the original model, assuming that the model is well-defined,
         # see the doc for the model which can be online learning compiled.
         self.jaxpr = jaxpr
+
+        # Structured scan descent (Phase 4): scan equations already analyzed
+        # by ``scan_descent.apply_scan_descent`` (keyed by ``id(eqn)``) are
+        # skipped entirely, and the hidden paths their body groups cover are
+        # excluded from the zero-recurrence fallback (their groups are merged
+        # into the outer graph by ``compile_etrace_graph``).
+        self.descended_scan_eqn_ids = descended_scan_eqn_ids
+        self.descended_hidden_paths = descended_hidden_paths
 
         # whether the recurrent ETP mixing primitives (``etp_mv``/``etp_mm``/
         # ``etp_conv``) are *traced into* the hidden-to-hidden transition jaxpr
@@ -976,6 +990,15 @@ class JaxprEvalForHiddenGroup(JaxprEvaluation):
         # reset the temporal data structures
         self.active_tracers = dict()
         return hid_groups, hid_path_to_group
+
+    def _eval_scan(self, eqn: JaxprEqn) -> None:
+        # A descended scan is fully handled by scan-descent analysis: its
+        # hidden groups are registered from the body (re-scoped to the outer
+        # carry vars) and merged by ``compile_etrace_graph``, so the equation
+        # must be neither rejected nor traced as an opaque transition here.
+        if id(eqn) in self.descended_scan_eqn_ids:
+            return
+        super()._eval_scan(eqn)
 
     def _eval_eqn(self, eqn: JaxprEqn) -> None:
         """
@@ -1314,6 +1337,11 @@ class JaxprEvalForHiddenGroup(JaxprEvaluation):
         for outvar in self.hidden_outvar_to_invar:
             if outvar in covered_outvars:
                 continue
+            # Hidden states carried by a descended scan get their group from
+            # the scan-body analysis (merged downstream); a zero-recurrence
+            # fallback here would shadow it.
+            if self.outvar_to_hidden_path[outvar] in self.descended_hidden_paths:
+                continue
             invar = self.hidden_outvar_to_invar[outvar]
             # ``h^t = outvar`` (a constvar): no eqns, output does not depend on the
             # ``h^{t-1}`` invar, so the recurrent Jacobian is exactly zero.
@@ -1570,6 +1598,8 @@ def find_hidden_groups_from_jaxpr(
     path_to_state: Dict[Path, brainstate.State],
     include_recurrent_mixing: bool = False,
     control_flow: ControlFlowPolicy = DEFAULT_CONTROL_FLOW_POLICY,
+    descended_scan_eqn_ids: FrozenSet[int] = frozenset(),
+    descended_hidden_paths: FrozenSet[Path] = frozenset(),
 ) -> Tuple[Sequence[HiddenGroup], brainstate.util.PrettyDict]:
     """
     Find hidden groups from the jaxpr.
@@ -1600,6 +1630,10 @@ def find_hidden_groups_from_jaxpr(
             opaque control-flow equations touching hidden states are handled
             (``'opaque-fwd'`` keeps a weight-free while/scan/cond as an opaque
             forward node; ``'error'`` raises as before Phase 3).
+        descended_scan_eqn_ids: ``id()`` values of scan equations rewritten by
+            structured scan descent (Phase 4); skipped by this walker.
+        descended_hidden_paths: Hidden-state paths covered by descended scan
+            bodies; excluded from the zero-recurrence fallback grouping.
 
     Returns:
         A tuple containing:
@@ -1619,6 +1653,8 @@ def find_hidden_groups_from_jaxpr(
         path_to_state=cast(Dict[Path, brainstate.HiddenState], path_to_state),  # type: ignore[redundant-cast]
         include_recurrent_mixing=include_recurrent_mixing,
         control_flow=control_flow,
+        descended_scan_eqn_ids=descended_scan_eqn_ids,
+        descended_hidden_paths=descended_hidden_paths,
     )
     hidden_groups, hid_path_to_group = evaluator.compile()
     return hidden_groups, brainstate.util.PrettyDict(hid_path_to_group)
@@ -1627,6 +1663,8 @@ def find_hidden_groups_from_jaxpr(
 def find_hidden_groups_from_minfo(
     minfo: ModuleInfo,
     include_recurrent_mixing: bool = False,
+    descended_scan_eqn_ids: FrozenSet[int] = frozenset(),
+    descended_hidden_paths: FrozenSet[Path] = frozenset(),
 ):
     """Find the hidden groups from the model information.
 
@@ -1637,6 +1675,12 @@ def find_hidden_groups_from_minfo(
     include_recurrent_mixing : bool, default False
         Whether to trace recurrent ETP mixing primitives into the transition
         jaxpr. See :func:`find_hidden_groups_from_jaxpr` for the full semantics.
+    descended_scan_eqn_ids : frozenset of int, default ``frozenset()``
+        ``id()`` values of scan equations rewritten by structured scan descent
+        (Phase 4); those equations are skipped by the hidden-group walker.
+    descended_hidden_paths : frozenset, default ``frozenset()``
+        Hidden-state paths covered by descended scan bodies; excluded from the
+        zero-recurrence fallback grouping.
 
     Returns
     -------
@@ -1661,6 +1705,8 @@ def find_hidden_groups_from_minfo(
         path_to_state=minfo.retrieved_model_states,
         include_recurrent_mixing=include_recurrent_mixing,
         control_flow=minfo.control_flow,
+        descended_scan_eqn_ids=descended_scan_eqn_ids,
+        descended_hidden_paths=descended_hidden_paths,
     )
     return hidden_groups, hid_path_to_group
 

--- a/braintrace/_compiler/hidden_group.py
+++ b/braintrace/_compiler/hidden_group.py
@@ -45,6 +45,7 @@
 # -*- coding: utf-8 -*-
 
 from itertools import combinations
+from typing import TYPE_CHECKING
 from typing import List, Dict, Sequence, Tuple, Set, Optional, Callable, NamedTuple, Any, cast
 
 import brainstate
@@ -80,6 +81,9 @@ __all__ = [
     'find_hidden_groups_from_minfo',
     'find_hidden_groups_from_module',
 ]
+
+if TYPE_CHECKING:
+    from .scan_descent import GroupDescent  # noqa: F401
 
 # Recurrent-weight mixing primitives -- dense / convolutional weights -- whose
 # consumption of a hidden state is a genuine *cross-position* coupling, i.e. that
@@ -128,6 +132,13 @@ class HiddenGroup(NamedTuple):
         The jaxpr computing the hidden-state transition for the group.
     transition_jaxpr_constvars : list of Var
         The other input variables required to evaluate ``transition_jaxpr``.
+    is_diagonal_recurrence : bool
+        Whether the recurrence is diagonal across the leading ``varshape``
+        positions (see the field comment for the full contract).
+    descent : GroupDescent or None
+        Descent context when this group's transition is one substep of a
+        descended scan (Phase 4 structured scan descent); ``None`` for
+        ordinary groups.
 
     See Also
     --------
@@ -186,6 +197,13 @@ class HiddenGroup(NamedTuple):
     # opts into the coupled transition that needs the block-diagonal path. Defaults
     # to ``True`` to preserve the cheap behavior for any positional construction.
     is_diagonal_recurrence: bool = True
+
+    descent: Optional['GroupDescent'] = None
+    """Set when this group's transition is one substep of a descended scan
+    (Phase 4 structured scan descent): ``transition_jaxpr``/
+    ``transition_jaxpr_constvars`` are body-scoped while ``hidden_invars``/
+    ``hidden_outvars`` are the outer scan carry vars. ``None`` for ordinary
+    groups."""
 
     @property
     def varshape(self) -> Tuple[int, ...]:

--- a/braintrace/_compiler/hidden_pertubation.py
+++ b/braintrace/_compiler/hidden_pertubation.py
@@ -14,7 +14,7 @@
 # ==============================================================================
 
 
-from typing import Dict, Set, Sequence, NamedTuple, Any
+from typing import Dict, FrozenSet, Set, Sequence, NamedTuple, Any
 
 import brainstate
 import jax.core
@@ -227,6 +227,9 @@ class JaxprEvalForHiddenPerturbation(JaxprEvaluation):
         invar_to_hidden_path: The mapping from the weight input variable to the hidden state path.
         control_flow: The :class:`~braintrace.ControlFlowPolicy` governing
             opaque control-flow handling.
+        descended_scan_eqn_ids: ``id()`` values of scan equations rewritten
+            by structured scan descent (Phase 4); exempt from the
+            unsupported-op checks.
 
     Returns:
         The revised closed jaxpr with the perturbations.
@@ -259,9 +262,18 @@ class JaxprEvalForHiddenPerturbation(JaxprEvaluation):
         outvar_to_hidden_path: Dict[Var, Path],
         path_to_state: Dict[Path, brainstate.HiddenState],
         control_flow: ControlFlowPolicy = DEFAULT_CONTROL_FLOW_POLICY,
+        descended_scan_eqn_ids: FrozenSet[int] = frozenset(),
     ):
         # necessary data structures
         self.closed_jaxpr = closed_jaxpr
+
+        # Structured scan descent (Phase 4): scan equations rewritten by
+        # ``scan_descent.apply_scan_descent`` (keyed by ``id(eqn)``) bypass
+        # ``check_unsupported_op`` — their weight usage is legal by
+        # construction, and ``_eval_eqn`` perturbs their hidden carry output
+        # exactly like any other producing equation (one perturbation per
+        # outer step; scans are reverse-differentiable, so no detach).
+        self.descended_scan_eqn_ids = descended_scan_eqn_ids
 
         # initialize the super class
         # Use dict.fromkeys to deduplicate while preserving insertion order
@@ -496,6 +508,7 @@ def add_hidden_perturbation_in_jaxpr(
     outvar_to_hidden_path: Dict[Var, Path],
     path_to_state: Dict[Path, brainstate.HiddenState],
     control_flow: ControlFlowPolicy = DEFAULT_CONTROL_FLOW_POLICY,
+    descended_scan_eqn_ids: FrozenSet[int] = frozenset(),
 ) -> HiddenPerturbation:
     """
     Adding perturbations to the hidden states in the jaxpr, and replacing the hidden states with the perturbed states.
@@ -512,6 +525,9 @@ def add_hidden_perturbation_in_jaxpr(
             hidden-producing ``while`` is kept and its inputs are detached
             in the perturbed jaxpr (see
             :class:`JaxprEvalForHiddenPerturbation`).
+        descended_scan_eqn_ids: ``id()`` values of scan equations rewritten
+            by structured scan descent (Phase 4); exempt from the
+            unsupported-op checks.
 
     Returns:
         The revised closed jaxpr with the perturbations.
@@ -524,11 +540,13 @@ def add_hidden_perturbation_in_jaxpr(
         outvar_to_hidden_path=outvar_to_hidden_path,
         path_to_state=path_to_state,
         control_flow=control_flow,
+        descended_scan_eqn_ids=descended_scan_eqn_ids,
     ).compile()
 
 
 def add_hidden_perturbation_from_minfo(
     minfo: ModuleInfo,
+    descended_scan_eqn_ids: FrozenSet[int] = frozenset(),
 ) -> HiddenPerturbation:
     """Add hidden-state perturbations from a ``ModuleInfo``.
 
@@ -539,6 +557,9 @@ def add_hidden_perturbation_from_minfo(
     ----------
     minfo : ModuleInfo
         The model information.
+    descended_scan_eqn_ids : frozenset of int, default ``frozenset()``
+        ``id()`` values of scan equations rewritten by structured scan
+        descent (Phase 4); exempt from the unsupported-op checks.
 
     Returns
     -------
@@ -557,6 +578,7 @@ def add_hidden_perturbation_from_minfo(
         outvar_to_hidden_path=minfo.outvar_to_hidden_path,
         path_to_state=minfo.retrieved_model_states,
         control_flow=minfo.control_flow,
+        descended_scan_eqn_ids=descended_scan_eqn_ids,
     )
 
 

--- a/braintrace/_compiler/jaxpr_graph.py
+++ b/braintrace/_compiler/jaxpr_graph.py
@@ -29,7 +29,7 @@ memory-address hashes for jaxpr ``Var`` objects).
 """
 
 from collections import deque
-from typing import Any, Dict, List
+from typing import Any, Dict, List, Optional
 
 from braintrace._compatible_imports import (
     ClosedJaxpr,
@@ -128,6 +128,59 @@ def _contains_jit_eqn(jaxpr: Jaxpr) -> bool:
     return any(is_jit_primitive(eqn) for eqn in jaxpr.eqns)
 
 
+def _sub_closed_jaxprs(eqn: JaxprEqn):
+    """Yield the ``ClosedJaxpr`` bodies of a control-flow equation.
+
+    Covers ``scan`` (``jaxpr``), ``while`` (``cond_jaxpr``/``body_jaxpr``),
+    and ``cond`` (``branches``). ``call_jaxpr`` (custom-derivative calls) is
+    deliberately excluded: those bodies carry derivative semantics and are
+    never rewritten by :func:`inline_jit_calls`.
+    """
+    for key in ('jaxpr', 'cond_jaxpr', 'body_jaxpr'):
+        sub = eqn.params.get(key)
+        if isinstance(sub, ClosedJaxpr):
+            yield sub
+    for b in eqn.params.get('branches', ()) or ():
+        if isinstance(b, ClosedJaxpr):
+            yield b
+
+
+def _contains_jit(jaxpr: Jaxpr) -> bool:
+    """``True`` when a jit eqn exists at top level or inside any
+    (transitively nested) control-flow body."""
+    for eqn in jaxpr.eqns:
+        if is_jit_primitive(eqn) and 'jaxpr' in eqn.params:
+            return True
+        for sub in _sub_closed_jaxprs(eqn):
+            if _contains_jit(sub.jaxpr):
+                return True
+    return False
+
+
+def _inline_jits_in_control_flow_params(eqn: JaxprEqn) -> Optional[dict]:
+    """Rewrite a control-flow eqn's body params so jit calls inside them are
+    inlined; return the new params dict, or ``None`` when every body is
+    already jit-free (so the caller can keep the eqn by identity)."""
+    new_params = dict(eqn.params)
+    changed = False
+    for key in ('jaxpr', 'cond_jaxpr', 'body_jaxpr'):
+        sub = new_params.get(key)
+        if isinstance(sub, ClosedJaxpr) and _contains_jit(sub.jaxpr):
+            new_params[key] = inline_jit_calls(sub)
+            changed = True
+    branches = new_params.get('branches')
+    if branches is not None:
+        new_branches = tuple(
+            inline_jit_calls(b)
+            if isinstance(b, ClosedJaxpr) and _contains_jit(b.jaxpr) else b
+            for b in branches
+        )
+        if any(nb is not ob for nb, ob in zip(new_branches, branches)):
+            new_params['branches'] = new_branches
+            changed = True
+    return new_params if changed else None
+
+
 def inline_jit_calls(closed_jaxpr: ClosedJaxpr) -> ClosedJaxpr:
     """Splice every top-level ``jit``/``pjit`` body into the enclosing jaxpr.
 
@@ -145,8 +198,11 @@ def inline_jit_calls(closed_jaxpr: ClosedJaxpr) -> ClosedJaxpr:
     verbatim more than once would define its variables twice and silently
     alias the calls' results. Top-level equations that are not jit calls keep
     their original ``Var`` objects. Control-flow bodies
-    (``scan``/``while``/``cond``) and custom-derivative call primitives are
-    left untouched: control flow is diagnosed separately, and
+    (``scan``/``while``/``cond``) are descended: a body containing a jit call
+    is rewritten with that call inlined (the eqn is rebuilt with new body
+    params), while eqns whose bodies are jit-free are kept unchanged **by
+    identity** — later passes key exemption sets on eqn identity.
+    Custom-derivative call primitives are left untouched:
     ``custom_jvp_call``/``custom_vjp_call`` carry derivative semantics that
     must not be flattened away.
 
@@ -163,7 +219,7 @@ def inline_jit_calls(closed_jaxpr: ClosedJaxpr) -> ClosedJaxpr:
         input object itself is returned unchanged.
     """
     jaxpr = closed_jaxpr.jaxpr
-    if not _contains_jit_eqn(jaxpr):
+    if not _contains_jit(jaxpr):
         return closed_jaxpr
 
     # Substitution at the top level only maps a jit call's outer outvars to
@@ -215,10 +271,15 @@ def inline_jit_calls(closed_jaxpr: ClosedJaxpr) -> ClosedJaxpr:
                 fresh_outvars = [new_var('', v.aval) for v in eqn.outvars]
                 for ov, fresh in zip(eqn.outvars, fresh_outvars):
                     local[ov] = fresh
-                new_eqns.append(eqn.replace(
+                replace_kwargs = dict(
                     invars=[res(v) for v in eqn.invars],
                     outvars=fresh_outvars,
-                ))
+                )
+                # a control-flow eqn inside a jit body may itself hide jits
+                new_params = _inline_jits_in_control_flow_params(eqn)
+                if new_params is not None:
+                    replace_kwargs['params'] = new_params
+                new_eqns.append(eqn.replace(**replace_kwargs))
         return [res(v) for v in inner.outvars]
 
     for eqn in jaxpr.eqns:
@@ -230,8 +291,11 @@ def inline_jit_calls(closed_jaxpr: ClosedJaxpr) -> ClosedJaxpr:
             for outer_ov, out_atom in zip(eqn.outvars, outs):
                 top_subst[outer_ov] = out_atom
         else:
+            new_params = _inline_jits_in_control_flow_params(eqn)
             new_invars = [resolve_top(v) for v in eqn.invars]
-            if all(a is b for a, b in zip(new_invars, eqn.invars)):
+            if new_params is not None:
+                new_eqns.append(eqn.replace(invars=new_invars, params=new_params))
+            elif all(a is b for a, b in zip(new_invars, eqn.invars)):
                 new_eqns.append(eqn)
             else:
                 new_eqns.append(eqn.replace(invars=new_invars))

--- a/braintrace/_compiler/jaxpr_graph_test.py
+++ b/braintrace/_compiler/jaxpr_graph_test.py
@@ -232,3 +232,89 @@ class TestInlineJitCalls:
             return _eval_closed(inlined, xi)[0]
 
         np.testing.assert_allclose(jax.grad(f_inlined)(x), jax.grad(f)(x))
+
+
+class TestInlineJitInsideControlFlow:
+    """Phase 4: jit bodies inside scan/while/cond are inlined so body-level
+    analysis (structured scan descent) sees flat ETP equations."""
+
+    def test_inline_jit_calls_descends_into_scan_body(self):
+        from braintrace._compatible_imports import is_scan_primitive
+
+        @jax.jit
+        def inner(a):
+            return a * 2.0
+
+        def body(c, x):
+            return c + inner(x), c
+
+        def f(xs):
+            return jax.lax.scan(body, jnp.zeros(()), xs)
+
+        closed = jax.make_jaxpr(f)(jnp.arange(4.0))
+        scan_eqn = next(e for e in closed.jaxpr.eqns if is_scan_primitive(e))
+        assert _has_jit_eqn(scan_eqn.params['jaxpr'].jaxpr)
+
+        cleaned = inline_jit_calls(closed)
+        scan_eqn2 = next(e for e in cleaned.jaxpr.eqns if is_scan_primitive(e))
+        assert not _has_jit_eqn(scan_eqn2.params['jaxpr'].jaxpr)
+        # outer interface identity preserved
+        assert cleaned.jaxpr.invars == closed.jaxpr.invars
+        assert list(cleaned.jaxpr.outvars) == list(closed.jaxpr.outvars)
+        # numerics preserved
+        xs = jnp.arange(4.0)
+        ref = _eval_closed(closed, xs)
+        got = _eval_closed(cleaned, xs)
+        for a, b in zip(ref, got):
+            np.testing.assert_allclose(a, b)
+
+    def test_inline_jit_calls_keeps_jitfree_scan_eqn_by_identity(self):
+        from braintrace._compatible_imports import is_scan_primitive
+
+        @jax.jit
+        def inner(a):
+            return a * 2.0
+
+        def body(c, x):
+            return c + x, c
+
+        def f(xs):
+            # a top-level jit forces the pass to actually run; the jit-free
+            # scan eqn must still come through by identity
+            return jax.lax.scan(body, inner(jnp.zeros(())), xs)
+
+        closed = jax.make_jaxpr(f)(jnp.arange(4.0))
+        cleaned = inline_jit_calls(closed)
+        e1 = next(e for e in closed.jaxpr.eqns if is_scan_primitive(e))
+        e2 = next(e for e in cleaned.jaxpr.eqns if is_scan_primitive(e))
+        assert e1.params['jaxpr'] is e2.params['jaxpr']
+
+    def test_jitfree_program_with_scan_returned_unchanged(self):
+        def body(c, x):
+            return c + x, c
+
+        closed = jax.make_jaxpr(
+            lambda xs: jax.lax.scan(body, jnp.zeros(()), xs))(jnp.arange(4.0))
+        assert inline_jit_calls(closed) is closed
+
+    def test_inline_jit_calls_descends_into_cond_branches(self):
+        from braintrace._compatible_imports import is_cond_primitive
+
+        @jax.jit
+        def inner(a):
+            return a * 3.0
+
+        def f(x):
+            return jax.lax.cond(x.sum() > 0., lambda: inner(x), lambda: x * 2.)
+
+        closed = jax.make_jaxpr(f)(jnp.arange(3.0) - 1.0)
+        cond_eqn = next(e for e in closed.jaxpr.eqns if is_cond_primitive(e))
+        assert any(_has_jit_eqn(b.jaxpr) for b in cond_eqn.params['branches'])
+
+        cleaned = inline_jit_calls(closed)
+        cond_eqn2 = next(e for e in cleaned.jaxpr.eqns if is_cond_primitive(e))
+        assert all(
+            not _has_jit_eqn(b.jaxpr) for b in cond_eqn2.params['branches'])
+        for arg in (jnp.arange(3.0) + 1.0, jnp.arange(3.0) - 5.0):
+            np.testing.assert_allclose(
+                _eval_closed(cleaned, arg)[0], f(arg))

--- a/braintrace/_compiler/module_info.py
+++ b/braintrace/_compiler/module_info.py
@@ -249,9 +249,14 @@ class ModuleInfo(NamedTuple):
         Number of state-variable outputs.
     control_flow : ControlFlowPolicy
         The control-flow policy the canonicalizer ran with. Downstream
-        passes (hidden-group discovery, relation discovery, hidden
-        perturbation) consult this same policy so opaque control-flow
-        handling is consistent across the whole compilation.
+        passes (structured scan descent, hidden-group discovery, relation
+        discovery, hidden perturbation) consult this same policy so opaque
+        control-flow handling is consistent across the whole compilation.
+
+        See Also
+        --------
+        braintrace._compiler.scan_descent : Structured descent of
+            ETP-relevant scans above the unroll limit (Phase 4).
 
     See Also
     --------

--- a/braintrace/_compiler/scan_descent.py
+++ b/braintrace/_compiler/scan_descent.py
@@ -38,15 +38,17 @@ perturbation, seam checks, and learning signals are untouched; only the
 Jacobian extraction and the trace update see the substep axis.
 """
 
-from typing import Optional, Set
+from typing import Dict, Optional, Sequence, Set, Tuple
 
 from braintrace._compatible_imports import (
+    ClosedJaxpr,
     Jaxpr,
     JaxprEqn,
     Var,
     is_cond_primitive,
     is_scan_primitive,
     is_while_primitive,
+    new_var,
 )
 from braintrace._op import is_etp_primitive
 from .canonicalize import ControlFlowPolicy
@@ -135,3 +137,52 @@ def _descent_blockers(
             return ('a trainable weight is scanned over as xs (per-iteration '
                     'weight slices); not supported by descent')
     return None
+
+
+def add_scan_ys(
+    eqn: JaxprEqn,
+    extra_body_outvars: Sequence[Var],
+) -> Tuple[JaxprEqn, Dict[Var, Var]]:
+    """Rebuild a scan eqn so its body also emits ``extra_body_outvars`` as ys.
+
+    Parameters
+    ----------
+    eqn : JaxprEqn
+        A ``scan`` equation (``is_scan_primitive(eqn)`` must hold).
+    extra_body_outvars : Sequence[Var]
+        Body-scope vars (computed vars or body invars — passthrough ys are
+        valid jaxpr) to stack over the trip axis. Deduplicated preserving
+        order; vars already among the body outvars are still appended as new
+        ys so the stacked outer var is dedicated.
+
+    Returns
+    -------
+    tuple
+        ``(new_eqn, stacked_var_map)`` where ``stacked_var_map[body_var]`` is
+        a fresh outer ``Var`` of aval ``(length, *body_var.aval.shape)``. The
+        new eqn keeps the original outvars (by identity) followed by the
+        stacked vars; ``num_consts``/``num_carry``/``length``/``linear`` are
+        unchanged, and the body's eqns/invars keep their identity.
+    """
+    body_closed = eqn.params['jaxpr']
+    body = body_closed.jaxpr
+    length = eqn.params['length']
+    extra = list(dict.fromkeys(extra_body_outvars))
+    new_body = Jaxpr(
+        constvars=body.constvars,
+        invars=body.invars,
+        outvars=list(body.outvars) + extra,
+        eqns=body.eqns,
+        effects=body.effects,
+        debug_info=body.debug_info,
+    )
+    new_closed = ClosedJaxpr(new_body, body_closed.consts)
+    stacked = {
+        v: new_var('', v.aval.update(shape=(length, *v.aval.shape)))
+        for v in extra
+    }
+    new_eqn = eqn.replace(
+        params={**eqn.params, 'jaxpr': new_closed},
+        outvars=list(eqn.outvars) + [stacked[v] for v in extra],
+    )
+    return new_eqn, stacked

--- a/braintrace/_compiler/scan_descent.py
+++ b/braintrace/_compiler/scan_descent.py
@@ -242,3 +242,166 @@ def add_scan_ys(
         outvars=list(eqn.outvars) + [stacked[v] for v in extra],
     )
     return new_eqn, stacked
+
+
+class ScanDescentBundle(NamedTuple):
+    """Everything :func:`analyze_and_rewrite_scan` produced for one scan.
+
+    ``groups``/``relations`` carry their descent context
+    (:class:`GroupDescent`/:class:`RelationDescent`); group ``index`` values
+    are body-local (0-based) and are re-assigned when the bundle is merged
+    into the outer graph.
+    """
+
+    info: ScanDescentInfo
+    new_eqn: JaxprEqn
+    groups: List['HiddenGroup']
+    relations: List['HiddenParamOpRelation']
+    stacked_outer_vars: List[Var]
+    """Ordered values of ``info.stacked_var_map`` — the fresh outer vars to
+    hoist as jaxpr outputs."""
+
+
+def analyze_and_rewrite_scan(eqn: JaxprEqn, minfo) -> Optional[ScanDescentBundle]:
+    """Analyze one descendable scan and rebuild it with stacked ys.
+
+    Runs the flat hidden-group / relation finders on the scan *body* (with
+    body-scoped hidden/weight maps derived from the carry/const positions),
+    hoists every body value the executor will need as extra stacked ys via
+    :func:`add_scan_ys`, and re-scopes the discovered groups so their
+    ``hidden_invars``/``hidden_outvars`` are the scan's outer carry vars.
+
+    Parameters
+    ----------
+    eqn : JaxprEqn
+        A scan equation for which :func:`_descent_blockers` returned ``None``.
+    minfo : ModuleInfo
+        The enclosing module info (supplies the outer hidden/weight maps).
+
+    Returns
+    -------
+    ScanDescentBundle or None
+        ``None`` when the scan carries no hidden state (nothing to descend).
+    """
+    from .hid_param_op import find_hidden_param_op_relations_from_jaxpr
+    from .hidden_group import find_hidden_groups_from_jaxpr
+    from .jaxpr_graph import inline_jit_calls
+
+    policy = minfo.control_flow
+    body_closed = inline_jit_calls(eqn.params['jaxpr'])
+    body = body_closed.jaxpr
+    num_consts = eqn.params['num_consts']
+    num_carry = eqn.params['num_carry']
+
+    # ---- outer<->body position maps ---------------------------------------
+    # scan invars [*consts, *carry, *xs] are positionally identical to
+    # body.invars; outvars are [*carry, *ys].
+    carry_hidden: Dict[int, 'Path'] = {}
+    for c in range(num_carry):
+        path = minfo.outvar_to_hidden_path.get(eqn.outvars[c])
+        if path is not None:
+            carry_hidden[c] = path
+    if not carry_hidden:
+        return None
+
+    # ---- body-scope maps ---------------------------------------------------
+    body_invar_to_hidden_path = {
+        body.invars[num_consts + c]: p for c, p in carry_hidden.items()
+    }
+    body_outvar_to_hidden_path = {
+        body.outvars[c]: p for c, p in carry_hidden.items()
+    }
+    body_hidden_outvar_to_invar = {
+        body.outvars[c]: body.invars[num_consts + c]
+        for c in carry_hidden
+    }
+    body_invar_to_weight_path: Dict[Var, 'Path'] = {}
+    body_weight_path_to_invars: Dict['Path', List[Var]] = {}
+    for bv, ov in zip(body.invars, eqn.invars):
+        if not isinstance(ov, Var):
+            continue
+        wp = minfo.invar_to_weight_path.get(ov)
+        if wp is not None:
+            body_invar_to_weight_path[bv] = wp
+            body_weight_path_to_invars.setdefault(wp, []).append(bv)
+    path_to_state = minfo.retrieved_model_states
+
+    # ---- reuse the flat finders on the body --------------------------------
+    body_groups, body_hid_path_to_group = find_hidden_groups_from_jaxpr(
+        body,
+        hidden_outvar_to_invar=body_hidden_outvar_to_invar,
+        weight_invars=set(body_invar_to_weight_path),
+        invar_to_hidden_path=body_invar_to_hidden_path,
+        outvar_to_hidden_path=body_outvar_to_hidden_path,
+        path_to_state=path_to_state,
+        include_recurrent_mixing=False,
+        control_flow=policy,
+    )
+    body_relations = find_hidden_param_op_relations_from_jaxpr(
+        body,
+        invar_to_weight_path=body_invar_to_weight_path,
+        path_to_state=path_to_state,
+        outvar_to_hidden_path=body_outvar_to_hidden_path,
+        hid_path_to_group=body_hid_path_to_group,
+        weight_path_to_invars=body_weight_path_to_invars,
+        control_flow=policy,
+    )
+
+    # ---- assemble the hoist list (ordered dedup, body vars) ----------------
+    hoist: Dict[Var, None] = {}
+    for r in body_relations:
+        if r.x_var is not None:
+            hoist[r.x_var] = None
+        for j in r.y_to_hidden_group_jaxprs:
+            for v in list(j.invars) + list(j.constvars):
+                hoist[v] = None
+    for g in body_groups:
+        for v in list(g.hidden_invars) + list(g.transition_jaxpr_constvars):
+            hoist[v] = None
+    hoist = list(hoist)
+
+    # ---- rewrite the eqn ----------------------------------------------------
+    inlined_eqn = eqn if body_closed is eqn.params['jaxpr'] else eqn.replace(
+        params={**eqn.params, 'jaxpr': body_closed})
+    new_eqn, stacked = add_scan_ys(inlined_eqn, hoist)
+    info = ScanDescentInfo(
+        length=eqn.params['length'],
+        num_consts=num_consts,
+        num_carry=num_carry,
+        body_jaxpr=body,
+        stacked_var_map=stacked,
+        scan_eqn_id=id(new_eqn),
+    )
+
+    # ---- re-scope groups to outer hidden vars -------------------------------
+    path_to_carry = {p: c for c, p in carry_hidden.items()}
+    final_groups = []
+    for g in body_groups:
+        outer_invars = [eqn.invars[num_consts + path_to_carry[p]]
+                        for p in g.hidden_paths]
+        outer_outvars = [eqn.outvars[path_to_carry[p]] for p in g.hidden_paths]
+        final_groups.append(g._replace(
+            hidden_invars=outer_invars,
+            hidden_outvars=outer_outvars,
+            descent=GroupDescent(scan=info,
+                                 body_hidden_invars=list(g.hidden_invars)),
+        ))
+
+    # ---- patch relations: point at final groups + attach context ------------
+    by_paths = {tuple(g.hidden_paths): g for g in final_groups}
+    final_relations = [
+        r._replace(
+            hidden_groups=[by_paths[tuple(g.hidden_paths)]
+                           for g in r.hidden_groups],
+            control_flow_context=RelationDescent(scan=info),
+        )
+        for r in body_relations
+    ]
+
+    return ScanDescentBundle(
+        info=info,
+        new_eqn=new_eqn,
+        groups=final_groups,
+        relations=final_relations,
+        stacked_outer_vars=[stacked[v] for v in hoist],
+    )

--- a/braintrace/_compiler/scan_descent.py
+++ b/braintrace/_compiler/scan_descent.py
@@ -1,0 +1,137 @@
+# Copyright 2026 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Structured scan descent (control-flow support, Phase 4).
+
+An ETP-relevant inner ``scan`` whose static length exceeds
+``ControlFlowPolicy.scan_unroll_limit`` used to be a dead end: the unroller
+skipped it and the downstream walkers raised ``NotImplementedError``. This
+pass gives such scans a third compile path — *descent*: the scan body is
+analyzed in place with the same hidden-group / relation finders that run on
+the flat top-level jaxpr, and the scan equation is rebuilt so the body emits
+every value those analyses need (relation inputs, pre-activation ``y``
+values, substep-entry hidden states, transition constants) as extra stacked
+``ys`` with a leading substep axis. The scan itself stays a single equation
+— compile size is independent of its length.
+
+Semantically, descent applies the eligibility-trace recurrence at *substep*
+granularity ("unrolling in time"): each substep contributes an injection
+``x_tau (x) df_tau`` and a body-scoped diagonal Jacobian ``D_tau``, and the
+algorithm folds ``eps <- D_tau * eps + x_tau (x) df_tau`` over the stacked
+axis instead of once per outer step. For bodies whose hidden-to-hidden path
+is elementwise (the SNN class), the folded trace equals the sum of the
+per-relation traces the unroll path would produce — exactly. Hidden groups
+produced here face outward through the scan's carry variables, so
+perturbation, seam checks, and learning signals are untouched; only the
+Jacobian extraction and the trace update see the substep axis.
+"""
+
+from typing import Optional, Set
+
+from braintrace._compatible_imports import (
+    Jaxpr,
+    JaxprEqn,
+    Var,
+    is_cond_primitive,
+    is_scan_primitive,
+    is_while_primitive,
+)
+from braintrace._op import is_etp_primitive
+from .canonicalize import ControlFlowPolicy
+from .jaxpr_graph import _sub_closed_jaxprs
+
+__all__ = []
+
+
+def _body_has_etp(jaxpr: Jaxpr) -> bool:
+    """``True`` when an ETP primitive appears in ``jaxpr`` or any nested
+    control-flow body inside it."""
+    for eqn in jaxpr.eqns:
+        if is_etp_primitive(eqn.primitive):
+            return True
+        for sub in _sub_closed_jaxprs(eqn):
+            if _body_has_etp(sub.jaxpr):
+                return True
+    return False
+
+
+def _is_etp_relevant(body_jaxpr: Jaxpr, eqn: JaxprEqn, weight_invars: Set[Var]) -> bool:
+    """Whether a scan matters to descent at all.
+
+    Mirrors the unroller's relevance rule (:mod:`.canonicalize`): a scan is
+    ETP-relevant iff it consumes a trainable weight invar or its body holds
+    an ETP primitive.
+
+    Parameters
+    ----------
+    body_jaxpr : Jaxpr
+        The scan's body jaxpr (``eqn.params['jaxpr'].jaxpr``).
+    eqn : JaxprEqn
+        The scan equation.
+    weight_invars : set of Var
+        Top-level weight invars of the enclosing module jaxpr.
+
+    Returns
+    -------
+    bool
+        ``True`` when descent (or unrolling) should consider this scan.
+    """
+    if any(isinstance(v, Var) and v in weight_invars for v in eqn.invars):
+        return True
+    return _body_has_etp(body_jaxpr)
+
+
+def _descent_blockers(
+    eqn: JaxprEqn,
+    policy: ControlFlowPolicy,
+    weight_invars: Set[Var],
+) -> Optional[str]:
+    """Check the v1 descendability restrictions for one scan equation.
+
+    Parameters
+    ----------
+    eqn : JaxprEqn
+        The (ETP-relevant) scan equation.
+    policy : ControlFlowPolicy
+        The active control-flow policy.
+    weight_invars : set of Var
+        Top-level weight invars of the enclosing module jaxpr.
+
+    Returns
+    -------
+    str or None
+        ``None`` when the scan is descendable; otherwise a human-readable
+        reason suitable for a ``SCAN_DESCENT_SKIPPED`` diagnostic message.
+    """
+    if policy.scan_descent != 'auto':
+        return "ControlFlowPolicy.scan_descent is 'off'"
+    length = eqn.params['length']
+    if length <= policy.scan_unroll_limit:
+        return (f'its length {length} is within scan_unroll_limit='
+                f'{policy.scan_unroll_limit}; the unroll path handles it')
+    if eqn.params.get('reverse', False):
+        return 'reverse scans are not supported by structured descent (v1)'
+    body = eqn.params['jaxpr'].jaxpr
+    for e in body.eqns:
+        if is_scan_primitive(e) or is_while_primitive(e) or is_cond_primitive(e):
+            return ('its body contains nested control flow '
+                    f'({e.primitive.name}); not supported by descent (v1)')
+    num_consts = eqn.params['num_consts']
+    num_carry = eqn.params['num_carry']
+    for v in eqn.invars[num_consts + num_carry:]:
+        if isinstance(v, Var) and v in weight_invars:
+            return ('a trainable weight is scanned over as xs (per-iteration '
+                    'weight slices); not supported by descent')
+    return None

--- a/braintrace/_compiler/scan_descent.py
+++ b/braintrace/_compiler/scan_descent.py
@@ -36,6 +36,16 @@ per-relation traces the unroll path would produce — exactly. Hidden groups
 produced here face outward through the scan's carry variables, so
 perturbation, seam checks, and learning signals are untouched; only the
 Jacobian extraction and the trace update see the substep axis.
+
+.. note:: Single-step (perturbation) limitation — the per-step hidden
+   perturbation is added to the descended scan's *carry* outvar. A loss
+   that reads the hidden state through the scan's stacked ys instead
+   (e.g. ``for_loop(...)[-1]``) bypasses the perturbation, so its
+   same-step reverse credit is dropped from the learning signal (the
+   one-step ETP gradient is zero). Read the state after the loop
+   (``self.h.value``) to route the output through the perturbed carry.
+   Multi-step VJP is unaffected. This parallels the Phase-3 while-hidden
+   same-step limitation.
 """
 
 from typing import Dict, List, NamedTuple, Optional, Sequence, Set, Tuple

--- a/braintrace/_compiler/scan_descent.py
+++ b/braintrace/_compiler/scan_descent.py
@@ -38,7 +38,7 @@ perturbation, seam checks, and learning signals are untouched; only the
 Jacobian extraction and the trace update see the substep axis.
 """
 
-from typing import Dict, Optional, Sequence, Set, Tuple
+from typing import Dict, List, NamedTuple, Optional, Sequence, Set, Tuple
 
 from braintrace._compatible_imports import (
     ClosedJaxpr,
@@ -55,6 +55,62 @@ from .canonicalize import ControlFlowPolicy
 from .jaxpr_graph import _sub_closed_jaxprs
 
 __all__ = []
+
+
+class ScanDescentInfo(NamedTuple):
+    """Compile-time context for one descended scan equation.
+
+    All ``Var``s in ``stacked_var_map`` keys (and ``body_jaxpr``) are
+    **body**-scoped; the map's values are fresh **outer**-scope vars produced
+    by :func:`add_scan_ys`, hoisted as jaxpr outputs so the executor can read
+    their runtime values (leading substep axis ``length``).
+    """
+
+    length: int
+    """Static trip count ``L`` of the scan."""
+
+    num_consts: int
+    """Number of const entries at the head of the scan invars."""
+
+    num_carry: int
+    """Number of carry entries following the consts."""
+
+    body_jaxpr: Jaxpr
+    """The (jit-inlined) scan body; ``invars = [*consts, *carry, *xs]``."""
+
+    stacked_var_map: Dict[Var, Var]
+    """Body var -> outer stacked var of aval ``(length, *shape)``;
+    insertion-ordered."""
+
+    scan_eqn_id: int
+    """``id()`` of the REWRITTEN scan eqn — the key the outer walkers use to
+    exempt this equation."""
+
+
+class GroupDescent(NamedTuple):
+    """Descent context attached to a :class:`~.hidden_group.HiddenGroup`.
+
+    The group's ``transition_jaxpr``/``transition_jaxpr_constvars`` are
+    **body**-scoped (one substep) while its ``hidden_invars``/
+    ``hidden_outvars`` are re-scoped to the **outer** scan carry vars;
+    ``body_hidden_invars`` preserves the body-scope carry invars (substep-
+    entry hidden values), matching ``transition_jaxpr.invars``.
+    """
+
+    scan: ScanDescentInfo
+    body_hidden_invars: List[Var]
+
+
+class RelationDescent(NamedTuple):
+    """Descent context attached to a
+    :class:`~.hid_param_op.HiddenParamOpRelation`.
+
+    The relation's ``x_var``/``y_var``/``y_to_hidden_group_jaxprs`` are
+    **body**-scoped; runtime values are read through
+    ``scan.stacked_var_map`` (stacked over the substep axis).
+    """
+
+    scan: ScanDescentInfo
 
 
 def _body_has_etp(jaxpr: Jaxpr) -> bool:

--- a/braintrace/_compiler/scan_descent.py
+++ b/braintrace/_compiler/scan_descent.py
@@ -52,6 +52,7 @@ from braintrace._compatible_imports import (
 )
 from braintrace._op import is_etp_primitive
 from .canonicalize import ControlFlowPolicy
+from .diagnostics import DiagnosticKind, DiagnosticLevel, emit
 from .jaxpr_graph import _sub_closed_jaxprs
 
 __all__ = []
@@ -405,3 +406,97 @@ def analyze_and_rewrite_scan(eqn: JaxprEqn, minfo) -> Optional[ScanDescentBundle
         relations=final_relations,
         stacked_outer_vars=[stacked[v] for v in hoist],
     )
+
+
+def apply_scan_descent(minfo) -> Tuple['ModuleInfo', List[ScanDescentBundle]]:
+    """Descend every eligible top-level scan in ``minfo`` and rewrite its jaxpr.
+
+    Walks the top-level equations of ``minfo.jaxpr``; for each ETP-relevant
+    ``scan`` that passes the v1 restrictions (:func:`_descent_blockers`), the
+    equation is analyzed and rewritten via :func:`analyze_and_rewrite_scan`
+    and a ``SCAN_DESCENT_APPLIED`` diagnostic is emitted. Scans that are
+    blocked *and* too long to unroll get a ``SCAN_DESCENT_SKIPPED`` warning
+    (short scans are the unroller's business; no diagnostic here).
+
+    Parameters
+    ----------
+    minfo : ModuleInfo
+        The module info produced by ``extract_module_info``.
+
+    Returns
+    -------
+    tuple
+        ``(minfo, bundles)``. When ``minfo.control_flow.scan_descent`` is not
+        ``'auto'`` or nothing was descended, the *original* ``minfo`` is
+        returned unchanged with an empty bundle list. Otherwise the returned
+        ``ModuleInfo`` holds a rebuilt ``closed_jaxpr`` whose descended scan
+        equations are the bundles' ``new_eqn`` objects (every other eqn and
+        every pre-existing ``Var`` keeps its identity).
+    """
+    policy: ControlFlowPolicy = minfo.control_flow
+    if policy.scan_descent != 'auto':
+        return minfo, []
+
+    weight_invars = set(minfo.weight_invars)
+    bundles: List[ScanDescentBundle] = []
+    new_eqns: List[JaxprEqn] = []
+    for eqn in minfo.jaxpr.eqns:
+        if not (
+            is_scan_primitive(eqn)
+            and _is_etp_relevant(eqn.params['jaxpr'].jaxpr, eqn, weight_invars)
+        ):
+            new_eqns.append(eqn)
+            continue
+        blocker = _descent_blockers(eqn, policy, weight_invars)
+        if blocker is not None:
+            if eqn.params['length'] > policy.scan_unroll_limit:
+                emit(
+                    kind=DiagnosticKind.SCAN_DESCENT_SKIPPED,
+                    level=DiagnosticLevel.WARNING,
+                    message=(
+                        f'Structured scan descent was requested '
+                        f"(scan_descent='auto') but this scan cannot be "
+                        f'descended: {blocker}. The existing control-flow '
+                        f'restrictions apply to it.'
+                    ),
+                    context={'blocker': blocker,
+                             'length': eqn.params['length']},
+                )
+            new_eqns.append(eqn)
+            continue
+        bundle = analyze_and_rewrite_scan(eqn, minfo)
+        if bundle is None:
+            # no hidden state in the carry: nothing to descend; the walkers
+            # keep their existing behavior for this equation.
+            new_eqns.append(eqn)
+            continue
+        bundles.append(bundle)
+        new_eqns.append(bundle.new_eqn)
+        emit(
+            kind=DiagnosticKind.SCAN_DESCENT_APPLIED,
+            level=DiagnosticLevel.INFO,
+            message=(
+                f'Applied structured descent to a length-'
+                f'{bundle.info.length} scan: {len(bundle.relations)} '
+                f'relation(s) and {len(bundle.groups)} hidden group(s) '
+                f'registered from its body.'
+            ),
+            hidden_paths=tuple(
+                p for g in bundle.groups for p in g.hidden_paths
+            ),
+            context={'length': bundle.info.length},
+        )
+
+    if not bundles:
+        return minfo, []
+    old = minfo.jaxpr
+    new_jaxpr = Jaxpr(
+        constvars=old.constvars,
+        invars=old.invars,
+        outvars=old.outvars,
+        eqns=new_eqns,
+        effects=old.effects,
+        debug_info=old.debug_info,
+    )
+    new_closed = ClosedJaxpr(new_jaxpr, minfo.closed_jaxpr.consts)
+    return minfo._replace(closed_jaxpr=new_closed), bundles

--- a/braintrace/_compiler/scan_descent.py
+++ b/braintrace/_compiler/scan_descent.py
@@ -46,6 +46,12 @@ Jacobian extraction and the trace update see the substep axis.
    (``self.h.value``) to route the output through the perturbed carry.
    Multi-step VJP is unaffected. This parallels the Phase-3 while-hidden
    same-step limitation.
+
+.. note:: Body analysis always runs in the default "without recurrence"
+   grouping mode (``include_recurrent_mixing=False``), independent of the
+   outer ``compile_etrace_graph(include_recurrent_mixing=...)`` flag: the
+   per-substep trace fold consumes diagonal Jacobians, so tracing recurrent
+   ETP mixing into a body transition has no consumer.
 """
 
 from typing import Dict, List, NamedTuple, Optional, Sequence, Set, Tuple
@@ -61,11 +67,20 @@ from braintrace._compatible_imports import (
     new_var,
 )
 from braintrace._op import is_etp_primitive
+from braintrace._typing import Path
 from .canonicalize import ControlFlowPolicy
 from .diagnostics import DiagnosticKind, DiagnosticLevel, emit
 from .jaxpr_graph import _sub_closed_jaxprs
 
-__all__ = []
+__all__ = [
+    'GroupDescent',
+    'RelationDescent',
+    'ScanDescentBundle',
+    'ScanDescentInfo',
+    'add_scan_ys',
+    'analyze_and_rewrite_scan',
+    'apply_scan_descent',
+]
 
 
 class ScanDescentInfo(NamedTuple):
@@ -307,13 +322,42 @@ def analyze_and_rewrite_scan(eqn: JaxprEqn, minfo) -> Optional[ScanDescentBundle
     # ---- outer<->body position maps ---------------------------------------
     # scan invars [*consts, *carry, *xs] are positionally identical to
     # body.invars; outvars are [*carry, *ys].
-    carry_hidden: Dict[int, 'Path'] = {}
+    carry_hidden: Dict[int, Path] = {}
     for c in range(num_carry):
         path = minfo.outvar_to_hidden_path.get(eqn.outvars[c])
         if path is not None:
             carry_hidden[c] = path
     if not carry_hidden:
         return None
+
+    # v1 guard: every hidden carry must be initialized from the *pristine*
+    # step-entry hidden invar. If the model transforms the hidden state
+    # between step entry and the scan (e.g. ``h.value = h.value * 0.5``
+    # before the loop), that outer segment of the per-step transition is
+    # invisible to the substep fold and the folded eligibility trace would
+    # be silently wrong. Skip descent; the scan then hits the existing loud
+    # control-flow restrictions.
+    for c, path in carry_hidden.items():
+        init_invar = eqn.invars[num_consts + c]
+        if not (
+            isinstance(init_invar, Var)
+            and minfo.invar_to_hidden_path.get(init_invar) == path
+        ):
+            emit(
+                kind=DiagnosticKind.SCAN_DESCENT_SKIPPED,
+                level=DiagnosticLevel.WARNING,
+                message=(
+                    f'Structured scan descent was skipped for a scan '
+                    f'carrying hidden state {path}: the carry is initialized '
+                    f'from a transformed value, not the step-entry hidden '
+                    f'state, so part of the per-step transition lies outside '
+                    f'the scan and the folded eligibility trace would be '
+                    f'wrong. Move the pre-scan update into the scan body, or '
+                    f"set ControlFlowPolicy(scan_descent='off')."
+                ),
+                hidden_paths=(path,),
+            )
+            return None
 
     # ---- body-scope maps ---------------------------------------------------
     body_invar_to_hidden_path = {
@@ -326,8 +370,8 @@ def analyze_and_rewrite_scan(eqn: JaxprEqn, minfo) -> Optional[ScanDescentBundle
         body.outvars[c]: body.invars[num_consts + c]
         for c in carry_hidden
     }
-    body_invar_to_weight_path: Dict[Var, 'Path'] = {}
-    body_weight_path_to_invars: Dict['Path', List[Var]] = {}
+    body_invar_to_weight_path: Dict[Var, Path] = {}
+    body_weight_path_to_invars: Dict[Path, List[Var]] = {}
     for bv, ov in zip(body.invars, eqn.invars):
         if not isinstance(ov, Var):
             continue
@@ -357,6 +401,31 @@ def analyze_and_rewrite_scan(eqn: JaxprEqn, minfo) -> Optional[ScanDescentBundle
         weight_path_to_invars=body_weight_path_to_invars,
         control_flow=policy,
     )
+
+    # A weight consumed by this scan but routed through no ETP primitive
+    # (plain-op usage) does not learn online — the primitive-based selection
+    # principle, same as at the flat level. Pre-descent this whole scan was
+    # a hard error, so surface the flip loudly instead of silently.
+    covered_paths = {
+        wp for r in body_relations for wp in r.trainable_paths.values()
+    }
+    missing = [wp for wp in body_weight_path_to_invars
+               if wp not in covered_paths]
+    if missing:
+        emit(
+            kind=DiagnosticKind.SCAN_DESCENT_NO_RELATIONS,
+            level=DiagnosticLevel.WARNING,
+            message=(
+                f'Weight state(s) {missing} are consumed by a descended '
+                f'scan but produce no ETP relation (they are used through '
+                f'plain ops, not ETP primitives), so they will NOT '
+                f'participate in online learning. Route them through an ETP '
+                f'op (e.g. braintrace.matmul) inside the scan body if they '
+                f'should learn, or ignore this warning if the exclusion is '
+                f'deliberate.'
+            ),
+            context={'weight_paths': tuple(missing)},
+        )
 
     # ---- assemble the hoist list (ordered dedup, body vars) ----------------
     hoist: Dict[Var, None] = {}
@@ -494,7 +563,13 @@ def apply_scan_descent(minfo) -> Tuple['ModuleInfo', List[ScanDescentBundle]]:
             hidden_paths=tuple(
                 p for g in bundle.groups for p in g.hidden_paths
             ),
-            context={'length': bundle.info.length},
+            context={
+                'length': bundle.info.length,
+                'weight_paths': tuple(sorted({
+                    wp for r in bundle.relations
+                    for wp in r.trainable_paths.values()
+                })),
+            },
         )
 
     if not bundles:

--- a/braintrace/_compiler/scan_descent_test.py
+++ b/braintrace/_compiler/scan_descent_test.py
@@ -1,0 +1,115 @@
+# Copyright 2026 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+import brainstate
+import jax
+import jax.numpy as jnp
+import pytest
+
+import braintrace
+from braintrace import ControlFlowPolicy
+from braintrace._compatible_imports import is_scan_primitive
+from braintrace._compiler.module_info import extract_module_info
+from braintrace._compiler.scan_descent import (
+    _descent_blockers,
+    _is_etp_relevant,
+)
+
+
+def _scan_model_jaxpr(loops):
+    """A leaky SNN-style model whose update runs ``loops`` inner sub-steps in a
+    ``for_loop``; extraction keeps the scan opaque (descent off, limit 4)."""
+
+    class Net(brainstate.nn.Module):
+        def __init__(self):
+            super().__init__()
+            self.w = brainstate.ParamState(jnp.ones((3, 3)) * 0.1)
+            self.h = brainstate.HiddenState(jnp.zeros((1, 3)))
+
+        def update(self, x):
+            x_row = x.reshape(1, -1)
+
+            def substep(_):
+                self.h.value = 0.9 * self.h.value + jnp.tanh(
+                    braintrace.matmul(x_row, self.w.value))
+                return self.h.value
+
+            return brainstate.transform.for_loop(substep, jnp.arange(loops))[-1]
+
+    net = Net()
+    brainstate.nn.init_all_states(net, batch_size=1)
+    minfo = extract_module_info(
+        net, jnp.ones((3,), dtype='float32'),
+        control_flow=ControlFlowPolicy(scan_unroll_limit=4, scan_descent='off'))
+    eqn = next(e for e in minfo.jaxpr.eqns if is_scan_primitive(e))
+    return eqn, minfo
+
+
+class TestDescendabilityPredicate:
+    def test_descendable_scan_has_no_blockers(self):
+        eqn, minfo = _scan_model_jaxpr(loops=8)
+        policy = ControlFlowPolicy(scan_unroll_limit=4, scan_descent='auto')
+        assert _is_etp_relevant(
+            eqn.params['jaxpr'].jaxpr, eqn, set(minfo.weight_invars))
+        assert _descent_blockers(eqn, policy, set(minfo.weight_invars)) is None
+
+    def test_policy_off_blocks_descent(self):
+        eqn, minfo = _scan_model_jaxpr(loops=8)
+        policy = ControlFlowPolicy(scan_unroll_limit=4, scan_descent='off')
+        blocker = _descent_blockers(eqn, policy, set(minfo.weight_invars))
+        assert 'scan_descent' in blocker
+
+    def test_short_scan_left_to_unroll(self):
+        eqn, minfo = _scan_model_jaxpr(loops=8)
+        policy = ControlFlowPolicy(scan_unroll_limit=16, scan_descent='auto')
+        blocker = _descent_blockers(eqn, policy, set(minfo.weight_invars))
+        assert 'unroll' in blocker
+
+    def test_reverse_scan_blocked(self):
+        def f(xs):
+            return jax.lax.scan(
+                lambda c, x: (c + x, c), jnp.zeros(()), xs, reverse=True)
+
+        closed = jax.make_jaxpr(f)(jnp.arange(8.0))
+        eqn = next(e for e in closed.jaxpr.eqns if is_scan_primitive(e))
+        policy = ControlFlowPolicy(scan_unroll_limit=4, scan_descent='auto')
+        blocker = _descent_blockers(eqn, policy, set())
+        assert 'reverse' in blocker
+
+    def test_nested_control_flow_blocked(self):
+        def body(c, x):
+            c2 = jax.lax.while_loop(
+                lambda v: jnp.sum(v) < 1.0, lambda v: v + x, c)
+            return c2, c
+
+        closed = jax.make_jaxpr(
+            lambda xs: jax.lax.scan(body, jnp.zeros((3,)), xs)
+        )(jnp.ones((8, 3)))
+        eqn = next(e for e in closed.jaxpr.eqns if is_scan_primitive(e))
+        policy = ControlFlowPolicy(scan_unroll_limit=4, scan_descent='auto')
+        blocker = _descent_blockers(eqn, policy, set())
+        assert 'nested control flow' in blocker
+
+    def test_weight_scanned_as_xs_blocked(self):
+        def f(w_stack, x):
+            return jax.lax.scan(lambda c, w: (c @ w, c), x, w_stack)
+
+        closed = jax.make_jaxpr(f)(jnp.ones((8, 3, 3)), jnp.ones((3,)))
+        eqn = next(e for e in closed.jaxpr.eqns if is_scan_primitive(e))
+        w_stack_var = closed.jaxpr.invars[0]
+        policy = ControlFlowPolicy(scan_unroll_limit=4, scan_descent='auto')
+        blocker = _descent_blockers(eqn, policy, {w_stack_var})
+        assert 'xs' in blocker
+
+    def test_etp_irrelevant_scan_not_relevant(self):
+        def f(xs):
+            return jax.lax.scan(lambda c, x: (c + x, c), jnp.zeros(()), xs)
+
+        closed = jax.make_jaxpr(f)(jnp.arange(8.0))
+        eqn = next(e for e in closed.jaxpr.eqns if is_scan_primitive(e))
+        assert not _is_etp_relevant(eqn.params['jaxpr'].jaxpr, eqn, set())

--- a/braintrace/_compiler/scan_descent_test.py
+++ b/braintrace/_compiler/scan_descent_test.py
@@ -367,11 +367,16 @@ class TestApplyScanDescentPipeline:
         with pytest.raises(NotImplementedError):
             algo.compile_graph(jnp.ones((4,), dtype='float32'))
 
-    def test_algorithm_gate_blocks_descended_graph_part1(self):
+    def test_algorithm_gate_admits_supporting_algorithm(self):
+        """Part 1 pinned this call as gate-blocked; since the Part 2 substep
+        fold landed, ``D_RTRL`` declares ``_supports_scan_descent`` and the
+        gate admits the descended graph. The io-dim family remains blocked —
+        pinned in ``scan_descent_support_test.test_io_dim_algorithm_still_gated``."""
         net = _make_snn_net(loops=40)
         algo = braintrace.D_RTRL(net, control_flow=DESCENT_POLICY)
-        with pytest.raises(NotImplementedError, match='scan descent'):
-            algo.compile_graph(jnp.ones((4,), dtype='float32'))
+        algo.compile_graph(jnp.ones((4,), dtype='float32'))
+        assert any(r.control_flow_context is not None
+                   for r in algo.graph.hidden_param_op_relations)
 
     def test_outer_relation_into_descended_group_raises(self):
         from braintrace._compiler.graph import compile_etrace_graph

--- a/braintrace/_compiler/scan_descent_test.py
+++ b/braintrace/_compiler/scan_descent_test.py
@@ -182,3 +182,21 @@ class TestAddScanYs:
         new_eqn, stacked = add_scan_ys(eqn, [carry_invar, carry_invar])
         assert len(stacked) == 1
         assert len(new_eqn.outvars) == len(eqn.outvars) + 1
+
+
+class TestDescentContextTypes:
+    def test_descent_context_types_and_default_fields(self):
+        from braintrace._compiler.scan_descent import (
+            ScanDescentInfo, GroupDescent, RelationDescent)
+        from braintrace._compiler.hid_param_op import HiddenParamOpRelation
+        from braintrace._compiler.hidden_group import HiddenGroup
+        assert HiddenParamOpRelation._field_defaults.get(
+            'control_flow_context') is None
+        assert 'control_flow_context' in HiddenParamOpRelation._field_defaults
+        assert HiddenGroup._field_defaults.get('descent') is None
+        assert 'descent' in HiddenGroup._field_defaults
+        assert ScanDescentInfo._fields == (
+            'length', 'num_consts', 'num_carry', 'body_jaxpr',
+            'stacked_var_map', 'scan_eqn_id')
+        assert GroupDescent._fields == ('scan', 'body_hidden_invars')
+        assert RelationDescent._fields == ('scan',)

--- a/braintrace/_compiler/scan_descent_test.py
+++ b/braintrace/_compiler/scan_descent_test.py
@@ -113,3 +113,72 @@ class TestDescendabilityPredicate:
         closed = jax.make_jaxpr(f)(jnp.arange(8.0))
         eqn = next(e for e in closed.jaxpr.eqns if is_scan_primitive(e))
         assert not _is_etp_relevant(eqn.params['jaxpr'].jaxpr, eqn, set())
+
+
+class TestAddScanYs:
+    def test_add_scan_ys_emits_per_substep_values(self):
+        from braintrace._compiler.scan_descent import add_scan_ys
+        from braintrace._compatible_imports import Jaxpr
+
+        def body(c, x):
+            y = jnp.tanh(c) + x
+            return y, y * 2.0
+
+        closed = jax.make_jaxpr(
+            lambda xs: jax.lax.scan(body, jnp.zeros(()), xs))(jnp.arange(4.0))
+        eqn = next(e for e in closed.jaxpr.eqns if is_scan_primitive(e))
+        body_jaxpr = eqn.params['jaxpr'].jaxpr
+        # hoist: the tanh intermediate (a body-computed var) and the carry invar
+        tanh_var = next(e.outvars[0] for e in body_jaxpr.eqns
+                        if e.primitive.name == 'tanh')
+        num_consts, num_carry = eqn.params['num_consts'], eqn.params['num_carry']
+        carry_invar = body_jaxpr.invars[num_consts]
+
+        new_eqn, stacked = add_scan_ys(eqn, [tanh_var, carry_invar])
+        assert list(new_eqn.outvars[:len(eqn.outvars)]) == list(eqn.outvars)
+        assert stacked[tanh_var].aval.shape == (4,)
+        assert stacked[carry_invar].aval.shape == (4,)
+        assert new_eqn.params['num_carry'] == num_carry
+        assert new_eqn.params['num_consts'] == num_consts
+        assert new_eqn.params['length'] == eqn.params['length']
+        # body eqns preserved by identity
+        assert new_eqn.params['jaxpr'].jaxpr.eqns == body_jaxpr.eqns
+
+        # evaluate the rewritten jaxpr: replace the eqn, extend outvars, compare
+        new_eqns = [new_eqn if e is eqn else e for e in closed.jaxpr.eqns]
+        new_jaxpr = Jaxpr(
+            constvars=closed.jaxpr.constvars, invars=closed.jaxpr.invars,
+            outvars=list(closed.jaxpr.outvars) + [stacked[tanh_var],
+                                                  stacked[carry_invar]],
+            eqns=new_eqns, effects=closed.jaxpr.effects,
+            debug_info=closed.jaxpr.debug_info)
+        xs = jnp.arange(4.0)
+        outs = jax.core.eval_jaxpr(new_jaxpr, closed.consts, xs)
+        # reference: replay by hand
+        cs, tanhs = [], []
+        c = jnp.zeros(())
+        for x in xs:
+            cs.append(c)
+            t = jnp.tanh(c)
+            c = t + x
+            tanhs.append(t)
+        assert jnp.allclose(outs[-2], jnp.stack(tanhs))
+        assert jnp.allclose(outs[-1], jnp.stack(cs))
+        # original outputs unchanged
+        ref = jax.core.eval_jaxpr(closed.jaxpr, closed.consts, xs)
+        assert jnp.allclose(outs[0], ref[0])
+        assert jnp.allclose(outs[1], ref[1])
+
+    def test_add_scan_ys_dedups_preserving_order(self):
+        from braintrace._compiler.scan_descent import add_scan_ys
+
+        def body(c, x):
+            return c + x, c
+
+        closed = jax.make_jaxpr(
+            lambda xs: jax.lax.scan(body, jnp.zeros(()), xs))(jnp.arange(4.0))
+        eqn = next(e for e in closed.jaxpr.eqns if is_scan_primitive(e))
+        carry_invar = eqn.params['jaxpr'].jaxpr.invars[eqn.params['num_consts']]
+        new_eqn, stacked = add_scan_ys(eqn, [carry_invar, carry_invar])
+        assert len(stacked) == 1
+        assert len(new_eqn.outvars) == len(eqn.outvars) + 1

--- a/braintrace/_compiler/scan_descent_test.py
+++ b/braintrace/_compiler/scan_descent_test.py
@@ -200,3 +200,85 @@ class TestDescentContextTypes:
             'stacked_var_map', 'scan_eqn_id')
         assert GroupDescent._fields == ('scan', 'body_hidden_invars')
         assert RelationDescent._fields == ('scan',)
+
+
+class TestAnalyzeAndRewriteScan:
+    def _analyze(self, loops):
+        eqn, minfo = _scan_model_jaxpr(loops)
+        from braintrace._compiler.scan_descent import analyze_and_rewrite_scan
+        return analyze_and_rewrite_scan(eqn, minfo), minfo
+
+    def test_snn_body_yields_one_group_one_relation(self):
+        bundle, minfo = self._analyze(loops=8)
+        assert bundle is not None
+        assert len(bundle.groups) == 1
+        g = bundle.groups[0]
+        assert g.descent is not None
+        assert g.num_state == 1
+        # outer-facing hidden vars are the scan carry vars, known to minfo
+        assert g.hidden_outvars[0] in minfo.outvar_to_hidden_path
+        assert g.hidden_invars[0] in minfo.invar_to_hidden_path
+        # body-scoped transition: one substep, invars == descent.body_hidden_invars
+        assert list(g.transition_jaxpr.invars) == list(g.descent.body_hidden_invars)
+
+        assert len(bundle.relations) == 1
+        r = bundle.relations[0]
+        assert r.control_flow_context is not None
+        assert r.trainable_paths['weight'] == ('w',)
+        assert r.hidden_groups[0] is g
+        # everything the executor needs is in the stacked map
+        m = bundle.info.stacked_var_map
+        assert r.x_var in m and r.y_var in m
+        for j in r.y_to_hidden_group_jaxprs:
+            assert all(v in m for v in j.constvars)
+        assert all(v in m for v in g.descent.body_hidden_invars)
+        assert all(v in m for v in g.transition_jaxpr_constvars)
+        # stacked avals carry the substep axis
+        L = bundle.info.length
+        assert L == 8
+        assert all(m[v].aval.shape[0] == L for v in m)
+        # the rewritten eqn's outvars extend the original with the stacked vars
+        assert list(bundle.new_eqn.outvars[-len(bundle.stacked_outer_vars):]) \
+            == list(bundle.stacked_outer_vars)
+        assert bundle.info.scan_eqn_id == id(bundle.new_eqn)
+
+    def test_mixing_body_registers_both_relations(self):
+        """Body ``h = tanh(x@w + h@w)`` (scan_body_rnn shape): within ONE
+        substep neither matmul's output crosses another ETP op before the
+        carry hidden (the tail add/tanh is non-parametric), so BOTH register
+        as body-scoped relations."""
+
+        class Net(brainstate.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.w = brainstate.ParamState(jnp.ones((3, 3)) * 0.1)
+                self.h = brainstate.HiddenState(jnp.zeros((1, 3)))
+
+            def update(self, x):
+                x_row = x.reshape(1, -1)
+
+                def substep(_):
+                    self.h.value = jax.nn.tanh(
+                        braintrace.matmul(x_row, self.w.value)
+                        + braintrace.matmul(self.h.value, self.w.value))
+                    return self.h.value
+
+                return brainstate.transform.for_loop(
+                    substep, jnp.arange(8))[-1]
+
+        net = Net()
+        brainstate.nn.init_all_states(net, batch_size=1)
+        from braintrace._compiler.scan_descent import analyze_and_rewrite_scan
+        minfo = extract_module_info(
+            net, jnp.ones((3,), dtype='float32'),
+            control_flow=ControlFlowPolicy(scan_unroll_limit=4,
+                                           scan_descent='off'))
+        eqn = next(e for e in minfo.jaxpr.eqns if is_scan_primitive(e))
+        bundle = analyze_and_rewrite_scan(eqn, minfo)
+        assert bundle is not None
+        assert len(bundle.groups) == 1
+        assert len(bundle.relations) == 2
+        assert all(r.control_flow_context is not None
+                   for r in bundle.relations)
+        # tied weight: both relations route the SAME param via distinct y_vars
+        assert bundle.relations[0].y_var is not bundle.relations[1].y_var

--- a/braintrace/_compiler/scan_descent_test.py
+++ b/braintrace/_compiler/scan_descent_test.py
@@ -282,3 +282,123 @@ class TestAnalyzeAndRewriteScan:
                    for r in bundle.relations)
         # tied weight: both relations route the SAME param via distinct y_vars
         assert bundle.relations[0].y_var is not bundle.relations[1].y_var
+
+
+DESCENT_POLICY = ControlFlowPolicy(scan_unroll_limit=4, scan_descent='auto')
+
+
+def _make_snn_net(loops, n_rec=4):
+    class Net(brainstate.nn.Module):
+        def __init__(self):
+            super().__init__()
+            with brainstate.random.seed_context(0):
+                self.w = brainstate.ParamState(
+                    0.1 * brainstate.random.randn(n_rec, n_rec))
+            self.h = brainstate.HiddenState(jnp.zeros((1, n_rec)))
+
+        def update(self, x):
+            x_row = x.reshape(1, -1)
+
+            def substep(_):
+                self.h.value = 0.9 * self.h.value + jnp.tanh(
+                    braintrace.matmul(x_row, self.w.value))
+                return self.h.value
+
+            return brainstate.transform.for_loop(substep, jnp.arange(loops))[-1]
+
+    net = Net()
+    brainstate.nn.init_all_states(net, batch_size=1)
+    return net
+
+
+class TestApplyScanDescentPipeline:
+    def test_long_scan_compiles_with_descent(self):
+        from braintrace._compiler.graph import compile_etrace_graph
+        from braintrace._compiler.diagnostics import DiagnosticKind
+        net = _make_snn_net(loops=40)
+        graph = compile_etrace_graph(
+            net, jnp.ones((4,), dtype='float32'), control_flow=DESCENT_POLICY)
+        rels = [r for r in graph.hidden_param_op_relations
+                if r.control_flow_context is not None]
+        grps = [g for g in graph.hidden_groups if g.descent is not None]
+        assert len(rels) == 1 and len(grps) == 1
+        assert [g.index for g in graph.hidden_groups] == list(
+            range(len(graph.hidden_groups)))
+        assert any(d.kind is DiagnosticKind.SCAN_DESCENT_APPLIED
+                   for d in graph.diagnostics)
+        # stacked temps are hoisted: every mapped outer var is a jaxpr outvar
+        m = rels[0].control_flow_context.scan.stacked_var_map
+        outvars = set(graph.module_info.jaxpr.outvars)
+        assert all(sv in outvars for sv in m.values())
+
+    def test_mixing_body_compiles_with_two_descended_relations(self):
+        from braintrace._compiler.graph import compile_etrace_graph
+
+        class Net(brainstate.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.w = brainstate.ParamState(jnp.ones((3, 3)) * 0.1)
+                self.h = brainstate.HiddenState(jnp.zeros((1, 3)))
+
+            def update(self, x):
+                x_row = x.reshape(1, -1)
+
+                def substep(_):
+                    self.h.value = jax.nn.tanh(
+                        braintrace.matmul(x_row, self.w.value)
+                        + braintrace.matmul(self.h.value, self.w.value))
+                    return self.h.value
+
+                return brainstate.transform.for_loop(
+                    substep, jnp.arange(40))[-1]
+
+        net = Net()
+        brainstate.nn.init_all_states(net, batch_size=1)
+        graph = compile_etrace_graph(
+            net, jnp.ones((3,), dtype='float32'), control_flow=DESCENT_POLICY)
+        rels = [r for r in graph.hidden_param_op_relations
+                if r.control_flow_context is not None]
+        assert len(rels) == 2
+
+    def test_policy_off_preserves_old_error(self):
+        net = _make_snn_net(loops=40)
+        algo = braintrace.D_RTRL(net, control_flow=ControlFlowPolicy(
+            scan_unroll_limit=4, scan_descent='off'))
+        with pytest.raises(NotImplementedError):
+            algo.compile_graph(jnp.ones((4,), dtype='float32'))
+
+    def test_algorithm_gate_blocks_descended_graph_part1(self):
+        net = _make_snn_net(loops=40)
+        algo = braintrace.D_RTRL(net, control_flow=DESCENT_POLICY)
+        with pytest.raises(NotImplementedError, match='scan descent'):
+            algo.compile_graph(jnp.ones((4,), dtype='float32'))
+
+    def test_outer_relation_into_descended_group_raises(self):
+        from braintrace._compiler.graph import compile_etrace_graph
+
+        class Net(brainstate.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.w_in = brainstate.ParamState(jnp.ones((3, 4)) * 0.1)
+                self.w = brainstate.ParamState(jnp.ones((4, 4)) * 0.1)
+                self.h = brainstate.HiddenState(jnp.zeros((1, 4)))
+
+            def update(self, x):
+                # outer ETP relation whose y reaches ``h`` through the scan
+                drive = braintrace.matmul(x.reshape(1, -1), self.w_in.value)
+                self.h.value = self.h.value * 0.5 + drive
+
+                def substep(_):
+                    self.h.value = 0.9 * self.h.value + jnp.tanh(
+                        braintrace.matmul(drive, self.w.value))
+                    return self.h.value
+
+                return brainstate.transform.for_loop(
+                    substep, jnp.arange(40))[-1]
+
+        net = Net()
+        brainstate.nn.init_all_states(net, batch_size=1)
+        with pytest.raises(NotImplementedError, match='descended scan'):
+            compile_etrace_graph(
+                net, jnp.ones((3,), dtype='float32'),
+                control_flow=DESCENT_POLICY)

--- a/braintrace/_compiler/scan_descent_test.py
+++ b/braintrace/_compiler/scan_descent_test.py
@@ -379,6 +379,9 @@ class TestApplyScanDescentPipeline:
                    for r in algo.graph.hidden_param_op_relations)
 
     def test_outer_relation_into_descended_group_raises(self):
+        """The carry init stays pristine (so the scan descends), but an
+        outer ETP relation's ``y`` reaches the carried hidden state through
+        the scan's consts — the v1 outer-injection guard must reject it."""
         from braintrace._compiler.graph import compile_etrace_graph
 
         class Net(brainstate.nn.Module):
@@ -391,7 +394,6 @@ class TestApplyScanDescentPipeline:
             def update(self, x):
                 # outer ETP relation whose y reaches ``h`` through the scan
                 drive = braintrace.matmul(x.reshape(1, -1), self.w_in.value)
-                self.h.value = self.h.value * 0.5 + drive
 
                 def substep(_):
                     self.h.value = 0.9 * self.h.value + jnp.tanh(
@@ -407,3 +409,76 @@ class TestApplyScanDescentPipeline:
             compile_etrace_graph(
                 net, jnp.ones((3,), dtype='float32'),
                 control_flow=DESCENT_POLICY)
+
+    def test_pre_scan_hidden_transform_blocks_descent(self):
+        """A hidden state transformed between step entry and the scan
+        (``h *= 0.5`` before the loop) puts part of the per-step transition
+        outside the scan body; descending anyway would fold a silently
+        wrong trace (review finding: chunked gradients off by O(1) vs
+        BPTT). Descent must skip loudly and the pre-descent hard error
+        must fire."""
+        from braintrace._compiler.graph import compile_etrace_graph
+
+        class Net(brainstate.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.w = brainstate.ParamState(jnp.ones((4, 4)) * 0.1)
+                self.h = brainstate.HiddenState(jnp.zeros((1, 4)))
+
+            def update(self, x):
+                x_row = x.reshape(1, -1)
+                self.h.value = self.h.value * 0.5
+
+                def substep(_):
+                    self.h.value = 0.9 * self.h.value + jnp.tanh(
+                        braintrace.matmul(x_row, self.w.value))
+                    return self.h.value
+
+                return brainstate.transform.for_loop(
+                    substep, jnp.arange(40))[-1]
+
+        net = Net()
+        brainstate.nn.init_all_states(net, batch_size=1)
+        with pytest.warns(UserWarning, match='transformed value'):
+            with pytest.raises(NotImplementedError, match='within a scan'):
+                compile_etrace_graph(
+                    net, jnp.ones((4,), dtype='float32'),
+                    control_flow=DESCENT_POLICY)
+
+    def test_plain_op_weight_in_body_warns_and_excludes(self):
+        """A weight consumed by a descended scan only through plain (non-
+        ETP) ops is excluded from online learning — the primitive-based
+        selection principle — but the exclusion must be loud, because
+        pre-descent this scan was a hard error."""
+        from braintrace._compiler.graph import compile_etrace_graph
+        from braintrace._compiler.diagnostics import DiagnosticKind
+
+        class Net(brainstate.nn.Module):
+            def __init__(self):
+                super().__init__()
+                self.w = brainstate.ParamState(jnp.ones((4, 4)) * 0.1)
+                self.h = brainstate.HiddenState(jnp.zeros((1, 4)))
+
+            def update(self, x):
+                x_row = x.reshape(1, -1)
+
+                def substep(_):
+                    # plain matmul: deliberately NOT an ETP primitive
+                    self.h.value = 0.9 * self.h.value + jnp.tanh(
+                        x_row @ self.w.value)
+                    return self.h.value
+
+                return brainstate.transform.for_loop(
+                    substep, jnp.arange(40))[-1]
+
+        net = Net()
+        brainstate.nn.init_all_states(net, batch_size=1)
+        with pytest.warns(UserWarning, match='no ETP relation'):
+            graph = compile_etrace_graph(
+                net, jnp.ones((4,), dtype='float32'),
+                control_flow=DESCENT_POLICY)
+        assert any(d.kind is DiagnosticKind.SCAN_DESCENT_NO_RELATIONS
+                   for d in graph.diagnostics)
+        assert len(graph.hidden_param_op_relations) == 0
+        assert sum(1 for g in graph.hidden_groups
+                   if g.descent is not None) == 1

--- a/changelog.md
+++ b/changelog.md
@@ -5,6 +5,60 @@
 
 ### Highlights
 
+#### New: structured scan descent — long ETP scans compile and learn online (Phase 4)
+
+- **A third compile path for ETP-relevant `scan`s above the unroll limit.**
+  Previously an ETP-relevant `lax.scan`/`for_loop` whose static length
+  exceeded `ControlFlowPolicy.scan_unroll_limit` was a dead end
+  (`NotImplementedError`). Under the new default
+  `ControlFlowPolicy(scan_descent='auto')`, the compiler *descends* such a
+  scan: relations and hidden groups are discovered inside the scan body
+  with the same flat finders, the equation is rewritten to emit stacked
+  per-substep values as extra ys (leading substep axis `L`), and the graph
+  executor computes stacked per-substep Jacobians by vmapping over that
+  axis — the compiled program stays a single scan equation, so compile size
+  is independent of the loop length (an `L=100` inner loop compiles in
+  under 60 equations). A `SCAN_DESCENT_APPLIED` INFO diagnostic records
+  each descent; blocked scans get `SCAN_DESCENT_SKIPPED`. Set
+  `ControlFlowPolicy(scan_descent='off')` to restore the pre-Phase-4 error.
+- **Param-dim algorithms fold the eligibility trace over the substep
+  axis.** `D_RTRL` (the `ParamDimVjpAlgorithm` family) applies its trace
+  update per substep with an inner `jax.lax.scan`
+  (`eps <- D_tau * eps + x_tau (x) df_tau`), declaring
+  `_supports_scan_descent = True`. The fold is values-only and
+  stop-gradient'd — never differentiated, so no checkpointing is needed.
+  The learning signal stays one-per-outer-step (`(*varshape, num_state)`;
+  the SNN learning-signal axis contract is unchanged). The io-dim family
+  (`pp_prop` / `ES_D_RTRL`) and other algorithms without the flag reject
+  descended graphs with an actionable `NotImplementedError` at
+  `compile_graph`.
+- **Exactness contract (pinned by oracle tests).** For diagonal-recurrence
+  bodies (elementwise hidden-to-hidden substep path — the SNN class),
+  descended D-RTRL is exact: whole-sequence, chunked (3-step and 1-step
+  chunks, where the gradient depends on the folded trace at every chunk
+  boundary), and one-step single-step gradients all match BPTT / the
+  unrolled twin element-wise, including a two-hidden-state
+  (`num_state == 2`) group through the fold. For bodies that mix the hidden
+  state through an ETP matmul, whole-sequence multi-step gradients remain
+  BPTT-exact; chunked gradients approximate cross-substep credit (the same
+  approximation class as the unroll path — documented divergence).
+- **Algorithm-level `control_flow` kwarg.** `D_RTRL`, `pp_prop`
+  (`IODimVjpAlgorithm`), `OTPE`, and `OTTT` now accept
+  `control_flow=ControlFlowPolicy(...)` and thread it through their graph
+  executors into compilation.
+- **v1 restrictions** (each blocks descent for that scan, with a
+  diagnostic): reverse scans, nested control flow inside the body,
+  trainable weights scanned over as xs, and an *outer* ETP relation
+  targeting a hidden state carried by a descended scan (raises with
+  restructuring guidance). `jit` bodies nested inside control-flow
+  equations are now inlined during extraction so descent sees a flat body.
+- **Single-step readout limitation.** The per-step hidden perturbation is
+  added to a descended scan's *carry* outvar; a loss that reads the hidden
+  state through the scan's stacked ys (e.g. `for_loop(...)[-1]`) bypasses
+  it, dropping the same-step learning signal (pinned by test; parallels
+  the Phase 3 while-hidden limitation). Read the state after the loop
+  (`self.h.value`) instead — multi-step VJP is unaffected either way.
+
 #### New: `while`-loop policy — weight-free opaque-forward support (Phase 3)
 
 - **Weight-free `lax.while_loop`s that read/update hidden state now


### PR DESCRIPTION
## Summary

Adds a third compile path for ETP-relevant inner scans whose static length exceeds `ControlFlowPolicy.scan_unroll_limit`: **structured scan descent**. Instead of unrolling (Phase 2) or dead-ending in `NotImplementedError`, the scan body is analyzed in place with the same hidden-group / relation finders that run on the flat jaxpr, and the scan equation is rewritten to emit every value those analyses need as extra stacked ys (leading substep axis `L`). Compile size stays independent of scan length — an L=100 SNN loop compiles in under 60 equations.

## How it works

- **Compile side** (`scan_descent.py` + pipeline integration): `apply_scan_descent` walks top-level scans, checks v1 descendability restrictions, runs the unmodified finders on the body with body-scoped maps, rewrites the eqn via `add_scan_ys`, and re-scopes discovered groups to the outer carry vars. Descended equations are exempted (by eqn identity) from the generic unsupported-control-flow checks and from the flat walkers; perturbation, seam checks, and learning signals face outward through the scan's carry vars and are untouched.
- **Runtime side** (executor + `ParamDimVjpAlgorithm`): the executor emits vmapped per-substep `x`/`df`/diagonal-Jacobian stacks; the param-dim trace update folds `eps <- D_tau * eps + x_tau (x) df_tau` over the substep axis with an inner `lax.scan`, seeded from the outer-step trace history. Algorithms declare support via `_supports_scan_descent`; a gate rejects descended graphs (relations *or* groups) for unsupported algorithms with an actionable error.
- **Policy**: `ControlFlowPolicy.scan_descent` defaults to `'auto'`; `'off'` restores the old behavior. Over-limit unroll skips downgrade to INFO under `'auto'` since descent handles them.

## Correctness

Pinned by `braintrace/_algorithm/tests/scan_descent_support_test.py` against BPTT and unrolled twins:

- Diagonal (SNN-class) bodies: **exact** whole-sequence, chunked, and single-step gradients; descended trace equals the elementwise sum of the unrolled twin's per-substep traces (1e-6).
- Recurrent-mixing bodies: whole-sequence exact.
- Two-state hidden groups (`num_state=2`) exercised.
- v1 restrictions enforced loudly: pre-scan hidden transforms skip descent (falling back to the old error), outer ETP relations injecting into a descended group raise, weights with no ETP relation in the body warn (`SCAN_DESCENT_NO_RELATIONS`) as deliberately excluded, io-dim algorithms remain gated.
- Known v1 limitation (documented + pinned): single-step VJP requires reading the hidden state via the carry (`self.h.value` after the loop), not the stacked ys (`for_loop(...)[-1]`), for same-step credit.

## Review

Whole-branch review by an independent agent found 1 Critical (unvalidated carry-init producing silently wrong chunked gradients for pre-scan hidden transforms), 2 Important, 4 Minor — all fixed in the final commit and re-verified by the reviewer ("ready to merge").

## Test plan

- Full suite: **2103 passed, 3 skipped** (`JAX_PLATFORMS=cpu python -m pytest braintrace`)
- New: `scan_descent_test.py` (unit + pipeline), `scan_descent_support_test.py` (numeric correctness vs BPTT/unroll oracles), canonicalize diagnostics pins, oracle helpers (`chunked_online_param_gradients`, SNN scan model specs).