### PR TITLE
Migrate sparse_matmul off brainevent's deprecated yw_to_w protocol

### DIFF
--- a/braintrace/_algorithm/vjp_graph_executor.py
+++ b/braintrace/_algorithm/vjp_graph_executor.py
@@ -46,11 +46,10 @@ import jax.core
 import jax.numpy as jnp
 import brainunit as u
 from brainstate._compatible_import import get_aval
-from jax.extend import linear_util as lu
 from jax.interpreters import partial_eval as pe
 from jax.tree_util import register_pytree_node_class
 
-from braintrace._compatible_imports import Var
+from braintrace._compatible_imports import Var, wrap_init
 from braintrace._compiler import ControlFlowPolicy, compile_etrace_graph, HiddenGroup, HiddenParamOpRelation
 from braintrace._input_data import (
     get_single_step_data,
@@ -885,8 +884,11 @@ class ETraceVjpGraphExecutor(ETraceGraphExecutor):
             hid2weight_jac_single_or_multi_steps, hid2hid_jac_single_or_multi_steps = aux
             final_etrace = None
 
-        out_flat, out_tree = jax.tree.flatten(((out_single_or_multi_steps, etrace_state_vals, other_state_vals),))
-        rule, in_tree = jax.api_util.flatten_fun_nokwargs(lu.wrap_init(f_vjp), out_tree)
+        vjp_cotangent_args = ((out_single_or_multi_steps, etrace_state_vals, other_state_vals),)
+        out_flat, out_tree = jax.tree.flatten(vjp_cotangent_args)
+        rule, in_tree = jax.api_util.flatten_fun_nokwargs(
+            wrap_init(f_vjp, vjp_cotangent_args, {}, 'braintrace_vjp_residual'), out_tree
+        )
         out_avals = [get_aval(x).at_least_vspace() for x in out_flat]
         jaxpr, _, consts = pe.trace_to_jaxpr_dynamic(rule, out_avals)
         residual = VjpResiduals(jaxpr, in_tree(), out_tree, consts)

--- a/braintrace/_compatible_imports.py
+++ b/braintrace/_compatible_imports.py
@@ -29,9 +29,10 @@ __all__ = [
     'is_scan_primitive',
     'is_while_primitive',
     'is_cond_primitive',
+    'wrap_init',
 ]
 
-from brainstate._compatible_import import Primitive, Var, JaxprEqn, Jaxpr, ClosedJaxpr, Literal
+from brainstate._compatible_import import Primitive, Var, JaxprEqn, Jaxpr, ClosedJaxpr, Literal, wrap_init
 
 try:
     from jax.extend.core import new_jaxpr_eqn

--- a/braintrace/_op/sparse.py
+++ b/braintrace/_op/sparse.py
@@ -20,8 +20,8 @@ structure is supplied as a static parameter (``sparse_mat``); only the
 non-zero values flow through the primitive as the ``weight_data`` invar.
 The structure object must be a :class:`brainevent.DataRepresentation`,
 which provides the ETP online-learning protocol: ``with_data`` (substitute
-new data into the structure), ``yw_to_w_transposed`` (apply the transposed
-sparse pattern to a trace) and ``yw_to_w`` (the non-transposed counterpart).
+new data into the structure), ``dt2t_transposed`` (apply the transposed
+sparse pattern to a trace) and ``dt2t`` (the non-transposed counterpart).
 
 **Forward operation**
 
@@ -49,7 +49,7 @@ frozen.
 
 * ``dt_to_t(hidden_dim, trace)`` — propagation of
   :math:`\mathbf{D}^t \boldsymbol{\epsilon}^{t-1}`. For the weight data,
-  delegates to ``sparse_mat.yw_to_w_transposed``: this contracts
+  delegates to ``sparse_mat.dt2t_transposed``: this contracts
   ``hidden_dim`` along ``out`` and restricts to the sparse pattern in a
   single kernel call — equivalent to computing the dense
   :math:`(\partial h/\partial y) \cdot \mathrm{scatter}^{\top}` but only
