### PR TITLE
Fix mypy errors in typecheck_and_build CI

### DIFF
--- a/braintrace/_algorithm/ottt.py
+++ b/braintrace/_algorithm/ottt.py
@@ -270,7 +270,7 @@ class OTTT(ETraceVjpAlgorithm):
             # The bias companion trace has no batch axis: bias's local
             # Jacobian dy/db = 1 is identical for every batch row, so it is
             # always a scalar regardless of `batch_size`.
-            self._bias_trace.value = jnp.zeros((), dtype=self._bias_trace.value.dtype)
+            self._bias_trace.value = jnp.zeros((), dtype=self._bias_trace.value.dtype)  # type: ignore[attr-defined]
 
     def _get_etrace_data(self) -> Any:
         d = {rid: t.value for rid, t in self._pre_traces.items()}

--- a/braintrace/_algorithm/param_dim_vjp.py
+++ b/braintrace/_algorithm/param_dim_vjp.py
@@ -235,7 +235,11 @@ def _update_param_dim_etrace_scan_fn(
             {i: hid_group_jacobians[i] for i in g_idx},  # (L, ...)
         )
 
-        def _substep(carry, sliced, _rels=rels):
+        def _substep(
+            carry: Dict[ETraceWG_Key, jax.Array],
+            sliced: Any,
+            _rels: Any = rels,
+        ) -> Tuple[Dict[ETraceWG_Key, jax.Array], None]:
             xs_t, dfs_t, diags_t = sliced
             carry = {**carry, **_apply_relation_step(
                 carry, xs_t, dfs_t, diags_t, _rels,

--- a/braintrace/_algorithm/vjp_graph_executor.py
+++ b/braintrace/_algorithm/vjp_graph_executor.py
@@ -51,7 +51,7 @@ from jax.interpreters import partial_eval as pe
 from jax.tree_util import register_pytree_node_class
 
 from braintrace._compatible_imports import Var
-from braintrace._compiler import ControlFlowPolicy, compile_etrace_graph, HiddenGroup
+from braintrace._compiler import ControlFlowPolicy, compile_etrace_graph, HiddenGroup, HiddenParamOpRelation
 from braintrace._input_data import (
     get_single_step_data,
     split_input_data_types,
@@ -307,10 +307,15 @@ class ETraceVjpGraphExecutor(ETraceGraphExecutor):
                     for v in j.constvars))
                 c_stacks = tuple(intermediate_values[m[v]] for v in cvars)
 
-                def _one_substep(y_t, c_ts, _rel=relation, _cvars=cvars):
+                def _one_substep(
+                    y_t: jax.Array,
+                    c_ts: Tuple[jax.Array, ...],
+                    _rel: HiddenParamOpRelation = relation,
+                    _cvars: list[Var] = cvars,
+                ) -> Tuple[jax.Array, ...]:
                     env = dict(zip(_cvars, c_ts))
 
-                    def _y2h(y_val):
+                    def _y2h(y_val: jax.Array) -> Any:
                         return _rel.y_to_hidden_groups(
                             y_val, env, concat_hidden_vals=True)
 
@@ -395,7 +400,11 @@ class ETraceVjpGraphExecutor(ETraceGraphExecutor):
                     intermediate_values[m[v]]
                     for v in group.transition_jaxpr_constvars)
 
-                def _one_substep(h_ts, c_ts, _g=group):
+                def _one_substep(
+                    h_ts: Tuple[jax.Array, ...],
+                    c_ts: Tuple[jax.Array, ...],
+                    _g: HiddenGroup = group,
+                ) -> Any:
                     return _g.diagonal_jacobian(list(h_ts), list(c_ts))
 
                 hid2hid_jacobian.append(jax.vmap(_one_substep)(h_stacks, c_stacks))

--- a/braintrace/_compiler/jaxpr_graph.py
+++ b/braintrace/_compiler/jaxpr_graph.py
@@ -271,7 +271,7 @@ def inline_jit_calls(closed_jaxpr: ClosedJaxpr) -> ClosedJaxpr:
                 fresh_outvars = [new_var('', v.aval) for v in eqn.outvars]
                 for ov, fresh in zip(eqn.outvars, fresh_outvars):
                     local[ov] = fresh
