### PR TITLE
JAX 0.11 compatibility (flattree scan port) + rename CLAUDE.md→AGENTS.md

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -34,7 +34,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: [ "3.14" ]
-        jax-version: [ "0.8.0", "0.9.0", "" ]  # "" means latest version
+        jax-version: [ "0.8.0", "0.9.0", "0.10.0", "" ]  # "" means latest version
 
     steps:
       - name: Cancel Previous Runs

--- a/.gitignore
+++ b/.gitignore
@@ -208,7 +208,6 @@ cython_debug/
 /braintrace/etp/CLAUDE.md
 /.claudegitignore
 /.codex
-/AGENTS.md
 /dev/research/
 
 # brainx-sphinx-header build artifacts

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,184 @@
+# braintrace
+
+Online learning for recurrent networks via Eligibility Trace Propagation (ETP).
+
+> This file holds **durable, abstract rules**: architecture, invariants, design
+> principles, and process requirements. It deliberately avoids concrete file
+> paths, exact symbol names, signatures, and counts — those drift. For the
+> current concrete layout, read the source: `braintrace/__init__.__all__` is the
+> source of truth for the public API; the package directory tree is the source of
+> truth for module structure.
+
+
+## Working agreement
+
+1. Before writing any code, describe approach, wait for approval.
+2. Requirements ambiguous? Ask clarifying questions before writing code.
+3. After writing code, list edge cases + suggest test cases.
+4. Bug? Write a test that reproduces it, then fix until the test passes.
+5. Every correction: reflect on the mistake, plan to avoid repeating it.
+6. All updates must be happened on the worktree branch, not main. 
+7. Write spec and plan under `/mnt/d/codes/projects/brainmass/dev/superpowers` as gitignored files before implementation. This makes them available for reference during implementation, but not clutter the repo history.
+8. Tests should >90% coverage, but focus on meaningful tests that cover edge cases and critical paths, not just trivial lines. 
+9. Co-locate tests with the code under test: each module `foo.py` has its tests in a sibling `foo_test.py` (suffix style — never a separate `tests/` directory, never the `test_*.py` prefix). 
+10. **Never drive a model with a bare Python `for`/`while` loop when it runs repeatedly.** Python loops execute op-by-op (dispatch overhead, no fusion) and trace fresh each step; the `brainstate.transform` primitives lower the whole loop into one compiled XLA program, tracing the body only once. Pick by shape of the work:
+    - **Single step or one-shot call** → `brainstate.transform.jit` — wrap the step/model call so it compiles once and reuses the trace.
+    - **Many steps, collect outputs** → `brainstate.transform.for_loop` — repeat a step `length` times or map over `xs`; `State` is carried automatically and stacked outputs are returned.
+    - **Many steps with an explicit carry** → `brainstate.transform.scan` — when threading a carry value alongside `State` (`f(carry, x) -> (carry, y)`).
+    - **Long rollout under autograd (backprop through time)** → `brainstate.transform.checkpointed_for_loop` / `brainstate.transform.checkpointed_scan` — same semantics as above but rematerialize activations on the backward pass (tune `base`) to bound peak memory at the cost of recomputation.
+
+    Compose them freely (e.g. `jit` an outer driver that calls a `for_loop`/`scan`). Reach for the checkpointed variants only when reverse-mode gradients through a long simulation would otherwise exhaust memory — otherwise prefer plain `for_loop`/`scan`.
+
+
+## What this package does
+
+Online learning algorithms (D-RTRL, ES-D-RTRL, and a family of SNN algorithms)
+for RNNs, built on JAX custom primitives. Models mark trainable operations with
+ETP user-API ops (e.g. an ETP `matmul`) rather than wrapping parameters in a
+special class. A compiler walks the jaxpr, identifies ETP primitives, and
+connects parameters to the hidden states they influence.
+
+## Architecture (layered)
+
+```
+Layer 1  ETP operators      Custom JAX primitives + per-primitive rule registries + user-facing ops
+Layer 2  ETP compiler       Jaxpr analysis: find ETP primitives, connect parameters to hidden states
+Layer 3  Graph executor     Forward pass + hidden→weight / hidden→hidden Jacobian computation
+Layer 4  Algorithms         Orchestrators (D-RTRL, pp_prop/ES-D-RTRL, EProp/OSTL/OTPE/OTTT/OSTTP)
+```
+
+Dependency direction is strictly downward: operators know nothing of the
+compiler; the compiler depends on the operator registry; algorithms depend on
+the compiler and executor. Legacy back-compat shims are a side branch nothing
+else depends on.
+
+## Core design principles
+
+These are the load-bearing rules. Preserve them across refactors.
+
+### Primitives are thin markers, not reimplementations
+
+Each ETP primitive's implementation delegates to a standard JAX op. All standard
+JAX rules (JVP, transpose, batching, abstract eval, lowering) are auto-derived
+from that implementation. **Never hand-write derivative formulas for standard
+rules.** Only the small set of *ETP-specific* rules is hand-written per
+primitive (trace propagation, the input/hidden→weight-gradient rule, and the
+trace-state initializers). Adding a primitive means supplying those few rules;
+everything else is free.
+
+### Selection is primitive-based, not class-based
+
+A parameter participates in online learning **iff it is used through an ETP
+primitive**. The same parameter used through a regular JAX op is excluded. There
+is no special parameter class controlling this — the *operation* decides. To
+include a parameter, route it through an ETP op; to exclude it, use a plain JAX
+op. The compiler considers all ordinary parameter states and filters by how each
+is used.
+
+### Identify primitives by type, not by name
+
+The compiler recognizes ETP primitives by primitive-type identity, never by
+string-matching op or trace names. Keep it that way.
+
+### Batched vs unbatched is encoded in the primitive
+
+Operations that have both batched and unbatched forms expose two primitives; the
+user-facing op dispatches by input rank. Do not reintroduce runtime
+batching-mode flags — the primitive identity carries that information.
+
+### Invariant: no "weight → weight → hidden" pathway
+
+Each ETP primitive's hand-written rules assume the map from its output to the
+hidden state contains **no other trainable ETP weight**. If one trainable ETP
+op's output flows through *another* (non-gradient-enabled) ETP op before
+reaching the hidden state, the first op must **not** be recorded as a relation —
+otherwise its contribution is double-counted, and per-primitive rules cannot
+express the correct joint decomposition. The compiler enforces this by stopping
+forward reachability at such primitives and treating them as boundaries.
+
+A small set of identity-like, explicitly *gradient-enabled* primitives are
+exempt and may sit on the tail of such a path.
+
+**Practical consequence:** a cell can have more trainable linear maps than ETP
+relations, because some parameters reach the hidden state only *through another
+trainable map* and are correctly excluded (and flagged non-temporal). When
+adding or modifying an RNN cell, trace each parameter's path to the hidden
+state and count only those whose tail to the hidden state is non-parametric.
+Tests that assert relation counts encode this invariant — update them
+deliberately, not reflexively.
+
+### Quantity (unit) support
+
+ETP user-API ops accept physical-unit quantities: split mantissa/unit, compute,
+recombine. New ops must preserve this.
+
+### SNN learning-signal axis invariant
+
+SNN learning signals carry a trailing per-hidden-state axis. Every learning-
+signal hook, every per-algorithm weight-gradient solver, and every new SNN
+algorithm must thread this axis explicitly (einsum/broadcast/collapse-expand).
+Misuse produces shape errors or silently wrong gradients. Treat this axis layout
+as a contract.
+
+## Algorithm taxonomy (for correctness reasoning)
+
+- **Exact algorithms** compute the same total gradient as backprop-through-time
+  (BPTT), just forward instead of backward. They must match a BPTT oracle
+  element-wise.
+- **Approximate algorithms** deliberately drop or factor part of the
+  computation. They match BPTT *only* in the degenerate regime their math
+  guarantees; elsewhere they are expected to diverge. Correctness for them means
+  "exact in the guaranteed regime" + "bounded, well-behaved divergence + descent"
+  generally — not element-wise equality everywhere.
+
+Know which class an algorithm belongs to before asserting anything about its
+gradients.
+
+## Dependencies (abstract)
+
+- A state-management + NN base-class library (provides parameter/hidden state
+  abstractions and cell base classes).
+- A physical-units library (mantissa/unit handling).
+- JAX as the core computation framework.
+- Additional brain-ecosystem utilities.
+
+Pin exact names/versions in `pyproject.toml` / requirements files,.
+
+## Known limitations
+
+First-cut SNN algorithms pass smoke/cross-checks but carry approximation edges
+and rough spots (e.g. approximation-mode validity beyond shallow depth,
+heterogeneous-population leak resolution, target-signal threading under JIT,
+single-readout/feedback-shape assumptions, and gaps in cross-algorithm
+equivalence coverage). These are enumerated and mapped to concrete improvement
+actions in the test-strategy findings list under `dev/`. Treat that list as the
+backlog of expected-failure / improvement items rather than duplicating it here.
+
+
+## Rules
+
+1. Use `brainstate.random` instead of `jax.random` directly for all random number generation. 
+2. Place superpowers spec and plans in `/mnt/d/codes/projects/braintrace/dev/superpowers` directory.
+
+## Docstring style (NumPy-doc)
+
+All public classes, methods, functions must use [NumPy-style docstrings](https://numpydoc.readthedocs.io/en/latest/format.html). Canonical section order:
+
+1. **Short summary** – one-line imperative description (no blank line before).
+2. **Extended summary** – optional, follow blank line after short summary.
+3. **Parameters** – each entry: `name : type` on own line, description indented below.
+4. **Returns** / **Yields** – same format as Parameters.
+5. **Raises** – exception type and when raised.
+6. **See Also** – related functions / classes.
+7. **Notes** – implementation details, math, references.
+8. **References** – numbered bibliography entries (`.. [1]`).
+9. **Examples** – runnable, doctestable code snippets.
+
+#### Rules for the Examples section
+
+- Wrap example code in `.. code-block:: python` directive so Sphinx render with syntax highlighting.
+- Prefix every input line with `>>>` (continuation lines with `...`) for `doctest` compatibility.
+- Show expected output on line immediately after statement, **without** prompt prefix.
+- Separate distinct scenarios with blank `>>>` line.
+- Always include necessary imports (`import brainunit as u`, etc.) at top of example block so self-contained.
+

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ Online learning for recurrent networks via Eligibility Trace Propagation (ETP).
 4. Bug? Write a test that reproduces it, then fix until the test passes.
 5. Every correction: reflect on the mistake, plan to avoid repeating it.
 6. All updates must be happened on the worktree branch, not main. 
-7. Write specs and plans under `docs/specs` before implementation.
+7. Write specs under `docs/specs` before implementation.
 8. Tests should >90% coverage, but focus on meaningful tests that cover edge cases and critical paths, not just trivial lines. 
 9. Co-locate tests with the code under test: each module `foo.py` has its tests in a sibling `foo_test.py` (suffix style — never a separate `tests/` directory, never the `test_*.py` prefix). 
 10. **Never drive a model with a bare Python `for`/`while` loop when it runs repeatedly.** Python loops execute op-by-op (dispatch overhead, no fusion) and trace fresh each step; the `brainstate.transform` primitives lower the whole loop into one compiled XLA program, tracing the body only once. Pick by shape of the work:
@@ -28,6 +28,7 @@ Online learning for recurrent networks via Eligibility Trace Propagation (ETP).
     - **Long rollout under autograd (backprop through time)** → `brainstate.transform.checkpointed_for_loop` / `brainstate.transform.checkpointed_scan` — same semantics as above but rematerialize activations on the backward pass (tune `base`) to bound peak memory at the cost of recomputation.
 
     Compose them freely (e.g. `jit` an outer driver that calls a `for_loop`/`scan`). Reach for the checkpointed variants only when reverse-mode gradients through a long simulation would otherwise exhaust memory — otherwise prefer plain `for_loop`/`scan`.
+11. Use `brainstate.random` instead of `jax.random` directly for all random number generation. 
 
 
 ## What this package does
@@ -154,10 +155,6 @@ equivalence coverage). These are enumerated and mapped to concrete improvement
 actions in the test-strategy findings list under `dev/`. Treat that list as the
 backlog of expected-failure / improvement items rather than duplicating it here.
 
