### PR TITLE
Chunk-factorized multi-step trace update for D_RTRL (2.4-4.5x faster multi-step windows)

### DIFF
--- a/braintrace/_algorithm/param_dim_vjp.py
+++ b/braintrace/_algorithm/param_dim_vjp.py
@@ -780,6 +780,23 @@ class ParamDimVjpAlgorithm(ETraceVjpAlgorithm):
         - ``"multi-step"``: the VJP is computed at multiple time steps, i.e.,
           :math:`\partial L^t/\partial h^{t-k}`, where :math:`k` is determined by
           the data input.
+    chunked_trace : bool, optional
+        When ``True`` (default) and the input spans multiple time steps, the
+        eligibility-trace roll over the window is computed in closed form —
+        suffix products of the hidden-to-hidden Jacobians plus a single
+        time-contracting einsum — instead of a per-step scan. Mathematically
+        identical to the per-step roll (up to floating-point reassociation),
+        but converts the dominant per-step elementwise passes over the
+        parameter-sized trace into matmul-class kernels (~an order of
+        magnitude faster on long windows). Relations without a chunk kernel
+        (conv / sparse / LoRA / grouped), descended-scan relations, and
+        relations with an active ``weight_fn`` / ``bias_fn`` transform fall
+        back to the per-step scan automatically. Single-step input is
+        unaffected. Note: chunking stacks the per-step Jacobians
+        (``O(T · B · (I + H))`` memory for a window of length ``T``) instead
+        of fusing the roll into the forward scan; for very long windows either
+        feed the sequence in smaller windows (the trace carries across calls)
+        or set ``chunked_trace=False``.
     control_flow : ControlFlowPolicy, optional
         Policy governing control-flow canonicalization (cond if-conversion,
         scan unrolling, structured scan descent, ...) during graph

--- a/braintrace/_algorithm/param_dim_vjp.py
+++ b/braintrace/_algorithm/param_dim_vjp.py
@@ -37,7 +37,7 @@ from braintrace._op._registries import (
     get_instant_drtrl_rule,
     get_solve_drtrl_rule,
 )