@@ -207,7 +207,7 @@ def _sp_mm_dt_to_t(hidden_dim: Any, trace: dict[str, Any], *,
     the dense-equivalent :math:`y_j = \sum_i x_i W_{ij}` we would write
     :math:`\partial y_j / \partial W_{ik} = \delta_{jk} x_i`. Restricted
     to the sparse support, only positions with
-    :math:`(i, j) \in \mathrm{pattern}` are kept; ``yw_to_w_transposed``
+    :math:`(i, j) \in \mathrm{pattern}` are kept; ``dt2t_transposed``
     performs the contraction and scatter-restrict in one sparse kernel:
 
     .. math::
@@ -233,7 +233,7 @@ def _sp_mm_dt_to_t(hidden_dim: Any, trace: dict[str, Any], *,
     **Batching (audit C3).** The scan-context call above hands this rule a
     2-D ``hidden_dim``/``trace['weight']`` pair straight from the online
     trace-recurrence update (no outer vmap — unlike the solve context).
-    ``brainevent``'s ``yw_to_w_transposed`` kernel (``csrmv_yw2y_p_call``)
+    ``brainevent``'s ``dt2t_transposed`` kernel (``csrmv_yw2y_p_call``)
     only accepts 1-D operands, so when ``hidden_dim.ndim == 2`` this rule
     ``jax.vmap``\ s the sparse call over the leading batch axis of both
     operands instead of handing it the batched arrays directly.
@@ -243,9 +243,9 @@ def _sp_mm_dt_to_t(hidden_dim: Any, trace: dict[str, Any], *,
     if hidden_dim.ndim == 2:
         # (batch, out), (batch, nnz) -> vmap the 1-D-only brainevent kernel
         # over the leading batch axis.
-        weight_out = jax.vmap(mat.yw_to_w_transposed)(hidden_dim, weight_trace)
+        weight_out = jax.vmap(mat.dt2t_transposed)(hidden_dim, weight_trace)
     else:
-        weight_out = mat.yw_to_w_transposed(hidden_dim, weight_trace)  # type: ignore[union-attr]  # sparse_mat is always supplied at bind time
+        weight_out = mat.dt2t_transposed(hidden_dim, weight_trace)  # type: ignore[union-attr]  # sparse_mat is always supplied at bind time
     out = {'weight': weight_out}
     if has_bias:
         out['bias'] = trace['bias'] * hidden_dim
@@ -376,7 +376,7 @@ def _sp_mv_dt_to_t(hidden_dim: Any, trace: dict[str, Any], *,
              ``trace['bias']   : (out,)``.
     """
     mat = _unwrap_sparse_mat(sparse_mat)
-    out = {'weight': mat.yw_to_w_transposed(hidden_dim, trace['weight'])}  # type: ignore[union-attr]  # sparse_mat is always supplied at bind time
+    out = {'weight': mat.dt2t_transposed(hidden_dim, trace['weight'])}  # type: ignore[union-attr]  # sparse_mat is always supplied at bind time
     if has_bias:
         out['bias'] = trace['bias'] * hidden_dim
     return out
@@ -482,8 +482,8 @@ def sparse_matmul(
         Sparse-matrix structure (e.g. a :class:`brainevent.CSR`). Must be a
         :class:`brainevent.DataRepresentation`, which implements the ETP
         online-learning protocol: ``with_data`` (substitute new data into the
-        structure), ``yw_to_w_transposed`` (apply the transposed sparse
-        pattern to a trace) and ``yw_to_w`` (its non-transposed counterpart).
+        structure), ``dt2t_transposed`` (apply the transposed sparse
+        pattern to a trace) and ``dt2t`` (its non-transposed counterpart).
         Passing any other object raises :class:`TypeError`.
     bias : ArrayLike or None, optional
         Bias vector. Default ``None``.
@@ -515,7 +515,7 @@ def sparse_matmul(
     if not isinstance(sparse_mat, brainevent.DataRepresentation):
         raise TypeError(
             'sparse_mat must be a brainevent.DataRepresentation providing the '
-            'with_data, yw_to_w_transposed and yw_to_w online-learning protocol '
+            'with_data, dt2t_transposed and dt2t online-learning protocol '
             f'methods, got {type(sparse_mat).__name__!r}.'
         )
     p = etp_sp_mm_p if x.ndim >= 2 else etp_sp_mv_p  # type: ignore[union-attr]  # x is an array here; ArrayLike also admits scalars without .ndim

--- a/braintrace/_op/sparse_test.py
+++ b/braintrace/_op/sparse_test.py
@@ -21,9 +21,9 @@ implementing the methods used by the ETP rules:
 
 * ``with_data(weight_data)`` — substitute new non-zero values into the
   structure, returning a sparse-matmul-able object.
-* ``yw_to_w_transposed(hidden_dim, trace)`` — apply the transposed
+* ``dt2t_transposed(hidden_dim, trace)`` — apply the transposed
   pattern when propagating the trace.
-* ``yw_to_w(hidden_dim, trace)`` — the non-transposed counterpart.
+* ``dt2t(hidden_dim, trace)`` — the non-transposed counterpart.
 
 For end-to-end forward correctness a real :class:`brainevent.CSR` works.
 For rule-level and compile/gradient tests a tiny stub *subclassing*
@@ -73,7 +73,7 @@ class _StubSparseMat(brainevent.DataRepresentation):
     Backed by a dense matrix internally; ``with_data`` rebuilds the dense
     form by reshaping the flat data vector into the original shape.
 
-    ``yw_to_w_transposed`` is called by the D-RTRL executor with
+    ``dt2t_transposed`` is called by the D-RTRL executor with
     ``trace`` having the same shape as the weight data (i.e. ``(nnz,)``
     per vmap step). For this stub, all non-zeros are in a specific pattern
     so the transposed application just multiplies each nnz-entry by the
@@ -94,7 +94,7 @@ class _StubSparseMat(brainevent.DataRepresentation):
     def with_data(self, data: jnp.ndarray) -> jnp.ndarray:
         return data.reshape(self._template.shape)
 
-    def yw_to_w_transposed(self, hidden_dim, trace):
+    def dt2t_transposed(self, hidden_dim, trace):
         if trace.ndim == 1:
             # Called by the executor per-vmap step: trace is (nnz,),
             # hidden_dim is (out_dim,) or scalar.
@@ -108,10 +108,10 @@ class _StubSparseMat(brainevent.DataRepresentation):
         # pass trace in the old full-matrix form.
         return trace * jnp.expand_dims(hidden_dim, axis=0)
 
-    def yw_to_w(self, hidden_dim, trace):
+    def dt2t(self, hidden_dim, trace):
         # Non-transposed counterpart; the diagonal stub is symmetric so it
         # delegates. Present to complete the DataRepresentation protocol.
-        return self.yw_to_w_transposed(hidden_dim, trace)
+        return self.dt2t_transposed(hidden_dim, trace)
 
 
 def _csr_from_dense(dense: jnp.ndarray):
@@ -229,7 +229,7 @@ class TestSpMmEtpRules:
         # trace is now a dict {'weight': ...}
         trace = {'weight': jnp.ones((3, 4))}
         out = rule(hidden, trace, sparse_mat=stub)
-        # stub.yw_to_w_transposed broadcasts hidden over rows.
+        # stub.dt2t_transposed broadcasts hidden over rows.
         np.testing.assert_allclose(out['weight'], jnp.ones((3, 4)) * hidden[None, :])
 
     def test_dt_to_t_with_bias(self):
@@ -357,7 +357,7 @@ class TestSparseMMBiasGradient:
     Uses a hashable stub sparse matrix (backed by a dense 3×4 identity-like
     template) so the test does not depend on brainunit.CSR being hashable in JAX.
     The stub's ``with_data`` reconstructs the dense matrix from the flat data
-    vector (one value per non-zero), and ``yw_to_w_transposed`` applies the
+    vector (one value per non-zero), and ``dt2t_transposed`` applies the
     transposed pattern.
     """
 
@@ -387,7 +387,7 @@ class TestSparseMMBiasGradient:
                 # Substitute flat data vector back into the dense template.
                 return dense_template.at[rows, cols].set(data)
 
-            def yw_to_w_transposed(self, hidden_dim, trace):
+            def dt2t_transposed(self, hidden_dim, trace):
                 # Per D-RTRL executor call: trace is (nnz,), hidden_dim is (out,).
                 # For a diagonal matrix col_i == i, so:
                 #   e^t_i = hidden_dim[col_i] * trace_i = hidden_dim[i] * trace_i.
@@ -396,8 +396,8 @@ class TestSparseMMBiasGradient:
                 n = trace.shape[0]
                 return trace * hidden_dim[:n]
 
-            def yw_to_w(self, hidden_dim, trace):
-                return self.yw_to_w_transposed(hidden_dim, trace)
+            def dt2t(self, hidden_dim, trace):
+                return self.dt2t_transposed(hidden_dim, trace)
 
         sparse_mat = _HashableStub()
         nnz = dim
@@ -489,14 +489,14 @@ class TestRuntimeTypeCheck:
         np.testing.assert_allclose(out, jnp.ones(3) @ (jnp.eye(3) * 2.0))
 
     def test_rejects_brainunit_sparse(self):
-        """A brainunit (saiunit) sparse matrix lacks ``yw_to_w_transposed`` and is rejected."""
+        """A brainunit (saiunit) sparse matrix lacks ``dt2t_transposed`` and is rejected."""
         bu_csr = u.sparse.CSR.fromdense(jnp.eye(3))
         assert not isinstance(bu_csr, brainevent.DataRepresentation)
         with pytest.raises(TypeError, match='brainevent.DataRepresentation'):
             sparse_matmul(jnp.ones(3), bu_csr.data, sparse_mat=bu_csr)
 
     def test_rejects_plain_array(self):
-        with pytest.raises(TypeError, match='yw_to_w_transposed'):
+        with pytest.raises(TypeError, match='dt2t_transposed'):
             sparse_matmul(jnp.ones(3), jnp.ones(3), sparse_mat=jnp.eye(3))
 
     def test_rejects_duck_typed_non_subclass(self):
@@ -506,10 +506,10 @@ class TestRuntimeTypeCheck:
             def with_data(self, data):
                 return data
 
-            def yw_to_w_transposed(self, hidden_dim, trace):
+            def dt2t_transposed(self, hidden_dim, trace):
                 return trace
 
-            def yw_to_w(self, hidden_dim, trace):
+            def dt2t(self, hidden_dim, trace):
                 return trace
 
         with pytest.raises(TypeError, match='brainevent.DataRepresentation'):
@@ -689,7 +689,7 @@ class TestBatchedSparseDRTRLOracle:
     """C3: ``_sp_mm_dt_to_t`` (the ``etp_sp_mm_p`` D-RTRL trace-recurrence rule)
     is handed a leading batch axis -- ``hidden_dim: (batch, out)``,
     ``trace['weight']: (batch, nnz)`` -- straight from the online-trace update.
-    ``brainevent``'s ``yw_to_w_transposed`` kernel only accepts 1-D operands, so
+    ``brainevent``'s ``dt2t_transposed`` kernel only accepts 1-D operands, so
     the rule must ``jax.vmap`` internally rather than handing it the batched
     arrays directly. Exactly-diagonal recurrence: D-RTRL (an *exact* algorithm)
     must match the BPTT oracle element-wise for a batch > 1 model.
@@ -761,7 +761,7 @@ class TestBatchedSparseDRTRLOracle:
 def _sparse_row_col_of_nnz(csr):
     """Derive per-nnz (row, col) indices directly from CSR structure.
 
-    Built independently of ``yw_to_w_transposed`` so it can serve as ground
+    Built independently of ``dt2t_transposed`` so it can serve as ground
     truth: ``csr.indices`` already *is* the per-nnz column index (standard
     CSR layout), and the per-nnz row index is recovered from ``indptr`` by
     repeating each row index by its nnz count.
@@ -788,7 +788,7 @@ class TestDtToTFirstPrinciplesFromJacobian:
     which case it equals ``x`` at that entry's row — a structural fact
     confirmed here numerically against ``row_of_nnz`` / ``col_of_nnz``
     derived directly from the CSR's own ``indptr`` / ``indices`` (never from
-    ``yw_to_w_transposed``). Because the Jacobian is "diagonal" in this
+    ``dt2t_transposed``). Because the Jacobian is "diagonal" in this
     per-nnz-column sense, the general contraction of a cotangent against it
     reduces to indexing the cotangent by each nnz's column and multiplying
     into the trace — exactly what the production rule computes. Checked
@@ -832,7 +832,7 @@ class TestDtToTFirstPrinciplesFromJacobian:
         # General contraction, specialized by the proven per-column-diagonal
         # structure: each nnz only "sees" the cotangent component at its own
         # column. Built from `col_of_nnz` (raw CSR structure), never from
-        # the rule's own `yw_to_w_transposed` call.
+        # the rule's own `dt2t_transposed` call.
         ref_w = trace_w * g[col_of_nnz]
         ref_b = trace_b * g
 

--- a/braintrace/nn/_linear_test.py
+++ b/braintrace/nn/_linear_test.py
@@ -39,7 +39,7 @@ def _be_csr_from_coo(values, rows, cols, shape):
     """Build a :class:`brainevent.CSR` from COO-style ``(values, rows, cols)``.
 
     ``SparseLinear`` requires a :class:`brainevent.DataRepresentation` (the type
-    that provides the ``yw_to_w_transposed`` online-learning protocol). brainunit
+    that provides the ``dt2t_transposed`` online-learning protocol). brainunit
     ``COO`` does not qualify, so the connectivity is densified and re-encoded as a
     brainevent CSR. These tests assert output shapes only, so duplicate-index
     summation during densification is irrelevant.

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,25 @@
 # Release Notes
 
 
+## UNRELEASED
+
+### Improvements
+
+- **`sparse_matmul` migrates off brainevent's deprecated trace protocol.**
+  `braintrace._op.sparse` now calls `brainevent.DataRepresentation.dt2t` /
+  `.dt2t_transposed` directly instead of the deprecated `.yw_to_w` /
+  `.yw_to_w_transposed` aliases (brainevent renamed its own trace-propagation
+  protocol to match braintrace's `DT_TO_T` terminology). The minimum
+  `brainevent` version is raised to **0.1.2** (the release that introduces
+  `dt2t`/`dt2t_transposed`) in `pyproject.toml` / `requirements.txt`.
+- **Fixed a JAX-internal `linear_util.wrap_init` `DeprecationWarning`** raised
+  by the single-step VJP residual construction in `vjp_graph_executor.py`.
+  The call now threads a `DebugInfo` object through the ecosystem-standard
+  `brainstate._compatible_import.wrap_init` shim (re-exported as
+  `braintrace._compatible_imports.wrap_init`), matching the pattern already
+  used elsewhere in the `brainstate`/`saiunit` stack. No behavior change.
+
+
 ## Version 0.2.4
 
 This release makes eligibility-trace online learning work *through* JAX control

--- a/docs/tutorials/etp_primitives.ipynb
+++ b/docs/tutorials/etp_primitives.ipynb
@@ -336,7 +336,7 @@
     }
    },
    "outputs": [],
-   "source": "import brainunit as u\nimport brainevent\n\n# Create a sparse connectivity matrix\ndense_w = jnp.where(\n    jax.random.uniform(jax.random.PRNGKey(0), (50, 50)) < 0.1,\n    jax.random.normal(jax.random.PRNGKey(1), (50, 50)),\n    0.0\n)\n# sparse_mat must be a brainevent.DataRepresentation (e.g. brainevent.CSR),\n# which implements the with_data / yw_to_w_transposed / yw_to_w protocol.\nsparse_mat = brainevent.CSR.fromdense(dense_w)\n\n# The learnable parameter is just the non-zero data\nweight_data = sparse_mat.data\n\nx_sp = jnp.ones((4, 50))  # batch=4, features=50\ny_sp = braintrace.sparse_matmul(x_sp, weight_data, sparse_mat=sparse_mat)\nprint(\"Sparse matmul output shape:\", y_sp.shape)  # (4, 50)"
+   "source": "import brainunit as u\nimport brainevent\n\n# Create a sparse connectivity matrix\ndense_w = jnp.where(\n    jax.random.uniform(jax.random.PRNGKey(0), (50, 50)) < 0.1,\n    jax.random.normal(jax.random.PRNGKey(1), (50, 50)),\n    0.0\n)\n# sparse_mat must be a brainevent.DataRepresentation (e.g. brainevent.CSR),\n# which implements the with_data / dt2t_transposed / dt2t protocol.\nsparse_mat = brainevent.CSR.fromdense(dense_w)\n\n# The learnable parameter is just the non-zero data\nweight_data = sparse_mat.data\n\nx_sp = jnp.ones((4, 50))  # batch=4, features=50\ny_sp = braintrace.sparse_matmul(x_sp, weight_data, sparse_mat=sparse_mat)\nprint(\"Sparse matmul output shape:\", y_sp.shape)  # (4, 50)"
   },
   {
    "cell_type": "markdown",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,7 +55,7 @@ classifiers = [
 dependencies = [
     "brainstate>=0.5.2",
     "brainunit",
-    "brainevent",
+    "brainevent>=0.1.2",
     "brainpy.state",
     "braintools",
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ jax
 numpy
 brainstate>=0.5.2
 brainunit
-brainevent
+brainevent>=0.1.2
 brainpy-state
 braintools
 


### PR DESCRIPTION
## Summary

- `brainevent` 0.1.2 renames its `DataRepresentation` trace protocol from
  `yw_to_w`/`yw_to_w_transposed` to `dt2t`/`dt2t_transposed` (mirroring
  braintrace's own `DT_TO_T` rename in #130), keeping the old names as
  **deprecated aliases slated for removal**. `braintrace._op.sparse` now calls
  `.dt2t`/`.dt2t_transposed` directly instead of the deprecated aliases, and
  the test stubs (`_StubSparseMat`, `_HashableStub`, `_DuckMat`) are updated to
  match. Minimum `brainevent` is raised to **0.1.2** in `pyproject.toml` /
  `requirements.txt`.
- Fixes a pre-existing JAX-internal `linear_util.wrap_init`
  `DeprecationWarning` in the single-step VJP residual construction
  (`vjp_graph_executor.py`), by threading a `DebugInfo` object through the
  ecosystem-standard `brainstate._compatible_import.wrap_init` shim
  (re-exported as `braintrace._compatible_imports.wrap_init`), matching the
  pattern already used elsewhere in the `brainstate`/`saiunit` stack.
- One doc-comment fix in `docs/tutorials/etp_primitives.ipynb` (brainevent
  protocol reference only — the notebook's stale `ETP_RULES_YW_TO_W` references
  to *braintrace's own* pre-#130 rule name are a separate, pre-existing issue
  and out of scope here).

No behavior change; both migrations are mechanical/annotation-only.

## Test plan

- [x] `pytest braintrace/` — 2123 passed, 0 failed, 3 skipped (matches baseline)
- [x] `pytest braintrace/_op/sparse_test.py braintrace/nn/_linear_test.py -W error::DeprecationWarning` — 107 passed, zero brainevent/JAX deprecation warnings surfaced
- [x] `mypy braintrace` — no issues found

## Summary by Sourcery

Migrate sparse matmul and related tests to brainevent’s updated dt2t/dt2t_transposed trace protocol and address a JAX wrap_init deprecation in the VJP graph executor, with corresponding documentation and dependency updates.

Enhancements:
- Update sparse_matmul implementation and eligibility-trace rules to use brainevent.DataRepresentation.dt2t and dt2t_transposed instead of the deprecated yw_to_w variants.
- Adjust sparse-matrix stubs and protocol checks in sparse tests and linear layer tests to align with the new brainevent trace-propagation API.
- Thread DebugInfo via the ecosystem-standard wrap_init shim when constructing single-step VJP residuals to silence JAX linear_util.wrap_init deprecation warnings.
- Re-export wrap_init from brainstate._compatible_import through braintrace._compatible_imports to provide a unified compatibility layer.

Build:
- Raise the minimum brainevent dependency to version 0.1.2 in pyproject.toml and requirements.txt.

Documentation:
- Refresh ETP primitives tutorial text to describe the brainevent DataRepresentation with_data / dt2t_transposed / dt2t protocol.
- Add unreleased changelog entry describing the sparse_matmul brainevent protocol migration, the JAX deprecation fix, and the raised brainevent minimum version.

Tests:
- Update sparse and SparseLinear test suites, including stubs and error messages, to target the dt2t/dt2t_transposed protocol and ensure compatibility with brainevent>=0.1.2.