-
-## Rules
-
-1. Use `brainstate.random` instead of `jax.random` directly for all random number generation. 
 
 ## Docstring style (NumPy-doc)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ Online learning for recurrent networks via Eligibility Trace Propagation (ETP).
 4. Bug? Write a test that reproduces it, then fix until the test passes.
 5. Every correction: reflect on the mistake, plan to avoid repeating it.
 6. All updates must be happened on the worktree branch, not main. 
-7. Write spec and plan under `/mnt/d/codes/projects/brainmass/dev/superpowers` as gitignored files before implementation. This makes them available for reference during implementation, but not clutter the repo history.
+7. Write specs and plans under `docs/specs` before implementation.
 8. Tests should >90% coverage, but focus on meaningful tests that cover edge cases and critical paths, not just trivial lines. 
 9. Co-locate tests with the code under test: each module `foo.py` has its tests in a sibling `foo_test.py` (suffix style — never a separate `tests/` directory, never the `test_*.py` prefix). 
 10. **Never drive a model with a bare Python `for`/`while` loop when it runs repeatedly.** Python loops execute op-by-op (dispatch overhead, no fusion) and trace fresh each step; the `brainstate.transform` primitives lower the whole loop into one compiled XLA program, tracing the body only once. Pick by shape of the work:
@@ -158,7 +158,6 @@ backlog of expected-failure / improvement items rather than duplicating it here.
 ## Rules
 
 1. Use `brainstate.random` instead of `jax.random` directly for all random number generation. 