-from braintrace._misc import etrace_df_key, etrace_x_key
+from braintrace._misc import etrace_df_key, etrace_x_key, suffix_products
 from braintrace._typing import (
     PyTree,
     WeightID,
@@ -429,6 +429,106 @@ def _apply_relation_step(
     return new_etrace_bwg
 
 
+def _chunk_supported(relation: HiddenParamOpRelation, fast_solve: bool) -> bool:
+    """Whether *relation* can take the chunk-factorized multi-step update.
+
+    Requires a flat (non-descended) relation whose primitive has a registered
+    chunk kernel with an applicable fast path, and no dedicated
+    ``instant_drtrl`` / ``solve_drtrl`` rule (trace structure == parameter
+    structure). Everything else falls back to the per-step scan.
+    """
+    if relation.control_flow_context is not None:
+        return False
+    if not fast_solve:
+        return False
+    if get_instant_drtrl_rule(relation.primitive) is not None:
+        return False
+    if get_solve_drtrl_rule(relation.primitive) is not None:
+        return False
+    fp = get_fast_path_rules(relation.primitive)
+    return (
+        fp is not None
+        and fp.chunk is not None
+        and fp.applicable(relation.eqn_params)
+    )
+
+
+def _update_param_dim_etrace_chunked(
+    hist_etrace_vals: Dict[ETraceWG_Key, PyTree],
+    stacked_jacobians: Tuple[
+        Dict[ETraceX_Key, jax.Array],   # stacked weight x, leading axis T
+        Dict[ETraceDF_Key, jax.Array],  # stacked weight df, leading axis T
+        Sequence[jax.Array],            # stacked hidden-group Jacobians
+    ],
+    hidden_param_op_relations: Any,
+    weight_path_to_vals: Dict[Path, PyTree],
+    fast_solve: bool = True,
+    trace_dtype: Optional[DTypeLike] = None,
+) -> Dict[ETraceWG_Key, PyTree]:
+    """Chunk-factorized multi-step trace update.
+
+    Rolls the eligibility trace over a whole multi-step window in closed form
+    (see ``FastPathRules.chunk`` and :func:`braintrace._misc.suffix_products`)
+    for chunk-eligible relations, and falls back to the historical per-step
+    ``jax.lax.scan`` (:func:`_update_param_dim_etrace_scan_fn`) for the rest —
+    including descended-scan relations. Equal to the per-step roll up to
+    floating-point reassociation.
+    """
+    xs_seq, dfs_seq, diags_seq = stacked_jacobians
+    chunkable = [r for r in hidden_param_op_relations
+                 if _chunk_supported(r, fast_solve)]
+    legacy = [r for r in hidden_param_op_relations
+              if not _chunk_supported(r, fast_solve)]
+
+    new_etrace_bwg: Dict[ETraceWG_Key, PyTree] = dict(hist_etrace_vals)
+
+    # suffix products are per hidden group; share them across relations
+    p_cache: Dict[int, Tuple[jax.Array, jax.Array]] = {}
+    relation: HiddenParamOpRelation
+    for relation in chunkable:
+        fp = get_fast_path_rules(relation.primitive)
+        assert fp is not None and fp.chunk is not None  # _chunk_supported
+        x_seq = (
+            None if relation.x_var is None
+            else _cast_to_dtype(xs_seq[etrace_x_key(relation.x_var)], trace_dtype)
+        )
+        group: HiddenGroup
+        for group in relation.hidden_groups:
+            gi = group.index
+            if gi not in p_cache:
+                p_seq, m_full = suffix_products(diags_seq[gi], group.num_state)
+                p_cache[gi] = (
+                    _cast_to_dtype(p_seq, trace_dtype),
+                    _cast_to_dtype(m_full, trace_dtype),
+                )
+            p_seq, m_full = p_cache[gi]
+            df_seq = _cast_to_dtype(
+                dfs_seq[etrace_df_key(relation.y_var, gi)], trace_dtype
+            )
+            w_key = (id(relation.y_var), gi)
+            new_etrace_bwg[w_key] = fp.chunk(
+                x_seq, df_seq, p_seq, m_full,
+                hist_etrace_vals[w_key], group.num_state,
+            )
+
+    if legacy:
+        scan_fn = partial(
+            _update_param_dim_etrace_scan_fn,
+            weight_path_to_vals=weight_path_to_vals,
+            hidden_param_op_relations=legacy,
+            fast_solve=fast_solve,
+            trace_dtype=trace_dtype,
+        )
+        legacy_keys = {
+            (id(r.y_var), g.index) for r in legacy for g in r.hidden_groups
+        }
+        sub_hist = {k: hist_etrace_vals[k] for k in legacy_keys}
+        sub_new = jax.lax.scan(scan_fn, sub_hist, stacked_jacobians)[0]
+        new_etrace_bwg.update(sub_new)
+
+    return new_etrace_bwg
+
+
 def _solve_param_dim_weight_gradients(
     hist_etrace_data: Dict[ETraceWG_Key, PyTree],  # the history etrace data
     dG_weights: Dict[Path, dG_Weight],  # weight gradients
@@ -794,6 +894,7 @@ class ParamDimVjpAlgorithm(ETraceVjpAlgorithm):
         vjp_method: str = 'single-step',
         fast_solve: bool = True,
         trace_dtype: Optional[DTypeLike] = None,
+        chunked_trace: bool = True,
         control_flow: Optional[ControlFlowPolicy] = None,
     ) -> None:
         super().__init__(model, name=name, vjp_method=vjp_method,
@@ -813,6 +914,12 @@ class ParamDimVjpAlgorithm(ETraceVjpAlgorithm):
         # produces native-precision arrays and a mismatched scan-carry dtype
         # would raise at trace time.
         self.trace_dtype = trace_dtype
+        # ``chunked_trace=True`` computes the multi-step trace roll in closed
+        # form (chunk factorization) instead of a per-step scan. Identical to
+        # the per-step roll up to floating-point reassociation; relations
+        # without a chunk kernel fall back automatically. Single-step input is
+        # unaffected.
+        self.chunked_trace = chunked_trace
 
     def init_etrace_state(self, *args: Any, **kwargs: Any) -> None:
         """Initialize the eligibility trace states of the etrace algorithm.
@@ -934,13 +1041,13 @@ class ParamDimVjpAlgorithm(ETraceVjpAlgorithm):
         for x, val in etrace_vals.items():
             self.etrace_bwg[x].value = val
 
-    def _make_etrace_stepper(self, weight_vals: Dict[Path, PyTree]) -> Callable:
-        """Build the per-step D-RTRL eligibility-trace stepper.
+    def _make_scan_fn(self, weight_vals: Dict[Path, PyTree]) -> Callable:
+        """Build the per-step D-RTRL eligibility-trace stepper (scan body).
 
-        Returns the ``partial`` of :func:`_update_param_dim_etrace_scan_fn` that
-        serves as the body of the trace scan. Exposing it lets the graph executor
-        fuse the roll into its over-time scan for multi-step input (see the
-        base-class :meth:`_make_etrace_stepper`).
+        Returns the ``partial`` of :func:`_update_param_dim_etrace_scan_fn`
+        used both as the fused in-scan stepper (see
+        :meth:`_make_etrace_stepper`) and as the body of
+        :meth:`_update_etrace_data`'s own trace scan.
         """
         return partial(
             _update_param_dim_etrace_scan_fn,
@@ -949,6 +1056,20 @@ class ParamDimVjpAlgorithm(ETraceVjpAlgorithm):
             fast_solve=self.fast_solve,
             trace_dtype=self.trace_dtype,
         )
+
+    def _make_etrace_stepper(self, weight_vals: Dict[Path, PyTree]) -> Optional[Callable]:
+        """Per-step stepper for in-scan fusion, or ``None`` under chunking.
+
+        When ``chunked_trace`` is disabled, returns the per-step scan body so
+        the graph executor fuses the roll into its over-time scan (see the
+        base-class :meth:`_make_etrace_stepper`). When ``chunked_trace`` is
+        enabled, returns ``None`` so the executor stacks the per-step
+        Jacobians, which :meth:`_update_etrace_data` then consumes in closed
+        form (:func:`_update_param_dim_etrace_chunked`).
+        """
+        if self.chunked_trace:
+            return None
+        return self._make_scan_fn(weight_vals)
 
     def _update_etrace_data(
         self,
@@ -988,27 +1109,33 @@ class ParamDimVjpAlgorithm(ETraceVjpAlgorithm):
                 same structure as hist_etrace_vals but containing new values for the current timestep.
         """
 
-        scan_fn = self._make_etrace_stepper(weight_vals)
+        jacobians = (
+            hid2weight_jac_single_or_multi_times[0],
+            hid2weight_jac_single_or_multi_times[1],
+            hid2hid_jac_single_or_multi_times,
+        )
 
         if input_is_multi_step:
-            new_etrace = jax.lax.scan(
-                scan_fn,
-                hist_etrace_vals,
-                (
-                    hid2weight_jac_single_or_multi_times[0],
-                    hid2weight_jac_single_or_multi_times[1],
-                    hid2hid_jac_single_or_multi_times,
+            if self.chunked_trace:
+                new_etrace = _update_param_dim_etrace_chunked(
+                    hist_etrace_vals,
+                    jacobians,
+                    self.graph.hidden_param_op_relations,
+                    weight_vals,
+                    fast_solve=self.fast_solve,
+                    trace_dtype=self.trace_dtype,
                 )
-            )[0]
+            else:
+                new_etrace = jax.lax.scan(
+                    self._make_scan_fn(weight_vals),
+                    hist_etrace_vals,
+                    jacobians,
+                )[0]
 
         else:
-            new_etrace = scan_fn(
+            new_etrace = self._make_scan_fn(weight_vals)(
                 hist_etrace_vals,
-                (
-                    hid2weight_jac_single_or_multi_times[0],
-                    hid2weight_jac_single_or_multi_times[1],
-                    hid2hid_jac_single_or_multi_times,
-                )
+                jacobians,
             )[0]
 
         return new_etrace

--- a/braintrace/_algorithm/param_dim_vjp_test.py
+++ b/braintrace/_algorithm/param_dim_vjp_test.py
@@ -719,3 +719,149 @@ class TestInstantSolveDrtrlDispatch:
             ETP_RULES_SOLVE_DRTRL.pop(etp_mm_p, None)
 
         oracle.assert_param_gradients_close(routed, baseline, atol=0.0, rtol=0.0)
+
+
+class _ChunkRNNNet(brainstate.nn.Module):
+    def __init__(self, n_in=3, n_rec=8, n_out=2, w_mask=None):
+        super().__init__()
+        self.cell = braintrace.nn.ValinaRNNCell(n_in, n_rec, activation='tanh')
+        if w_mask is not None:
+            self.readout = braintrace.nn.Linear(n_rec, n_out, w_mask=w_mask)
+        else:
+            self.readout = braintrace.nn.Linear(n_rec, n_out)
+
+    def update(self, x):
+        return self.readout(self.cell(x))
+
+
+class _ChunkGRUNet(brainstate.nn.Module):
+    def __init__(self, n_in=3, n_rec=8, n_out=2):
+        super().__init__()
+        self.cell = braintrace.nn.GRUCell(n_in, n_rec)
+        self.readout = braintrace.nn.Linear(n_rec, n_out)
+
+    def update(self, x):
+        return self.readout(self.cell(x))
+
+
+_CK_B, _CK_T, _CK_NIN, _CK_NOUT = 4, 6, 3, 2
+
+
+def _chunk_make_learner(model_cls, seed=0, **options):
+    brainstate.random.seed(seed)
+    model = model_cls()
+    learner = braintrace.compile(
+        model, 'D_RTRL', jnp.zeros((_CK_B, _CK_NIN)), batch_size=_CK_B,
+        vjp_method='multi-step', **options,
+    )
+    return model, learner
+
+
+def _chunk_make_masked_learner(mask, chunked, seed=0):
+    brainstate.random.seed(seed)
+    model = _ChunkRNNNet(w_mask=mask)
+    learner = braintrace.compile(
+        model, 'D_RTRL', jnp.zeros((_CK_B, _CK_NIN)), batch_size=_CK_B,
+        vjp_method='multi-step', chunked_trace=chunked,
+    )
+    return model, learner
+
+
+def _chunk_trace_leaves_sorted(learner):
+    leaves = []
+    for st in learner.etrace_bwg.values():
+        leaves += jax.tree.leaves(st.value)
+    return sorted(leaves, key=lambda a: str(a.shape))
+
+
+def _chunk_two_window_grads(model, learner, xs1, xs2, ys):
+    weights = model.states(brainstate.ParamState)
+
+    def loss(inp):
+        out = learner(braintrace.MultiStepData(inp))
+        return ((out - ys) ** 2).mean()
+
+    g1 = brainstate.transform.grad(loss, weights)(xs1)
+    g2 = brainstate.transform.grad(loss, weights)(xs2)
+    return g1, g2
+
+
+def _chunk_assert_grads_close(ga, gb, rtol=1e-4, atol=1e-6):
+    la, ta = jax.tree.flatten(ga)
+    lb, tb = jax.tree.flatten(gb)
+    assert ta == tb
+    for a, b in zip(la, lb):
+        assert jnp.allclose(a, b, rtol=rtol, atol=atol), (
+            f'max abs diff {jnp.max(jnp.abs(a - b))}')
+
+
+class TestChunkedTraceEquivalence:
+    def test_trace_values_match_legacy_after_multistep_call(self):
+        brainstate.random.seed(42)
+        xs = brainstate.random.normal(size=(_CK_T, _CK_B, _CK_NIN))
+        _, lc = _chunk_make_learner(_ChunkRNNNet, chunked_trace=True)
+        _, ll = _chunk_make_learner(_ChunkRNNNet, chunked_trace=False)
+        lc(braintrace.MultiStepData(xs))
+        ll(braintrace.MultiStepData(xs))
+        for a, b in zip(_chunk_trace_leaves_sorted(lc), _chunk_trace_leaves_sorted(ll)):
+            assert a.shape == b.shape
+            assert jnp.allclose(a, b, rtol=1e-4, atol=1e-6), (
+                f'max abs diff {jnp.max(jnp.abs(a - b))}')
+
+    def test_gru_two_window_gradients_match_legacy(self):
+        brainstate.random.seed(43)
+        xs1 = brainstate.random.normal(size=(_CK_T, _CK_B, _CK_NIN))
+        xs2 = brainstate.random.normal(size=(_CK_T, _CK_B, _CK_NIN))
+        ys = brainstate.random.normal(size=(_CK_T, _CK_B, _CK_NOUT))
+        mc, lc = _chunk_make_learner(_ChunkGRUNet, chunked_trace=True)
+        ml, ll = _chunk_make_learner(_ChunkGRUNet, chunked_trace=False)
+        gc1, gc2 = _chunk_two_window_grads(mc, lc, xs1, xs2, ys)
+        gl1, gl2 = _chunk_two_window_grads(ml, ll, xs1, xs2, ys)
+        _chunk_assert_grads_close(gc1, gl1)
+        # window 2 exposes trace-roll differences (window-1 trace feeds it)
+        _chunk_assert_grads_close(gc2, gl2)
+
+    def test_mixed_partition_masked_readout_matches_legacy(self):
+        # w_mask installs a weight_fn -> fast path not applicable ->
+        # readout relation falls back to the per-step scan while the
+        # cell relations chunk.
+        brainstate.random.seed(44)
+        mask = (brainstate.random.rand(8, _CK_NOUT) > 0.5).astype(jnp.float32)
+        xs1 = brainstate.random.normal(size=(_CK_T, _CK_B, _CK_NIN))
+        xs2 = brainstate.random.normal(size=(_CK_T, _CK_B, _CK_NIN))
+        ys = brainstate.random.normal(size=(_CK_T, _CK_B, _CK_NOUT))
+        mc, lc = _chunk_make_masked_learner(mask, chunked=True)
+        ml, ll = _chunk_make_masked_learner(mask, chunked=False)
+        gc1, gc2 = _chunk_two_window_grads(mc, lc, xs1, xs2, ys)
+        gl1, gl2 = _chunk_two_window_grads(ml, ll, xs1, xs2, ys)
+        _chunk_assert_grads_close(gc1, gl1)
+        _chunk_assert_grads_close(gc2, gl2)
+
+    def test_full_fallback_fast_solve_false_matches_legacy(self):
+        brainstate.random.seed(45)
+        xs = brainstate.random.normal(size=(_CK_T, _CK_B, _CK_NIN))
+        _, la = _chunk_make_learner(
+            _ChunkRNNNet, chunked_trace=True, fast_solve=False)
+        _, lb = _chunk_make_learner(
+            _ChunkRNNNet, chunked_trace=False, fast_solve=False)
+        la(braintrace.MultiStepData(xs))
+        lb(braintrace.MultiStepData(xs))
+        for a, b in zip(_chunk_trace_leaves_sorted(la), _chunk_trace_leaves_sorted(lb)):
+            assert jnp.allclose(a, b, rtol=1e-5, atol=1e-7)
+
+    def test_knob_default_and_threading(self):
+        _, l_default = _chunk_make_learner(_ChunkRNNNet)
+        assert l_default.chunked_trace is True
+        _, l_off = _chunk_make_learner(_ChunkRNNNet, chunked_trace=False)
+        assert l_off.chunked_trace is False
+
+    def test_single_step_input_unaffected(self):
+        brainstate.random.seed(46)
+        x = brainstate.random.normal(size=(_CK_B, _CK_NIN))
+        _, lc = _chunk_make_learner(_ChunkRNNNet, chunked_trace=True)
+        _, ll = _chunk_make_learner(_ChunkRNNNet, chunked_trace=False)
+        oc = lc(x)
+        ol = ll(x)
+        assert jnp.allclose(oc, ol, rtol=1e-6, atol=1e-8)
+        for a, b in zip(_chunk_trace_leaves_sorted(lc), _chunk_trace_leaves_sorted(ll)):
+            assert jnp.allclose(a, b, rtol=1e-6, atol=1e-8)

--- a/braintrace/_compile.py
+++ b/braintrace/_compile.py
@@ -195,7 +195,10 @@ def compile(
 
     *Per algorithm:*
 
-    - ``'D_RTRL'`` — ``vjp_method``, ``fast_solve``, ``trace_dtype``, ``name``.
+    - ``'D_RTRL'`` — ``vjp_method``, ``fast_solve``, ``trace_dtype``,
+      ``chunked_trace`` (bool, default ``True``: closed-form multi-step trace
+      roll via chunk factorization; see :class:`ParamDimVjpAlgorithm`),
+      ``name``.
     - ``'es_d_rtrl'`` / ``'pp_prop'`` — ``decay_or_rank`` (**required**: float in
       (0, 1) ⇒ decay, or int ≥ 1 ⇒ rank), ``vjp_method``, ``fast_solve``,
       ``name``.

--- a/braintrace/_misc.py
+++ b/braintrace/_misc.py
@@ -21,6 +21,8 @@ from enum import Enum
 from typing import Sequence, Callable, Any
 
 import brainstate
+import jax
+import jax.numpy as jnp
 import jax.tree
 import brainunit as u
 
@@ -372,3 +374,50 @@ class BaseEnum(Enum):
             return cls.get_by_name(item)
         else:
             raise ValueError(f'Cannot find the {cls.__name__} type {item}.')
+
+
+def suffix_products(diag_seq: jax.Array, num_state: int) -> tuple[jax.Array, jax.Array]:
+    r"""Suffix products of a stacked hidden-to-hidden Jacobian sequence.
+
+    For the linear trace recurrence
+    :math:`\boldsymbol{\epsilon}_t = \mathbf{M}_t \boldsymbol{\epsilon}_{t-1} + \mathbf{u}_t`,
+    the chunk-factorized update needs the suffix products
+    :math:`\mathbf{P}_s = \mathbf{M}_{T-1} \cdots \mathbf{M}_{s+1}` (with
+    :math:`\mathbf{P}_{T-1} = \mathbf{I}`) and the full-window product
+    :math:`\mathbf{M}_{T-1} \cdots \mathbf{M}_0`.
+
+    Parameters
+    ----------
+    diag_seq : jax.Array
+        Stacked per-step Jacobians, shape ``(T, ..., S, S)`` with
+        ``S == num_state``. The matrix product acts on the trailing two axes;
+        matrices need not commute — the temporal order is preserved.
+    num_state : int
+        Number of hidden states per group (``S``). ``1`` uses an elementwise
+        ``cumprod`` shortcut; ``> 1`` uses an associative matmul scan.
+
+    Returns
+    -------
+    tuple of jax.Array
+        ``(p_seq, m_full)`` with shapes ``(T, ..., S, S)`` and ``(..., S, S)``.
+
+    Notes
+    -----
+    No division is used, so exact-zero decays (e.g. spiking hard resets) are
+    handled exactly. Computed via :func:`jax.lax.associative_scan` over the
+    reversed stack with the operator ``a @ b``, which yields the inclusive
+    left-fold prefixes of the reversed sequence — i.e. the suffix products of
+    the original order.
+    """
+    rev = diag_seq[::-1]
+    if num_state == 1:
+        cum = jnp.cumprod(rev, axis=0)
+        ident = jnp.ones_like(diag_seq[:1])
+    else:
+        cum = jax.lax.associative_scan(
+            lambda a, b: jnp.einsum('...ab,...bc->...ac', a, b), rev, axis=0
+        )
+        eye = jnp.eye(num_state, dtype=diag_seq.dtype)
+        ident = jnp.broadcast_to(eye, diag_seq[:1].shape)
+    p_seq = jnp.concatenate([ident, cum[:-1]], axis=0)[::-1]
+    return p_seq, cum[-1]

--- a/braintrace/_misc_test.py
+++ b/braintrace/_misc_test.py
@@ -161,3 +161,56 @@ class TestBaseEnum:
     def test_get_rejects_other_types(self):
         with pytest.raises(ValueError):
             _Color.get(123)
+
+
+from braintrace._misc import suffix_products
+
+
+def _naive_suffix(diag_seq):
+    T = diag_seq.shape[0]
+    S = diag_seq.shape[-1]
+    eye = jnp.broadcast_to(jnp.eye(S, dtype=diag_seq.dtype), diag_seq.shape[1:])
+    ps = []
+    for s in range(T):
+        acc = eye
+        for r in range(T - 1, s, -1):
+            acc = jnp.einsum('...ab,...bc->...ac', acc, diag_seq[r])
+        ps.append(acc)
+    full = jnp.einsum('...ab,...bc->...ac', ps[0], diag_seq[0])
+    return jnp.stack(ps), full
+
+
+class TestSuffixProducts:
+    def test_s1_matches_naive(self):
+        brainstate.random.seed(0)
+        d = brainstate.random.uniform(0.3, 1.0, (5, 2, 3, 1, 1))
+        p, full = suffix_products(d, num_state=1)
+        p_ref, full_ref = _naive_suffix(d)
+        assert p.shape == d.shape
+        assert jnp.allclose(p, p_ref, rtol=1e-5, atol=1e-7)
+        assert jnp.allclose(full, full_ref, rtol=1e-5, atol=1e-7)
+
+    def test_s3_noncommuting_matches_naive(self):
+        brainstate.random.seed(1)
+        d = brainstate.random.normal(size=(7, 2, 4, 3, 3)) * 0.5
+        p, full = suffix_products(d, num_state=3)
+        p_ref, full_ref = _naive_suffix(d)
+        assert jnp.allclose(p, p_ref, rtol=1e-4, atol=1e-6)
+        assert jnp.allclose(full, full_ref, rtol=1e-4, atol=1e-6)
+
+    def test_zero_decay_step(self):
+        brainstate.random.seed(2)
+        d = brainstate.random.uniform(0.3, 1.0, (6, 2, 1, 1))
+        d = d.at[3].set(0.0)  # hard reset mid-window
+        p, full = suffix_products(d, num_state=1)
+        p_ref, full_ref = _naive_suffix(d)
+        assert jnp.allclose(p, p_ref, rtol=1e-5, atol=1e-7)
+        assert jnp.allclose(full, full_ref, rtol=1e-5, atol=1e-7)
+
+    def test_t1_gives_identity_suffix(self):
+        brainstate.random.seed(3)
+        d = brainstate.random.normal(size=(1, 4, 2, 2))
+        p, full = suffix_products(d, num_state=2)
+        eye = jnp.broadcast_to(jnp.eye(2), d[0].shape)
+        assert jnp.allclose(p[0], eye)
+        assert jnp.allclose(full, d[0])

--- a/braintrace/_op/_registries.py
+++ b/braintrace/_op/_registries.py
@@ -253,12 +253,24 @@ class FastPathRules(NamedTuple):
         transform factor, so a primitive carrying an active transform hook
         (``weight_fn`` / ``bias_fn``) must report ``False`` and fall back to
         the rule path.
+    chunk : Callable, optional
+        Chunk-factorized multi-step trace update (closed form over a window).
+        Signature ``(x_seq, df_seq, p_seq, m_full, old_bwg, num_state) -> dict``
+        where ``x_seq`` is the stacked input ``(T, ..., in)`` (``None`` for
+        primitives without an ``x`` carrier), ``df_seq`` the stacked
+        state-to-output Jacobian ``(T, ..., out, S)``, ``p_seq`` the suffix
+        products of the hidden-to-hidden Jacobians ``(T, ..., S, S)``
+        (``p_seq[T-1]`` is the identity), ``m_full`` the full-window product
+        ``(..., S, S)``, and ``old_bwg`` the window-entry trace dict. ``None``
+        (default) means the primitive has no chunk kernel and multi-step
+        chunking falls back to the per-step scan for its relations.
     """
 
     instant: Callable
     recurrent: Callable
     solve: Callable
     applicable: Callable
+    chunk: Optional[Callable] = None
 
 
 ETP_FAST_PATH_RULES: Dict[Primitive, FastPathRules] = {}

--- a/braintrace/_op/_registries_test.py
+++ b/braintrace/_op/_registries_test.py
@@ -183,6 +183,42 @@ def test_get_fast_path_rules_none_for_sparse_conv_lora():
         assert get_fast_path_rules(prim) is None, prim.name
 
 
+class TestFastPathRulesChunkField:
+    def test_chunk_defaults_none_with_positional_construction(self):
+        from braintrace._op._registries import FastPathRules
+
+        fp = FastPathRules(
+            lambda x, df, has_bias: {},
+            lambda diag, old, n: {},
+            lambda dl, tr, *, fold_batch=False: {},
+            lambda params: True,
+        )
+        assert fp.chunk is None
+
+    def test_chunk_field_settable(self):
+        from braintrace._op._registries import FastPathRules
+
+        marker = object()
+        fp = FastPathRules(
+            lambda x, df, has_bias: {},
+            lambda diag, old, n: {},
+            lambda dl, tr, *, fold_batch=False: {},
+            lambda params: True,
+            marker,
+        )
+        assert fp.chunk is marker
+
+    def test_registered_bundles_expose_chunk(self):
+        # importing the op modules runs primitive registration
+        import braintrace._op.dense  # noqa: F401
+        import braintrace._op.elemwise  # noqa: F401
+        from braintrace._op._registries import ETP_FAST_PATH_RULES
+
+        assert len(ETP_FAST_PATH_RULES) > 0
+        for fp in ETP_FAST_PATH_RULES.values():
+            assert hasattr(fp, 'chunk')
+
+
 class TestBatchedCounterparts:
     def test_lookup_unregistered_returns_none(self):
         p = register_primitive('etp_test_ctr_unreg', lambda x, w: x @ w, batched=False)

--- a/braintrace/_op/dense.py
+++ b/braintrace/_op/dense.py
@@ -422,6 +422,69 @@ def _dense_fast_solve(diag_like: ArrayLike, etrace_data: dict[str, Any], *, fold
     return out
 
 
+def _dense_fast_chunk(
+    x_seq: ArrayLike,
+    df_seq: ArrayLike,
+    p_seq: jax.Array,
+    m_full: jax.Array,
+    old_bwg: dict[str, Any],
+    num_state: int,
+) -> dict[str, Any]:
+    r"""Chunk-factorized multi-step trace update (closed form over a window).
+
+    Parameters
+    ----------
+    x_seq : ArrayLike
+        Stacked presynaptic input, shape ``(T, ..., in)`` (``(T, B, in)`` for
+        mm, ``(T, in)`` for mv).
+    df_seq : ArrayLike
+        Stacked state-to-output Jacobian, shape ``(T, ..., out, num_state)``.
+    p_seq : jax.Array
+        Suffix products of the hidden-to-hidden Jacobians,
+        shape ``(T, ..., out, num_state, num_state)``; ``p_seq[T-1]`` is the
+        identity (see :func:`braintrace._misc.suffix_products`).
+    m_full : jax.Array
+        Full-window Jacobian product, shape ``(..., out, num_state, num_state)``.
+    old_bwg : dict
+        Window-entry trace dict; ``'weight'`` shape ``(..., in, out, num_state)``
+        and optional ``'bias'`` shape ``(..., out, num_state)``.
+    num_state : int
+        Number of hidden states per group.
+
+    Returns
+    -------
+    dict
+        The window-exit trace dict, same structure as ``old_bwg``.
+
+    Notes
+    -----
+    Implements, per hidden unit ``k`` (with :math:`\mathbf{P}_s` the suffix
+    product and :math:`\mathbf{M}` the full-window product):
+
+    .. math::
+
+        \boldsymbol{\epsilon}_{T-1} = \mathbf{M}\,\boldsymbol{\epsilon}_{-1}
+        + \sum_s \mathbf{x}_s \otimes (\mathbf{P}_s \, \mathbf{df}_s)
+
+    Equal to ``T`` applications of ``instant``/``recurrent`` up to
+    floating-point reassociation. The time-contracting einsum uses
+    ``Precision.HIGHEST`` so fp32 results stay at reassociation-level
+    deviation (no TF32).
+    """
+    if num_state == 1:
+        pdf = p_seq[..., 0] * df_seq
+    else:
+        pdf = jnp.einsum('t...ab,t...b->t...a', p_seq, df_seq)
+    out = _dense_fast_recurrent(m_full, old_bwg, num_state)
+    out['weight'] = out['weight'] + jnp.einsum(
+        't...i,t...ka->...ika', x_seq, pdf,
+        precision=jax.lax.Precision.HIGHEST,
+    )
+    if 'bias' in out:
+        out['bias'] = out['bias'] + pdf.sum(axis=0)
+    return out
+
+
 def _dense_fast_applicable(eqn_params: dict[str, Any]) -> bool:
     r"""Gate: is the dense fast path valid for this equation?
 
@@ -451,6 +514,7 @@ _DENSE_FAST_PATH = FastPathRules(
     _dense_fast_recurrent,
     _dense_fast_solve,
     _dense_fast_applicable,
+    _dense_fast_chunk,
 )
 
 

--- a/braintrace/_op/dense_test.py
+++ b/braintrace/_op/dense_test.py
@@ -887,3 +887,70 @@ class TestDtToTFirstPrinciplesFromJacobian:
         out = _mv_dt_to_t(g, {'weight': trace_w, 'bias': trace_b}, has_bias=True)
         np.testing.assert_allclose(out['weight'], ref_w, atol=1e-10)
         np.testing.assert_allclose(out['bias'], ref_b, atol=1e-10)
+
+
+class TestDenseFastChunk:
+    def _imports(self):
+        from braintrace._misc import suffix_products
+        from braintrace._op.dense import (
+            _DENSE_FAST_PATH,
+            _dense_fast_instant,
+            _dense_fast_recurrent,
+        )
+        return suffix_products, _DENSE_FAST_PATH, _dense_fast_instant, _dense_fast_recurrent
+
+    def _roll_reference(self, x_seq, df_seq, diag_seq, init_bwg, num_state, has_bias):
+        _, _, instant, recurrent = self._imports()
+        bwg = init_bwg
+        for t in range(df_seq.shape[0]):
+            inst = instant(x_seq[t], df_seq[t], has_bias)
+            rec = recurrent(diag_seq[t], bwg, num_state)
+            bwg = jax.tree.map(jnp.add, rec, inst)
+        return bwg
+
+    @pytest.mark.parametrize('num_state', [1, 2])
+    def test_mm_matches_per_step_roll(self, num_state):
+        suffix_products, fast_path, _, _ = self._imports()
+        brainstate.random.seed(0)
+        T, B, I, O, S = 13, 4, 5, 6, num_state
+        x = brainstate.random.normal(size=(T, B, I))
+        df = brainstate.random.normal(size=(T, B, O, S))
+        diag = brainstate.random.uniform(0.3, 1.0, (T, B, O, S, S))
+        diag = diag.at[3].set(0.0)  # zero-decay step
+        init = {
+            'weight': brainstate.random.normal(size=(B, I, O, S)),
+            'bias': brainstate.random.normal(size=(B, O, S)),
+        }
+        ref = self._roll_reference(x, df, diag, init, S, has_bias=True)
+        p_seq, m_full = suffix_products(diag, S)
+        got = fast_path.chunk(x, df, p_seq, m_full, init, S)
+        assert set(got) == {'weight', 'bias'}
+        assert jnp.allclose(got['weight'], ref['weight'], rtol=1e-4, atol=1e-6)
+        assert jnp.allclose(got['bias'], ref['bias'], rtol=1e-4, atol=1e-6)
+
+    @pytest.mark.parametrize('num_state', [1, 3])
+    def test_mv_matches_per_step_roll(self, num_state):
+        suffix_products, fast_path, _, _ = self._imports()
+        brainstate.random.seed(1)
+        T, I, O, S = 9, 5, 6, num_state
+        x = brainstate.random.normal(size=(T, I))
+        df = brainstate.random.normal(size=(T, O, S))
+        diag = brainstate.random.uniform(0.3, 1.0, (T, O, S, S))
+        init = {'weight': brainstate.random.normal(size=(I, O, S))}
+        ref = self._roll_reference(x, df, diag, init, S, has_bias=False)
+        p_seq, m_full = suffix_products(diag, S)
+        got = fast_path.chunk(x, df, p_seq, m_full, init, S)
+        assert jnp.allclose(got['weight'], ref['weight'], rtol=1e-4, atol=1e-6)
+
+    def test_t1_equals_single_step(self):
+        suffix_products, fast_path, _, _ = self._imports()
+        brainstate.random.seed(2)
+        T, B, I, O, S = 1, 2, 3, 4, 1
+        x = brainstate.random.normal(size=(T, B, I))
+        df = brainstate.random.normal(size=(T, B, O, S))
+        diag = brainstate.random.uniform(0.3, 1.0, (T, B, O, S, S))
+        init = {'weight': brainstate.random.normal(size=(B, I, O, S))}
+        ref = self._roll_reference(x, df, diag, init, S, has_bias=False)
+        p_seq, m_full = suffix_products(diag, S)
+        got = fast_path.chunk(x, df, p_seq, m_full, init, S)
+        assert jnp.allclose(got['weight'], ref['weight'], rtol=1e-5, atol=1e-7)

--- a/braintrace/_op/elemwise.py
+++ b/braintrace/_op/elemwise.py
@@ -341,6 +341,48 @@ def _elemwise_fast_solve(diag_like: ArrayLike, etrace_data: dict[str, Any], *, f
     return {'weight': jnp.einsum(spec, diag_like, etrace_data['weight'])}
 
 
+def _elemwise_fast_chunk(
+    x_seq: Any,
+    df_seq: ArrayLike,
+    p_seq: jax.Array,
+    m_full: jax.Array,
+    old_bwg: dict[str, Any],
+    num_state: int,
+) -> dict[str, Any]:
+    r"""Chunk-factorized multi-step trace update for the diagonal identity op.
+
+    Parameters
+    ----------
+    x_seq : Any
+        Unused (the elemwise op has no ``x`` input). Accepted for a uniform
+        chunk-kernel signature.
+    df_seq : ArrayLike
+        Stacked state-to-output Jacobian, shape ``(T, ..., num_state)``.
+    p_seq : jax.Array
+        Suffix products of the hidden-to-hidden Jacobians, shape
+        ``(T, ..., num_state, num_state)``; ``p_seq[T-1]`` is the identity.
+    m_full : jax.Array
+        Full-window Jacobian product, shape ``(..., num_state, num_state)``.
+    old_bwg : dict
+        Window-entry trace dict; ``'weight'`` shape ``(..., num_state)``.
+    num_state : int
+        Number of hidden states per group.
+
+    Returns
+    -------
+    dict
+        ``{'weight': M_full · ε_{-1} + Σ_s P_s · df_s}`` — equal to ``T``
+        applications of ``instant``/``recurrent`` up to floating-point
+        reassociation.
+    """
+    if num_state == 1:
+        pdf = p_seq[..., 0] * df_seq
+    else:
+        pdf = jnp.einsum('t...ab,t...b->t...a', p_seq, df_seq)
+    out = _elemwise_fast_recurrent(m_full, old_bwg, num_state)
+    return {'weight': out['weight'] + pdf.sum(axis=0)}
+
+
 def _elemwise_fast_applicable(eqn_params: dict[str, Any]) -> bool:
     r"""Gate: is the elemwise fast path valid for this equation?
 
@@ -382,6 +424,7 @@ etp_elemwise_p.register_etp_rules(
         _elemwise_fast_recurrent,
         _elemwise_fast_solve,
         _elemwise_fast_applicable,
+        _elemwise_fast_chunk,
     ),
 )
 

--- a/braintrace/_op/elemwise_test.py
+++ b/braintrace/_op/elemwise_test.py
@@ -450,3 +450,36 @@ class TestDtToTFirstPrinciplesFromJacobian:
         ref = g * trace
         out = _elemwise_dt_to_t(g, {'weight': trace})
         np.testing.assert_allclose(out['weight'], ref, atol=1e-10)
+
+
+class TestElemwiseFastChunk:
+    @pytest.mark.parametrize('num_state', [1, 2])
+    def test_matches_per_step_roll(self, num_state):
+        import brainstate
+
+        from braintrace._misc import suffix_products
+        from braintrace._op._registries import get_fast_path_rules
+        from braintrace._op.elemwise import (
+            _elemwise_fast_instant,
+            _elemwise_fast_recurrent,
+            etp_elemwise_p,
+        )
+
+        brainstate.random.seed(0)
+        T, S = 11, num_state
+        shape = (4, 5)  # group varshape
+        df = brainstate.random.normal(size=(T, *shape, S))
+        diag = brainstate.random.uniform(0.3, 1.0, (T, *shape, S, S))
+        diag = diag.at[2].set(0.0)  # zero-decay step
+        init = {'weight': brainstate.random.normal(size=(*shape, S))}
+
+        bwg = init
+        for t in range(T):
+            inst = _elemwise_fast_instant(None, df[t], False)
+            rec = _elemwise_fast_recurrent(diag[t], bwg, S)
+            bwg = jax.tree.map(jnp.add, rec, inst)
+
+        p_seq, m_full = suffix_products(diag, S)
+        fp = get_fast_path_rules(etp_elemwise_p)
+        got = fp.chunk(None, df, p_seq, m_full, init, S)
+        assert jnp.allclose(got['weight'], bwg['weight'], rtol=1e-4, atol=1e-6)


### PR DESCRIPTION
## Summary

`D_RTRL` with `vjp_method='multi-step'` previously rolled the eligibility trace with a per-step `lax.scan`: each step launches elementwise passes over every parameter-sized trace `(B, I, O, S)`, so a `T`-step window costs `T` full read-modify-write sweeps of the largest tensors in the algorithm — the dominant share of D-RTRL's slowdown vs BPTT.

The trace recurrence is linear in the trace, so the whole window is now computed in closed form (chunk factorization):

```
ε_{T-1} = M_full · ε_{-1} + Σ_s x_s ⊗ (P_s · df_s),   P_s = M_{T-1} ⋯ M_{s+1}
```

Suffix products `P_s` are computed once per hidden group (`cumprod` for `S == 1`, `associative_scan` of the `S×S` Jacobians otherwise, no division — exact-zero decays are safe), and the sum over `s` is a single time-contracting einsum in matmul-class kernels. Within-window weight gradients are unchanged — they come from the BPTT residuals; only the trace roll is replaced.

## What changed

- `FastPathRules` gains an optional `chunk` kernel field; dense (`etp_mm`/`etp_mv`) and `etp_elemwise` register chunk kernels. Time-contracting einsums use `Precision.HIGHEST` to avoid tf32 drift.
- New `suffix_products` helper in `_misc.py`.
- `ParamDimVjpAlgorithm` (and thus `D_RTRL`) gains `chunked_trace: bool = True`. When enabled and input is multi-step, the executor stacks per-step Jacobians and the trace roll is computed in closed form. Per-relation gating: relations without a chunk kernel (conv / sparse / LoRA / grouped), descended-scan relations, and relations with active `weight_fn`/`bias_fn` transforms fall back to the per-step scan automatically, so mixed models work unchanged. Single-step input is unaffected.
- Semantics are identical to the per-step roll up to floating-point reassociation (float64 agreement ~4e-16 in the derivation checks; fp32 norm-relative ~3e-4 under tf32, mitigated by `Precision.HIGHEST`).

## Benchmarks

GRU (`n_in=32`, `n_out=10`), multi-step gradient over one `T`-step window, GPU (WSL2), interleaved timed blocks, median reported:

| B | H | T | per-step scan | chunked (default) | speedup |
|---|---|---|---|---|---|
| 16 | 128 | 100 | 8.3 ms | 7.9 ms | 1.05× |
| 64 | 256 | 100 | 28.3 ms | 11.9 ms | 2.4× |
| 32 | 512 | 50 | 23.3 ms | 8.0 ms | 2.9× |
| 16 | 1024 | 50 | 44.6 ms | 14.9 ms | 3.0× |
| 64 | 512 | 100 | 80.8 ms | 17.8 ms | 4.5× |

The win grows with trace size (`B·I·O·S`) and window length; tiny configs are launch-overhead-bound and stay at parity. Isolated trace-update microbenchmark at (T=32, B=32, I=1024, O=3072): 62 ms → 7.2 ms (8.7×).

Trade-off: chunking stacks per-step Jacobians (`O(T · B · (I + H))` memory) instead of fusing the roll into the forward scan; for very long windows feed smaller windows (the trace carries across calls) or set `chunked_trace=False`.

## Tests

- `TestChunkedTraceEquivalence` (6 tests): trace equality chunked vs per-step after a multi-step call; GRU two-window gradient equality; mixed-partition model (masked readout falls back, dense stays chunked); full fallback under `fast_solve=False`; knob defaulting/threading; single-step unaffected.
- New unit tests for `suffix_products` (non-commuting S×S, zero decay, T=1) and the dense/elemwise chunk kernels vs a per-step reference roll.
- Full suite: 2119 passed, 3 skipped. The 4 failures in `conv_test.py::TestConvPatchExtraction` are pre-existing GPU-precision flakes (`atol=1e-5` vs tf32 conv autotuning) — they reproduce identically on unmodified `main`.

## Summary by Sourcery

Introduce chunk-factorized multi-step eligibility-trace updates for D_RTRL to accelerate multi-step windows while preserving numerical behavior, with automatic fallback to the legacy per-step scan where unsupported.

Enhancements:
- Add chunked closed-form multi-step trace update path in ParamDimVjpAlgorithm, gated by a new chunked_trace option and relation-level capability checks.
- Extend dense and elemwise fast-path rules with chunk kernels and a new chunk field in FastPathRules, enabling efficient time-contracting einsum-based trace updates.
- Introduce a suffix_products utility for computing Jacobian suffix products and full-window products to support chunked trace factorization.
- Adjust the D_RTRL compile API and internal stepper wiring so multi-step runs either stack Jacobians for chunking or fuse the legacy per-step scan as before.

Documentation:
- Document the new chunked_trace parameter for D_RTRL in ParamDimVjpAlgorithm and the compile() API, including performance and memory trade-offs.
- Add docstrings describing the semantics and usage of suffix_products and the new chunk kernels in dense and elemwise ops.

Tests:
- Add TestChunkedTraceEquivalence suite to verify trace equality, gradient equivalence across windows, mixed fast-path/fallback behavior, fast_solve fallback, configuration threading, and single-step invariance.
- Add dense and elemwise chunk fast-path tests to confirm agreement with per-step reference rolls across various num_state and shape configurations.
- Add tests for the suffix_products helper, including non-commuting matrices, zero-decay steps, and T=1 behavior.
- Add FastPathRules chunk-field tests to ensure defaulting, field assignment, and registration of chunk-capable fast paths.