-                replace_kwargs = dict(
+                replace_kwargs: Dict[str, Any] = dict(
                     invars=[res(v) for v in eqn.invars],
                     outvars=fresh_outvars,
                 )

--- a/braintrace/_compiler/scan_descent.py
+++ b/braintrace/_compiler/scan_descent.py
@@ -54,7 +54,7 @@ Jacobian extraction and the trace update see the substep axis.
    ETP mixing into a body transition has no consumer.
 """
 
-from typing import Dict, List, NamedTuple, Optional, Sequence, Set, Tuple
+from typing import Dict, List, NamedTuple, Optional, Sequence, Set, Tuple, TYPE_CHECKING
 
 from braintrace._compatible_imports import (
     ClosedJaxpr,
@@ -71,6 +71,11 @@ from braintrace._typing import Path
 from .canonicalize import ControlFlowPolicy
 from .diagnostics import DiagnosticKind, DiagnosticLevel, emit
 from .jaxpr_graph import _sub_closed_jaxprs
+
+if TYPE_CHECKING:
+    from .hid_param_op import HiddenParamOpRelation
+    from .hidden_group import HiddenGroup
+    from .module_info import ModuleInfo
 
 __all__ = [
     'GroupDescent',
@@ -428,17 +433,17 @@ def analyze_and_rewrite_scan(eqn: JaxprEqn, minfo) -> Optional[ScanDescentBundle
         )
 
     # ---- assemble the hoist list (ordered dedup, body vars) ----------------
-    hoist: Dict[Var, None] = {}
+    hoist_seen: Dict[Var, None] = {}
     for r in body_relations:
         if r.x_var is not None:
-            hoist[r.x_var] = None
+            hoist_seen[r.x_var] = None
         for j in r.y_to_hidden_group_jaxprs:
             for v in list(j.invars) + list(j.constvars):
-                hoist[v] = None
+                hoist_seen[v] = None
     for g in body_groups:
         for v in list(g.hidden_invars) + list(g.transition_jaxpr_constvars):
-            hoist[v] = None
-    hoist = list(hoist)
+            hoist_seen[v] = None
+    hoist: List[Var] = list(hoist_seen)
 
     # ---- rewrite the eqn ----------------------------------------------------
     inlined_eqn = eqn if body_closed is eqn.params['jaxpr'] else eqn.replace(

--- a/braintrace/_op/dense.py
+++ b/braintrace/_op/dense.py
@@ -768,8 +768,8 @@ def matmul(
     if x.ndim > 2:  # type: ignore[union-attr]
         raise ValueError(
             f'matmul() supports x.ndim of 1 (unbatched `(in_features,)`) or 2 '
-            f'(batched `(batch, in_features)`); got x.ndim={x.ndim} '
-            f'(shape={x.shape}). Every ETP trace rule for etp_mm_p / etp_mv_p '
+            f'(batched `(batch, in_features)`); got x.ndim={x.ndim} '  # type: ignore[union-attr]
+            f'(shape={x.shape}). Every ETP trace rule for etp_mm_p / etp_mv_p '  # type: ignore[union-attr]
             f'assumes one of those two layouts, so higher-rank inputs (e.g. '
             f'`(batch, time, in_features)`) are not supported -- reshape/vmap '
             f'over the extra axes before calling matmul(), or use '

--- a/braintrace/_op/lora.py
+++ b/braintrace/_op/lora.py
@@ -652,8 +652,8 @@ def lora_matmul(
     if x.ndim > 2:  # type: ignore[union-attr]
         raise ValueError(
             f'lora_matmul() supports x.ndim of 1 (unbatched `(in_features,)`) or 2 '
-            f'(batched `(batch, in_features)`); got x.ndim={x.ndim} '
-            f'(shape={x.shape}). Every ETP trace rule for etp_lora_mm_p / '
+            f'(batched `(batch, in_features)`); got x.ndim={x.ndim} '  # type: ignore[union-attr]
+            f'(shape={x.shape}). Every ETP trace rule for etp_lora_mm_p / '  # type: ignore[union-attr]
             f'etp_lora_mv_p assumes one of those two layouts, so higher-rank '
             f'inputs (e.g. `(batch, time, in_features)`) are not supported -- '
             f'reshape/vmap over the extra axes before calling lora_matmul().'

--- a/braintrace/nn/_linear.py
+++ b/braintrace/nn/_linear.py
@@ -36,7 +36,7 @@ __all__ = [
 ]
 
 
-def _fold_leading_axes(x: ArrayLike):
+def _fold_leading_axes(x: ArrayLike) -> tuple[ArrayLike, Callable[[ArrayLike], ArrayLike]]:
     """Fold all leading axes of ``x`` into a single batch axis.
 
     The rank-guarded ETP ops (:func:`braintrace.matmul`,
@@ -66,11 +66,11 @@ def _fold_leading_axes(x: ArrayLike):
     """
     if x.ndim <= 2:  # type: ignore[union-attr]  # scalars never reach here: callers feed (..., in_size)
         return x, lambda y: y
-    lead_shape = x.shape[:-1]
-    x2 = u.math.reshape(x, (-1, x.shape[-1]))
+    lead_shape = x.shape[:-1]  # type: ignore[union-attr]
+    x2 = u.math.reshape(x, (-1, x.shape[-1]))  # type: ignore[union-attr]
 
     def unfold(y: ArrayLike) -> ArrayLike:
-        return u.math.reshape(y, (*lead_shape, y.shape[-1]))
+        return u.math.reshape(y, (*lead_shape, y.shape[-1]))  # type: ignore[union-attr]
 
     return x2, unfold
 


### PR DESCRIPTION
## Summary
- `typecheck_and_build` has been failing since 2026-07-02 due to unpinned `mypy`/`jax` in CI plus newer untyped code; the error count crept from 0 to 40 across 8 files with no single offending commit.
- Fixes all 40 mypy errors: annotation-only / `type: ignore[...]` additions, no logic changes.
  - `jaxpr_graph.py`: explicit `Dict[str, Any]` annotation so a later heterogeneous assignment isn't pinned to a narrower inferred type.
  - `lora.py` / `dense.py` / `_linear.py`: `type: ignore[union-attr]` on `ArrayLike.ndim`/`.shape` accesses inside error-message f-strings (matches the ignore already one line above each); added `_fold_leading_axes`'s missing return annotation.
  - `scan_descent.py`: import `HiddenGroup`/`HiddenParamOpRelation`/`ModuleInfo` under `TYPE_CHECKING` so existing forward-ref string annotations resolve, without touching the deliberate runtime circular-import avoidance; split the dict/list double-duty `hoist` variable into two properly typed names.
  - `vjp_graph_executor.py` / `param_dim_vjp.py`: annotate nested scan/vmap helper closures (these modules require full annotations per the project's `disallow_untyped_defs` allowlist in `pyproject.toml`).
  - `ottt.py`: silence a `brainstate.State.value` PyTree-typing false positive on `.dtype`, mirroring the existing `Any`-typed workaround already used in `otpe.py`.

## Test plan
- [x] `python -m mypy braintrace` — 0 errors (was 40)
- [x] `python -m build` — wheel + sdist build succeed
- [x] `pytest braintrace/` — 2119 passed, 3 skipped, 4 deselected; the only failures are the 4 pre-existing, unrelated `TestConvPatchExtraction` flakes (also reproduce on `main` untouched)

## Summary by Sourcery

Address mypy failures in typecheck_and_build by tightening type annotations and type-checking-only imports across core algorithm and compiler modules, without changing runtime behavior.

Bug Fixes:
- Resolve mypy errors in vjp_graph_executor and param_dim_vjp by adding explicit type annotations to nested helper functions and using the correct relation types.
- Eliminate mypy issues in scan_descent by introducing TYPE_CHECKING-only imports for hidden-group and module metadata types and separating the hoist tracking dict from the hoisted var list.
- Fix mypy union-attr and attr-defined complaints in linear, dense, lora, and ottt modules with targeted type: ignore markers and a missing return-type annotation.

Enhancements:
- Clarify jaxpr_graph mutation semantics by explicitly annotating the replace_kwargs mapping used during eqn replacement.