-2. Place superpowers spec and plans in `/mnt/d/codes/projects/braintrace/dev/superpowers` directory.
 
 ## Docstring style (NumPy-doc)
 

--- a/braintrace/_compatible_imports.py
+++ b/braintrace/_compatible_imports.py
@@ -29,8 +29,12 @@ __all__ = [
     'is_scan_primitive',
     'is_while_primitive',
     'is_cond_primitive',
+    'scan_num_consts_carry',
+    'scan_params_add_ys',
     'wrap_init',
 ]
+
+from typing import Dict, Tuple
 
 from brainstate._compatible_import import Primitive, Var, JaxprEqn, Jaxpr, ClosedJaxpr, Literal, wrap_init
 
@@ -82,3 +86,63 @@ def is_while_primitive(eqn: JaxprEqn) -> bool:
 
 def is_cond_primitive(eqn: JaxprEqn) -> bool:
     return eqn.primitive.name == 'cond'
+
+
+def scan_num_consts_carry(eqn: JaxprEqn) -> Tuple[int, int]:
+    """Return ``(num_consts, num_carry)`` for a ``scan`` equation.
+
+    JAX < 0.11 stores ``num_consts`` / ``num_carry`` directly in the equation
+    params. JAX 0.11 removed them (part of the "flattree" scan refactor) and
+    instead encodes the ``(consts, carry, xs)`` input split in the ``ft_in``
+    flattree; the counts are the leaf counts of its first two groups. Detection
+    is capability-based (which params exist), so this works across every
+    supported JAX version without a hard-coded version comparison.
+
+    Parameters
+    ----------
+    eqn : JaxprEqn
+        A ``scan`` equation (``is_scan_primitive(eqn)`` must hold).
+
+    Returns
+    -------
+    tuple of int
+        ``(num_consts, num_carry)``.
+    """
+    params = eqn.params
+    if 'num_consts' in params:  # JAX < 0.11
+        return params['num_consts'], params['num_carry']
+    consts, carry, _xs = params['ft_in'].unpack()  # JAX >= 0.11
+    return len(consts), len(carry)
+
+
+def scan_params_add_ys(params: Dict, n_extra: int) -> Dict:
+    """Return ``scan`` params describing ``n_extra`` extra trailing ``ys`` outputs.
+
+    Used when rebuilding a scan whose body gains extra stacked ``ys`` outvars.
+
+    On JAX < 0.11 the number of ``ys`` is implicit (``len(outvars) - num_carry``),
+    so appending outvars needs no param change and ``params`` is returned
+    unchanged. On JAX 0.11 the ``ft_out`` flattree — which records the
+    ``(carry, ys)`` output split — must grow by ``n_extra`` leaves in its ``ys``
+    (second) component; the extra leaves are appended *after* the original ys so
+    the flattree leaf order matches ``[*carry, *original_ys, *extra]``.
+
+    Parameters
+    ----------
+    params : dict
+        The params of a ``scan`` equation (typically ``{**eqn.params, ...}``).
+    n_extra : int
+        Number of extra trailing ``ys`` leaves to describe.
+
+    Returns
+    -------
+    dict
+        Params updated for the extra ``ys`` (the same object when no change is
+        needed).
+    """
+    if n_extra == 0 or 'ft_out' not in params:  # JAX < 0.11, or nothing to add
+        return params
+    from jax._src import flattree as _ft  # only reached on JAX >= 0.11
+    carry_ft, ys_ft = params['ft_out'].unpack()
+    new_ft_out = _ft.pack((carry_ft, _ft.pack((ys_ft, _ft.nones(n_extra)))))
+    return {**params, 'ft_out': new_ft_out}

--- a/braintrace/_compatible_imports.py
+++ b/braintrace/_compatible_imports.py
@@ -37,7 +37,9 @@ from brainstate._compatible_import import Primitive, Var, JaxprEqn, Jaxpr, Close
 try:
     from jax.extend.core import new_jaxpr_eqn
 except ImportError:  # older JAX exposes it on jax.core only
-    from jax.core import new_jaxpr_eqn
+    # jax.core dropped ``new_jaxpr_eqn`` in JAX 0.11; this fallback only runs on
+    # older JAX, so silence mypy's static attr-defined/no-redef complaints.
+    from jax.core import new_jaxpr_eqn  # type: ignore[attr-defined, no-redef]
 
 try:
     from jax._src.ad_util import stop_gradient_p

--- a/braintrace/_compatible_imports_test.py
+++ b/braintrace/_compatible_imports_test.py
@@ -13,13 +13,72 @@
 # limitations under the License.
 # ==============================================================================
 
+import types
+
 import jax.numpy as jnp
 from jax import jit, make_jaxpr, lax
 
 from braintrace._compatible_imports import (
     is_jit_primitive, is_scan_primitive, is_while_primitive,
-    is_cond_primitive
+    is_cond_primitive, scan_num_consts_carry, scan_params_add_ys,
 )
+
+
+def _one_const_one_carry_one_xs_scan_eqn():
+    """A scan with exactly 1 const, 1 carry, 1 xs and 1 y."""
+
+    def scan_function(w, init, xs):
+        def step(c, x):
+            return c + w + x, c * 2.0  # w=const, c=carry, x=xs, y=c*2
+
+        return lax.scan(step, init, xs)
+
+    jaxpr = make_jaxpr(scan_function)(2.0, 1.0, jnp.arange(4.0))
+    return next(e for e in jaxpr.eqns if is_scan_primitive(e))
+
+
+class TestScanConstsCarry:
+    """`scan_num_consts_carry` across the JAX <0.11 and 0.11 scan encodings."""
+
+    def test_real_scan_eqn(self):
+        # Works on either encoding: old jax reads num_consts/num_carry params,
+        # jax 0.11 derives them from the ft_in flattree.
+        eqn = _one_const_one_carry_one_xs_scan_eqn()
+        assert scan_num_consts_carry(eqn) == (1, 1)
+
+    def test_old_jax_param_branch(self):
+        # Exercise the pre-0.11 branch without an old jax installed by handing
+        # the shim an eqn-like object whose params carry the legacy keys.
+        fake = types.SimpleNamespace(params={'num_consts': 3, 'num_carry': 2})
+        assert scan_num_consts_carry(fake) == (3, 2)
+
+
+class TestScanAddYs:
+    """`scan_params_add_ys` extends the ys arity only where the encoding needs it."""
+
+    def test_zero_extra_is_identity(self):
+        eqn = _one_const_one_carry_one_xs_scan_eqn()
+        params = dict(eqn.params)
+        assert scan_params_add_ys(params, 0) is params
+
+    def test_no_ft_out_is_identity(self):
+        # Legacy encoding (no ft_out): num_ys is implicit, params untouched.
+        legacy = {'num_consts': 1, 'num_carry': 1, 'length': 4}
+        assert scan_params_add_ys(legacy, 2) is legacy
+
+    def test_extends_ft_out_when_present(self):
+        eqn = _one_const_one_carry_one_xs_scan_eqn()
+        params = dict(eqn.params)
+        if 'ft_out' not in params:
+            # Old jax: nothing to extend, identity contract holds.
+            assert scan_params_add_ys(params, 2) is params
+            return
+        old_carry, old_ys = params['ft_out'].unpack()
+        new_params = scan_params_add_ys(params, 2)
+        new_carry, new_ys = new_params['ft_out'].unpack()
+        assert len(new_params['ft_out']) == len(params['ft_out']) + 2
+        assert len(new_carry) == len(old_carry)      # carry unchanged
+        assert len(new_ys) == len(old_ys) + 2        # ys grew by 2
 
 
 class TestPrimitive:

--- a/braintrace/_compiler/canonicalize.py
+++ b/braintrace/_compiler/canonicalize.py
@@ -60,6 +60,7 @@ from braintrace._compatible_imports import (
     is_while_primitive,
     new_jaxpr_eqn,
     new_var,
+    scan_num_consts_carry,
 )
 from braintrace._op import is_etp_primitive
 from .diagnostics import DiagnosticKind, DiagnosticLevel, emit
@@ -706,8 +707,7 @@ def _unroll_scans_once(
         body_closed = params['jaxpr']
         body = body_closed.jaxpr
         length: int = params['length']
-        num_consts: int = params['num_consts']
-        num_carry: int = params['num_carry']
+        num_consts, num_carry = scan_num_consts_carry(eqn)
         reverse: bool = params['reverse']
 
         const_atoms = list(eqn.invars[:num_consts])
@@ -920,7 +920,8 @@ def _unroll_scans_once(
                     )
             new_eqns.append(eqn)
             continue
-        num_prefix = eqn.params['num_consts'] + eqn.params['num_carry']
+        num_consts, num_carry = scan_num_consts_carry(eqn)
+        num_prefix = num_consts + num_carry
         sliced_weight = [
             v for v in eqn.invars[num_prefix:] if reaches_weight(v)
         ]
@@ -953,15 +954,15 @@ def _unroll_scans_once(
             level=DiagnosticLevel.INFO,
             message=(
                 f'Unrolled a scan of length {eqn.params["length"]} '
-                f'(num_consts={eqn.params["num_consts"]}, '
-                f'num_carry={eqn.params["num_carry"]}, '
+                f'(num_consts={num_consts}, '
+                f'num_carry={num_carry}, '
                 f'reverse={eqn.params["reverse"]}) into flat equations '
                 f'because {reason}.'
             ),
             context={
                 'length': eqn.params['length'],
-                'num_consts': eqn.params['num_consts'],
-                'num_carry': eqn.params['num_carry'],
+                'num_consts': num_consts,
+                'num_carry': num_carry,
                 'reverse': eqn.params['reverse'],
                 'reason': reason,
             },

--- a/braintrace/_compiler/hidden_group.py
+++ b/braintrace/_compiler/hidden_group.py
@@ -62,6 +62,7 @@ from braintrace._compatible_imports import (
     is_scan_primitive,
     is_while_primitive,
     is_cond_primitive,
+    scan_num_consts_carry,
 )
 from braintrace._op import is_etp_primitive, is_etp_enable_gradient_primitive
 from braintrace._misc import NotSupportedError
@@ -590,8 +591,7 @@ def _map_positions_to_subjaxpr_seeds(
             results.append((body, seeds, feedback))
     elif is_scan_primitive(eqn):
         body = eqn.params['jaxpr'].jaxpr
-        num_consts = eqn.params['num_consts']
-        num_carry = eqn.params['num_carry']
+        num_consts, num_carry = scan_num_consts_carry(eqn)
         seeds = [body.invars[j] for j in positions]
         feedback = {}
         for c in range(num_carry):

--- a/braintrace/_compiler/module_info.py
+++ b/braintrace/_compiler/module_info.py
@@ -350,10 +350,13 @@ class ModuleInfo(NamedTuple):
         )
 
         # closed jaxpr
-        closed_jaxpr = ClosedJaxpr(
-            jaxpr=jaxpr,
-            consts=self.closed_jaxpr.consts,
-        )
+        #
+        # NOTE: pass ``jaxpr`` and ``consts`` positionally. JAX 0.11 merged
+        # ``ClosedJaxpr`` into the unified ``Jaxpr`` whose first parameter is
+        # ``constvars`` (it specially accepts a whole ``Jaxpr``); there is no
+        # ``jaxpr=`` keyword anymore. The positional form works on old and new
+        # JAX alike, matching the other ``ClosedJaxpr(...)`` call sites.
+        closed_jaxpr = ClosedJaxpr(jaxpr, self.closed_jaxpr.consts)
 
         # new instance of `ModuleInfo`
         items = self.dict()

--- a/braintrace/_compiler/scan_descent.py
+++ b/braintrace/_compiler/scan_descent.py
@@ -65,6 +65,8 @@ from braintrace._compatible_imports import (
     is_scan_primitive,
     is_while_primitive,
     new_var,
+    scan_num_consts_carry,
+    scan_params_add_ys,
 )
 from braintrace._op import is_etp_primitive
 from braintrace._typing import Path
@@ -217,8 +219,7 @@ def _descent_blockers(
         if is_scan_primitive(e) or is_while_primitive(e) or is_cond_primitive(e):
             return ('its body contains nested control flow '
                     f'({e.primitive.name}); not supported by descent (v1)')
-    num_consts = eqn.params['num_consts']
-    num_carry = eqn.params['num_carry']
+    num_consts, num_carry = scan_num_consts_carry(eqn)
     for v in eqn.invars[num_consts + num_carry:]:
         if isinstance(v, Var) and v in weight_invars:
             return ('a trainable weight is scanned over as xs (per-iteration '
@@ -248,8 +249,10 @@ def add_scan_ys(
         ``(new_eqn, stacked_var_map)`` where ``stacked_var_map[body_var]`` is
         a fresh outer ``Var`` of aval ``(length, *body_var.aval.shape)``. The
         new eqn keeps the original outvars (by identity) followed by the
-        stacked vars; ``num_consts``/``num_carry``/``length``/``linear`` are
-        unchanged, and the body's eqns/invars keep their identity.
+        stacked vars; the scan's input structure (consts/carry/xs) and
+        ``length`` are unchanged — only the ys/output arity grows — and the
+        body's eqns/invars keep their identity. On JAX 0.11 the output flattree
+        (``ft_out``) is grown to match via :func:`scan_params_add_ys`.
     """
     body_closed = eqn.params['jaxpr']
     body = body_closed.jaxpr
@@ -268,8 +271,11 @@ def add_scan_ys(
         v: new_var('', v.aval.update(shape=(length, *v.aval.shape)))
         for v in extra
     }
+    new_params = scan_params_add_ys(
+        {**eqn.params, 'jaxpr': new_closed}, len(extra)
+    )
     new_eqn = eqn.replace(
-        params={**eqn.params, 'jaxpr': new_closed},
+        params=new_params,
         outvars=list(eqn.outvars) + [stacked[v] for v in extra],
     )
     return new_eqn, stacked
@@ -321,8 +327,7 @@ def analyze_and_rewrite_scan(eqn: JaxprEqn, minfo) -> Optional[ScanDescentBundle
     policy = minfo.control_flow
     body_closed = inline_jit_calls(eqn.params['jaxpr'])
     body = body_closed.jaxpr
-    num_consts = eqn.params['num_consts']
-    num_carry = eqn.params['num_carry']
+    num_consts, num_carry = scan_num_consts_carry(eqn)
 
     # ---- outer<->body position maps ---------------------------------------
     # scan invars [*consts, *carry, *xs] are positionally identical to

--- a/braintrace/_compiler/scan_descent_test.py
+++ b/braintrace/_compiler/scan_descent_test.py
@@ -13,7 +13,7 @@ import pytest
 
 import braintrace
 from braintrace import ControlFlowPolicy
-from braintrace._compatible_imports import is_scan_primitive
+from braintrace._compatible_imports import is_scan_primitive, scan_num_consts_carry
 from braintrace._compiler.module_info import extract_module_info
 from braintrace._compiler.scan_descent import (
     _descent_blockers,
@@ -131,15 +131,15 @@ class TestAddScanYs:
         # hoist: the tanh intermediate (a body-computed var) and the carry invar
         tanh_var = next(e.outvars[0] for e in body_jaxpr.eqns
                         if e.primitive.name == 'tanh')
-        num_consts, num_carry = eqn.params['num_consts'], eqn.params['num_carry']
+        num_consts, num_carry = scan_num_consts_carry(eqn)
         carry_invar = body_jaxpr.invars[num_consts]
 
         new_eqn, stacked = add_scan_ys(eqn, [tanh_var, carry_invar])
         assert list(new_eqn.outvars[:len(eqn.outvars)]) == list(eqn.outvars)
         assert stacked[tanh_var].aval.shape == (4,)
         assert stacked[carry_invar].aval.shape == (4,)
-        assert new_eqn.params['num_carry'] == num_carry
-        assert new_eqn.params['num_consts'] == num_consts
+        # the input structure (consts/carry) is preserved; only ys grow
+        assert scan_num_consts_carry(new_eqn) == (num_consts, num_carry)
         assert new_eqn.params['length'] == eqn.params['length']
         # body eqns preserved by identity
         assert new_eqn.params['jaxpr'].jaxpr.eqns == body_jaxpr.eqns
@@ -178,7 +178,8 @@ class TestAddScanYs:
         closed = jax.make_jaxpr(
             lambda xs: jax.lax.scan(body, jnp.zeros(()), xs))(jnp.arange(4.0))
         eqn = next(e for e in closed.jaxpr.eqns if is_scan_primitive(e))
-        carry_invar = eqn.params['jaxpr'].jaxpr.invars[eqn.params['num_consts']]
+        num_consts, _ = scan_num_consts_carry(eqn)
+        carry_invar = eqn.params['jaxpr'].jaxpr.invars[num_consts]
         new_eqn, stacked = add_scan_ys(eqn, [carry_invar, carry_invar])
         assert len(stacked) == 1
         assert len(new_eqn.outvars) == len(eqn.outvars) + 1


### PR DESCRIPTION
Fixes the daily CI failure caused by three independent JAX 0.11.0 internal API breaks, and renames the project instruction file. Compatible with all **jax ≥ 0.8.0** via capability detection (no hard-coded version checks).

## JAX 0.11 fixes
- **`ClosedJaxpr` merged into `Jaxpr`** — the unified constructor dropped the `jaxpr=` keyword; `ModuleInfo.add_jaxpr_outs` now passes `jaxpr`/`consts` positionally.
- **`jax.core.new_jaxpr_eqn` removed** — annotate the older-JAX import fallback with `type: ignore` so mypy passes on new JAX.
- **scan primitive "flattree" refactor** — `num_consts`/`num_carry`/`linear`/`_split_transpose` params were removed; the input/output splits now live in `ft_in`/`ft_out` flattrees. Added two capability-detecting shims in `_compatible_imports` (`scan_num_consts_carry`, `scan_params_add_ys`), routed all `num_consts`/`num_carry` reads through them, and rebuild `ft_out` in `add_scan_ys`. `while`/`cond` params are unchanged in 0.11 and untouched.

## CI
- Add `0.10.0` to the jax-version matrix (now covers `0.8.0`, `0.9.0`, `0.10.0`, latest — old encoding + flattree).

## Docs / meta
- Rename the gitignored `CLAUDE.md` to a tracked **`AGENTS.md`** (contents unchanged, then working-agreement rules refined: spec location → `docs/specs`).

## Verification
- Full suite on local jax 0.11: **2128 passed, 3 skipped**.
- `mypy braintrace`: clean (59 files).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Summary by Sourcery

Make braintrace compatible with JAX 0.11's updated jaxpr and scan flattree APIs while retaining support for older JAX versions, expand CI JAX coverage, and introduce a tracked AGENTS.md project guidance document.

Bug Fixes:
- Adapt scan handling to JAX 0.11's flattree-based scan encoding so const/carry and output structure are derived compatibly across supported versions.
- Update ClosedJaxpr construction to work with the unified Jaxpr constructor introduced in JAX 0.11.
- Silence mypy issues around the deprecated new_jaxpr_eqn import path when running on newer JAX versions.

Enhancements:
- Add compatibility shims and refactor scan analysis and rewrite code to consistently query scan metadata via helper functions rather than direct param access.
- Strengthen tests around scan const/carry counting and scan output extension to cover both legacy and flattree encodings.

CI:
- Extend the CI matrix to test against JAX 0.10 in addition to existing versions.

Documentation:
- Replace the gitignored CLAUDE.md with a tracked AGENTS.md that documents durable architecture and contributor working agreements.