### PR TITLE
P3: SnAp-n — generalise recurrence_scope to an n-step neighbourhood

### DIFF
--- a/braintrace/__init__.py
+++ b/braintrace/__init__.py
@@ -83,6 +83,7 @@ from ._algorithm import (
     pp_prop,
     ES_D_RTRL,
     IODimVjpAlgorithm,
+    SnAp,
     EProp,
     OSTLRecurrent,
     OSTLFeedforward,
@@ -165,6 +166,7 @@ __all__ = [
     'pp_prop',
     'ES_D_RTRL',
     'IODimVjpAlgorithm',
+    'SnAp',
 
     # one-call entry point
     'compile',

--- a/braintrace/_algorithm/__init__.py
+++ b/braintrace/_algorithm/__init__.py
@@ -32,6 +32,7 @@ from .ostl import OSTLFeedforward, OSTLRecurrent
 from .io_dim_vjp import IODimVjpAlgorithm
 from .param_dim_vjp import ParamDimVjpAlgorithm
 from .pp_prop import ES_D_RTRL, pp_prop  # ES_D_RTRL: back-compat alias
+from .snap_n import SnAp
 from .vjp_base import ETraceVjpAlgorithm
 from .vjp_graph_executor import ETraceVjpGraphExecutor
 
@@ -50,6 +51,7 @@ __all__ = [
     'pp_prop',
     'ES_D_RTRL',
     'IODimVjpAlgorithm',
+    'SnAp',
     # SNN
     'EProp',
     'OSTLRecurrent',

--- a/braintrace/_algorithm/axes.py
+++ b/braintrace/_algorithm/axes.py
@@ -27,6 +27,7 @@ and ``docs/specs/2026-07-25-p2-axis-decomposition.md`` for this module's design.
 from __future__ import annotations
 
 import dataclasses
+import operator
 from typing import Any, Dict, Optional, Tuple, Union
 
 __all__ = ['ETraceConfig']
@@ -48,7 +49,6 @@ _VOCABULARY: Dict[str, Tuple[str, ...]] = {
 #: ``(axis, value) -> where it is scheduled``. Rejected by matrix rule 8.
 _UNIMPLEMENTED: Dict[Tuple[str, str], str] = {
     ('trace_factorization', 'random_projection'): 'P4 (UORO)',
-    ('recurrence_scope', 'sparse_n'): 'P3 (SnAp-n)',
     ('learning_signal', 'modulatory'): 'P4 (three-factor)',
     ('learning_signal', 'bootstrapped'): 'P4 (DNI)',
     ('update_schedule', 'window'): 'no phase yet',
@@ -84,6 +84,36 @@ def _check_decay(value: Any, what: str) -> float:
             'itself, so a coordinate has one spelling.'
         )
     return value
+
+
+def _check_snap_order(value: Any) -> int:
+    """Validate the SnAp order ``sparse_n`` and return it as a plain ``int``.
+
+    The order counts how many steps of influence the trace retains, so it is a
+    positive integer with no upper bound: any ``n`` at or above a hidden group's
+    diameter saturates, and saturation is a property of the model, not of the
+    vocabulary. ``bool`` is rejected explicitly -- ``True == 1`` would otherwise
+    canonicalise silently onto ``recurrence_scope='coupled'``.
+    """
+    if isinstance(value, bool):
+        raise TypeError(
+            f'sparse_n must be an integer >= 1, got {value!r}. A bool is not a '
+            'SnAp order (True would silently mean n=1).'
+        )
+    try:
+        order = operator.index(value)
+    except TypeError:
+        raise TypeError(
+            f'sparse_n must be an integer >= 1, got {value!r}.'
+        ) from None
+    if order < 1:
+        raise ValueError(
+            f'sparse_n must be at least 1, got {order}. n=1 is SnAp-1 (the '
+            "instantaneous pattern, propagated zero times) and canonicalises to "
+            "recurrence_scope='coupled'; there is no smaller order. "
+            "recurrence_scope='diagonal' is a different rule, not n=0."
+        )
+    return order
 
 
 def _as_pair(value: Any, what: str) -> Tuple[Any, Any]:
@@ -125,7 +155,13 @@ class ETraceConfig:
     recurrence_scope : str, default 'diagonal'
         How much hidden-to-hidden coupling enters ``D``. ``'diagonal'`` keeps
         only each state's own recurrence; ``'coupled'`` traces recurrent mixing
-        between states of a hidden group.
+        between states of a hidden group; ``'sparse_n'`` retains influence over
+        an ``n``-step neighbourhood derived from the model's own transition
+        (SnAp-n), with ``n`` supplied as ``sparse_n``. The last two form one
+        scale: SnAp-1 *is* ``'coupled'`` (the instantaneous pattern propagated
+        zero times), and ``sparse_n=1`` canonicalises onto it. ``'diagonal'``
+        sits below the scale -- it drops the recurrent mixing primitive from the
+        transition before differentiating -- so no ``n`` reaches it.
     learning_signal : str, default 'symmetric'
         Where the per-hidden-group signal comes from. ``'symmetric'`` uses the
         true ``dL/dh``; ``'random_feedback'`` projects it through a fixed random
@@ -143,7 +179,10 @@ class ETraceConfig:
     kappa : float, optional
         Coefficient of ``trace_filter='kappa'``, in ``[0, 1)``.
     sparse_n : int, optional
-        Coefficient of ``recurrence_scope='sparse_n'``.
+        Coefficient of ``recurrence_scope='sparse_n'``: the SnAp order, an
+        integer ``>= 1``. Any order at or above a hidden group's diameter
+        saturates to full within-group RTRL, so there is no "infinity"
+        spelling -- saturation is a property of the model, not the vocabulary.
     window_size : int, optional
         Coefficient of ``update_schedule='window'``.
 
@@ -166,6 +205,9 @@ class ETraceConfig:
       expands to a pair.
     - ``trace_filter='kappa'`` with ``kappa == 0`` becomes ``'none'``, matching
       ``EProp(kappa_filter_decay=0)``'s documented reduction to ``D_RTRL``.
+    - ``recurrence_scope='sparse_n'`` with ``sparse_n == 1`` becomes
+      ``'coupled'`` with no coefficient — SnAp-1 and the block-diagonal
+      recursion are one rule.
 
     Examples
     --------
@@ -226,6 +268,17 @@ class ETraceConfig:
             self._canonicalise_factorized()
         else:
             self._canonicalise_scalar()
+
+        # SnAp-1 retains the instantaneous pattern and propagates it zero times,
+        # which is precisely the per-position block-diagonal recursion `coupled`
+        # already computes. One coordinate, one spelling — and `coupled` keeps
+        # the established name. The order is type-checked *before* the
+        # comparison so `sparse_n=True` cannot slip through as n=1.
+        if self.sparse_n is not None:
+            self._set('sparse_n', _check_snap_order(self.sparse_n))
+            if self.sparse_n == 1 and self.recurrence_scope == 'sparse_n':
+                self._set('recurrence_scope', 'coupled')
+                self._set('sparse_n', None)
 
         # `kappa == 0` is no filter at all: EProp documents `kappa_filter_decay=0`
         # as reducing exactly to D_RTRL, so the two are one coordinate. Clearing
@@ -331,6 +384,8 @@ class ETraceConfig:
             self._rules_4_5_per_param_decay,
             self._rule_6_factorized_needs_decay,
             self._rule_7_coefficients_need_their_category,
+            self._rule_9_sparse_n_needs_per_param,
+            self._rule_10_sparse_n_is_a_widening_order,
         ):
             rule()
 
@@ -435,6 +490,32 @@ class ETraceConfig:
         if self.kappa is not None:
             _check_decay(self.kappa, 'kappa')
 
+    def _rule_9_sparse_n_needs_per_param(self) -> None:
+        if self.recurrence_scope != 'sparse_n':
+            return
+        if self.trace_factorization != 'per_param':
+            raise ValueError(
+                "recurrence_scope='sparse_n' requires "
+                "trace_factorization='per_param', not "
+                f'{self.trace_factorization!r}. SnAp-n widens the trace\'s '
+                'trailing state axis into a (neighbour, state) axis, and the '
+                'factorised x-side carries no hidden index at all to widen — '
+                'the whole widening would have to land on the f-side, which is '
+                'a different rule and would break the O(I+O) memory the '
+                "factorisation exists for. Use recurrence_scope='coupled'."
+            )
+
+    def _rule_10_sparse_n_is_a_widening_order(self) -> None:
+        if self.recurrence_scope != 'sparse_n':
+            return
+        # Post-condition of canonicalisation: n == 1 has already been rewritten
+        # onto `coupled`, so a surviving `sparse_n` coordinate genuinely widens.
+        order = _check_snap_order(self.sparse_n)
+        assert order >= 2, (
+            f'sparse_n={order} survived canonicalisation; n=1 must have been '
+            "rewritten onto recurrence_scope='coupled'."
+        )
+
     # -- derived views ----------------------------------------------------- #
 
     @property
@@ -476,8 +557,12 @@ class ETraceConfig:
         """Whether the compiler should trace hidden-to-hidden ETP mixing.
 
         The graph executor's spelling of :attr:`recurrence_scope`.
+
+        ``True`` for both non-diagonal scopes: ``'coupled'`` needs the coupled
+        transition to take its per-position block diagonal, and ``'sparse_n'``
+        needs the same transition to gather its widened operator out of.
         """
-        return self.recurrence_scope == 'coupled'
+        return self.recurrence_scope in ('coupled', 'sparse_n')
 
     def replace(self, **changes: Any) -> 'ETraceConfig':
         """Return a copy with ``changes`` applied, re-canonicalised and re-checked.

--- a/braintrace/_algorithm/axes_test.py
+++ b/braintrace/_algorithm/axes_test.py
@@ -219,7 +219,6 @@ class TestCompatibilityMatrix:
 
     @pytest.mark.parametrize('kwargs,phase', [
         (dict(trace_factorization='random_projection'), 'P4'),
-        (dict(recurrence_scope='sparse_n', sparse_n=2), 'P3'),
         (dict(learning_signal='modulatory'), 'P4'),
         (dict(learning_signal='bootstrapped'), 'P4'),
         (dict(update_schedule='window', window_size=4), 'no phase yet'),
@@ -277,14 +276,105 @@ class TestDerivedViews:
         with pytest.raises(ValueError, match='may only be a pair'):
             ETraceConfig(temporal_recursion='scalar_leak', decay=(0.9, 0.9))
 
-    @pytest.mark.parametrize('scope,expected', [
-        ('diagonal', False), ('coupled', True),
+    @pytest.mark.parametrize('kwargs,expected', [
+        (dict(recurrence_scope='diagonal'), False),
+        (dict(recurrence_scope='coupled'), True),
+        (dict(recurrence_scope='sparse_n', sparse_n=3), True),
     ])
-    def test_include_recurrent_mixing_is_the_executors_spelling(self, scope, expected):
-        assert ETraceConfig(recurrence_scope=scope).include_recurrent_mixing is expected
+    def test_include_recurrent_mixing_is_the_executors_spelling(self, kwargs, expected):
+        # SnAp-n gathers its widened transition operator out of the true
+        # cross-position Jacobian, so it needs the coupled transition traced
+        # just as much as `coupled` itself does.
+        assert ETraceConfig(**kwargs).include_recurrent_mixing is expected
 
 
 @pytest.mark.parametrize('name', sorted(PRESET_COORDINATES))
 def test_every_preset_coordinate_is_constructible(name):
     """The matrix must admit all five surviving presets, or P2 cannot land."""
     assert isinstance(ETraceConfig(**PRESET_COORDINATES[name]), ETraceConfig)
+
+
+class TestSparseNAxis:
+    """``recurrence_scope='sparse_n'`` -- the SnAp-n scale (P3).
+
+    The scale's identity element is ``coupled``, not ``diagonal``: SnAp-1 keeps
+    the instantaneous pattern and propagates it zero times, which is exactly the
+    per-position block-diagonal recursion ``coupled`` computes. ``diagonal``
+    sits *below* the scale -- it deletes the recurrent mixing primitive from the
+    transition before differentiating -- so it is not reachable by any ``n``.
+    """
+
+    def test_sparse_n_is_implemented(self):
+        cfg = ETraceConfig(recurrence_scope='sparse_n', sparse_n=3)
+        assert cfg.recurrence_scope == 'sparse_n'
+        assert cfg.sparse_n == 3
+
+    def test_n_equals_one_canonicalises_onto_coupled(self):
+        cfg = ETraceConfig(recurrence_scope='sparse_n', sparse_n=1)
+        assert cfg.recurrence_scope == 'coupled'
+        assert cfg.sparse_n is None
+        assert cfg == ETraceConfig(recurrence_scope='coupled')
+
+    def test_the_canonicalisation_is_idempotent(self):
+        once = ETraceConfig(recurrence_scope='sparse_n', sparse_n=1)
+        twice = dataclasses.replace(once)
+        assert once == twice
+
+    def test_n_at_least_two_is_left_alone(self):
+        for n in (2, 3, 17):
+            cfg = ETraceConfig(recurrence_scope='sparse_n', sparse_n=n)
+            assert (cfg.recurrence_scope, cfg.sparse_n) == ('sparse_n', n)
+
+    def test_diagonal_is_not_reachable_by_any_n(self):
+        for n in (1, 2, 5):
+            cfg = ETraceConfig(recurrence_scope='sparse_n', sparse_n=n)
+            assert cfg.recurrence_scope != 'diagonal'
+
+    def test_rule_9_sparse_n_requires_per_param(self):
+        with pytest.raises(ValueError, match="requires trace_factorization='per_param'"):
+            ETraceConfig(
+                trace_factorization='io_factorized',
+                temporal_recursion=('scalar_leak', 'jacobian'),
+                decay=0.9,
+                recurrence_scope='sparse_n',
+                sparse_n=2,
+            )
+
+    def test_rule_9_negative_control_coupled_stays_legal_under_io_factorized(self):
+        # rule 9 must reject `sparse_n` specifically, not every non-diagonal scope
+        cfg = ETraceConfig(
+            trace_factorization='io_factorized',
+            temporal_recursion=('scalar_leak', 'jacobian'),
+            decay=0.9,
+            recurrence_scope='coupled',
+        )
+        assert cfg.recurrence_scope == 'coupled'
+
+    @pytest.mark.parametrize('n', [0, -1, -5])
+    def test_rule_10_rejects_a_non_positive_order(self, n):
+        with pytest.raises(ValueError, match='at least 1'):
+            ETraceConfig(recurrence_scope='sparse_n', sparse_n=n)
+
+    @pytest.mark.parametrize('n', [True, False, 2.0, '2', None.__class__])
+    def test_rule_10_rejects_a_non_integer_order(self, n):
+        # `True == 1` would otherwise canonicalise silently onto `coupled`
+        with pytest.raises(TypeError, match='must be an integer'):
+            ETraceConfig(recurrence_scope='sparse_n', sparse_n=n)
+
+    def test_rule_2_sparse_n_still_needs_a_jacobian_recursion(self):
+        with pytest.raises(ValueError, match="to be 'jacobian'"):
+            ETraceConfig(
+                recurrence_scope='sparse_n', sparse_n=2,
+                temporal_recursion='scalar_leak', decay=0.9,
+            )
+
+    def test_rule_7_pairs_the_coefficient_with_its_axis_both_ways(self):
+        with pytest.raises(ValueError, match='`sparse_n` is required'):
+            ETraceConfig(recurrence_scope='sparse_n')
+        with pytest.raises(ValueError, match='no.*category to act on'):
+            ETraceConfig(recurrence_scope='coupled', sparse_n=2)
+
+    def test_describe_names_the_order(self):
+        text = ETraceConfig(recurrence_scope='sparse_n', sparse_n=4).describe()
+        assert "recurrence_scope='sparse_n'" in text
+        assert 'sparse_n=4' in text

--- a/braintrace/_algorithm/graph_executor.py
+++ b/braintrace/_algorithm/graph_executor.py
@@ -41,7 +41,12 @@ from typing import Dict, Any, Optional
 
 import brainstate
 
-from braintrace._compiler import ControlFlowPolicy, ETraceGraph, compile_etrace_graph
+from braintrace._compiler import (
+    ControlFlowPolicy,
+    DEFAULT_MAX_JACOBIAN_ELEMENTS,
+    ETraceGraph,
+    compile_etrace_graph,
+)
 from .._input_data import get_single_step_data
 from .._typing import Path
 
@@ -68,6 +73,13 @@ class ETraceGraphExecutor:
     include_recurrent_mixing: bool, optional
         Hidden-group grouping mode for the hidden-to-hidden transition; see
         ``compile_etrace_graph(..., include_recurrent_mixing=...)``.
+    sparse_n: int, optional
+        SnAp order for ``recurrence_scope='sparse_n'``; each hidden group then
+        carries the derived n-step neighbourhood its trace is widened onto.
+        ``None`` (default) for every other scope.
+    snap_max_jacobian_elements: int, optional
+        Ceiling on each group's widened block Jacobian, ``P * (K * S) ** 2``
+        elements; only consulted when *sparse_n* is given.
     control_flow: ControlFlowPolicy, optional
         Policy governing control-flow canonicalization (cond if-conversion,
         scan unrolling, structured scan descent, ...) during graph
@@ -80,6 +92,8 @@ class ETraceGraphExecutor:
         self,
         model: brainstate.nn.Module,
         include_recurrent_mixing: bool = False,
+        sparse_n: Optional[int] = None,
+        snap_max_jacobian_elements: int = DEFAULT_MAX_JACOBIAN_ELEMENTS,
         control_flow: Optional[ControlFlowPolicy] = None,
     ) -> None:
         # The original model
@@ -94,6 +108,13 @@ class ETraceGraphExecutor:
         # hidden-group grouping mode for the hidden-to-hidden transition; see
         # ``compile_etrace_graph(..., include_recurrent_mixing=...)``.
         self.include_recurrent_mixing = include_recurrent_mixing
+
+        # SnAp order for ``recurrence_scope='sparse_n'``; ``None`` for every
+        # other scope, which leaves each hidden group's ``snap`` pattern unset.
+        self.sparse_n = sparse_n
+
+        # ceiling on the widened block Jacobian; only read when sparse_n is set
+        self.snap_max_jacobian_elements = snap_max_jacobian_elements
 
         # control-flow canonicalization policy; None -> compiler default
         self.control_flow = control_flow
@@ -197,6 +218,8 @@ class ETraceGraphExecutor:
         self._compiled_graph = compile_etrace_graph(
             self.model, *args,
             include_recurrent_mixing=self.include_recurrent_mixing,
+            sparse_n=self.sparse_n,
+            snap_max_jacobian_elements=self.snap_max_jacobian_elements,
             control_flow=self.control_flow,
         )
 

--- a/braintrace/_algorithm/oracle_models.py
+++ b/braintrace/_algorithm/oracle_models.py
@@ -440,6 +440,216 @@ def snn_scan_two_state_rnn(n_rec: int = 3, loops: int = 40,
                      plain_param_keys=())
 
 
+def _ring_csr(n_rec: int, offsets: Tuple[int, ...]):
+    """The CSR matrix connecting ``q -> (q + off) % n_rec`` for each offset.
+
+    Shared by the ring fixtures below so their position graphs are the *same*
+    graph: a test that reads a neighbourhood size off one of them and an
+    expected ``K(n)`` off the other is comparing like with like.
+
+    Returns
+    -------
+    tuple
+        ``(csr, nnz)`` — the matrix and its stored-entry count, which is the
+        shape of the ETP data vector.
+    """
+    import brainevent
+
+    dense_mask = np.zeros((n_rec, n_rec), dtype='float32')
+    for q in range(n_rec):
+        for off in offsets:
+            dense_mask[q, (q + off) % n_rec] = 1.0
+    return brainevent.CSR.fromdense(jnp.asarray(dense_mask)), int(dense_mask.sum())
+
+
+def sparse_ring_rnn(
+    n_in: int = 3, n_rec: int = 6, offsets: Tuple[int, ...] = (0, 1), seed: int = 0
+) -> ModelSpec:
+    """Tanh RNN whose recurrence is a **fixed sparse ring**, via ``sparse_matmul``.
+
+    ``h^t = tanh(x^t @ win + sparse_matmul(h^{t-1}, w, sparse_mat=CSR))`` where
+    the CSR pattern connects ``q -> (q + off) % n_rec`` for each ``off`` in
+    ``offsets``. This is the reference model for the ``sparse_n`` recurrence
+    scope: unlike a dense recurrent weight — whose position graph has diameter
+    1, so ``n = 2`` already saturates — a ring of ``n_rec`` units has diameter
+    ``n_rec - 1``, so the SnAp neighbourhood grows one position per order and
+    ``K(n) == min(n, n_rec)`` exactly.
+
+    The default ``offsets=(0, 1)`` keeps the **self** edge. Without it (a pure
+    cycle) position ``p``'s hidden state does not depend on its own previous
+    value at all, so the per-position block of the recurrent Jacobian is
+    identically zero and ``recurrence_scope='diagonal'`` and ``'coupled'``
+    produce *bit-identical* gradients — which would make every negative control
+    that separates them vacuous on this model. The self edge is also the more
+    realistic recurrent unit. It does not change ``K(n)``: closing ``I | shift``
+    still reaches exactly one further position per order.
+
+    Structural properties the acceptance suite pins:
+
+    * one hidden group, ``varshape == (n_rec,)``, ``num_state == 1`` — the
+      ``S = 1, K > 1`` configuration that exercises every ``num_state == 1``
+      shortcut in the engine under a widened trace;
+    * the relation's primitive is ``etp_sp_mv``, whose D-RTRL trace is
+      ``nnz``-shaped rather than position-shaped, so it also pins that the
+      widening is transparent to a primitive with a non-trivial anchor map;
+    * the ``y -> hidden`` tail is elementwise (``add`` then ``tanh``), so a
+      saturated within-group SnAp is full RTRL and must equal BPTT.
+
+    Parameters
+    ----------
+    n_in : int, optional
+        Input dimension.
+    n_rec : int, optional
+        Number of recurrent units (the ring length, hence the diameter).
+    offsets : tuple of int, optional
+        Ring offsets present in the sparse pattern. ``(1,)`` gives the pure
+        cycle; adding offsets shortens the diameter.
+    seed : int, optional
+        Seed for the deterministic weight draw.
+
+    Returns
+    -------
+    ModelSpec
+        Spec whose ETP parameter is the sparse data vector ``w`` (shape
+        ``(nnz,)``) and whose plain parameter is the input projection ``win``.
+    """
+    csr, nnz = _ring_csr(n_rec, offsets)
+
+    def factory():
+        class Net(brainstate.nn.Module):
+            def __init__(self):
+                super().__init__()
+                with brainstate.random.seed_context(seed):
+                    self.w = brainstate.ParamState(
+                        0.6 * brainstate.random.randn(nnz))
+                    self.win = brainstate.ParamState(
+                        0.5 * brainstate.random.randn(n_in, n_rec))
+                self.h = brainstate.HiddenState(jnp.zeros((n_rec,)))
+
+            def update(self, x):
+                rec = braintrace.sparse_matmul(self.h.value, self.w.value, sparse_mat=csr)
+                self.h.value = jax.nn.tanh(x @ self.win.value + rec)
+                return self.h.value
+
+        return Net()
+
+    return ModelSpec(factory=factory, etp_param_keys=(('w',),), plain_param_keys=(('win',),))
+
+
+def rolled_tail_rnn(
+    n_in: int = 3, n_rec: int = 5, roll: int = 1, seed: int = 0
+) -> ModelSpec:
+    """Dense tanh RNN whose ``y -> hidden`` tail **relabels positions** (F-31).
+
+    ``h^t = tanh(x @ win + roll(matmul(h^{t-1}, w), roll))``. The mixing
+    primitive is the ordinary dense ``etp_mm``/``etp_mv``, whose position graph
+    has diameter 1, so ``sparse_n`` saturates at ``n = 2`` and a *saturated*
+    within-group rule is full within-group RTRL. What the roll breaks is the
+    premise underneath the whole ``recurrence_scope`` axis: the trace indexes
+    hidden units by position, and here the position that a mixing output lands
+    on is not the position it was computed for.
+
+    ``roll=0`` gives the control — the same model with a position-preserving
+    tail — which is what makes the comparison legible: at ``roll=0`` saturation
+    equals BPTT to round-off, and at ``roll=1`` it does not, while the model is
+    otherwise identical. Use the pair, never the rolled model alone.
+
+    The position analysis detects the tail (the ``slice`` equations ``roll``
+    lowers to are not position-preserving) and widens to all-to-all with a
+    ``SNAP_PATTERN_CONSERVATIVE`` diagnostic, so the shortfall is warned about
+    rather than silent. See "Notes on F-31" in
+    ``docs/specs/2026-07-25-known-limitations.md``.
+
+    Parameters
+    ----------
+    n_in : int, optional
+        Input dimension.
+    n_rec : int, optional
+        Number of recurrent units.
+    roll : int, optional
+        Positions to roll the recurrent term by. ``0`` disables the relabelling
+        and yields the control model.
+    seed : int, optional
+        Seed for the deterministic weight draw.
+
+    Returns
+    -------
+    ModelSpec
+        Spec whose ETP parameter is the recurrent matrix ``w``.
+    """
+
+    def factory():
+        class Net(brainstate.nn.Module):
+            def __init__(self):
+                super().__init__()
+                with brainstate.random.seed_context(seed):
+                    self.w = brainstate.ParamState(
+                        0.6 * brainstate.random.randn(n_rec, n_rec))
+                    self.win = brainstate.ParamState(
+                        0.5 * brainstate.random.randn(n_in, n_rec))
+                self.h = brainstate.HiddenState(jnp.zeros((n_rec,)))
+
+            def update(self, x):
+                rec = braintrace.matmul(self.h.value, self.w.value)
+                if roll:
+                    rec = jnp.roll(rec, roll)
+                self.h.value = jax.nn.tanh(x @ self.win.value + rec)
+                return self.h.value
+
+        return Net()
+
+    return ModelSpec(factory=factory, etp_param_keys=(('w',),), plain_param_keys=(('win',),))
+
+
+def sparse_ring_two_state_rnn(
+    n_in: int = 3, n_rec: int = 5, offsets: Tuple[int, ...] = (0, 1), seed: int = 0
+) -> ModelSpec:
+    """:func:`sparse_ring_rnn` with a second, coupled hidden state.
+
+    ``v^t = tanh(x @ win + sparse_matmul(v^{t-1}, w) - 0.1 a^{t-1})`` and
+    ``a^t = 0.95 a^{t-1} + v^{t-1}``. The compiler groups ``(v, a)`` into one
+    HiddenGroup with ``num_state == 2``, so the widened trace axis is
+    ``M = K * 2`` — the ``S > 1, K > 1`` configuration. The adjacency analysis
+    still sees exactly one mixing equation (on ``v``); the ``a`` coupling is
+    hand-written arithmetic and contributes no position mixing, which is why
+    the pattern stays the precise ring rather than falling back to conservative.
+
+    Parameters
+    ----------
+    n_in, n_rec, offsets, seed
+        As in :func:`sparse_ring_rnn`.
+
+    Returns
+    -------
+    ModelSpec
+        Spec whose ETP parameter is the sparse data vector ``w``.
+    """
+    csr, nnz = _ring_csr(n_rec, offsets)
+
+    def factory():
+        class Net(brainstate.nn.Module):
+            def __init__(self):
+                super().__init__()
+                with brainstate.random.seed_context(seed):
+                    self.w = brainstate.ParamState(
+                        0.6 * brainstate.random.randn(nnz))
+                    self.win = brainstate.ParamState(
+                        0.5 * brainstate.random.randn(n_in, n_rec))
+                self.v = brainstate.HiddenState(jnp.zeros((n_rec,)))
+                self.a = brainstate.HiddenState(jnp.zeros((n_rec,)))
+
+            def update(self, x):
+                v, a = self.v.value, self.a.value
+                rec = braintrace.sparse_matmul(v, self.w.value, sparse_mat=csr)
+                self.v.value = jax.nn.tanh(x @ self.win.value + rec - 0.1 * a)
+                self.a.value = 0.95 * a + v
+                return self.v.value
+
+        return Net()
+
+    return ModelSpec(factory=factory, etp_param_keys=(('w',),), plain_param_keys=(('win',),))
+
+
 def while_settle_rnn(
     n_in: int = 3, n_rec: int = 4, k: int = 3, decay: float = 0.8, seed: int = 0
 ) -> ModelSpec:

--- a/braintrace/_algorithm/param_dim_vjp.py
+++ b/braintrace/_algorithm/param_dim_vjp.py
@@ -23,7 +23,14 @@ import jax
 import jax.numpy as jnp
 import brainunit as u
 
-from braintrace._compiler import ControlFlowPolicy, HiddenParamOpRelation, HiddenGroup
+from braintrace._compiler import (
+    ControlFlowPolicy,
+    DEFAULT_MAX_JACOBIAN_ELEMENTS,
+    HiddenGroup,
+    HiddenParamOpRelation,
+    gather_learning_signal,
+    widen_instant_term,
+)
 from braintrace._op import (
     etp_conv_p,
     etp_elemwise_p,
@@ -115,11 +122,16 @@ def _init_param_dim_state(
             init_kw['group'] = group
         elif relation.primitive is etp_conv_p:
             init_kw['eqn_params'] = relation.eqn_params
+        # ``trace_state_width`` is ``num_state`` at every recurrence_scope but
+        # ``sparse_n``, where the trailing state axis carries the SnAp-n
+        # neighbourhood as well: ``M = K * num_state``. Every per-primitive rule
+        # is generic in the size of that axis, so widening is a sizing change
+        # here and nowhere else.
         init_val = init_fn(
             relation.x_var,
             relation.y_var,
             relation.trainable_vars,
-            group.num_state,
+            group.trace_state_width,
             **init_kw,
         )
         if not isinstance(init_val, dict):
@@ -394,6 +406,12 @@ def _apply_relation_step(
         for group in relation.hidden_groups:
 
             df = etrace_ys_at_t[etrace_df_key(relation.y, group.index)]
+            if group.snap is not None:
+                # `sparse_n`: the instantaneous term lands on the position the
+                # relation anchors at, i.e. neighbour slot 0. Padding it here --
+                # rather than inside each primitive's `instant` rule -- keeps
+                # every rule generic in the width of the trailing axis.
+                df = widen_instant_term(df, group.snap.num_neighbour)
 
             # Instantaneous term: diag(D_f^t) ⊗ x^t  (Dict[str, Array]).
             # Cast the update inputs to ``trace_dtype`` (no-op when None) so the
@@ -420,10 +438,11 @@ def _apply_relation_step(
                 new_bwg_pre = fp.recurrent(
                     _cast_to_dtype(diag, trace_dtype),
                     old_bwg,
-                    group.num_state,
+                    group.trace_state_width,
                 )
             else:
-                new_bwg_pre = _comp_recurrent_legacy(diag, old_bwg, group.num_state)
+                new_bwg_pre = _comp_recurrent_legacy(
+                    diag, old_bwg, group.trace_state_width)
 
             # new_bwg_pre + phg_to_pw per-leaf.
             new_bwg = jax.tree.map(
@@ -501,19 +520,23 @@ def _update_param_dim_etrace_chunked(
         for group in relation.hidden_groups:
             gi = group.index
             if gi not in p_cache:
-                p_seq, m_full = suffix_products(diags_seq[gi], group.num_state)
+                p_seq, m_full = suffix_products(
+                    diags_seq[gi], group.trace_state_width)
                 p_cache[gi] = (
                     _cast_to_dtype(p_seq, trace_dtype),
                     _cast_to_dtype(m_full, trace_dtype),
                 )
             p_seq, m_full = p_cache[gi]
-            df_seq = _cast_to_dtype(
-                dfs_seq[etrace_df_key(relation.y_var, gi)], trace_dtype
-            )
+            df_seq = dfs_seq[etrace_df_key(relation.y_var, gi)]
+            if group.snap is not None:
+                # same widening as the per-step body; ``df_seq`` is stacked over
+                # time but the padded axis is still the trailing one.
+                df_seq = widen_instant_term(df_seq, group.snap.num_neighbour)
+            df_seq = _cast_to_dtype(df_seq, trace_dtype)
             w_key = (id(relation.y_var), gi)
             new_etrace_bwg[w_key] = fp.chunk(
                 x_seq, df_seq, p_seq, m_full,
-                hist_etrace_vals[w_key], group.num_state,
+                hist_etrace_vals[w_key], group.trace_state_width,
             )
 
     if legacy:
@@ -628,6 +651,11 @@ def _solve_param_dim_weight_gradients(
             w_key = (id(relation.y_var), group.index)
             etrace_data = hist_etrace_data[w_key]  # Dict[str, Array]
             dg_hidden = dG_hidden_groups[group.index]
+            if group.snap is not None:
+                # `sparse_n`: the trace's trailing axis indexes (neighbour,
+                # state) pairs, so the learning signal has to be expressed in
+                # the same coordinates before the contraction.
+                dg_hidden = gather_learning_signal(dg_hidden, group.snap)
 
             # dimensionless processing (unit strip + restore). Apply per-leaf.
             etrace_data_unitless, fn_unit_restore = _remove_units(etrace_data)
@@ -669,8 +697,10 @@ def _solve_param_dim_weight_gradients(
                 )
                 if batched:
                     folded_paths.update(relation.trainable_paths.values())
-            elif group.num_state == 1:
-                # num_state==1 shortcut: skip outer vmap of size 1.
+            elif group.trace_state_width == 1:
+                # width==1 shortcut: skip outer vmap of size 1. Reads the widened
+                # width, not num_state: under `sparse_n` a single-state group
+                # with K > 1 has a size-K trailing axis and must NOT take it.
                 dg_hid_squeezed = jax.tree.map(
                     lambda a: u.math.squeeze(a, axis=-1), dg_hidden_unitless
                 )
@@ -926,10 +956,12 @@ class ParamDimVjpAlgorithm(ETraceVjpAlgorithm):
         control_flow: Optional[ControlFlowPolicy] = None,
         config: Optional[ETraceConfig] = None,
         random_feedback_key: Optional[jax.Array] = None,
+        snap_max_jacobian_elements: int = DEFAULT_MAX_JACOBIAN_ELEMENTS,
     ) -> None:
         super().__init__(model, name=name, vjp_method=vjp_method,
                          control_flow=control_flow, config=config,
-                         random_feedback_key=random_feedback_key)
+                         random_feedback_key=random_feedback_key,
+                         snap_max_jacobian_elements=snap_max_jacobian_elements)
         if self.config.trace_factorization != 'per_param':
             raise ValueError(
                 f'{type(self).__name__} is the per-parameter trace engine, but '

--- a/braintrace/_algorithm/snap_n.py
+++ b/braintrace/_algorithm/snap_n.py
@@ -1,0 +1,209 @@
+# Copyright 2026 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""SnAp-n — Sparse n-step Approximation (Menick et al., 2021).
+
+SnAp-n interpolates between the cheap and the exact end of the
+``recurrence_scope`` axis by *sparsifying the influence matrix*
+:math:`\\mathbf{J} = \\partial \\mathbf{h} / \\partial \\boldsymbol{\\theta}`
+to the sparsity pattern that the instantaneous term acquires after being
+propagated ``n - 1`` further times through the transition operator
+:math:`\\mathbf{D}`.
+
+The scale is a genuine interpolation, and both of its endpoints already existed
+in this codebase under different names:
+
+- ``n = 1`` keeps only the influence a parameter has on the hidden units it
+  *directly* drives. That is exactly ``recurrence_scope='coupled'`` — the
+  per-position block-diagonal Jacobian that :class:`~braintrace.OSTLRecurrent`
+  uses — so ``SnAp(model, n=1)`` canonicalises to that coordinate rather than
+  introducing a second spelling of it.
+- ``n`` at or above the hidden group's *position-graph diameter* saturates: the
+  neighbourhood of every position is the whole group, and the rule becomes full
+  within-group RTRL.
+
+``recurrence_scope='diagonal'`` sits *below* this scale rather than on it: it
+deletes the recurrent mixing primitive before differentiating (the e-prop /
+RFLO regime), which is not any ``n``.
+
+See :class:`SnAp` for the formulation, the limitations, and an example.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import brainstate
+
+from braintrace._compiler import DEFAULT_MAX_JACOBIAN_ELEMENTS
+from .axes import ETraceConfig
+from .param_dim_vjp import ParamDimVjpAlgorithm
+
+__all__ = ['SnAp']
+
+
+class SnAp(ParamDimVjpAlgorithm):
+    r"""Sparse n-step Approximation of RTRL.
+
+    RTRL carries the full influence matrix
+    :math:`\mathbf{J}^t_{q,\theta} = \partial h^t_q / \partial \theta` and rolls
+    it with
+
+    .. math::
+
+        \mathbf{J}^t = \mathbf{D}^t \mathbf{J}^{t-1} + \mathbf{J}_f^t ,
+        \qquad
+        \mathbf{D}^t = \frac{\partial \mathbf{h}^t}{\partial \mathbf{h}^{t-1}},
+        \qquad
+        (\mathbf{J}_f^t)_{q,\theta} = \frac{\partial h^t_q}{\partial \theta}
+        \bigg|_{\mathbf{h}^{t-1}} ,
+
+    which costs :math:`O(P \cdot |\theta|)` memory. SnAp-:math:`n` keeps the
+    same recursion but *masks* :math:`\mathbf{J}` to the sparsity pattern
+
+    .. math::
+
+        \mathcal{S}_n \;=\; \operatorname{nz}\!\Bigl(
+          \textstyle\bigvee_{k < n} \mathbf{A}^k \Bigr),
+
+    where :math:`\mathbf{A}` is the one-step position-adjacency of the hidden
+    group (position :math:`p` influences position :math:`q` in one step). Only
+    the retained entries are stored and rolled, so the trace's trailing state
+    axis widens from :math:`S` (states per position) to :math:`M = K \cdot S`,
+    with :math:`K = |\mathcal{N}_n(p)|` the largest retained neighbourhood.
+
+    Parameters
+    ----------
+    model : brainstate.nn.Module
+        The model whose weights are trained online.
+    n : int, default 2
+        The SnAp order — how many propagation steps of the instantaneous term
+        are kept. Must be an integer ``>= 1``. ``n = 1`` canonicalises to
+        ``recurrence_scope='coupled'`` (:class:`~braintrace.OSTLRecurrent`'s
+        coordinate); any ``n`` at or above a group's diameter saturates to full
+        within-group RTRL. There is deliberately no "infinity" spelling:
+        saturation is a property of the model, not of the vocabulary.
+    name : str, optional
+        Name of the algorithm instance. Forwarded verbatim.
+    vjp_method : {'single-step', 'multi-step'}, default 'single-step'
+        Execution option, forwarded verbatim. The finite-window oracle
+        (``chunked_online_param_gradients``) needs ``'multi-step'``.
+    fast_solve : bool, default True
+        Execution option, forwarded verbatim: whether to use the per-primitive
+        fast contraction instead of the legacy vmap path.
+    snap_max_jacobian_elements : int, optional
+        Ceiling on each hidden group's widened block Jacobian,
+        ``P * (K * S) ** 2`` elements. Raising it is how a deliberately large
+        neighbourhood is admitted; the default rejects roughly half a gigabyte
+        per operator. Forwarded to the compiler.
+    **kwargs
+        Forwarded verbatim to :class:`~braintrace.ParamDimVjpAlgorithm`.
+
+    Attributes
+    ----------
+    n : int
+        The requested order, as passed (before canonicalisation).
+
+    Notes
+    -----
+    **The pattern is computed, not assumed.** The compiler analyses the hidden
+    group's transition jaxpr and derives :math:`\mathbf{A}` from the recurrent
+    mixing primitive it finds. Two primitive families yield a *precise* pattern:
+    dense (``etp_mm`` / ``etp_mv``, all-to-all) and sparse (``etp_sp_mm`` /
+    ``etp_sp_mv``, the structural pattern of ``sparse_mat``, transposed). For
+    **every other** primitive, more than one mixing equation, any control flow
+    around it, or a non-position-preserving tail, the analysis falls back to the
+    all-to-all pattern and emits a
+    ``DiagnosticKind.SNAP_PATTERN_CONSERVATIVE`` diagnostic. A conservative
+    pattern is always *correct* — it retains a superset of the true influence —
+    but it costs saturated memory, so the diagnostic is worth reading.
+
+    **The scale is within-group.** :math:`\mathcal{N}_n(p)` never leaves the
+    hidden group that owns :math:`p`; cross-group influence is not represented
+    by the per-parameter trace at any coordinate. On a model with exactly one
+    hidden group and an elementwise ``y -> hidden`` tail, saturation therefore
+    equals BPTT; on a multi-group model it equals full RTRL *within* each group,
+    which is not BPTT.
+
+    **Memory.** The trace grows linearly in :math:`K`; the widened transition
+    operator :math:`\mathbf{D}_g` costs :math:`P \cdot K^2 \cdot S^2` on top,
+    which is the term that actually bounds usable :math:`n` on large groups.
+
+    References
+    ----------
+    .. [1] Menick, J., Elsen, E., Evci, U., Osindero, S., Simonyan, K., &
+       Graves, A. (2021). "Practical Real Time Recurrent Learning with Sparse
+       Non-Linear Recurrence" (SnAp). *ICLR 2021*. arXiv:2006.07232
+    .. [2] Williams, R. J., & Zipser, D. (1989). "A Learning Algorithm for
+       Continually Running Fully Recurrent Neural Networks" (RTRL). *Neural
+       Computation*, 1(2), 270-280. https://doi.org/10.1162/neco.1989.1.2.270
+
+    Examples
+    --------
+    .. code-block:: python
+
+        >>> import brainstate
+        >>> import braintrace
+        >>>
+        >>> class Net(brainstate.nn.Module):
+        ...     def __init__(self):
+        ...         super().__init__()
+        ...         self.cell = braintrace.nn.ValinaRNNCell(1, 20, activation='tanh')
+        ...         self.out = braintrace.nn.Linear(20, 1)
+        ...     def update(self, x):
+        ...         return x >> self.cell >> self.out
+        >>>
+        >>> model = Net()
+        >>> x0 = brainstate.random.randn(1)
+        >>> learner = braintrace.compile(model, braintrace.SnAp, x0, n=2)
+        >>> y = learner(x0)
+    """
+
+    __module__ = 'braintrace'
+
+    def __init__(
+        self,
+        model: brainstate.nn.Module,
+        n: int = 2,
+        name: Optional[str] = None,
+        vjp_method: str = 'single-step',
+        fast_solve: bool = True,
+        snap_max_jacobian_elements: int = DEFAULT_MAX_JACOBIAN_ELEMENTS,
+        **kwargs: Any,
+    ) -> None:
+        # The preset's constructor is the boundary where the paper's parameter
+        # name becomes an axis coordinate. `n=1` canonicalises back to
+        # `recurrence_scope='coupled'` inside ETraceConfig -- one coordinate,
+        # one spelling -- so `SnAp(model, n=1)` *is* OSTLRecurrent's rule by
+        # construction rather than by an `if` at the use site. Validation of
+        # `n` (int, >= 1, bool rejected) also lives in ETraceConfig, so the
+        # error message is identical however the coordinate is reached.
+        config = ETraceConfig(recurrence_scope='sparse_n', sparse_n=n)
+        super().__init__(
+            model,
+            name=name,
+            vjp_method=vjp_method,
+            fast_solve=fast_solve,
+            config=config,
+            snap_max_jacobian_elements=snap_max_jacobian_elements,
+            **kwargs,
+        )
+        self.n = n
+        # Provenance for the anchor check. The coordinate alone cannot carry it:
+        # at `n = 1` the coordinate *is* `coupled`, which is legal on models
+        # with no anchored primitive, but a caller who asked for SnAp must not
+        # be handed `coupled` in its place. See
+        # ``ETraceVjpAlgorithm._assert_relations_are_snap_anchored``.
+        self._requested_snap_order = n

--- a/braintrace/_algorithm/snap_n_test.py
+++ b/braintrace/_algorithm/snap_n_test.py
@@ -1,0 +1,1289 @@
+# Copyright 2026 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Acceptance suite for ``recurrence_scope='sparse_n'`` (SnAp-n) — P3.
+
+Two rules govern every gradient assertion here, both inherited from the
+axis-decomposition roadmap:
+
+* **Finite window only.** The full-window multi-step VJP path returns BPTT for
+  every algorithm at every coordinate (finding F-23), so a criterion phrased
+  there is vacuous. Everything below goes through
+  :func:`~braintrace._algorithm.oracle.chunked_online_param_gradients` with
+  ``chunk_size < T``.
+* **Structural pins.** A gradient criterion is read against the compiled
+  neighbourhood width ``K``, the widened state axis ``M = K * S``, the
+  relation's primitive, whether the position analysis was conservative, and the
+  number of hidden groups. Without them a criterion can pass at ``K == 1``
+  while believing it exercised the scale.
+"""
+
+import unittest
+
+import brainevent
+import brainstate
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+import braintrace
+from braintrace._algorithm import oracle_models as om
+from braintrace._algorithm.axes import ETraceConfig
+from braintrace._algorithm.oracle import (
+    assert_gradients_differ,
+    assert_model_is_live,
+    assert_param_gradients_close,
+    bptt_param_gradients,
+    chunked_online_param_gradients,
+    flat_gradient_leaves,
+    relative_deviation,
+)
+from braintrace._compiler.diagnostics import DiagnosticKind, DiagnosticLevel
+
+T = 8
+N_IN = 3
+#: Relative deviation below which a finite-window gradient counts as equal to
+#: BPTT. Calibrated on an algorithm that *is* exact on its model (D_RTRL on
+#: ``leaky_linear``), which lands at ~6e-8 for every chunk size and both trace
+#: implementations; 1e-6 leaves two orders of headroom without approaching the
+#: 6e-2 that the diagonal approximation costs on a recurrent model.
+EXACT_RTOL = 1e-6
+
+
+# ---------------------------------------------------------------------------
+# helpers
+# ---------------------------------------------------------------------------
+
+def _snap(n: int, **kwargs):
+    """Algorithm factory for ``SnAp`` on the finite-window oracle path."""
+    return lambda m: braintrace.SnAp(m, n=n, vjp_method='multi-step', **kwargs)
+
+
+def _compiled(spec, algo_factory, xs):
+    """Build + compile one algorithm, without running any gradient."""
+    model = spec.factory()
+    brainstate.nn.init_all_states(model, batch_size=1)
+    algo = algo_factory(model)
+    algo.compile_graph(xs[0])
+    return algo
+
+
+def _pins(algo) -> dict:
+    """The structural facts a gradient criterion has to be read against."""
+    groups = algo.graph.hidden_groups
+    return dict(
+        n_groups=len(groups),
+        K=tuple(1 if g.snap is None else g.snap.num_neighbour for g in groups),
+        M=tuple(g.trace_state_width for g in groups),
+        S=tuple(g.num_state for g in groups),
+        P=tuple(int(np.prod(g.varshape)) if g.varshape else 1 for g in groups),
+        conservative=tuple(
+            False if g.snap is None else g.snap.conservative for g in groups),
+        saturated=tuple(
+            False if g.snap is None else g.snap.is_saturated for g in groups),
+        primitives=tuple(sorted({
+            r.primitive.name for r in algo.graph.hidden_param_op_relations})),
+    )
+
+
+def _grads(spec, algo_factory, xs, chunk_size):
+    return chunked_online_param_gradients(
+        spec.factory, xs, algo_factory=algo_factory, chunk_size=chunk_size)
+
+
+def _rel_etp(actual, expected, spec) -> float:
+    """Relative deviation restricted to the spec's **ETP** parameters.
+
+    A comparison against BPTT has to be read on the eligibility-trace
+    parameters only. A model's *plain* parameters (``win`` here) are not carried
+    by any trace: under chunking their gradient is exactly truncated BPTT, and
+    it truncates by construction at every coordinate of every axis. Measuring
+    the whole tree therefore reports the window length, not the learning rule —
+    on the ring at ``chunk_size=1`` the plain projection alone contributes a
+    4.5e-01 deviation while the ETP weight is exact to 7e-08.
+
+    Algorithm-vs-algorithm comparisons stay on the *full* tree: two rules run at
+    the same window truncate identically, so agreeing everywhere is the stronger
+    statement.
+    """
+    keys = set(spec.etp_param_keys)
+    assert keys, 'the spec declares no ETP parameters; the comparison is empty'
+    return relative_deviation(
+        {k: v for k, v in actual.items() if k in keys},
+        {k: v for k, v in expected.items() if k in keys},
+    )
+
+
+def _trace_element_count(algo) -> int:
+    """Total number of scalars held in the algorithm's eligibility traces."""
+    algo.init_etrace_state()
+    return sum(
+        int(np.prod(jnp.shape(leaf)))
+        for state in algo.etrace_bwg.values()
+        for leaf in jax.tree.leaves(state.value)
+    )
+
+
+# The reference model for the whole scale: a sparse ring, whose position graph
+# has diameter ``n_rec - 1``, so ``K(n) == min(n, n_rec)`` and every order
+# between the two endpoints is structurally distinct. A *dense* recurrent weight
+# has diameter 1 and saturates at n=2, which would collapse the scale into its
+# two endpoints and hide every intermediate behaviour.
+RING = 6
+
+
+def _ring_spec():
+    return om.sparse_ring_rnn(n_in=N_IN, n_rec=RING, seed=0)
+
+
+def _ring_inputs(seed=0):
+    return _ring_spec().make_inputs(T, N_IN, seed=seed)
+
+
+# ---------------------------------------------------------------------------
+# criterion 11 + 2: coordinates, and the near end of the squeeze
+# ---------------------------------------------------------------------------
+
+class TestCoordinates(unittest.TestCase):
+    """Criterion 11 — the preset's axis coordinates, asserted so they cannot drift."""
+
+    def test_snap_n_ge_2_is_the_sparse_n_coordinate(self):
+        algo = braintrace.SnAp(_ring_spec().factory(), n=3)
+        cfg = algo.config
+        assert cfg.trace_factorization == 'per_param'
+        assert cfg.temporal_recursion == 'jacobian'
+        assert cfg.recurrence_scope == 'sparse_n'
+        assert cfg.sparse_n == 3
+        assert cfg.learning_signal == 'symmetric'
+        assert cfg.trace_filter == 'none'
+
+    def test_snap_1_canonicalises_to_the_coupled_coordinate(self):
+        """``n = 1`` is ``coupled``, not a second spelling of it."""
+        algo = braintrace.SnAp(_ring_spec().factory(), n=1)
+        assert algo.config.recurrence_scope == 'coupled'
+        assert algo.config.sparse_n is None
+        # ...which is exactly OSTLRecurrent's coordinate.
+        ostl = braintrace.OSTLRecurrent(_ring_spec().factory())
+        assert algo.config.recurrence_scope == ostl.config.recurrence_scope
+        assert algo.config.temporal_recursion == ostl.config.temporal_recursion
+        assert algo.config.trace_factorization == ostl.config.trace_factorization
+
+    def test_preset_records_the_requested_order(self):
+        assert braintrace.SnAp(_ring_spec().factory(), n=4).n == 4
+
+    def test_include_recurrent_mixing_is_on(self):
+        cfg = ETraceConfig(recurrence_scope='sparse_n', sparse_n=2)
+        assert cfg.include_recurrent_mixing is True
+
+    def test_describe_round_trips(self):
+        """``describe()`` emits keyword arguments, so feed them back in.
+
+        A substring check would pass on a description that named the order but
+        lost the scope, or vice versa. Reconstructing the config from its own
+        text and comparing the whole dataclass checks the pair, and the ``n=1``
+        row additionally pins canonicalisation: the description of a SnAp-1
+        config says ``coupled``, and rebuilding from that text lands back on the
+        very config that produced it.
+        """
+        for cfg in [
+            ETraceConfig(recurrence_scope='sparse_n', sparse_n=3),
+            ETraceConfig(recurrence_scope='sparse_n', sparse_n=2),
+            ETraceConfig(recurrence_scope='sparse_n', sparse_n=1),
+            ETraceConfig(recurrence_scope='coupled'),
+            ETraceConfig(recurrence_scope='diagonal'),
+        ]:
+            text = cfg.describe()
+            rebuilt = eval(f'ETraceConfig({text})', {'ETraceConfig': ETraceConfig})
+            assert rebuilt == cfg, f'{text!r} rebuilt as {rebuilt}'
+
+
+class TestSnAp1EqualsOSTLRecurrent(unittest.TestCase):
+    """Criterion 2 — the near end of the squeeze."""
+
+    def test_snap_1_equals_ostl_recurrent_elementwise(self):
+        spec = _ring_spec()
+        xs = _ring_inputs()
+        assert_model_is_live(spec.factory, xs)
+
+        g_snap = _grads(spec, _snap(1), xs, chunk_size=2)
+        g_ostl = _grads(
+            spec, lambda m: braintrace.OSTLRecurrent(m, vjp_method='multi-step'),
+            xs, chunk_size=2)
+        g_drtrl = _grads(
+            spec, lambda m: braintrace.D_RTRL(m, vjp_method='multi-step'),
+            xs, chunk_size=2)
+
+        # Negative control first: the comparison has content only if the
+        # coupled and diagonal scopes are actually distinguishable here.
+        assert_gradients_differ(g_drtrl, g_ostl, min_rel=1e-6)
+        assert relative_deviation(g_snap, g_ostl) < 1e-12
+
+    def test_snap_1_allocates_the_unwidened_trace(self):
+        """Structural pin: ``n = 1`` must not widen anything."""
+        algo = _compiled(_ring_spec(), _snap(1), _ring_inputs())
+        pins = _pins(algo)
+        assert pins['n_groups'] == 1
+        assert pins['K'] == (1,)
+        assert pins['M'] == pins['S'] == (1,)
+        assert all(g.snap is None for g in algo.graph.hidden_groups)
+
+
+# ---------------------------------------------------------------------------
+# criterion 3: the far end of the squeeze
+# ---------------------------------------------------------------------------
+
+class TestSaturationEqualsBPTT(unittest.TestCase):
+    """Criterion 3 — a saturated within-group SnAp is full RTRL, hence BPTT.
+
+    Valid only because the model has **exactly one** hidden group (asserted,
+    not chosen quietly) and an elementwise ``y -> hidden`` tail. On a
+    multi-group model saturation is full RTRL *within* each group, which is not
+    BPTT.
+    """
+
+    def _assert_single_group_saturated(self, algo):
+        pins = _pins(algo)
+        assert pins['n_groups'] == 1, 'criterion 3 requires one hidden group'
+        assert pins['saturated'] == (True,), pins
+        assert pins['K'] == (RING,), pins
+        assert pins['M'] == (RING,), pins   # S == 1
+        assert pins['conservative'] == (False,), pins
+        assert pins['primitives'] == ('etp_sp_mv',), pins
+        return pins
+
+    def test_saturation_matches_bptt_across_chunk_sizes(self):
+        spec = _ring_spec()
+        xs = _ring_inputs()
+        assert_model_is_live(spec.factory, xs)
+        bptt = bptt_param_gradients(spec.factory, xs)
+
+        self._assert_single_group_saturated(
+            _compiled(spec, _snap(RING), xs))
+
+        # chunk sizes: the most aggressive window, a non-divisor of T, and T-1.
+        for chunk_size in (1, 3, T - 1):
+            for chunked_trace in (True, False):
+                g = _grads(spec, _snap(RING, chunked_trace=chunked_trace),
+                           xs, chunk_size)
+                rel = _rel_etp(g, bptt, spec)
+                assert rel < EXACT_RTOL, (
+                    f'saturated SnAp deviates from BPTT by {rel:.3e} at '
+                    f'chunk_size={chunk_size}, chunked_trace={chunked_trace}')
+
+    def test_the_far_end_is_not_trivially_reachable(self):
+        """Negative control: SnAp-1 on the same model is *not* BPTT."""
+        spec = _ring_spec()
+        xs = _ring_inputs()
+        bptt = bptt_param_gradients(spec.factory, xs)
+        g1 = _grads(spec, _snap(1), xs, chunk_size=3)
+        assert _rel_etp(g1, bptt, spec) > 1e-3
+
+    def test_saturation_matches_bptt_with_two_states_per_position(self):
+        """``S > 1, K > 1``: the widened axis is ``M = K * S``, not ``K``."""
+        n_rec = 5
+        spec = om.sparse_ring_two_state_rnn(n_in=N_IN, n_rec=n_rec, seed=0)
+        xs = spec.make_inputs(T, N_IN, seed=0)
+        assert_model_is_live(spec.factory, xs)
+
+        algo = _compiled(spec, _snap(n_rec), xs)
+        pins = _pins(algo)
+        assert pins['n_groups'] == 1, pins
+        assert pins['S'] == (2,), pins
+        assert pins['K'] == (n_rec,), pins
+        assert pins['M'] == (2 * n_rec,), pins
+        assert pins['conservative'] == (False,), pins
+
+        bptt = bptt_param_gradients(spec.factory, xs)
+        g = _grads(spec, _snap(n_rec), xs, chunk_size=3)
+        rel = _rel_etp(g, bptt, spec)
+        assert rel < EXACT_RTOL, f'S=2 saturated SnAp vs BPTT: {rel:.3e}'
+
+    def test_dense_recurrence_saturates_at_n_2(self):
+        """A dense recurrent weight has diameter 1, so ``n = 2`` is already full RTRL."""
+        spec = om.tanh_rnn(n_in=N_IN, n_rec=4, seed=0)
+        xs = spec.make_inputs(T, N_IN, seed=0)
+        assert_model_is_live(spec.factory, xs)
+
+        algo = _compiled(spec, _snap(2), xs)
+        pins = _pins(algo)
+        # varshape is (batch, n_rec): the batch axis is structurally
+        # uncoupled, so K is n_rec and not batch * n_rec.
+        assert pins['n_groups'] == 1, pins
+        assert pins['K'] == (4,), pins
+        assert pins['P'] == (4,), pins    # batch == 1 here
+        assert pins['saturated'] == (True,), pins
+        assert pins['primitives'] == ('etp_mm',), pins
+
+        bptt = bptt_param_gradients(spec.factory, xs)
+        g = _grads(spec, _snap(2), xs, chunk_size=2)
+        rel = _rel_etp(g, bptt, spec)
+        assert rel < EXACT_RTOL, f'dense saturated SnAp vs BPTT: {rel:.3e}'
+
+
+class TestTracePathAgreement(unittest.TestCase):
+    """All three trace-update implementations must produce one gradient.
+
+    ``chunked_trace=False`` fuses the roll into the executor's over-time scan;
+    ``chunked_trace=True`` takes the closed-form chunk factorisation (with a
+    legacy scan fallback for relations whose primitive has no chunk kernel).
+    A widening applied on one path and not another would show up here.
+    """
+
+    def test_chunked_and_fused_paths_agree(self):
+        spec = _ring_spec()
+        xs = _ring_inputs()
+        a = _grads(spec, _snap(3, chunked_trace=True), xs, chunk_size=3)
+        b = _grads(spec, _snap(3, chunked_trace=False), xs, chunk_size=3)
+        assert relative_deviation(a, b) < 1e-6
+
+    def test_dense_chunk_kernel_agrees_with_the_scan(self):
+        """``etp_mm`` *does* have a chunk kernel, so this pins the third path."""
+        spec = om.tanh_rnn(n_in=N_IN, n_rec=4, seed=0)
+        xs = spec.make_inputs(T, N_IN, seed=0)
+        a = _grads(spec, _snap(2, chunked_trace=True), xs, chunk_size=3)
+        b = _grads(spec, _snap(2, chunked_trace=False), xs, chunk_size=3)
+        assert relative_deviation(a, b) < 1e-6
+
+
+# ---------------------------------------------------------------------------
+# criterion 4: nestedness (not accuracy)
+# ---------------------------------------------------------------------------
+
+class TestNestedness(unittest.TestCase):
+    """Criterion 4 — the neighbourhoods nest and saturation is a fixed point.
+
+    The *gradient error* curve in ``n`` is reported, never asserted monotone:
+    nested masks do not imply monotone error, because a newly retained path can
+    overshoot terms the truncation was previously cancelling against. Only the
+    two endpoints are asserted (they are criteria 2 and 3).
+    """
+
+    def _neighbour_sets(self, n):
+        algo = _compiled(_ring_spec(), _snap(n), _ring_inputs())
+        group = algo.graph.hidden_groups[0]
+        if group.snap is None:            # n == 1 canonicalises to 'coupled'
+            return [{p} for p in range(RING)]
+        nbr, valid = group.snap.neighbours, group.snap.valid
+        return [set(nbr[p][valid[p]].tolist()) for p in range(nbr.shape[0])]
+
+    def test_neighbourhoods_are_nested_in_n(self):
+        sets = {n: self._neighbour_sets(n) for n in range(1, RING + 2)}
+        for n in range(1, RING + 1):
+            for p in range(RING):
+                assert sets[n][p] <= sets[n + 1][p], (n, p, sets[n][p], sets[n + 1][p])
+
+    def test_self_is_always_a_neighbour(self):
+        for n in range(1, RING + 2):
+            for p, s in enumerate(self._neighbour_sets(n)):
+                assert p in s
+
+    def test_saturation_is_a_fixed_point(self):
+        at_diameter = self._neighbour_sets(RING)
+        beyond = self._neighbour_sets(RING + 3)
+        assert at_diameter == beyond
+        assert all(s == set(range(RING)) for s in at_diameter)
+
+    def test_error_curve_endpoints(self):
+        """Assert the two ends; report the middle in the failure message."""
+        spec = _ring_spec()
+        xs = _ring_inputs()
+        bptt = bptt_param_gradients(spec.factory, xs)
+        curve = {
+            n: _rel_etp(_grads(spec, _snap(n), xs, chunk_size=3), bptt, spec)
+            for n in range(1, RING + 1)
+        }
+        report = ', '.join(f'n={n}: {v:.3e}' for n, v in curve.items())
+        assert all(np.isfinite(v) for v in curve.values()), report
+        assert curve[1] > 1e-3, f'SnAp-1 should be visibly approximate — {report}'
+        assert curve[RING] < EXACT_RTOL, f'saturation should be exact — {report}'
+
+
+# ---------------------------------------------------------------------------
+# the interior of the scale, against an independent reference
+# ---------------------------------------------------------------------------
+
+#: Ring width for the masked-RTRL comparison. Smaller than ``RING`` so the
+#: hand-written reference stays cheap; diameter 4, so n = 2, 3, 4 are all
+#: strictly between the two endpoints.
+MASKED_RING = 5
+
+
+def _masked_rtrl_trace(model, xs, order, snap, n_rec=MASKED_RING):
+    """Roll the SnAp-*order* influence matrix by hand, in numpy, in float64.
+
+    This is the independent reference the interior of the scale is read against.
+    It shares no code with the compiler: the adjacency, the mask, the transition
+    operator and the instantaneous term are all written out from the model's own
+    arithmetic (``h_t = tanh(x_t W_in + h_{t-1} W)``), and only the neighbour
+    *index* comes from the compiled pattern — because that index is precisely
+    the layout of the array being compared, not part of the value being checked.
+
+    Returns
+    -------
+    list of numpy.ndarray
+        Per step, the reference trace laid out as ``(nnz, K)`` — reference
+        influence ``J[e, p]`` read at the position each trace slot stands for.
+    """
+    w = np.asarray(model.w.value)
+    win = np.asarray(model.win.value)
+    dense = np.zeros((n_rec, n_rec), dtype='float32')
+    for q in range(n_rec):
+        for off in (0, 1):
+            dense[q, (q + off) % n_rec] = 1.0
+    rows, cols = np.nonzero(dense)         # row-major, i.e. CSR data order
+    weight = np.zeros((n_rec, n_rec))
+    weight[rows, cols] = w
+    nnz = len(rows)
+
+    # The mask: positions the anchor *influences* within ``order - 1`` steps.
+    # `adjacency[p, q]` is "h_p depends on h_q", so influence is the column.
+    adjacency = (dense != 0).T
+    reach = np.eye(n_rec, dtype=bool)
+    closure = reach.copy()
+    for _ in range(order - 1):
+        reach = reach @ adjacency
+        closure |= reach
+    mask = np.stack([closure[:, cols[e]] for e in range(nnz)])
+
+    h = np.zeros(n_rec)
+    influence = np.zeros((nnz, n_rec))
+    out = []
+    for t in range(len(xs)):
+        x = np.asarray(xs[t], dtype='float64')
+        z = x @ win + h @ weight
+        h_new = np.tanh(z)
+        dphi = 1.0 - h_new ** 2
+        transition = dphi[:, None] * weight.T          # D[p, s] = phi'(z_p) W[s, p]
+        instant = np.zeros((nnz, n_rec))
+        # weight entry e = (row q, col r) enters h[r] only, scaled by h_{t-1}[q]
+        instant[np.arange(nnz), cols] = dphi[cols] * h[rows]
+        influence = mask * (influence @ transition.T + instant)
+        h = h_new
+        out.append(np.stack(
+            [influence[np.arange(nnz), snap.neighbours[cols, k]] * snap.valid[cols, k]
+             for k in range(snap.num_neighbour)],
+            axis=1,
+        ))
+    return out
+
+
+class TestInteriorAgainstMaskedRTRL(unittest.TestCase):
+    """The interior of the scale, pinned against a hand-written recursion.
+
+    The endpoint criteria (SnAp-1 == coupled, saturation == BPTT) leave the
+    whole middle of the scale unasserted, and the middle is where this feature's
+    one real bug lived: a neighbourhood taken in the wrong direction produced a
+    gradient error curve that was *flat* in ``n`` and only collapsed at
+    saturation, with every structural pin — ``K``, nestedness, saturation,
+    padding — still passing. An implementation that quietly returned ``coupled``
+    for every ``1 < n < P`` and full RTRL at saturation would pass the endpoints
+    too. So the interior gets its own reference.
+    """
+
+    def _run(self, order, steps=6):
+        spec = om.sparse_ring_rnn(n_in=N_IN, n_rec=MASKED_RING, seed=0)
+        xs = spec.make_inputs(steps, N_IN, seed=0)
+        model = spec.factory()
+        brainstate.nn.init_all_states(model)
+        algo = braintrace.SnAp(model, n=order)
+        algo.compile_graph(xs[0])
+        algo.init_etrace_state(xs[0])
+        snap = algo.graph.hidden_groups[0].snap
+        # A Python step loop is deliberate here: the reference is compared to
+        # the trace *after every step*, which a compiled scan does not expose.
+        traces = []
+        for t in range(steps):
+            algo(xs[t])
+            traces.append(np.asarray(
+                jax.tree.leaves(list(algo.etrace_bwg.values())[0].value)[0]))
+        return model, xs, snap, traces
+
+    @staticmethod
+    def _deviation(got, want):
+        num = max(float(np.abs(g - w).max()) for g, w in zip(got, want))
+        den = max(float(np.abs(w).max()) for w in want)
+        assert den > 1e-6, 'the reference trace is ~zero; the comparison is vacuous'
+        return num / den
+
+    def test_interior_orders_match_the_masked_recursion(self):
+        for order in (2, 3, 4):
+            model, xs, snap, traces = self._run(order)
+            assert snap.num_neighbour == order, (order, snap.num_neighbour)
+            want = _masked_rtrl_trace(model, xs, order, snap)
+            rel = self._deviation(traces, want)
+            assert rel < EXACT_RTOL, f'SnAp-{order} trace deviates by {rel:.3e}'
+
+    def test_a_narrower_reference_does_not_match(self):
+        """Negative control: the comparison above has content.
+
+        Rolling the reference with a mask one order too narrow must disagree —
+        otherwise the test would pass against an implementation stuck at
+        ``coupled``. It only discriminates *downward* on this fixture: the ring
+        edges run one way, so widening the mask adds positions strictly
+        downstream of the ones already retained, and those cannot feed back into
+        the slots being compared.
+        """
+        for order in (3, 4):
+            model, xs, snap, traces = self._run(order)
+            want = _masked_rtrl_trace(model, xs, order - 1, snap)
+            rel = self._deviation(traces, want)
+            assert rel > 1e-3, (
+                f'SnAp-{order} agrees with an order-{order - 1} reference to '
+                f'{rel:.3e}; the interior comparison cannot see the order')
+
+    def test_the_widened_slots_carry_mass(self):
+        """The neighbour slots are not decoration: they hold real influence."""
+        for order in (2, 3, 4):
+            _, _, _, traces = self._run(order)
+            last = traces[-1]
+            anchor = float(np.abs(last[:, 0]).max())
+            neighbours = float(np.abs(last[:, 1:]).max())
+            assert neighbours > 1e-3 * anchor, (
+                f'SnAp-{order}: neighbour slots hold {neighbours:.3e} against an '
+                f'anchor slot of {anchor:.3e} — the widening is inert')
+
+
+# ---------------------------------------------------------------------------
+# criterion 5: trace-state storage
+# ---------------------------------------------------------------------------
+
+class TestTraceStateStorage(unittest.TestCase):
+    """Criterion 5 — the *trace* metric only; ``Dg`` is budgeted separately."""
+
+    def test_exact_k_sequence_on_the_ring(self):
+        observed = []
+        for n in range(1, RING + 2):
+            algo = _compiled(_ring_spec(), _snap(n), _ring_inputs())
+            group = algo.graph.hidden_groups[0]
+            observed.append(1 if group.snap is None else group.snap.num_neighbour)
+        assert observed == [1, 2, 3, 4, 5, 6, 6], observed
+
+    def test_trace_element_count_is_non_decreasing(self):
+        counts = [
+            _trace_element_count(_compiled(_ring_spec(), _snap(n), _ring_inputs()))
+            for n in range(1, RING + 2)
+        ]
+        assert counts == sorted(counts), counts
+        # and it genuinely grows: a flat sequence would mean nothing widened.
+        assert counts[-1] > counts[0]
+
+    def test_trace_width_is_k_times_num_state(self):
+        for n in (2, 4, RING):
+            algo = _compiled(_ring_spec(), _snap(n), _ring_inputs())
+            group = algo.graph.hidden_groups[0]
+            assert group.trace_state_width == group.snap.num_neighbour * group.num_state
+
+
+# ---------------------------------------------------------------------------
+# criterion 6: model-agnostic
+# ---------------------------------------------------------------------------
+
+def _lora_rec_net(n_in=N_IN, n_rec=4, rank=2, seed=0):
+    """Recurrence *through* ``lora_matmul`` — a primitive with no fast path
+    and no registered ``snap_adjacency`` rule, so the pattern is conservative
+    (all-to-all) and therefore saturated at any ``n >= 2``."""
+
+    def factory():
+        class Net(brainstate.nn.Module):
+            def __init__(self):
+                super().__init__()
+                rng = brainstate.random.RandomState(seed)
+                self.B = brainstate.ParamState(0.3 * rng.randn(n_rec, rank))
+                self.A = brainstate.ParamState(0.3 * rng.randn(rank, n_rec))
+                self.win = brainstate.ParamState(
+                    0.5 * rng.randn(n_in, n_rec))
+                self.h = brainstate.HiddenState(jnp.zeros((1, n_rec)))
+
+            def update(self, x):
+                rec = braintrace.lora_matmul(self.h.value, self.B.value, self.A.value)
+                self.h.value = jax.nn.tanh(x @ self.win.value + rec)
+                return self.h.value
+
+        return Net()
+
+    return om.ModelSpec(factory=factory, etp_param_keys=(('B',), ('A',)),
+                        plain_param_keys=(('win',),))
+
+
+def _lora_mv_rec_net(n_in=N_IN, n_rec=4, rank=2, seed=0):
+    """``etp_lora_mv`` — the unbatched twin, reached by an unbatched hidden state.
+
+    It shares every rule with ``etp_lora_mm`` and is dispatched purely on
+    ``x.ndim``, so a fixture that only ever presents a batch axis never reaches
+    it. Same for ``etp_gmv`` below.
+    """
+
+    def factory():
+        class Net(brainstate.nn.Module):
+            def __init__(self):
+                super().__init__()
+                rng = brainstate.random.RandomState(seed)
+                self.B = brainstate.ParamState(0.3 * rng.randn(n_rec, rank))
+                self.A = brainstate.ParamState(0.3 * rng.randn(rank, n_rec))
+                self.win = brainstate.ParamState(0.5 * rng.randn(n_in, n_rec))
+                self.h = brainstate.HiddenState(jnp.zeros((n_rec,)))
+
+            def update(self, x):
+                rec = braintrace.lora_matmul(self.h.value, self.B.value, self.A.value)
+                self.h.value = jax.nn.tanh(x @ self.win.value + rec)
+                return self.h.value
+
+        return Net()
+
+    return om.ModelSpec(factory=factory, etp_param_keys=(('B',), ('A',)),
+                        plain_param_keys=(('win',),))
+
+
+def _gmv_rec_net(G=2, K=3, n_in=N_IN, seed=0):
+    """``etp_gmv`` — the unbatched twin of ``etp_gmm``."""
+
+    def factory():
+        class Net(brainstate.nn.Module):
+            def __init__(self):
+                super().__init__()
+                rng = brainstate.random.RandomState(seed)
+                self.w = brainstate.ParamState(0.4 * rng.randn(G, K, K))
+                self.win = brainstate.ParamState(0.5 * rng.randn(n_in, G * K))
+                self.h = brainstate.HiddenState(jnp.zeros((G, K)))
+
+            def update(self, x):
+                rec = braintrace.grouped_matmul(self.h.value, self.w.value)
+                self.h.value = jax.nn.tanh((x @ self.win.value).reshape(G, K) + rec)
+                return self.h.value
+
+        return Net()
+
+    return om.ModelSpec(factory=factory, etp_param_keys=(('w',),),
+                        plain_param_keys=(('win',),))
+
+
+def _elemwise_plus_dense_net(n_in=N_IN, n_rec=4, seed=0):
+    """``etp_elemwise`` as a co-relation on a group whose mixing is dense.
+
+    The elementwise gain ``a`` is a second ETP relation feeding the *same*
+    hidden group, so its trace must widen to ``K * S`` even though the
+    elementwise primitive itself couples nothing.
+    """
+
+    def factory():
+        class Net(brainstate.nn.Module):
+            def __init__(self):
+                super().__init__()
+                rng = brainstate.random.RandomState(seed)
+                self.w = brainstate.ParamState(0.4 * rng.randn(n_rec, n_rec))
+                self.alpha = brainstate.ParamState(jnp.ones((n_rec,)) * 0.8)
+                self.win = brainstate.ParamState(
+                    0.5 * rng.randn(n_in, n_rec))
+                self.h = brainstate.HiddenState(jnp.zeros((1, n_rec)))
+
+            def update(self, x):
+                gain = braintrace.element_wise(self.alpha.value)
+                rec = braintrace.matmul(self.h.value, self.w.value)
+                self.h.value = jax.nn.tanh(x @ self.win.value + gain * rec)
+                return self.h.value
+
+        return Net()
+
+    return om.ModelSpec(factory=factory, etp_param_keys=(('w',), ('alpha',)),
+                        plain_param_keys=(('win',),))
+
+
+def _grouped_rec_net(G=2, K=3, n_in=N_IN, seed=0):
+    """Recurrence through ``grouped_matmul`` (block diagonal, no adjacency rule)."""
+
+    def factory():
+        class Net(brainstate.nn.Module):
+            def __init__(self):
+                super().__init__()
+                rng = brainstate.random.RandomState(seed)
+                self.w = brainstate.ParamState(0.4 * rng.randn(G, K, K))
+                self.win = brainstate.ParamState(
+                    0.5 * rng.randn(n_in, G * K))
+                # (1, G, K), not (1, G*K): a reshape between the ETP output
+                # and the hidden state severs the relation entirely (the
+                # compiler requires y broadcastable to the hidden shape), and
+                # this model exists to exercise etp_gmm, not that limitation.
+                self.h = brainstate.HiddenState(jnp.zeros((1, G, K)))
+
+            def update(self, x):
+                rec = braintrace.grouped_matmul(self.h.value, self.w.value)
+                inp = (x @ self.win.value).reshape(1, G, K)
+                self.h.value = jax.nn.tanh(inp + rec)
+                return self.h.value
+
+        return Net()
+
+    return om.ModelSpec(factory=factory, etp_param_keys=(('w',),),
+                        plain_param_keys=(('win',),))
+
+
+def _conv_rec_net(length=5, ch=2, n_in=N_IN, seed=0):
+    """Recurrence through a 1-D ``conv`` — an anchored primitive whose D-RTRL
+    trace is kernel-shaped per output position rather than position-shaped."""
+
+    def factory():
+        class Net(brainstate.nn.Module):
+            def __init__(self):
+                super().__init__()
+                rng = brainstate.random.RandomState(seed)
+                self.p = brainstate.ParamState({
+                    'weight': 0.2 * rng.randn(3, ch, ch),
+                    'bias': jnp.zeros((ch,)),
+                })
+                self.win = brainstate.ParamState(
+                    0.5 * rng.randn(n_in, length * ch))
+                self.h = brainstate.HiddenState(jnp.zeros((1, length, ch)))
+
+            def update(self, x):
+                rec = braintrace.conv(
+                    self.h.value, self.p.value['weight'], self.p.value['bias'],
+                    strides=(1,), padding='SAME',
+                    dimension_numbers=('NHC', 'HIO', 'NHC'),
+                )
+                inp = (x @ self.win.value).reshape(1, length, ch)
+                self.h.value = jax.nn.tanh(inp + rec)
+                return self.h.value
+
+        return Net()
+
+    return om.ModelSpec(factory=factory, etp_param_keys=(('p',),),
+                        plain_param_keys=(('win',),))
+
+
+def _einsum_rec_net(n_rec=4, n_in=N_IN, seed=0):
+    """Recurrence through ``etp_einsum`` with **no shared axis** — anchored."""
+
+    def factory():
+        class Net(brainstate.nn.Module):
+            def __init__(self):
+                super().__init__()
+                rng = brainstate.random.RandomState(seed)
+                self.w = brainstate.ParamState(0.4 * rng.randn(n_rec, n_rec))
+                self.win = brainstate.ParamState(
+                    0.5 * rng.randn(n_in, n_rec))
+                self.h = brainstate.HiddenState(jnp.zeros((1, n_rec)))
+
+            def update(self, x):
+                rec = braintrace.einsum('bk,kn->bn', self.h.value, self.w.value)
+                self.h.value = jax.nn.tanh(x @ self.win.value + rec)
+                return self.h.value
+
+        return Net()
+
+    return om.ModelSpec(factory=factory, etp_param_keys=(('w',),),
+                        plain_param_keys=(('win',),))
+
+
+def _mv_rec_net(n_rec=4, n_in=N_IN, seed=0):
+    """Unbatched dense recurrence — ``etp_mv``."""
+
+    def factory():
+        class Net(brainstate.nn.Module):
+            def __init__(self):
+                super().__init__()
+                rng = brainstate.random.RandomState(seed)
+                self.w = brainstate.ParamState(0.4 * rng.randn(n_rec, n_rec))
+                self.win = brainstate.ParamState(
+                    0.5 * rng.randn(n_in, n_rec))
+                self.h = brainstate.HiddenState(jnp.zeros((n_rec,)))
+
+            def update(self, x):
+                rec = braintrace.matmul(self.h.value, self.w.value)
+                self.h.value = jax.nn.tanh(x @ self.win.value + rec)
+                return self.h.value
+
+        return Net()
+
+    return om.ModelSpec(factory=factory, etp_param_keys=(('w',),),
+                        plain_param_keys=(('win',),))
+
+
+def _sp_mm_rec_net(n_rec=5, n_in=N_IN, seed=0):
+    """Batched sparse recurrence — ``etp_sp_mm``."""
+    mask = np.zeros((n_rec, n_rec), dtype='float32')
+    for q in range(n_rec):
+        mask[q, (q + 1) % n_rec] = 1.0
+    csr = brainevent.CSR.fromdense(jnp.asarray(mask))
+    nnz = int(mask.sum())
+
+    def factory():
+        class Net(brainstate.nn.Module):
+            def __init__(self):
+                super().__init__()
+                rng = brainstate.random.RandomState(seed)
+                self.w = brainstate.ParamState(0.6 * rng.randn(nnz))
+                self.win = brainstate.ParamState(
+                    0.5 * rng.randn(n_in, n_rec))
+                self.h = brainstate.HiddenState(jnp.zeros((1, n_rec)))
+
+            def update(self, x):
+                rec = braintrace.sparse_matmul(self.h.value, self.w.value, sparse_mat=csr)
+                self.h.value = jax.nn.tanh(x @ self.win.value + rec)
+                return self.h.value
+
+        return Net()
+
+    return om.ModelSpec(factory=factory, etp_param_keys=(('w',),),
+                        plain_param_keys=(('win',),))
+
+
+#: One recurrent model per anchored ETP primitive — *every* one of them, the
+#: unbatched twins included. ``etp_gmv`` / ``etp_lora_mv`` share their rules with
+#: ``etp_gmm`` / ``etp_lora_mm`` but are dispatched on ``x.ndim``, so leaving
+#: them out would leave a whole dispatch branch unexecuted. ``etp_emb`` /
+#: ``etp_emb_v`` are absent on purpose: they declare *no* anchor (a gathered row
+#: has no single hidden position to land on) and are covered by the default-deny
+#: test in ``_op/_registries_test.py`` and by ``TestAnchorRejection``.
+_ANCHORED_MODELS = {
+    'etp_mm': lambda: om.tanh_rnn(n_in=N_IN, n_rec=4, seed=0),
+    'etp_mv': _mv_rec_net,
+    'etp_sp_mv': _ring_spec,
+    'etp_sp_mm': _sp_mm_rec_net,
+    'etp_elemwise': _elemwise_plus_dense_net,
+    'etp_lora_mm': _lora_rec_net,
+    'etp_lora_mv': _lora_mv_rec_net,
+    'etp_gmm': _grouped_rec_net,
+    'etp_gmv': _gmv_rec_net,
+    'etp_conv': _conv_rec_net,
+    'etp_einsum': _einsum_rec_net,
+}
+
+#: An order above every fixture's position-graph diameter, so each one
+#: saturates and its gradient is comparable to BPTT.
+SATURATING_N = 8
+
+
+class TestModelAgnostic(unittest.TestCase):
+    """Criterion 6 — the scale is not a property of the dense fast path."""
+
+    def test_every_anchored_primitive_widens_its_trace(self):
+        for prim_name in sorted(_ANCHORED_MODELS):
+            spec = _ANCHORED_MODELS[prim_name]()
+            xs = spec.make_inputs(T, N_IN, seed=0)
+            algo = _compiled(spec, _snap(2), xs)
+            pins = _pins(algo)
+            assert prim_name in pins['primitives'], (prim_name, pins)
+            # Every group the traces attach to must have widened, and every
+            # trace leaf must carry the widened axis as its last dimension.
+            groups = {g.index: g for g in algo.graph.hidden_groups}
+            assert any(g.trace_state_width > g.num_state for g in groups.values()), pins
+            algo.init_etrace_state()
+            for (_, gi), state in algo.etrace_bwg.items():
+                width = groups[gi].trace_state_width
+                for leaf in jax.tree.leaves(state.value):
+                    assert jnp.shape(leaf)[-1] == width, (
+                        prim_name, gi, jnp.shape(leaf), width)
+
+    def test_every_anchored_primitive_matches_bptt_at_saturation(self):
+        """Run the widened recurrence and solve, per primitive, on both paths.
+
+        Allocating a trace of the right shape is not evidence that anything
+        consumes it correctly: the test above compiles and initialises, and
+        would pass against a widened recurrence that never executes or a solve
+        that reads the wrong slots. So every primitive is driven to a *saturated*
+        order — where SnAp is full within-group RTRL and therefore equals BPTT —
+        through both the per-primitive fast contraction and the legacy vmap
+        path, which are separate implementations of the same contraction.
+        """
+        report = {}
+        for prim_name in sorted(_ANCHORED_MODELS):
+            spec = _ANCHORED_MODELS[prim_name]()
+            xs = spec.make_inputs(T, N_IN, seed=0)
+            assert_model_is_live(spec.factory, xs)
+            algo = _compiled(spec, _snap(SATURATING_N), xs)
+            pins = _pins(algo)
+            assert prim_name in pins['primitives'], (prim_name, pins)
+            assert all(pins['saturated']), (prim_name, pins)
+
+            bptt = bptt_param_gradients(spec.factory, xs)
+            fast = _grads(spec, _snap(SATURATING_N), xs, chunk_size=3)
+            legacy = _grads(
+                spec, _snap(SATURATING_N, fast_solve=False), xs, chunk_size=3)
+            rel_fast = _rel_etp(fast, bptt, spec)
+            rel_legacy = _rel_etp(legacy, bptt, spec)
+            report[prim_name] = (rel_fast, rel_legacy)
+            assert rel_fast < EXACT_RTOL, (prim_name, 'fast', rel_fast, pins)
+            assert rel_legacy < EXACT_RTOL, (prim_name, 'legacy', rel_legacy, pins)
+            # the two solve paths must also agree with *each other*, which is
+            # the stronger statement where both happen to be wrong the same way
+            assert relative_deviation(fast, legacy) < EXACT_RTOL, (
+                prim_name, relative_deviation(fast, legacy))
+        assert len(report) == len(_ANCHORED_MODELS), report
+
+    def test_lora_saturates_and_matches_bptt(self):
+        """The flagship no-fast-path case, pinned by its primitive."""
+        spec = _lora_rec_net()
+        xs = spec.make_inputs(T, N_IN, seed=0)
+        assert_model_is_live(spec.factory, xs)
+
+        algo = _compiled(spec, _snap(2), xs)
+        pins = _pins(algo)
+        assert pins['n_groups'] == 1, pins
+        assert pins['primitives'] == ('etp_lora_mm',), pins
+        assert pins['conservative'] == (True,), pins   # no adjacency rule
+        assert pins['saturated'] == (True,), pins
+        assert pins['K'] == (4,), pins
+
+        bptt = bptt_param_gradients(spec.factory, xs)
+        g = _grads(spec, _snap(2), xs, chunk_size=3)
+        rel = _rel_etp(g, bptt, spec)
+        assert rel < EXACT_RTOL, f'LoRA saturated SnAp vs BPTT: {rel:.3e}'
+
+    def test_two_relations_on_one_group_both_widen(self):
+        spec = _elemwise_plus_dense_net()
+        xs = spec.make_inputs(T, N_IN, seed=0)
+        algo = _compiled(spec, _snap(2), xs)
+        pins = _pins(algo)
+        assert pins['n_groups'] == 1, pins
+        assert set(pins['primitives']) == {'etp_mm', 'etp_elemwise'}, pins
+        assert pins['K'] == (4,), pins
+
+        bptt = bptt_param_gradients(spec.factory, xs)
+        g = _grads(spec, _snap(2), xs, chunk_size=3)
+        rel = _rel_etp(g, bptt, spec)
+        assert rel < EXACT_RTOL, f'two-relation saturated SnAp vs BPTT: {rel:.3e}'
+
+
+# ---------------------------------------------------------------------------
+# criterion 7: anchor rejection
+# ---------------------------------------------------------------------------
+
+def _shared_axis_einsum_net(T2=2, N=3, n_in=N_IN, seed=0):
+    """``'btk,kn->btn'`` — the weight is reused across the shared ``t`` axis,
+    so a trace slot has no single hidden position to anchor on."""
+
+    def factory():
+        class Net(brainstate.nn.Module):
+            def __init__(self):
+                super().__init__()
+                rng = brainstate.random.RandomState(seed)
+                self.w = brainstate.ParamState(0.3 * rng.randn(N, N))
+                self.win = brainstate.ParamState(
+                    0.3 * rng.randn(n_in, T2 * N))
+                self.h = brainstate.HiddenState(jnp.zeros((1, T2, N)))
+
+            def update(self, x):
+                rec = braintrace.einsum('btk,kn->btn', self.h.value, self.w.value)
+                inp = (x @ self.win.value).reshape(1, T2, N)
+                self.h.value = jax.nn.tanh(inp + rec)
+                return self.h.value
+
+        return Net()
+
+    return om.ModelSpec(factory=factory, etp_param_keys=(('w',),),
+                        plain_param_keys=(('win',),))
+
+
+class TestAnchorRejection(unittest.TestCase):
+    """Criterion 7 — an unanchored primitive must fail loudly, not silently."""
+
+    def _model_and_input(self):
+        spec = _shared_axis_einsum_net()
+        xs = spec.make_inputs(T, N_IN, seed=0)
+        model = spec.factory()
+        brainstate.nn.init_all_states(model, batch_size=1)
+        return model, xs[0]
+
+    def test_shared_axis_einsum_is_rejected_under_sparse_n(self):
+        model, x0 = self._model_and_input()
+        algo = braintrace.SnAp(model, n=2)
+        with pytest.raises(NotImplementedError) as excinfo:
+            algo.compile_graph(x0)
+        msg = str(excinfo.value)
+        assert 'etp_einsum' in msg
+        assert 'sparse_n' in msg
+
+    def test_the_same_model_still_compiles_under_diagonal_and_coupled(self):
+        for scope in ('diagonal', 'coupled'):
+            model, x0 = self._model_and_input()
+            algo = braintrace.D_RTRL(
+                model, config=ETraceConfig(recurrence_scope=scope))
+            algo.compile_graph(x0)          # must not raise
+            assert algo.is_compiled
+
+    def test_snap_1_is_rejected_too_even_though_it_canonicalises_to_coupled(self):
+        """The preset is checked on what was *asked for*, not on the coordinate.
+
+        ``SnAp(n=1)`` canonicalises to ``recurrence_scope='coupled'``, so a check
+        keyed on the coordinate skips it — and the caller silently receives
+        ``coupled``. On an unanchored primitive the two are not the same rule:
+        SnAp-1 is defined as the instantaneous nonzero pattern of ``dh/dtheta``,
+        which here spans several positions, while ``coupled`` keeps only the
+        per-position block diagonal and drops the rest. The test above shows
+        ``n=2`` rejected; without the provenance flag ``n=1`` would compile.
+        """
+        model, x0 = self._model_and_input()
+        algo = braintrace.SnAp(model, n=1)
+        assert algo.config.recurrence_scope == 'coupled'   # the canonical form
+        with pytest.raises(NotImplementedError) as excinfo:
+            algo.compile_graph(x0)
+        assert 'etp_einsum' in str(excinfo.value)
+
+    def test_snap_1_still_compiles_where_an_anchor_exists(self):
+        """Negative control: the provenance flag is not a blanket rejection."""
+        spec = _ring_spec()
+        model = spec.factory()
+        brainstate.nn.init_all_states(model, batch_size=1)
+        algo = braintrace.SnAp(model, n=1)
+        algo.compile_graph(_ring_inputs()[0])              # must not raise
+        assert algo.is_compiled
+
+    def test_embedding_is_rejected_under_sparse_n(self):
+        """``etp_emb`` declares no anchor at all (default deny)."""
+        n_vocab, n_rec = 5, 4
+
+        class Net(brainstate.nn.Module):
+            def __init__(self):
+                super().__init__()
+                rng = brainstate.random.RandomState(0)
+                self.emb = brainstate.ParamState(
+                    0.3 * rng.randn(n_vocab, n_rec))
+                self.w = brainstate.ParamState(
+                    0.3 * rng.randn(n_rec, n_rec))
+                self.h = brainstate.HiddenState(jnp.zeros((1, n_rec)))
+
+            def update(self, ids):
+                e = braintrace.embedding(ids, self.emb.value)
+                rec = braintrace.matmul(self.h.value, self.w.value)
+                self.h.value = jax.nn.tanh(e + rec)
+                return self.h.value
+
+        model = Net()
+        brainstate.nn.init_all_states(model, batch_size=1)
+        algo = braintrace.SnAp(model, n=2)
+        with pytest.raises(NotImplementedError) as excinfo:
+            algo.compile_graph(jnp.asarray([1]))
+        assert 'sparse_n' in str(excinfo.value)
+
+
+# ---------------------------------------------------------------------------
+# criterion 8: degeneracy pins
+# ---------------------------------------------------------------------------
+
+class TestDegeneracyPins(unittest.TestCase):
+    """Criterion 8 — a degenerate pattern must reproduce ``coupled`` exactly,
+    *and* be degenerate for a structural reason rather than by defaulting."""
+
+    def test_two_state_rnn_has_no_mixing_equation(self):
+        spec = om.two_state_rnn(n_in=N_IN, n_rec=3, seed=0)
+        xs = spec.make_inputs(T, N_IN, seed=0)
+        algo = _compiled(spec, _snap(4), xs)
+        group = algo.graph.hidden_groups[0]
+        pins = _pins(algo)
+        assert pins['n_groups'] == 1, pins
+        assert pins['S'] == (2,), pins
+        assert pins['K'] == (1,), pins
+        assert pins['M'] == (2,), pins
+        # structural, not a fallback: the analysis found no mixing equation and
+        # returned the identity, so `conservative` is False.
+        assert pins['conservative'] == (False,), pins
+        assert group.snap.is_degenerate
+        assert all(bool(np.all(a == np.eye(a.shape[0], dtype=bool)))
+                   for a in group.snap.axes)
+
+    def test_degenerate_sparse_n_equals_coupled_equals_d_rtrl(self):
+        spec = om.two_state_rnn(n_in=N_IN, n_rec=3, seed=0)
+        xs = spec.make_inputs(T, N_IN, seed=0)
+        assert_model_is_live(spec.factory, xs)
+
+        g_snap = _grads(spec, _snap(4), xs, chunk_size=3)
+        g_coupled = _grads(
+            spec, lambda m: braintrace.D_RTRL(
+                m, vjp_method='multi-step',
+                config=ETraceConfig(recurrence_scope='coupled')),
+            xs, chunk_size=3)
+        g_diag = _grads(
+            spec, lambda m: braintrace.D_RTRL(m, vjp_method='multi-step'),
+            xs, chunk_size=3)
+
+        assert relative_deviation(g_snap, g_coupled) < 1e-12
+        # With no ETP mixing primitive at all, `diagonal` and `coupled` are the
+        # same rule on this model too — that identity is the pin, and a pair
+        # that *starts* differing is as much a regression as one that stops.
+        assert relative_deviation(g_snap, g_diag) < 1e-12
+
+
+# ---------------------------------------------------------------------------
+# criterion 9: conservative fallbacks fire where they should
+# ---------------------------------------------------------------------------
+
+class TestConservativeFallbackEndToEnd(unittest.TestCase):
+    """Criterion 9 — end-to-end: the diagnostic reaches the compilation report."""
+
+    def test_unregistered_mixing_primitive_reports_conservative(self):
+        spec = _lora_rec_net()
+        xs = spec.make_inputs(T, N_IN, seed=0)
+        algo = _compiled(spec, _snap(2), xs)
+        kinds = [r.kind for r in algo.graph.diagnostics]
+        assert DiagnosticKind.SNAP_PATTERN_CONSERVATIVE in kinds
+        assert algo.graph.hidden_groups[0].snap.conservative
+        record = next(r for r in algo.graph.diagnostics
+                      if r.kind is DiagnosticKind.SNAP_PATTERN_CONSERVATIVE)
+        assert record.level is DiagnosticLevel.WARNING
+        assert 'etp_lora_mm' in record.message
+
+    def test_two_mixing_equations_report_conservative(self):
+        spec = om.stacked_tanh_rnn(n_in=N_IN, n_rec=4, seed=0)
+        xs = spec.make_inputs(T, N_IN, seed=0)
+        algo = _compiled(spec, _snap(2), xs)
+        kinds = [r.kind for r in algo.graph.diagnostics]
+        assert DiagnosticKind.SNAP_PATTERN_CONSERVATIVE in kinds
+        assert any(g.snap.conservative for g in algo.graph.hidden_groups)
+
+    def test_degenerate_pattern_reports_its_own_kind(self):
+        spec = om.two_state_rnn(n_in=N_IN, n_rec=3, seed=0)
+        xs = spec.make_inputs(T, N_IN, seed=0)
+        algo = _compiled(spec, _snap(3), xs)
+        kinds = [r.kind for r in algo.graph.diagnostics]
+        assert DiagnosticKind.SNAP_PATTERN_DEGENERATE in kinds
+        assert DiagnosticKind.SNAP_PATTERN_CONSERVATIVE not in kinds
+
+    def test_a_conservative_pattern_is_still_correct(self):
+        """Widening is never *wrong* — it costs memory and moves the rule
+        towards within-group RTRL (which is BPTT only when the group's tail is
+        position-preserving; see F-31 in the known-limitations list)."""
+        spec = _lora_rec_net()
+        xs = spec.make_inputs(T, N_IN, seed=0)
+        bptt = bptt_param_gradients(spec.factory, xs)
+        g = _grads(spec, _snap(2), xs, chunk_size=3)
+        assert _rel_etp(g, bptt, spec) < EXACT_RTOL
+
+    def test_a_relabelling_tail_defeats_saturation_and_says_so(self):
+        """F-31: the axis presumes the tail preserves positions.
+
+        The rolled model and its control differ by one ``jnp.roll`` and nothing
+        else. On the control, saturation is BPTT to round-off and the cheaper
+        scopes are visibly approximate — the axis reads as advertised. With the
+        roll, the trace's position index no longer denotes the unit whose
+        influence it carries, so *every* within-group scope misses, saturated
+        included, and buying more neighbours does not close the gap.
+
+        This is not a SnAp defect: `diagonal` and `coupled` are hit the same way
+        and never even consult a position graph. What is asserted here is that
+        the shortfall is (a) real, (b) not fixable by raising ``n``, and (c)
+        warned about rather than silent.
+        """
+        control = om.rolled_tail_rnn(n_in=N_IN, n_rec=5, roll=0, seed=0)
+        rolled = om.rolled_tail_rnn(n_in=N_IN, n_rec=5, roll=1, seed=0)
+        xs = control.make_inputs(T, N_IN, seed=1)
+        assert_model_is_live(rolled.factory, xs)
+
+        # (a) the control: a dense mixing graph has diameter 1, so n=2 saturates
+        ctrl_bptt = bptt_param_gradients(control.factory, xs)
+        ctrl_pins = _pins(_compiled(control, _snap(2), xs))
+        assert all(ctrl_pins['saturated']) and not any(ctrl_pins['conservative'])
+        ctrl_rel = _rel_etp(_grads(control, _snap(2), xs, 2), ctrl_bptt, control)
+        assert ctrl_rel < EXACT_RTOL, ctrl_rel
+
+        # (b) the same order on the rolled model misses, and n=4 does not help
+        bptt = bptt_param_gradients(rolled.factory, xs)
+        rel_2 = _rel_etp(_grads(rolled, _snap(2), xs, 2), bptt, rolled)
+        rel_4 = _rel_etp(_grads(rolled, _snap(4), xs, 2), bptt, rolled)
+        assert rel_2 > 1e-2, rel_2
+        np.testing.assert_allclose(rel_4, rel_2, rtol=1e-5)
+
+        # the coordinate below it is hit too, so this is not SnAp's failure
+        rel_coupled = _rel_etp(
+            _grads(rolled, lambda m: braintrace.OSTLRecurrent(
+                m, vjp_method='multi-step'), xs, 2), bptt, rolled)
+        assert rel_coupled > 1e-2, rel_coupled
+
+        # (c) and the compiler says the pattern could not be derived
+        algo = _compiled(rolled, _snap(2), xs)
+        records = [r for r in algo.graph.diagnostics
+                   if r.kind == DiagnosticKind.SNAP_PATTERN_CONSERVATIVE]
+        assert records, [r.kind for r in algo.graph.diagnostics]
+        assert 'position-preserving' in records[0].message, records[0].message
+
+
+# ---------------------------------------------------------------------------
+# criterion 10: illegal combinations
+# ---------------------------------------------------------------------------
+
+class TestIllegalCombinations(unittest.TestCase):
+    """Criterion 10 — every rejected pairing names the legal ones."""
+
+    def test_io_factorized_plus_sparse_n(self):
+        with pytest.raises(ValueError) as e:
+            ETraceConfig(trace_factorization='io_factorized', decay=0.9,
+                         recurrence_scope='sparse_n', sparse_n=2)
+        assert 'per_param' in str(e.value)
+
+    def test_sparse_n_plus_scalar_leak(self):
+        with pytest.raises(ValueError) as e:
+            ETraceConfig(recurrence_scope='sparse_n', sparse_n=2,
+                         temporal_recursion='scalar_leak', decay=0.9)
+        assert 'jacobian' in str(e.value)
+
+    def test_sparse_n_zero(self):
+        with pytest.raises(ValueError) as e:
+            ETraceConfig(recurrence_scope='sparse_n', sparse_n=0)
+        assert 'at least 1' in str(e.value)
+
+    def test_sparse_n_true_is_not_an_order(self):
+        with pytest.raises(TypeError) as e:
+            ETraceConfig(recurrence_scope='sparse_n', sparse_n=True)
+        assert 'bool' in str(e.value).lower()
+
+    def test_sparse_n_without_the_coefficient(self):
+        with pytest.raises(ValueError):
+            ETraceConfig(recurrence_scope='sparse_n')
+
+    def test_coefficient_without_the_axis_value(self):
+        with pytest.raises(ValueError):
+            ETraceConfig(recurrence_scope='coupled', sparse_n=3)
+
+    def test_sparse_n_inside_a_descended_scan(self):
+        spec = om.snn_scan_rnn(n_rec=4, loops=40, seed=0)
+        xs = spec.make_inputs(T, 4, seed=0)
+        model = spec.factory()
+        brainstate.nn.init_all_states(model, batch_size=1)
+        algo = braintrace.SnAp(model, n=2)
+        with pytest.raises(NotImplementedError) as e:
+            algo.compile_graph(xs[0])
+        msg = str(e.value)
+        assert 'sparse_n' in msg
+        assert 'scan' in msg
+
+
+# ---------------------------------------------------------------------------
+# criterion 1: the cheap end must not move
+# ---------------------------------------------------------------------------
+
+class TestDiagonalRegression(unittest.TestCase):
+    """Criterion 1 — ``recurrence_scope='diagonal'`` allocates exactly what it did.
+
+    The frozen golden values live in ``_algorithm/tests/axis_golden_test.py``;
+    what this adds is the structural half: the diagonal path must not acquire a
+    snap pattern, a widened trace, or a different allocation just because the
+    machinery exists.
+    """
+
+    def test_diagonal_allocates_no_snap_pattern(self):
+        spec = _ring_spec()
+        xs = _ring_inputs()
+        algo = _compiled(spec, lambda m: braintrace.D_RTRL(m, vjp_method='multi-step'), xs)
+        for g in algo.graph.hidden_groups:
+            assert g.snap is None
+            assert g.trace_state_width == g.num_state
+
+    def test_diagonal_and_snap_are_distinguishable(self):
+        spec = _ring_spec()
+        xs = _ring_inputs()
+        g_diag = _grads(
+            spec, lambda m: braintrace.D_RTRL(m, vjp_method='multi-step'), xs, 3)
+        g_snap = _grads(spec, _snap(3), xs, 3)
+        assert_gradients_differ(g_diag, g_snap, min_rel=1e-6)

--- a/braintrace/_algorithm/vjp_base.py
+++ b/braintrace/_algorithm/vjp_base.py
@@ -40,7 +40,8 @@ from braintrace._typing import (
     dG_Hidden,
     dG_State,
 )
-from braintrace._compiler import ControlFlowPolicy
+from braintrace._compiler import ControlFlowPolicy, DEFAULT_MAX_JACOBIAN_ELEMENTS
+from braintrace._op import is_snap_anchored
 from ._common import FixedRandomFeedback
 from .axes import ETraceConfig
 from .base import ETraceAlgorithm
@@ -131,6 +132,7 @@ class ETraceVjpAlgorithm(ETraceAlgorithm):
         control_flow: Optional[ControlFlowPolicy] = None,
         config: Optional[ETraceConfig] = None,
         random_feedback_key: Optional[jax.Array] = None,
+        snap_max_jacobian_elements: int = DEFAULT_MAX_JACOBIAN_ELEMENTS,
     ):
 
         # the VJP method
@@ -163,6 +165,8 @@ class ETraceVjpAlgorithm(ETraceAlgorithm):
             model,
             vjp_method=vjp_method,
             include_recurrent_mixing=config.include_recurrent_mixing,
+            sparse_n=config.sparse_n,
+            snap_max_jacobian_elements=snap_max_jacobian_elements,
             control_flow=control_flow,
         )
 
@@ -188,9 +192,10 @@ class ETraceVjpAlgorithm(ETraceAlgorithm):
         super().compile_graph(*args)
         if self.is_compiled:
             self._assert_recurrence_scope_is_honoured()
+            self._assert_relations_are_snap_anchored()
 
     def _assert_recurrence_scope_is_honoured(self) -> None:
-        """Raise if ``recurrence_scope='coupled'`` cannot be delivered.
+        """Raise if a non-diagonal ``recurrence_scope`` cannot be delivered.
 
         ``_compiler/scan_descent.py`` analyses a descended scan body with
         ``include_recurrent_mixing=False`` unconditionally: the per-substep
@@ -199,10 +204,17 @@ class ETraceVjpAlgorithm(ETraceAlgorithm):
         the flag is private, but ``recurrence_scope`` is a public axis — asking
         for ``'coupled'`` and silently getting ``'diagonal'`` inside the scan is
         exactly the silent-degradation failure the axis decomposition exists to
-        remove. Generalising the scope *inside* descended scans belongs with P3,
-        which rebuilds the recurrence representation anyway.
+        remove.
+
+        ``'sparse_n'`` inherits the same limitation, and for a second reason on
+        top of the first: a descended group's per-substep Jacobian is folded
+        before the trace ever sees it, so there is no single transition jaxpr
+        for the position analysis to read. ``_attach_snap_pattern`` therefore
+        skips descended groups outright, which would leave the requested order
+        silently unapplied.
         """
-        if self.config.recurrence_scope != 'coupled':
+        scope = self.config.recurrence_scope
+        if scope not in ('coupled', 'sparse_n'):
             return
         # A descended *group* can exist without any descended relation (all body
         # weights routed through plain ops), so check both — as
@@ -214,13 +226,62 @@ class ETraceVjpAlgorithm(ETraceAlgorithm):
         groups = sum(g.descent is not None for g in self.graph.hidden_groups)
         if relations or groups:
             raise NotImplementedError(
-                f"recurrence_scope='coupled' is not honoured inside a "
+                f"recurrence_scope={scope!r} is not honoured inside a "
                 f'descended scan ({relations} ETP relation(s) and {groups} '
                 f'hidden group(s) were discovered inside a scan body, whose '
                 f'transition is always analysed with diagonal recurrence). Use '
                 f"recurrence_scope='diagonal', or keep the recurrent weights "
                 f"outside the scan body, or set "
                 f"ControlFlowPolicy(scan_descent='off')."
+            )
+
+    def _assert_relations_are_snap_anchored(self) -> None:
+        """Raise if ``sparse_n`` meets a primitive with no well-defined anchor.
+
+        SnAp-n widens each trace slot into ``(neighbour, state)`` pairs relative
+        to *the one hidden position the slot's instantaneous term lands on*. A
+        primitive that spreads one weight entry across several hidden positions
+        — ``etp_einsum`` with a shared axis, ``etp_embedding``'s gathered row —
+        has no such position, so the widened representation is not merely
+        approximate for it, it is undefined.
+
+        Whether a primitive has an anchor is a property of the primitive, so it
+        is declared in the operator protocol (``register_etp_rules(
+        snap_anchor=...)``) and *default-deny*: a newly added primitive is
+        rejected here until it says otherwise, rather than silently producing a
+        gradient nobody derived.
+
+        The check also fires for ``SnAp(n=1)``, whose coordinate canonicalises
+        to ``'coupled'``. That is deliberate. ``coupled`` itself needs no
+        anchor — it takes the per-position block diagonal of the full Jacobian
+        and never asks where an instantaneous term lands — so plain
+        ``recurrence_scope='coupled'`` stays legal on every model. But SnAp-1 is
+        *defined* as the instantaneous nonzero pattern of ``∂h/∂θ``, and on a
+        primitive that spreads one weight entry across positions that pattern is
+        not a single position: ``coupled`` then drops cross-position
+        instantaneous terms which true SnAp-1 retains. Accepting the request
+        silently would hand back a rule the caller did not ask for, so the
+        preset carries its provenance (``_requested_snap_order``) and is checked
+        on it rather than on the canonicalised scope.
+        """
+        requested = getattr(self, '_requested_snap_order', None)
+        if self.config.recurrence_scope != 'sparse_n' and requested is None:
+            return
+        order = self.config.sparse_n if requested is None else requested
+        offenders = sorted({
+            relation.primitive.name
+            for relation in self.graph.hidden_param_op_relations
+            if not is_snap_anchored(relation.primitive, relation.eqn_params)
+        })
+        if offenders:
+            raise NotImplementedError(
+                f"recurrence_scope='sparse_n' (sparse_n="
+                f'{order}) requires every eligibility-trace '
+                f'relation to anchor on a single hidden position, but '
+                f'{", ".join(offenders)} does not declare a SnAp anchor: one '
+                f'weight entry of it reaches several hidden positions, so a '
+                f'widened trace slot has no position to be a neighbourhood of. '
+                f"Use recurrence_scope='coupled' or 'diagonal' for this model."
             )
 
     # ------------------------------------------------------------------ #

--- a/braintrace/_algorithm/vjp_graph_executor.py
+++ b/braintrace/_algorithm/vjp_graph_executor.py
@@ -50,7 +50,13 @@ from jax.interpreters import partial_eval as pe
 from jax.tree_util import register_pytree_node_class
 
 from braintrace._compatible_imports import Var, wrap_init
-from braintrace._compiler import ControlFlowPolicy, compile_etrace_graph, HiddenGroup, HiddenParamOpRelation
+from braintrace._compiler import (
+    ControlFlowPolicy,
+    DEFAULT_MAX_JACOBIAN_ELEMENTS,
+    HiddenGroup,
+    HiddenParamOpRelation,
+    compile_etrace_graph,
+)
 from braintrace._input_data import (
     get_single_step_data,
     split_input_data_types,
@@ -155,6 +161,11 @@ class ETraceVjpGraphExecutor(ETraceGraphExecutor):
     include_recurrent_mixing : bool, optional
         Hidden-group grouping mode for the hidden-to-hidden transition; see
         ``compile_etrace_graph(..., include_recurrent_mixing=...)``.
+    sparse_n : int, optional
+        SnAp order for ``recurrence_scope='sparse_n'``. Default ``None``.
+    snap_max_jacobian_elements : int, optional
+        Ceiling on each group's widened block Jacobian, ``P * (K * S) ** 2``
+        elements; only consulted when *sparse_n* is given.
     control_flow : ControlFlowPolicy, optional
         Policy governing control-flow canonicalization during graph
         compilation. ``None`` (default) uses
@@ -167,11 +178,15 @@ class ETraceVjpGraphExecutor(ETraceGraphExecutor):
         model: brainstate.nn.Module,
         vjp_method: str = 'single-step',
         include_recurrent_mixing: bool = False,
+        sparse_n: Optional[int] = None,
+        snap_max_jacobian_elements: int = DEFAULT_MAX_JACOBIAN_ELEMENTS,
         control_flow: Optional[ControlFlowPolicy] = None,
     ):
         super().__init__(
             model,
             include_recurrent_mixing=include_recurrent_mixing,
+            sparse_n=sparse_n,
+            snap_max_jacobian_elements=snap_max_jacobian_elements,
             control_flow=control_flow,
         )
 
@@ -228,6 +243,8 @@ class ETraceVjpGraphExecutor(ETraceGraphExecutor):
             self.model, *args,
             include_hidden_perturb=self.is_single_step_vjp,
             include_recurrent_mixing=self.include_recurrent_mixing,
+            sparse_n=self.sparse_n,
+            snap_max_jacobian_elements=self.snap_max_jacobian_elements,
             control_flow=self.control_flow,
         )
 

--- a/braintrace/_compiler/__init__.py
+++ b/braintrace/_compiler/__init__.py
@@ -51,6 +51,8 @@ from braintrace._compiler.hidden_group import (
     HiddenGroup,
     find_hidden_groups_from_minfo,
     find_hidden_groups_from_module,
+    gather_learning_signal,
+    widen_instant_term,
 )
 from braintrace._compiler.hidden_pertubation import (
     HiddenPerturbation,
@@ -60,4 +62,9 @@ from braintrace._compiler.hidden_pertubation import (
 from braintrace._compiler.module_info import (
     ModuleInfo,
     extract_module_info,
+)
+from braintrace._compiler.position_graph import (
+    DEFAULT_MAX_JACOBIAN_ELEMENTS,
+    SnapPattern,
+    build_snap_pattern,
 )

--- a/braintrace/_compiler/diagnostics.py
+++ b/braintrace/_compiler/diagnostics.py
@@ -142,6 +142,18 @@ class DiagnosticKind(str, Enum):
     PRIMITIVE_INSIDE_CONTROL_FLOW = 'primitive_inside_control_flow'
     MULTI_OUTPUT_PRIMITIVE_DETECTED = 'multi_output_primitive_detected'
     PYTREE_WEIGHT_LEAF_AMBIGUOUS = 'pytree_weight_leaf_ambiguous'
+    # SnAp-n position analysis (P3; see _compiler/position_graph.py)
+    #
+    # ``SNAP_PATTERN_CONSERVATIVE``: the n-step position neighbourhood could
+    # not be derived from the transition jaxpr, so it widened to all-to-all
+    # (WARNING -- the approximation is not degraded, since a superset only moves
+    # the rule towards within-group RTRL, but the trace is larger than the
+    # requested order implies).
+    # ``SNAP_PATTERN_DEGENERATE``: the group has no cross-position coupling, so
+    # SnAp-n retains a single position and coincides with `coupled` (INFO).
+    SNAP_PATTERN_CONSERVATIVE = 'snap_pattern_conservative'
+    SNAP_PATTERN_DEGENERATE = 'snap_pattern_degenerate'
+
     TRANSITION_TAIL_BOUNDED = 'transition_tail_bounded'
     HIDDEN_GROUP_MERGED = 'hidden_group_merged'
     STATE_MISMATCH = 'state_mismatch'

--- a/braintrace/_compiler/graph.py
+++ b/braintrace/_compiler/graph.py
@@ -20,7 +20,9 @@ from typing import Dict, Sequence, Tuple, Optional, NamedTuple
 
 import brainstate
 import jax
+import numpy as np
 
+from braintrace._misc import NotSupportedError
 from braintrace._typing import (
     Inputs,
     Path,
@@ -39,6 +41,7 @@ from .hidden_group import (
     find_hidden_groups_from_minfo,
     HiddenGroup,
 )
+from .position_graph import DEFAULT_MAX_JACOBIAN_ELEMENTS
 from .hidden_pertubation import (
     add_hidden_perturbation_from_minfo,
     HiddenPerturbation,
@@ -279,11 +282,63 @@ def compiler_context(name: str):
         context.compilers.pop()
 
 
+def _check_sparse_n_request(
+    sparse_n: Optional[int],
+    include_recurrent_mixing: bool,
+) -> None:
+    """Reject a ``sparse_n`` request the compiler cannot honour.
+
+    Both checks guard *silent degradation* rather than a crash. Without them
+    ``sparse_n`` still compiles: with ``include_recurrent_mixing=False`` the
+    recurrent mixing primitive never enters the transition, the position
+    analysis finds no cross-position coupling, every neighbourhood collapses to
+    ``K = 1`` and the result is the diagonal rule under a SnAp label. And
+    because ``bool`` is a subclass of ``int``, ``sparse_n=True`` would sail
+    through a plain ``isinstance`` check and be read as SnAp-1.
+
+    Parameters
+    ----------
+    sparse_n : int or None
+        The requested SnAp order.
+    include_recurrent_mixing : bool
+        Whether recurrent ETP mixing primitives are traced into the transition.
+
+    Raises
+    ------
+    TypeError
+        If *sparse_n* is a ``bool`` or not an integer.
+    ValueError
+        If *sparse_n* is below 1.
+    NotSupportedError
+        If *sparse_n* is requested without ``include_recurrent_mixing=True``.
+    """
+    if sparse_n is None:
+        return
+    if isinstance(sparse_n, bool) or not isinstance(sparse_n, (int, np.integer)):
+        raise TypeError(
+            f'sparse_n must be an integer SnAp order or None, got '
+            f'{sparse_n!r} ({type(sparse_n).__name__}).'
+        )
+    if int(sparse_n) < 1:
+        raise ValueError(f'sparse_n must be at least 1, got {sparse_n}.')
+    if not include_recurrent_mixing:
+        raise NotSupportedError(
+            f'sparse_n={sparse_n} needs include_recurrent_mixing=True: the '
+            'widened SnAp operator is gathered out of the coupled transition '
+            "Jacobian, so with the mixing primitive excluded there is no "
+            'cross-position coupling left to retain and every neighbourhood '
+            'would collapse to K=1 -- the diagonal rule under a SnAp label. '
+            'Pass include_recurrent_mixing=True, or drop sparse_n.'
+        )
+
+
 def compile_etrace_graph(
     model: brainstate.nn.Module,
     *model_args: Tuple,
     include_hidden_perturb: bool = True,
     include_recurrent_mixing: bool = False,
+    sparse_n: Optional[int] = None,
+    snap_max_jacobian_elements: int = DEFAULT_MAX_JACOBIAN_ELEMENTS,
     control_flow: Optional[ControlFlowPolicy] = None,
 ) -> ETraceGraph:
     """Construct the eligibility-trace graph for a given model and inputs.
@@ -314,6 +369,19 @@ def compile_etrace_graph(
         recurrence becomes coupled, and the true per-position block-diagonal
         Jacobian is extracted (RTRL-exact temporal credit, e.g. for
         :class:`~braintrace.OSTLRecurrent`).
+    sparse_n : int, optional
+        SnAp order for ``recurrence_scope='sparse_n'``. When given, every hidden
+        group carries the ``n``-step position neighbourhood derived from its own
+        transition (:mod:`~braintrace._compiler.position_graph`) in
+        ``HiddenGroup.snap``, and its trace's trailing state axis widens to
+        ``K * num_state``. Requires ``include_recurrent_mixing=True`` -- the
+        widened operator is gathered out of the coupled transition's Jacobian --
+        and raises rather than degrading to ``K = 1`` if it is not set.
+        ``None`` (default) for every other scope.
+    snap_max_jacobian_elements : int, optional
+        Ceiling on each group's widened block Jacobian, ``P * (K * S) ** 2``
+        elements. Only consulted when *sparse_n* is given. Default
+        :data:`~braintrace._compiler.position_graph.DEFAULT_MAX_JACOBIAN_ELEMENTS`.
     control_flow : ControlFlowPolicy or None, optional
         Policy governing control-flow canonicalization and downstream
         handling, forwarded to :func:`~braintrace.extract_module_info` and
@@ -379,6 +447,8 @@ def compile_etrace_graph(
         1
     """
 
+    _check_sparse_n_request(sparse_n, include_recurrent_mixing)
+
     with compiler_context('compile_graph'), diagnostic_context() as reporter:
 
         assert isinstance(model_args, tuple)
@@ -401,6 +471,8 @@ def compile_etrace_graph(
         # ---       evaluating the relationship for hidden-to-hidden        --- #
         hidden_groups, hid_path_to_group = find_hidden_groups_from_minfo(
             minfo, include_recurrent_mixing=include_recurrent_mixing,
+            sparse_n=sparse_n,
+            snap_max_jacobian_elements=snap_max_jacobian_elements,
             descended_scan_eqn_ids=descended_eqn_ids,
             descended_hidden_paths=descended_paths,
         )

--- a/braintrace/_compiler/graph_test.py
+++ b/braintrace/_compiler/graph_test.py
@@ -416,3 +416,78 @@ class TestVmappedModelCompilation:
         g_vmapped = build_and_grads(self._VmappedCell)
         for a, b in zip(jax.tree.leaves(g_native), jax.tree.leaves(g_vmapped)):
             assert jnp.allclose(a, b, atol=1e-5), (a - b)
+
+
+class TestCompileEtraceGraphSparseNGuards(unittest.TestCase):
+    """``compile_etrace_graph(..., sparse_n=...)`` must not degrade silently.
+
+    The compiler is a *public* entry point, and it takes ``sparse_n`` and
+    ``include_recurrent_mixing`` as independent keywords. Nothing about the
+    combination ``sparse_n=2, include_recurrent_mixing=False`` fails: the mixing
+    primitive stays out of the transition, the position analysis finds no
+    cross-position coupling, every neighbourhood collapses to ``K = 1`` and the
+    caller gets the diagonal rule with a SnAp label on it. Same class of failure
+    as the algorithm-level guardrails, one layer lower.
+    """
+
+    @staticmethod
+    def _model():
+        class Net(brainstate.nn.Module):
+            def __init__(self, n_in=3, n_rec=4):
+                super().__init__()
+                with brainstate.random.seed_context(0):
+                    self.w = brainstate.ParamState(
+                        brainstate.random.randn(n_rec, n_rec) * 0.5)
+                    self.win = brainstate.ParamState(
+                        brainstate.random.randn(n_in, n_rec) * 0.5)
+                self.h = brainstate.HiddenState(jnp.zeros((n_rec,)))
+
+            def update(self, x):
+                rec = braintrace.matmul(self.h.value, self.w.value)
+                self.h.value = jax.nn.tanh(rec + x @ self.win.value)
+                return self.h.value
+
+        model = Net()
+        brainstate.nn.init_all_states(model)
+        return model, jnp.zeros((3,))
+
+    def test_sparse_n_without_recurrent_mixing_raises(self):
+        model, x = self._model()
+        with self.assertRaises(braintrace.NotSupportedError) as ctx:
+            braintrace.compile_etrace_graph(model, x, sparse_n=2)
+        msg = str(ctx.exception)
+        assert 'include_recurrent_mixing' in msg and 'K=1' in msg
+
+    def test_sparse_n_with_recurrent_mixing_widens(self):
+        model, x = self._model()
+        graph = braintrace.compile_etrace_graph(
+            model, x, sparse_n=2, include_recurrent_mixing=True)
+        # negative control for the test above: the same order *does* widen once
+        # the mixing primitive is in the transition, so the guard is rejecting a
+        # degenerate configuration rather than a valid one.
+        assert [g.snap.num_neighbour for g in graph.hidden_groups] == [4]
+
+    def test_boolean_sparse_n_is_rejected(self):
+        # ``bool`` is a subclass of ``int``, so ``sparse_n=True`` would pass an
+        # ``isinstance(..., int)`` check and be read as SnAp-1.
+        model, x = self._model()
+        with self.assertRaises(TypeError):
+            braintrace.compile_etrace_graph(
+                model, x, sparse_n=True, include_recurrent_mixing=True)
+
+    def test_non_integer_and_out_of_range_sparse_n_are_rejected(self):
+        model, x = self._model()
+        with self.assertRaises(TypeError):
+            braintrace.compile_etrace_graph(
+                model, x, sparse_n=2.0, include_recurrent_mixing=True)
+        with self.assertRaises(ValueError):
+            braintrace.compile_etrace_graph(
+                model, x, sparse_n=0, include_recurrent_mixing=True)
+
+    def test_jacobian_ceiling_is_reachable_from_the_compiler(self):
+        model, x = self._model()
+        with self.assertRaises(braintrace.NotSupportedError) as ctx:
+            braintrace.compile_etrace_graph(
+                model, x, sparse_n=2, include_recurrent_mixing=True,
+                snap_max_jacobian_elements=8)
+        assert 'snap_max_jacobian_elements' in str(ctx.exception)

--- a/braintrace/_compiler/hidden_group.py
+++ b/braintrace/_compiler/hidden_group.py
@@ -51,6 +51,7 @@ from typing import List, Dict, FrozenSet, Sequence, Tuple, Set, Optional, Callab
 import brainstate
 import brainunit as u
 import jax.core
+import jax.numpy as jnp
 import numpy as np
 from brainstate import HiddenGroupState
 
@@ -76,15 +77,20 @@ from .base import JaxprEvaluation, find_matched_vars
 from .canonicalize import ControlFlowPolicy, DEFAULT_CONTROL_FLOW_POLICY
 from .diagnostics import DiagnosticKind, DiagnosticLevel, emit
 from .module_info import extract_module_info, ModuleInfo
+from .position_graph import DEFAULT_MAX_JACOBIAN_ELEMENTS, build_snap_pattern
 
 __all__ = [
     'HiddenGroup',
+    'widened_block_jacobian',
+    'widen_instant_term',
+    'gather_learning_signal',
     'find_hidden_groups_from_minfo',
     'find_hidden_groups_from_module',
 ]
 
 if TYPE_CHECKING:
     from .scan_descent import GroupDescent  # noqa: F401
+    from .position_graph import SnapPattern  # noqa: F401
 
 # Recurrent-weight mixing primitives -- dense / convolutional weights -- whose
 # consumption of a hidden state is a genuine *cross-position* coupling, i.e. that
@@ -136,6 +142,9 @@ class HiddenGroup(NamedTuple):
     is_diagonal_recurrence : bool
         Whether the recurrence is diagonal across the leading ``varshape``
         positions (see the field comment for the full contract).
+    snap : SnapPattern or None
+        The SnAp-n neighbourhood the trace is widened onto
+        (``recurrence_scope='sparse_n'``); ``None`` for every other scope.
     descent : GroupDescent or None
         Descent context when this group's transition is one substep of a
         descended scan (Phase 4 structured scan descent); ``None`` for
@@ -199,6 +208,22 @@ class HiddenGroup(NamedTuple):
     # to ``True`` to preserve the cheap behavior for any positional construction.
     is_diagonal_recurrence: bool = True
 
+    snap: Optional['SnapPattern'] = None
+    """The SnAp-n neighbourhood this group's trace is widened onto, or ``None``.
+
+    Set only when ``recurrence_scope='sparse_n'``; ``'diagonal'`` and
+    ``'coupled'`` groups carry ``None`` and every pre-P3 code path is reached
+    unchanged. When set, :meth:`diagonal_jacobian` returns the widened operator
+    (:func:`widened_block_jacobian`) instead of the per-position block diagonal,
+    and :attr:`trace_state_width` -- not :attr:`num_state` -- sizes the trailing
+    axis of every trace leaf.
+
+    Orthogonal to :attr:`is_diagonal_recurrence`, which answers a different
+    question: *is this transition position-diagonal, so the cheap column-sum
+    Jacobian is exact?* SnAp-n needs the coupled transition, so a widened group
+    always has ``is_diagonal_recurrence=False``.
+    """
+
     descent: Optional['GroupDescent'] = None
     """Set when this group's transition is one substep of a descended scan
     (Phase 4 structured scan descent): ``transition_jaxpr``/
@@ -227,6 +252,25 @@ class HiddenGroup(NamedTuple):
             The total number of hidden states across the group.
         """
         return sum([st.num_state for st in self.hidden_states])
+
+    @property
+    def trace_state_width(self) -> int:
+        """The width of a trace leaf's trailing axis.
+
+        ``num_state`` normally; ``K * num_state`` under SnAp-n, where the
+        trailing axis carries a ``(neighbour, state)`` pair rather than a state
+        alone. Every trace allocation, recursion and solve reads this rather
+        than :attr:`num_state`, which keeps the per-primitive kernels -- all
+        generic in that axis's size -- untouched.
+
+        Returns
+        -------
+        int
+            The trailing-axis width of this group's trace leaves.
+        """
+        if self.snap is None:
+            return self.num_state
+        return int(self.snap.num_neighbour) * self.num_state
 
     def check_consistent_varshape(self):
         """Check whether the shapes of the hidden states are consistent.
@@ -290,7 +334,11 @@ class HiddenGroup(NamedTuple):
         jax.Array
             The per-position block-diagonal of the recurrent Jacobian
             ``d h^t / d h^{t-1}``, with shape
-            ``(*varshape, num_states, num_states)``. Entry ``[p, a, b]`` is
+            ``(*varshape, num_states, num_states)`` -- or, when :attr:`snap` is
+            set, the SnAp-n widened operator of shape
+            ``(*varshape, trace_state_width, trace_state_width)`` whose entry
+            ``[p, (k, a), (k', b)]`` is
+            ``d h^t[nbr[p,k], a] / d h^{t-1}[nbr[p,k'], b]``. Entry ``[p, a, b]`` is
             ``d h^t[p, a] / d h^{t-1}[p, b]`` -- the cross-position terms
             ``d h^t[p] / d h^{t-1}[q]`` (``p != q``) are intentionally dropped
             (the D-RTRL / e-prop diagonal approximation).
@@ -315,6 +363,11 @@ class HiddenGroup(NamedTuple):
         fn = lambda hid: self.concat_hidden(self.transition(self.split_hidden(hid), input_vals))
         concat_hid = self.concat_hidden(hidden_vals)
         needs_fwd = _transition_contains_while(self.transition_jaxpr)
+        if self.snap is not None:
+            return widened_block_jacobian(
+                fn, concat_hid, self.snap.neighbours, self.snap.valid,
+                use_forward_mode=needs_fwd,
+            )
         if self.is_diagonal_recurrence:
             extract = jacfwd_last_dim if needs_fwd else jacrev_last_dim
             return extract(fn, concat_hid)
@@ -524,6 +577,168 @@ def block_diagonal_last_dim(
     block = u.math.diagonal(full_jac, axis1=0, axis2=2)  # (num_state, num_state, num_pos)
     block = u.math.moveaxis(block, -1, 0)  # (num_pos, num_state, num_state)
     return u.math.reshape(block, (*varshape, num_state, num_state))
+
+
+def widened_block_jacobian(
+    fn: Callable[..., jax.Array],
+    hid_vals: jax.Array,
+    neighbours: np.ndarray,
+    valid: np.ndarray,
+    use_forward_mode: bool = False,
+) -> jax.Array:
+    r"""Gather the SnAp-n widened transition operator out of the full Jacobian.
+
+    Where :func:`block_diagonal_last_dim` keeps only ``J[p, :, p, :]``, this
+    keeps the whole ``K x K`` block over position ``p``'s neighbourhood:
+
+    .. math::
+
+        Dg[p, (k, a), (k', b)] = J[\mathrm{nbr}[p,k],\, a,\,
+                                   \mathrm{nbr}[p,k'],\, b]
+                                 \cdot v[p,k] \cdot v[p,k'],
+
+    which is exactly the recursion SnAp-n truncates the influence matrix onto.
+    The result's trailing pair of axes has width ``M = K * num_state``, so every
+    downstream kernel -- all of which are generic in the size of that axis --
+    runs unchanged.
+
+    Parameters
+    ----------
+    fn : Callable[[jax.Array], jax.Array]
+        A shape-preserving map on ``(*varshape, num_state)`` arrays.
+    hid_vals : jax.Array
+        The point at which to linearize, shape ``(*varshape, num_state)``.
+    neighbours : numpy.ndarray
+        ``(num_position, K)`` flat neighbour indices, ``neighbours[p, 0] == p``.
+    valid : numpy.ndarray
+        ``(num_position, K)`` boolean mask; a ``False`` slot gets a zero row and
+        a zero column, so its trace stays zero for all time and contributes
+        nothing to the gradient.
+    use_forward_mode : bool, optional
+        Materialize the full Jacobian with :func:`jax.jacfwd` instead of
+        :func:`jax.jacrev`, as :func:`block_diagonal_last_dim` does for a
+        transition containing a ``while``. Default ``False``.
+
+    Returns
+    -------
+    jax.Array
+        The widened operator, shape ``(*varshape, K * num_state, K * num_state)``.
+
+    Notes
+    -----
+    Peak memory is the full ``(P*S) x (P*S)`` Jacobian -- the same array
+    ``block_diagonal_last_dim`` already materializes for the coupled path -- but
+    the *stored* result is ``O(P * K^2 * S^2)``, which at saturation is
+    ``P^3 S^2``. Affordable for the small dense groups this targets; a
+    matrix-free per-position ``vmap(jacrev)`` would trade it for compute.
+
+    At ``K == 1`` with an all-valid mask this returns exactly
+    :func:`block_diagonal_last_dim`'s output: the scale's identity element is
+    exact, not approximately exact.
+    """
+    num_state = hid_vals.shape[-1]
+    varshape = hid_vals.shape[:-1]
+    num_pos = int(np.prod(varshape)) if varshape else 1
+    num_nbr = int(neighbours.shape[1])
+    jac_fn = jax.jacfwd if use_forward_mode else jax.jacrev
+    full_jac = jac_fn(fn)(hid_vals)  # (*varshape, num_state, *varshape, num_state)
+    full_jac = u.math.reshape(full_jac, (num_pos, num_state, num_pos, num_state))
+
+    neighbours = np.asarray(neighbours)
+    rows = np.repeat(neighbours[:, :, None], num_nbr, axis=2)  # (P, K, K)
+    cols = np.repeat(neighbours[:, None, :], num_nbr, axis=1)  # (P, K, K)
+    # Advanced indices separated by a slice: the broadcast (P, K, K) leads, the
+    # two sliced state axes follow -> sub[p, k, k', a, b].
+    sub = full_jac[rows, :, cols, :]
+    mask = (valid[:, :, None] & valid[:, None, :]).astype(hid_vals.dtype)
+    sub = sub * mask[:, :, :, None, None]
+    sub = u.math.transpose(sub, (0, 1, 3, 2, 4))  # (P, K, S, K', S)
+    width = num_nbr * num_state
+    return u.math.reshape(sub, (*varshape, width, width))
+
+
+def widen_instant_term(df: Any, num_neighbour: int) -> Any:
+    r"""Zero-pad an instantaneous term onto the SnAp-n widened state axis.
+
+    The trace slot ``(p, (k, a))`` holds
+    :math:`\partial h[\mathrm{nbr}[p,k], a] / \partial \theta_p`, and the
+    instantaneous term of a relation anchored at position ``p`` lands on ``p``
+    itself. Since ``nbr[p, 0] == p`` by construction, that is slot ``k = 0``:
+
+    .. math::
+
+        \widetilde{D_f}[\dots, p, (k, a)] =
+            \begin{cases} D_f[\dots, p, a] & k = 0 \\ 0 & \text{otherwise.}\end{cases}
+
+    Padded (invalid) slots therefore start at zero and, because
+    :func:`widened_block_jacobian` gives them a zero row, stay zero for all
+    time — which is what makes the repeated ``p`` index in ``neighbours``
+    harmless rather than a double count.
+
+    Parameters
+    ----------
+    df : ArrayLike
+        The instantaneous term, shape ``(..., num_state)``. Only the trailing
+        axis is touched, so single-step ``(*varshape, S)`` and stacked
+        ``(T, *varshape, S)`` layouts are both accepted.
+    num_neighbour : int
+        The neighbourhood width ``K``.
+
+    Returns
+    -------
+    ArrayLike
+        Shape ``(..., K * num_state)``; the input unchanged when ``K == 1``.
+    """
+    if num_neighbour == 1:
+        return df
+    tail = u.math.repeat(u.math.zeros_like(df), num_neighbour - 1, axis=-1)
+    return u.math.concatenate([df, tail], axis=-1)
+
+
+def gather_learning_signal(signal: Any, snap: 'SnapPattern') -> Any:
+    r"""Gather :math:`\partial L / \partial h` onto the SnAp-n neighbour index.
+
+    The solve contracts the trace's widened axis with the learning signal, so
+    the signal has to be expressed in the *same* coordinates the trace is:
+
+    .. math::
+
+        \widetilde{s}[\dots, p, (k, a)] =
+            \frac{\partial L}{\partial h}[\dots, \mathrm{nbr}[p,k], a]
+            \cdot v[p, k] .
+
+    The mask is applied for the same reason it is applied to the transition
+    operator: a padded slot's neighbour index is ``p`` itself (an in-range dummy
+    that keeps the gather safe), and zeroing it makes the slot's contribution
+    identically zero rather than merely zero-by-consequence.
+
+    Parameters
+    ----------
+    signal : ArrayLike
+        Shape ``(..., *varshape, num_state)``; leading axes are carried through.
+    snap : SnapPattern
+        The group's neighbourhood.
+
+    Returns
+    -------
+    ArrayLike
+        Shape ``(..., *varshape, K * num_state)``.
+    """
+    varshape = tuple(snap.varshape)
+    num_position = snap.num_position
+    num_neighbour = snap.num_neighbour
+    rank = len(varshape)
+    lead = tuple(u.math.shape(signal))[:u.math.ndim(signal) - rank - 1]
+    num_state = tuple(u.math.shape(signal))[-1]
+
+    flat = u.math.reshape(signal, (*lead, num_position, num_state))
+    # One advanced index on axis -2, so the gathered (P, K) block stays in place
+    # and the result is (*lead, P, K, num_state).
+    gathered = flat[..., np.asarray(snap.neighbours), :]
+    mask = jnp.asarray(snap.valid, dtype=jnp.result_type(u.get_mantissa(flat)))
+    gathered = gathered * mask[:, :, None]
+    return u.math.reshape(
+        gathered, (*lead, *varshape, num_neighbour * num_state))
 
 
 def _param_subjaxprs(eqn: JaxprEqn) -> List[Jaxpr]:
@@ -911,6 +1126,10 @@ class JaxprEvalForHiddenGroup(JaxprEvaluation):
         invar_to_hidden_path: The mapping from the weight input variable to the hidden state path.
         outvar_to_hidden_path: The mapping from the hidden output variable to the hidden state path.
         path_to_state: The mapping from the hidden state path to the state.
+        include_recurrent_mixing: Whether recurrent ETP mixing primitives are
+            traced into the hidden-to-hidden transition jaxpr.
+        sparse_n: SnAp order for ``recurrence_scope='sparse_n'``; ``None``
+            (default) leaves every group's ``snap`` pattern unset.
         control_flow: The :class:`~braintrace.ControlFlowPolicy` governing
             opaque control-flow handling (see ``base.check_unsupported_op``).
         descended_scan_eqn_ids: ``id()`` values of scan equations rewritten by
@@ -929,6 +1148,8 @@ class JaxprEvalForHiddenGroup(JaxprEvaluation):
         outvar_to_hidden_path: Dict[HiddenOutVar, Path],
         path_to_state: Dict[Path, brainstate.HiddenState],
         include_recurrent_mixing: bool = False,
+        sparse_n: Optional[int] = None,
+        snap_max_jacobian_elements: int = DEFAULT_MAX_JACOBIAN_ELEMENTS,
         control_flow: ControlFlowPolicy = DEFAULT_CONTROL_FLOW_POLICY,
         descended_scan_eqn_ids: FrozenSet[int] = frozenset(),
         descended_hidden_paths: FrozenSet[Path] = frozenset(),
@@ -950,6 +1171,16 @@ class JaxprEvalForHiddenGroup(JaxprEvaluation):
         # (``True``) or treated as boundaries and excluded (``False``, default).
         # See :func:`find_hidden_groups_from_jaxpr` for the rationale.
         self.include_recurrent_mixing = include_recurrent_mixing
+
+        # SnAp order (``recurrence_scope='sparse_n'``): when set, every group
+        # built below carries the derived n-step neighbourhood its trace is
+        # widened onto. ``None`` (every other scope) leaves ``HiddenGroup.snap``
+        # unset and no pre-P3 code path changes.
+        self.sparse_n = sparse_n
+
+        # Ceiling on the widened block Jacobian, in elements. Only consulted
+        # when ``sparse_n`` is set; see ``DEFAULT_MAX_JACOBIAN_ELEMENTS``.
+        self.snap_max_jacobian_elements = snap_max_jacobian_elements
 
         # the hidden state groups
         self.hidden_outvar_to_invar = hidden_outvar_to_invar
@@ -1187,6 +1418,58 @@ class JaxprEvalForHiddenGroup(JaxprEvaluation):
             for sub, seeds, feedback in _map_positions_to_subjaxpr_seeds(eqn, positions)
         )
 
+    def _attach_snap_pattern(self, group: HiddenGroup) -> HiddenGroup:
+        """Derive and attach this group's SnAp-n neighbourhood, if one is asked for.
+
+        A degenerate result (``K == 1``) is legitimate -- a group with no
+        cross-position coupling has nothing to retain, and ``sparse_n`` there is
+        exactly ``coupled`` -- but it is also what a silently failing analysis
+        would produce, so it is reported. A conservative result is reported too,
+        since it can inflate the trace by orders of magnitude.
+        """
+        if self.sparse_n is None or group.descent is not None:
+            return group
+        pattern = build_snap_pattern(
+            group.transition_jaxpr, group.varshape, self.sparse_n,
+            num_state=group.num_state,
+            max_jacobian_elements=self.snap_max_jacobian_elements,
+        )
+        if pattern.conservative:
+            emit(
+                kind=DiagnosticKind.SNAP_PATTERN_CONSERVATIVE,
+                level=DiagnosticLevel.WARNING,
+                message=(
+                    f'The SnAp-n position analysis could not derive a pattern for '
+                    f'hidden group {group.index} ({group.hidden_paths}) and widened '
+                    f'to all-to-all (K={pattern.num_neighbour} of '
+                    f'{pattern.num_position} positions): {pattern.reason} The '
+                    f'approximation is not degraded -- a superset neighbourhood '
+                    f'only moves the rule towards within-group RTRL -- but the '
+                    f'trace is larger than sparse_n={self.sparse_n} implies. '
+                    f'Note that within-group RTRL equals BPTT only when the '
+                    f'group\'s tail is position-preserving; see F-31 in '
+                    f'docs/specs/2026-07-25-known-limitations.md.'
+                ),
+                hidden_paths=tuple(group.hidden_paths),
+                context={'num_neighbour': pattern.num_neighbour,
+                         'num_position': pattern.num_position,
+                         'sparse_n': self.sparse_n},
+            )
+        elif pattern.is_degenerate:
+            emit(
+                kind=DiagnosticKind.SNAP_PATTERN_DEGENERATE,
+                level=DiagnosticLevel.INFO,
+                message=(
+                    f'Hidden group {group.index} ({group.hidden_paths}) has no '
+                    f'cross-position coupling in its transition, so SnAp-n at '
+                    f'sparse_n={self.sparse_n} retains a single position and '
+                    f"computes exactly what recurrence_scope='coupled' computes."
+                ),
+                hidden_paths=tuple(group.hidden_paths),
+                context={'sparse_n': self.sparse_n},
+            )
+        return group._replace(snap=pattern)
+
     def _post_check(self) -> Tuple[
         Sequence[HiddenGroup],
         Dict[Path, HiddenGroup],
@@ -1295,6 +1578,7 @@ class JaxprEvalForHiddenGroup(JaxprEvaluation):
                 transition_jaxpr_constvars=list(jaxpr.constvars),
                 is_diagonal_recurrence=not self.include_recurrent_mixing,
             )
+            group = self._attach_snap_pattern(group)
             # Belt-and-braces: the per-transition shape filter in
             # ``_simplify_hid2hid_tracer`` should already guarantee this, but
             # a merged group violating it would corrupt concat/split downstream.
@@ -1597,6 +1881,8 @@ def find_hidden_groups_from_jaxpr(
     outvar_to_hidden_path: Dict[HiddenOutVar, Path],
     path_to_state: Dict[Path, brainstate.State],
     include_recurrent_mixing: bool = False,
+    sparse_n: Optional[int] = None,
+    snap_max_jacobian_elements: int = DEFAULT_MAX_JACOBIAN_ELEMENTS,
     control_flow: ControlFlowPolicy = DEFAULT_CONTROL_FLOW_POLICY,
     descended_scan_eqn_ids: FrozenSet[int] = frozenset(),
     descended_hidden_paths: FrozenSet[Path] = frozenset(),
@@ -1652,6 +1938,8 @@ def find_hidden_groups_from_jaxpr(
         # brainstate is currently untyped (both collapse to Any).
         path_to_state=cast(Dict[Path, brainstate.HiddenState], path_to_state),  # type: ignore[redundant-cast]
         include_recurrent_mixing=include_recurrent_mixing,
+        sparse_n=sparse_n,
+        snap_max_jacobian_elements=snap_max_jacobian_elements,
         control_flow=control_flow,
         descended_scan_eqn_ids=descended_scan_eqn_ids,
         descended_hidden_paths=descended_hidden_paths,
@@ -1663,6 +1951,8 @@ def find_hidden_groups_from_jaxpr(
 def find_hidden_groups_from_minfo(
     minfo: ModuleInfo,
     include_recurrent_mixing: bool = False,
+    sparse_n: Optional[int] = None,
+    snap_max_jacobian_elements: int = DEFAULT_MAX_JACOBIAN_ELEMENTS,
     descended_scan_eqn_ids: FrozenSet[int] = frozenset(),
     descended_hidden_paths: FrozenSet[Path] = frozenset(),
 ):
@@ -1675,6 +1965,10 @@ def find_hidden_groups_from_minfo(
     include_recurrent_mixing : bool, default False
         Whether to trace recurrent ETP mixing primitives into the transition
         jaxpr. See :func:`find_hidden_groups_from_jaxpr` for the full semantics.
+    sparse_n : int, optional
+        SnAp order for ``recurrence_scope='sparse_n'``. When given, each group
+        carries the derived n-step neighbourhood in its ``snap`` field. Default
+        ``None``.
     descended_scan_eqn_ids : frozenset of int, default ``frozenset()``
         ``id()`` values of scan equations rewritten by structured scan descent
         (Phase 4); those equations are skipped by the hidden-group walker.
@@ -1704,6 +1998,8 @@ def find_hidden_groups_from_minfo(
         outvar_to_hidden_path=minfo.outvar_to_hidden_path,
         path_to_state=minfo.retrieved_model_states,
         include_recurrent_mixing=include_recurrent_mixing,
+        sparse_n=sparse_n,
+        snap_max_jacobian_elements=snap_max_jacobian_elements,
         control_flow=minfo.control_flow,
         descended_scan_eqn_ids=descended_scan_eqn_ids,
         descended_hidden_paths=descended_hidden_paths,
@@ -1715,6 +2011,8 @@ def find_hidden_groups_from_module(
     model: brainstate.nn.Module,
     *model_args,
     include_recurrent_mixing: bool = False,
+    sparse_n: Optional[int] = None,
+    snap_max_jacobian_elements: int = DEFAULT_MAX_JACOBIAN_ELEMENTS,
     **model_kwargs,
 ) -> Tuple[Sequence[HiddenGroup], brainstate.util.PrettyDict]:
     """Find hidden groups from a model.
@@ -1729,6 +2027,9 @@ def find_hidden_groups_from_module(
         Whether to trace recurrent ETP mixing primitives into the transition
         jaxpr. Keyword-only. See :func:`find_hidden_groups_from_jaxpr` for the
         full semantics.
+    sparse_n : int, optional
+        SnAp order for ``recurrence_scope='sparse_n'``. Keyword-only. Default
+        ``None``.
     **model_kwargs
         The keyword arguments of the model.
 
@@ -1757,4 +2058,9 @@ def find_hidden_groups_from_module(
         1
     """
     minfo = extract_module_info(model, *model_args, **model_kwargs)
-    return find_hidden_groups_from_minfo(minfo, include_recurrent_mixing=include_recurrent_mixing)
+    return find_hidden_groups_from_minfo(
+        minfo,
+        include_recurrent_mixing=include_recurrent_mixing,
+        sparse_n=sparse_n,
+        snap_max_jacobian_elements=snap_max_jacobian_elements,
+    )

--- a/braintrace/_compiler/hidden_group_test.py
+++ b/braintrace/_compiler/hidden_group_test.py
@@ -1591,3 +1591,206 @@ class TestWhileRecurrentMixingGuard:
         assert list(group.transition_jaxpr.eqns) == []
         kinds = [r.kind for r in reporter.records()]
         assert DiagnosticKind.CONTROL_FLOW_RECURRENT_MIXING in kinds
+
+
+# ---------------------------------------------------------------------------
+# SnAp-n: the widened transition operator (P3)
+# ---------------------------------------------------------------------------
+
+from braintrace._compiler.hidden_group import widened_block_jacobian
+from braintrace._compiler.position_graph import SnapPattern, build_snap_pattern
+
+
+def _full_jacobian(fn, h):
+    """The whole ``(P, S, P, S)`` cross-position Jacobian, for reference."""
+    num_state = h.shape[-1]
+    num_pos = int(np.prod(h.shape[:-1]))
+    return np.asarray(jax.jacrev(fn)(h)).reshape(num_pos, num_state, num_pos, num_state)
+
+
+def _identity_snap(num_pos):
+    return (np.arange(num_pos, dtype=np.int32)[:, None],
+            np.ones((num_pos, 1), dtype=bool))
+
+
+def _saturated_snap(num_pos):
+    return (np.tile(np.arange(num_pos, dtype=np.int32), (num_pos, 1)),
+            np.ones((num_pos, num_pos), dtype=bool))
+
+
+class TestWidenedBlockJacobian:
+    """``widened_block_jacobian`` gathers ``Dg`` out of the full Jacobian.
+
+    ``Dg[p, (k, a), (k', b)] = J[nbr[p,k], a, nbr[p,k'], b]`` masked by the
+    validity of both slots. Its identity element (``K == 1``) must reproduce
+    ``block_diagonal_last_dim`` exactly, and its saturated form must reproduce
+    the whole Jacobian for every position -- those two ends are what make the
+    SnAp scale a scale.
+    """
+
+    def _fn_and_point(self, num_pos=4, num_state=2, seed=0):
+        rng = brainstate.random.RandomState(seed)
+        w = rng.randn(num_pos * num_state, num_pos * num_state)
+        h = rng.randn(num_pos, num_state)
+        b = rng.randn(num_pos * num_state)
+
+        def fn(hid):
+            flat = hid.reshape(-1)
+            return jnp.tanh(flat @ w + b).reshape(hid.shape)
+
+        return fn, h
+
+    def test_single_neighbour_reproduces_the_block_diagonal(self):
+        fn, h = self._fn_and_point()
+        nbr, valid = _identity_snap(h.shape[0])
+        got = widened_block_jacobian(fn, h, nbr, valid)
+        want = block_diagonal_last_dim(fn, h)
+        assert got.shape == want.shape
+        np.testing.assert_array_equal(np.asarray(got), np.asarray(want))
+
+    def test_saturated_reproduces_the_full_jacobian_for_every_position(self):
+        fn, h = self._fn_and_point()
+        num_pos, num_state = h.shape
+        nbr, valid = _saturated_snap(num_pos)
+        got = np.asarray(widened_block_jacobian(fn, h, nbr, valid))
+        assert got.shape == (num_pos, num_pos * num_state, num_pos * num_state)
+        want = _full_jacobian(fn, h).transpose(0, 1, 2, 3)
+        want = _full_jacobian(fn, h).reshape(num_pos * num_state, num_pos * num_state)
+        for p in range(num_pos):
+            np.testing.assert_allclose(got[p], want, rtol=1e-6, atol=1e-6)
+
+    def test_an_invalid_slot_has_a_zero_row_and_a_zero_column(self):
+        fn, h = self._fn_and_point()
+        num_pos, num_state = h.shape
+        # two neighbour slots, but position 0's second slot is padding
+        nbr = np.stack([np.arange(num_pos), (np.arange(num_pos) + 1) % num_pos], 1)
+        nbr = nbr.astype(np.int32)
+        valid = np.ones((num_pos, 2), dtype=bool)
+        valid[0, 1] = False
+        nbr[0, 1] = 0  # padded slots repeat self
+        got = np.asarray(widened_block_jacobian(fn, h, nbr, valid))
+        pad = slice(num_state, 2 * num_state)
+        np.testing.assert_array_equal(got[0, pad, :], 0.0)
+        np.testing.assert_array_equal(got[0, :, pad], 0.0)
+        # ... while a *valid* second slot at another position is not zero
+        assert np.abs(got[1, pad, :]).max() > 0
+
+    def test_entries_match_the_gather_definition(self):
+        fn, h = self._fn_and_point(num_pos=5, num_state=2, seed=3)
+        num_pos, num_state = h.shape
+        rng = np.random.RandomState(0)
+        nbr = np.stack(
+            [np.arange(num_pos), rng.permutation(num_pos), rng.permutation(num_pos)],
+            axis=1,
+        ).astype(np.int32)
+        valid = np.ones((num_pos, 3), dtype=bool)
+        got = np.asarray(widened_block_jacobian(fn, h, nbr, valid))
+        full = _full_jacobian(fn, h)
+        num_nbr = nbr.shape[1]
+        for p in range(num_pos):
+            for k in range(num_nbr):
+                for a in range(num_state):
+                    for k2 in range(num_nbr):
+                        for b in range(num_state):
+                            np.testing.assert_allclose(
+                                got[p, k * num_state + a, k2 * num_state + b],
+                                full[nbr[p, k], a, nbr[p, k2], b],
+                                rtol=1e-6, atol=1e-6,
+                            )
+
+    def test_forward_mode_agrees_with_reverse_mode(self):
+        fn, h = self._fn_and_point()
+        nbr, valid = _saturated_snap(h.shape[0])
+        rev = np.asarray(widened_block_jacobian(fn, h, nbr, valid))
+        fwd = np.asarray(widened_block_jacobian(fn, h, nbr, valid, use_forward_mode=True))
+        np.testing.assert_allclose(rev, fwd, rtol=1e-6, atol=1e-6)
+
+    def test_varshape_with_several_axes_is_preserved(self):
+        w = brainstate.random.RandomState(1).randn(6, 6)
+        h = jnp.zeros((2, 3, 1))
+
+        def fn(hid):
+            return jnp.tanh(hid.reshape(1, -1) @ w).reshape(hid.shape)
+
+        nbr, valid = _saturated_snap(6)
+        got = widened_block_jacobian(fn, h, nbr, valid)
+        assert got.shape == (2, 3, 6, 6)  # (*varshape, K*S, K*S), S == 1
+
+
+class _SnapTanhRNN(brainstate.nn.Module):
+    """``h <- tanh(x @ win + matmul(h, w))`` -- one group, dense recurrence."""
+
+    def __init__(self, n_in=3, n_rec=4):
+        super().__init__()
+        self.w = brainstate.ParamState(
+            0.5 * brainstate.random.RandomState(0).randn(n_rec, n_rec))
+        self.win = brainstate.ParamState(
+            0.5 * brainstate.random.RandomState(1).randn(n_in, n_rec))
+        self.h = brainstate.HiddenState(jnp.zeros((1, n_rec)))
+
+    def update(self, x):
+        self.h.value = jnp.tanh(
+            x @ self.win.value + braintrace.matmul(self.h.value, self.w.value))
+        return self.h.value
+
+
+class TestHiddenGroupSnapWidening:
+    """``HiddenGroup`` carries the pattern and dispatches on it."""
+
+    def _compiled(self):
+        net = _SnapTanhRNN()
+        brainstate.nn.init_all_states(net)
+        x = jnp.ones((1, 3))
+        groups, _ = find_hidden_groups_from_module(net, x, include_recurrent_mixing=True)
+        assert len(groups) == 1
+        group = groups[0]
+        hidden_vals = [
+            brainstate.random.RandomState(7 + i).randn(*v.aval.shape).astype(v.aval.dtype)
+            for i, v in enumerate(group.hidden_invars)
+        ]
+        input_vals = [
+            brainstate.random.RandomState(11 + i).randn(*v.aval.shape).astype(v.aval.dtype)
+            for i, v in enumerate(group.transition_jaxpr_constvars)
+        ]
+        return group, hidden_vals, input_vals
+
+    def test_trace_state_width_defaults_to_num_state(self):
+        group, _, _ = self._compiled()
+        assert group.snap is None
+        assert group.trace_state_width == group.num_state
+
+    def test_trace_state_width_is_k_times_num_state(self):
+        group, _, _ = self._compiled()
+        pattern = build_snap_pattern(group.transition_jaxpr, group.varshape, 2)
+        widened = group._replace(snap=pattern)
+        assert pattern.num_neighbour == 4  # dense recurrence saturates at n=2
+        assert widened.trace_state_width == 4 * group.num_state
+
+    def test_diagonal_jacobian_dispatches_on_the_pattern(self):
+        group, hidden_vals, input_vals = self._compiled()
+        pattern = build_snap_pattern(group.transition_jaxpr, group.varshape, 2)
+        widened = group._replace(snap=pattern)
+
+        plain = group.diagonal_jacobian(hidden_vals, input_vals)
+        wide = widened.diagonal_jacobian(hidden_vals, input_vals)
+        width = widened.trace_state_width
+        s = group.num_state
+        assert plain.shape == (*group.varshape, s, s)
+        assert wide.shape == (*group.varshape, width, width)
+        # slot 0 of the widened operator is the un-widened block diagonal, and
+        # the off-diagonal blocks it adds are genuinely non-zero (otherwise the
+        # equality above would hold vacuously)
+        np.testing.assert_allclose(
+            np.asarray(wide)[..., :s, :s], np.asarray(plain), rtol=1e-6, atol=1e-6
+        )
+        assert np.abs(np.asarray(wide)[..., s:, :s]).max() > 1e-6
+
+    def test_a_degenerate_pattern_reproduces_the_coupled_jacobian(self):
+        group, hidden_vals, input_vals = self._compiled()
+        pattern = build_snap_pattern(group.transition_jaxpr, group.varshape, 1)
+        assert pattern.num_neighbour == 1
+        widened = group._replace(snap=pattern)
+        np.testing.assert_array_equal(
+            np.asarray(widened.diagonal_jacobian(hidden_vals, input_vals)),
+            np.asarray(group.diagonal_jacobian(hidden_vals, input_vals)),
+        )

--- a/braintrace/_compiler/position_graph.py
+++ b/braintrace/_compiler/position_graph.py
@@ -1,0 +1,636 @@
+# Copyright 2026 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+r"""Position-adjacency analysis for SnAp-n (``recurrence_scope='sparse_n'``).
+
+SnAp-n (Menick et al., 2021) fixes the influence matrix
+:math:`J^t = \partial h^t / \partial \theta` to the sparsity pattern of its
+instantaneous term propagated :math:`n - 1` times through the hidden-to-hidden
+Jacobian, and masks every update back onto that pattern. This module derives
+the pattern -- which hidden *position* can influence which, within one hidden
+group -- from the group's own transition jaxpr, so the user supplies only the
+integer ``n``.
+
+Representation
+--------------
+
+The one-step dependency ``A[p, q]`` ("``h_p^t`` may depend on ``h_q^{t-1}``")
+is stored **per axis** of the group's ``varshape``, one square boolean pattern
+per axis, with the flat adjacency their Kronecker product. That is not an
+optimisation: a hidden state of shape ``(batch, n_rec)`` has a leading axis
+across which coupling is structurally impossible, and a flat all-to-all pattern
+would inflate the neighbourhood width -- and hence the trace -- by a factor of
+``batch``.
+
+The factorised :math:`n`-step closure :math:`\bigvee_{k<n} A^k` is **exact when
+at most one axis is non-identity** and a conservative superset otherwise, since
+:math:`\bigvee_k \bigotimes_i A_i^k \subseteq \bigotimes_i \bigvee_k A_i^k`
+(the right-hand side also admits combinations that take a different number of
+steps on different axes). Both registered adjacency rules produce at most one
+non-identity axis, so on those the factorisation is exact.
+
+Soundness
+---------
+
+Every uncertain case widens to all-to-all. A **superset** neighbourhood costs
+memory and moves the learning rule *towards* exact; a subset would silently
+compute a different rule than the one the caller asked for. The analysis
+returns a precise pattern only when all of the following hold, and reports
+which condition failed otherwise:
+
+1. Exactly one position-mixing equation is reachable from the hidden invars.
+2. Every *other* equation reachable from the hidden invars is elementwise and
+   position-preserving -- no reshape, transpose, reduction, gather, control
+   flow or call-like equation. A single ``dot`` inside a length-``L`` scan
+   transfers :math:`A^L`, not :math:`A`; a reshape between the mixing equation
+   and the hidden state relabels the axes an axis-indexed pattern is attached
+   to; a reduction couples every position without being a mixing primitive at
+   all.
+3. That equation's primitive registered a ``snap_adjacency`` rule, and the rule
+   accepted the equation (see :data:`~braintrace._op.ETP_RULES_SNAP_ADJACENCY`).
+4. Its ``x`` and ``y`` both have exactly the group's ``varshape``, so the
+   rule's last-axis pattern refers to the group's own last position axis.
+"""
+
+from __future__ import annotations
+
+import itertools
+from typing import Dict, List, NamedTuple, Optional, Sequence, Set, Tuple
+
+import numpy as np
+
+from braintrace._compatible_imports import Jaxpr, JaxprEqn, Var
+from braintrace._misc import NotSupportedError
+from braintrace._op import (
+    get_snap_adjacency_rule,
+    get_x_invar_index,
+    get_y_outvar_index,
+    is_etp_enable_gradient_primitive,
+    is_etp_primitive,
+)
+
+__all__ = [
+    'AxisAdjacency',
+    'SnapPattern',
+    'analyze_position_adjacency',
+    'build_snap_pattern',
+    'close_adjacency',
+    'flat_adjacency',
+]
+
+#: Default ceiling on the widened block Jacobian ``Dg``, in elements:
+#: ``num_position * (num_neighbour * num_state) ** 2``.
+#:
+#: ``Dg`` -- not the trace -- is what the ceiling has to be read against,
+#: because it is the only quantity that grows *quadratically* in ``K``. The
+#: trace widens by a factor ``K·S`` per leaf; ``Dg`` is ``P·(K·S)²``, so at
+#: ``P = K = 512, S = 1`` a linear ``P·K`` budget of ``1 << 18`` passes exactly
+#: while the allocation is 134M float32 values (512 MiB) per operator. The
+#: default here admits ``P = K = 256, S = 1`` (16.7M elements, 64 MiB) and
+#: rejects the 512 case, which is a configuration error worth naming rather
+#: than an out-of-memory crash deep inside the Jacobian extraction.
+DEFAULT_MAX_JACOBIAN_ELEMENTS = 1 << 24
+
+# Equations that map position ``p`` of their input to position ``p`` of their
+# output and touch no other position. Deliberately an allow-list: a deny-list
+# would be unsound, because shape preservation alone does not imply position
+# preservation (``rev`` reverses an axis, ``transpose`` of a square array
+# permutes positions, ``sort`` reorders them -- all shape-preserving).
+_POSITION_PRESERVING_PRIMITIVES = frozenset({
+    # arithmetic
+    'add', 'add_any', 'sub', 'mul', 'div', 'rem', 'pow', 'integer_pow',
+    'neg', 'abs', 'sign', 'max', 'min', 'nextafter',
+    # exponential / logarithmic / power
+    'exp', 'exp2', 'expm1', 'log', 'log1p', 'logistic', 'sqrt', 'rsqrt', 'cbrt',
+    'square',
+    # trigonometric / hyperbolic
+    'sin', 'cos', 'tan', 'asin', 'acos', 'atan', 'atan2',
+    'sinh', 'cosh', 'tanh', 'asinh', 'acosh', 'atanh',
+    # special
+    'erf', 'erfc', 'erf_inv', 'lgamma', 'digamma',
+    # rounding / clamping / selection
+    'floor', 'ceil', 'round', 'clamp', 'select_n',
+    # comparison / logical
+    'eq', 'ne', 'lt', 'le', 'gt', 'ge', 'and', 'or', 'xor', 'not',
+    'is_finite',
+    # structural no-ops
+    'convert_element_type', 'stop_gradient', 'copy', 'real', 'imag', 'conj',
+})
+
+
+class AxisAdjacency(NamedTuple):
+    """One-step position dependency of a hidden group, factorised per axis.
+
+    Attributes
+    ----------
+    axes : tuple of numpy.ndarray
+        One square boolean pattern per axis of the group's ``varshape``.
+        ``axes[i][p, q]`` is ``True`` iff position index ``p`` on axis ``i`` may
+        depend on index ``q`` on that axis after one transition step. Empty for
+        a group whose ``varshape`` is ``()``.
+    conservative : bool
+        ``True`` when the analysis could not derive the pattern and widened to
+        all-to-all.
+    reason : str
+        Why the analysis was conservative; the empty string when it was not.
+    """
+
+    axes: Tuple[np.ndarray, ...]
+    conservative: bool
+    reason: str
+
+
+class SnapPattern(NamedTuple):
+    """The :math:`n`-step neighbourhood a SnAp-n trace is widened onto.
+
+    Attributes
+    ----------
+    n : int
+        The SnAp order this pattern was built for.
+    varshape : tuple of int
+        The hidden group's position layout.
+    axes : tuple of numpy.ndarray
+        The **closed** per-axis adjacency :math:`\\bigvee_{k<n} A_i^k`.
+    neighbours : numpy.ndarray
+        ``(num_position, num_neighbour)`` integer index. ``neighbours[p, k]`` is
+        the flat position index of ``p``'s ``k``-th neighbour;
+        ``neighbours[p, 0] == p`` always. Padded slots repeat ``p`` itself, so a
+        gather on this array can never read out of bounds.
+    valid : numpy.ndarray
+        ``(num_position, num_neighbour)`` boolean mask; ``False`` marks a padded
+        slot, whose row and column in the widened transition operator -- and
+        whose learning signal -- are zeroed.
+    conservative : bool
+        Whether the underlying one-step analysis widened to all-to-all.
+    reason : str
+        Why, if it did.
+    """
+
+    n: int
+    varshape: Tuple[int, ...]
+    axes: Tuple[np.ndarray, ...]
+    neighbours: np.ndarray
+    valid: np.ndarray
+    conservative: bool
+    reason: str
+
+    @property
+    def num_position(self) -> int:
+        """int : Number of hidden positions in the group, ``prod(varshape)``."""
+        return int(self.neighbours.shape[0])
+
+    @property
+    def num_neighbour(self) -> int:
+        """int : Neighbourhood width ``K``; the trace's state axis widens by this."""
+        return int(self.neighbours.shape[1])
+
+    @property
+    def is_degenerate(self) -> bool:
+        """bool : Whether the neighbourhood collapsed to the position itself.
+
+        A degenerate pattern makes ``sparse_n`` compute exactly what ``coupled``
+        computes. That is legitimate on a model with no cross-position coupling
+        (the truncation has nothing to retain), but it is worth reporting, since
+        it is also what a silently failing analysis would produce.
+        """
+        return self.num_neighbour == 1
+
+    @property
+    def is_saturated(self) -> bool:
+        """bool : Whether every position sees every other -- full within-group RTRL."""
+        return self.num_neighbour == self.num_position and bool(np.all(self.valid))
+
+
+# -----------------------------------------------------------------------------
+# jaxpr walk
+# -----------------------------------------------------------------------------
+
+def _is_mixing(eqn: JaxprEqn) -> bool:
+    """Whether *eqn* is a candidate cross-position weight-mixing equation.
+
+    Mirrors the classification the grouping compiler already applies: the
+    structural-marker ETP primitives (``etp_mm``, ``etp_conv``, ``etp_sp_mv``,
+    ...) plus the raw mixing primitives. ``etp_elemwise`` is gradient-enabled
+    and elementwise, so it is *not* mixing.
+    """
+    from .hidden_group import _RECURRENT_WEIGHT_MIXING_PRIMITIVES
+
+    if eqn.primitive.name in _RECURRENT_WEIGHT_MIXING_PRIMITIVES:
+        return True
+    return (
+        is_etp_primitive(eqn.primitive)
+        and not is_etp_enable_gradient_primitive(eqn.primitive)
+    )
+
+
+def _is_position_preserving(eqn: JaxprEqn, varshape: Tuple[int, ...]) -> bool:
+    """Whether *eqn* maps each position to itself and touches no other.
+
+    Requires an allow-listed elementwise primitive whose reachable operands and
+    outputs all carry ``varshape`` as their leading axes (scalars, which JAX
+    admits as broadcast operands, are exempt).
+    """
+    if is_etp_primitive(eqn.primitive):
+        if not is_etp_enable_gradient_primitive(eqn.primitive):
+            return False
+    elif eqn.primitive.name not in _POSITION_PRESERVING_PRIMITIVES:
+        return False
+    rank = len(varshape)
+    for v in list(eqn.invars) + list(eqn.outvars):
+        aval = getattr(v, 'aval', None)
+        shape = tuple(getattr(aval, 'shape', ()))
+        if shape == ():
+            continue  # a scalar operand broadcasts to every position alike
+        if len(shape) < rank or shape[:rank] != varshape:
+            return False
+    return True
+
+
+def _aligned_shape(var, varshape: Tuple[int, ...]) -> bool:
+    """Whether *var* has exactly the group's position layout."""
+    aval = getattr(var, 'aval', None)
+    return tuple(getattr(aval, 'shape', ())) == varshape
+
+
+def _axis_patterns(varshape: Tuple[int, ...], last: np.ndarray) -> Tuple[np.ndarray, ...]:
+    """Identity on every axis but the last, *last* on the last."""
+    return tuple(
+        [np.eye(d, dtype=bool) for d in varshape[:-1]] + [np.asarray(last, dtype=bool)]
+    )
+
+
+def _all_full(varshape: Tuple[int, ...]) -> Tuple[np.ndarray, ...]:
+    return tuple(np.ones((d, d), dtype=bool) for d in varshape)
+
+
+def _all_identity(varshape: Tuple[int, ...]) -> Tuple[np.ndarray, ...]:
+    return tuple(np.eye(d, dtype=bool) for d in varshape)
+
+
+def analyze_position_adjacency(
+    transition_jaxpr: Jaxpr,
+    varshape: Tuple[int, ...],
+    *,
+    hidden_invars: Optional[Sequence[Var]] = None,
+) -> AxisAdjacency:
+    """Derive a hidden group's one-step position adjacency from its transition.
+
+    Parameters
+    ----------
+    transition_jaxpr : Jaxpr
+        The group's transition jaxpr, whose ``invars`` are the hidden states at
+        the previous step and whose ``constvars`` carry the inputs (the layout
+        :meth:`~braintrace._compiler.hidden_group.HiddenGroup.transition` calls
+        it with).
+    varshape : tuple of int
+        The group's position layout.
+    hidden_invars : sequence of Var, optional
+        The variables to seed forward reachability from. Default ``None``, i.e.
+        ``transition_jaxpr.invars``.
+
+    Returns
+    -------
+    AxisAdjacency
+        The per-axis one-step patterns, together with whether the analysis had
+        to widen to all-to-all and why.
+
+    Notes
+    -----
+    The result may over-approximate the true dependency but never
+    under-approximates it -- see the module docstring.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        >>> import jax, jax.numpy as jnp, braintrace
+        >>> w = jnp.ones((4, 4))
+        >>> jaxpr = jax.make_jaxpr(
+        ...     lambda h: jnp.tanh(braintrace.matmul(h, w)))(jnp.zeros((1, 4))).jaxpr
+        >>> adj = analyze_position_adjacency(jaxpr, (1, 4))
+        >>> adj.conservative
+        False
+        >>> [a.shape for a in adj.axes]
+        [(1, 1), (4, 4)]
+    """
+    varshape = tuple(int(d) for d in varshape)
+    if not varshape:
+        # a single position: nothing can couple to anything
+        return AxisAdjacency(axes=(), conservative=False, reason='')
+
+    seeds = list(transition_jaxpr.invars if hidden_invars is None else hidden_invars)
+    reachable: Set[Var] = {v for v in seeds if isinstance(v, Var)}
+    mixing: List[JaxprEqn] = []
+    last: Optional[np.ndarray] = None
+
+    def _conservative(reason: str) -> AxisAdjacency:
+        return AxisAdjacency(axes=_all_full(varshape), conservative=True, reason=reason)
+
+    for eqn in transition_jaxpr.eqns:
+        hits = [
+            j for j, v in enumerate(eqn.invars)
+            if isinstance(v, Var) and v in reachable
+        ]
+        if not hits:
+            continue
+        if _is_mixing(eqn):
+            mixing.append(eqn)
+            if len(mixing) > 1:
+                return _conservative(
+                    f"the transition applies more than one position-mixing equation "
+                    f"reachable from the hidden state "
+                    f"({', '.join(e.primitive.name for e in mixing)}); their composed "
+                    f"transfer is not the pattern of either one."
+                )
+            # Validate the mixing equation where it is found, so the reason names
+            # it rather than whatever incidental downstream equation trips next.
+            outcome = _mixing_axis_pattern(eqn, varshape, set(hits))
+            if isinstance(outcome, str):
+                return _conservative(outcome)
+            last = outcome
+        elif not _is_position_preserving(eqn, varshape):
+            return _conservative(
+                f"equation '{eqn.primitive.name}' on the hidden path is not an "
+                f"elementwise position-preserving operation, so it may relabel or "
+                f"couple positions in a way an axis-indexed pattern cannot express."
+            )
+        reachable.update(v for v in eqn.outvars if isinstance(v, Var))
+
+    if last is None:
+        # No cross-position coupling exists at all: every position evolves on its
+        # own. Legitimate, and exactly what two_state_rnn-style models produce.
+        return AxisAdjacency(axes=_all_identity(varshape), conservative=False, reason='')
+    return AxisAdjacency(
+        axes=_axis_patterns(varshape, last), conservative=False, reason=''
+    )
+
+
+def _mixing_axis_pattern(
+    eqn: JaxprEqn,
+    varshape: Tuple[int, ...],
+    hit_positions: Set[int],
+):
+    """The last-axis pattern of a mixing equation, or a reason string.
+
+    Returns the boolean ``(d, d)`` pattern on success and a human-readable
+    reason for widening to all-to-all on any failure. Checks run
+    most-specific-first so the reason names the actual obstacle: no registered
+    rule, then the hidden state entering somewhere other than ``x``, then a
+    position layout that is not the group's, then a declining or malformed rule.
+    """
+    rule = get_snap_adjacency_rule(eqn.primitive)
+    if rule is None:
+        return (
+            f"the mixing equation '{eqn.primitive.name}' registered no "
+            f"snap_adjacency rule, so its cross-position coupling is unknown."
+        )
+    x_index = get_x_invar_index(eqn.primitive)
+    if x_index is None or hit_positions != {x_index}:
+        return (
+            f"the hidden state reaches the mixing equation "
+            f"'{eqn.primitive.name}' at invar position(s) "
+            f"{sorted(hit_positions)}, not only at its declared 'x' input."
+        )
+    x_var = eqn.invars[x_index]
+    y_var = eqn.outvars[get_y_outvar_index(eqn.primitive)]
+    if not (_aligned_shape(x_var, varshape) and _aligned_shape(y_var, varshape)):
+        return (
+            f"the mixing equation '{eqn.primitive.name}' has x shape "
+            f"{tuple(getattr(x_var.aval, 'shape', ()))} and y shape "
+            f"{tuple(getattr(y_var.aval, 'shape', ()))}; both must equal the "
+            f"group's varshape {varshape} for the rule's axes to be the group's "
+            f"axes."
+        )
+    pattern = rule(dict(eqn.params), varshape[-1])
+    if pattern is None:
+        return (
+            f"the snap_adjacency rule of '{eqn.primitive.name}' declined this "
+            f"equation."
+        )
+    pattern = np.asarray(pattern, dtype=bool)
+    if pattern.shape != (varshape[-1], varshape[-1]):
+        return (
+            f"the snap_adjacency rule of '{eqn.primitive.name}' returned a "
+            f"{pattern.shape} pattern, expected {(varshape[-1], varshape[-1])}."
+        )
+    return pattern
+
+
+# -----------------------------------------------------------------------------
+# closure and neighbourhood
+# -----------------------------------------------------------------------------
+
+def close_adjacency(
+    axes: Sequence[np.ndarray],
+    n: int,
+) -> Tuple[np.ndarray, ...]:
+    r"""Close each per-axis pattern over :math:`n` SnAp steps.
+
+    Computes :math:`\bigvee_{k=0}^{n-1} A^k` per axis, so ``n = 1`` is the
+    identity (SnAp-1 retains the instantaneous pattern only, propagating it zero
+    times) and larger ``n`` admits paths of up to ``n - 1`` steps.
+
+    Parameters
+    ----------
+    axes : sequence of numpy.ndarray
+        The one-step per-axis boolean patterns.
+    n : int
+        The SnAp order; must be at least 1.
+
+    Returns
+    -------
+    tuple of numpy.ndarray
+        The closed per-axis patterns.
+
+    Raises
+    ------
+    ValueError
+        If ``n < 1``.
+    """
+    if n < 1:
+        raise ValueError(f'SnAp order n must be at least 1, got {n}.')
+    closed: List[np.ndarray] = []
+    for a in axes:
+        a = np.asarray(a, dtype=bool)
+        out = np.eye(a.shape[0], dtype=bool)
+        power = out.copy()
+        for _ in range(n - 1):
+            # Boolean matmul, *not* an integer one. NumPy's bool `@` accumulates
+            # with logical-or, so it saturates; casting to uint8 first would
+            # count paths and wrap modulo 256, turning a position pair joined by
+            # exactly 256 parallel two-hop paths into "unreachable" -- a silent
+            # under-approximation of the neighbourhood, which is the one error
+            # mode this analysis must never have.
+            power = (power @ a)
+            new = out | power
+            if np.array_equal(new, out):
+                break  # saturated: further steps add nothing
+            out = new
+        closed.append(out)
+    return tuple(closed)
+
+
+def flat_adjacency(axes: Sequence[np.ndarray]) -> np.ndarray:
+    """Assemble the flat ``(P, P)`` adjacency from the per-axis patterns.
+
+    The flat index is C-order over ``varshape``, which is exactly the ordering
+    the Kronecker product produces.
+
+    Parameters
+    ----------
+    axes : sequence of numpy.ndarray
+        The per-axis boolean patterns.
+
+    Returns
+    -------
+    numpy.ndarray
+        The ``(P, P)`` boolean adjacency, or the ``1 x 1`` identity when there
+        are no axes.
+    """
+    out = np.ones((1, 1), dtype=bool)
+    for a in axes:
+        out = np.kron(out, np.asarray(a, dtype=bool))
+    return out
+
+
+def build_snap_pattern(
+    transition_jaxpr: Jaxpr,
+    varshape: Tuple[int, ...],
+    n: int,
+    *,
+    num_state: int = 1,
+    hidden_invars: Optional[Sequence[Var]] = None,
+    max_jacobian_elements: int = DEFAULT_MAX_JACOBIAN_ELEMENTS,
+) -> SnapPattern:
+    """Build the SnAp-n neighbourhood index for one hidden group.
+
+    Parameters
+    ----------
+    transition_jaxpr : Jaxpr
+        The group's transition jaxpr.
+    varshape : tuple of int
+        The group's position layout.
+    n : int
+        The SnAp order; ``n = 1`` yields the degenerate single-neighbour pattern
+        that reproduces ``recurrence_scope='coupled'``.
+    num_state : int, optional
+        States per position, ``S``. Only the memory guard uses it, and only
+        because the widened block Jacobian is ``P·(K·S)²`` -- a group with
+        several states per position pays ``S²`` on top of the widening.
+        Default ``1``.
+    hidden_invars : sequence of Var, optional
+        Seeds for the reachability sweep. Default ``None`` (the jaxpr's invars).
+    max_jacobian_elements : int, optional
+        Ceiling on ``num_position * (num_neighbour * num_state) ** 2``. Default
+        :data:`DEFAULT_MAX_JACOBIAN_ELEMENTS`.
+
+    Returns
+    -------
+    SnapPattern
+        The closed adjacency plus the padded neighbour index and validity mask.
+
+    Raises
+    ------
+    ValueError
+        If ``n < 1``.
+    NotSupportedError
+        If the widened block Jacobian would exceed *max_jacobian_elements*.
+    """
+    varshape = tuple(int(d) for d in varshape)
+    adj = analyze_position_adjacency(
+        transition_jaxpr, varshape, hidden_invars=hidden_invars
+    )
+    closed = close_adjacency(adj.axes, n)
+    num_position = int(np.prod(varshape)) if varshape else 1
+
+    if not closed:
+        return SnapPattern(
+            n=n,
+            varshape=varshape,
+            axes=(),
+            neighbours=np.zeros((1, 1), dtype=np.int32),
+            valid=np.ones((1, 1), dtype=bool),
+            conservative=adj.conservative,
+            reason=adj.reason,
+        )
+
+    # Per-axis neighbour lists, taken **column-wise**.
+    #
+    # ``closed[i][r, p]`` reads "r depends on p" (see AxisAdjacency), but the
+    # trace slot for a parameter anchored at ``p`` has to cover the positions
+    # that ``p`` *influences*: SnAp-n is the instantaneous pattern -- nonzero at
+    # ``p`` alone -- propagated n-1 times through D, which spreads it to every
+    # ``r`` with ``(A^k)[r, p]``. That is column ``p``, not row ``p``. Taking the
+    # row instead is not a mere relabelling: on a directed graph it retains the
+    # positions ``p`` reads *from*, whose influence on ``p``'s parameter is
+    # exactly zero, so the trace pays the full widening and the gradient does
+    # not improve at all until the neighbourhood saturates.
+    #
+    # K is the max over positions of the product of per-axis counts, and because
+    # the position indices range over the full Cartesian product that max is
+    # exactly the product of the per-axis maxima.
+    axis_neighbours = [
+        [np.flatnonzero(pattern[:, i]) for i in range(pattern.shape[1])]
+        for pattern in closed
+    ]
+    num_neighbour = 1
+    for lists in axis_neighbours:
+        num_neighbour *= max(len(entry) for entry in lists)
+
+    num_state = int(num_state)
+    jacobian_elements = num_position * (num_neighbour * num_state) ** 2
+    if jacobian_elements > max_jacobian_elements:
+        raise NotSupportedError(
+            f"recurrence_scope='sparse_n' with sparse_n={n} widens this hidden "
+            f"group's trace state axis by K={num_neighbour} over "
+            f"P={num_position} positions (varshape={varshape}, "
+            f'num_state={num_state}), so its block Jacobian is '
+            f'P*(K*S)**2 = {jacobian_elements} elements, above the '
+            f'{max_jacobian_elements} ceiling. '
+            + (
+                'The position analysis was conservative here '
+                f'({adj.reason}) so K is the whole group; '
+                if adj.conservative else ''
+            )
+            + "Use a smaller sparse_n, recurrence_scope='coupled', or pass a "
+              'larger snap_max_jacobian_elements if the memory is affordable.'
+        )
+
+    strides = [int(s) for s in np.array(varshape[1:] + (1,))[::-1].cumprod()[::-1]]
+    neighbours = np.zeros((num_position, num_neighbour), dtype=np.int32)
+    valid = np.zeros((num_position, num_neighbour), dtype=bool)
+    for flat_p in range(num_position):
+        idx = np.unravel_index(flat_p, varshape)
+        per_axis = [axis_neighbours[i][idx[i]] for i in range(len(varshape))]
+        flat_q = sorted(
+            int(sum(int(q) * s for q, s in zip(combo, strides)))
+            for combo in itertools.product(*per_axis)
+        )
+        # self first, so slot 0 always carries the instantaneous term
+        flat_q.remove(flat_p)
+        flat_q.insert(0, flat_p)
+        neighbours[flat_p, :len(flat_q)] = flat_q
+        valid[flat_p, :len(flat_q)] = True
+        neighbours[flat_p, len(flat_q):] = flat_p  # in-range dummy for the gather
+
+    return SnapPattern(
+        n=n,
+        varshape=varshape,
+        axes=closed,
+        neighbours=neighbours,
+        valid=valid,
+        conservative=adj.conservative,
+        reason=adj.reason,
+    )

--- a/braintrace/_compiler/position_graph_test.py
+++ b/braintrace/_compiler/position_graph_test.py
@@ -1,0 +1,604 @@
+# Copyright 2026 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Tests for the SnAp-n position-adjacency analysis.
+
+Every assertion here is *structural*: the analysis reads a transition jaxpr and
+returns boolean patterns, so nothing in this file needs a gradient, an oracle or
+a model. Gradient-level acceptance lives in ``_algorithm/snap_n_test.py``.
+
+The governing soundness rule, restated once so every test below can be read
+against it: the returned adjacency may be a **superset** of the true one-step
+position dependency, never a subset. A superset costs memory and moves the
+learning rule *towards* exact; a subset would silently compute a different rule
+than the one the user asked for.
+"""
+
+import itertools
+
+import brainevent
+import brainstate
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+import braintrace
+from braintrace._compiler.position_graph import (
+    AxisAdjacency,
+    SnapPattern,
+    analyze_position_adjacency,
+    build_snap_pattern,
+    close_adjacency,
+    flat_adjacency,
+)
+from braintrace._misc import NotSupportedError
+
+
+# -----------------------------------------------------------------------------
+# fixtures: transition jaxprs built directly, without the full compiler
+# -----------------------------------------------------------------------------
+
+def _jaxpr(fn, *args):
+    """The open jaxpr of *fn*, with closed-over arrays as constvars."""
+    return jax.make_jaxpr(fn)(*args).jaxpr
+
+
+def _dense_rnn_jaxpr(varshape=(1, 4), seed=0):
+    """``h -> tanh(etp_mm(h, W))`` — one top-level ETP mixing equation."""
+    n = varshape[-1]
+    with brainstate.random.seed_context(seed):
+        w = brainstate.random.randn(n, n)
+    return _jaxpr(lambda h: jnp.tanh(braintrace.matmul(h, w)), jnp.zeros(varshape))
+
+
+def _sparse_pattern(n=6, density=0.4, seed=0):
+    rng = np.random.RandomState(seed)
+    dense = (rng.rand(n, n) < density).astype(np.float32)
+    # guarantee at least one entry per row so the pattern is not vacuous
+    dense[np.arange(n), (np.arange(n) + 1) % n] = 1.0
+    return dense
+
+
+def _sparse_rnn_jaxpr(dense):
+    n = dense.shape[0]
+    csr = brainevent.CSR.fromdense(jnp.asarray(dense))
+    data = jnp.asarray(csr.data)
+    return _jaxpr(
+        lambda h: jnp.tanh(braintrace.sparse_matmul(h, data, sparse_mat=csr)),
+        jnp.zeros((n,)),
+    )
+
+
+def _identity_pattern(d):
+    return np.eye(d, dtype=bool)
+
+
+def _full_pattern(d):
+    return np.ones((d, d), dtype=bool)
+
+
+def _matrix_closure(a: np.ndarray, n: int) -> np.ndarray:
+    """``⋁_{k=0..n-1} a^k`` computed on the *flat* (un-factorised) matrix."""
+    p = np.eye(a.shape[0], dtype=bool)
+    out = p.copy()
+    for _ in range(n - 1):
+        p = (p @ a) > 0
+        out |= p
+    return out
+
+
+# -----------------------------------------------------------------------------
+# one-step adjacency
+# -----------------------------------------------------------------------------
+
+class TestAnalyzeOneStepAdjacency:
+
+    def test_scalar_varshape_has_no_axes(self):
+        jaxpr = _jaxpr(lambda h: h * 0.9, jnp.zeros(()))
+        adj = analyze_position_adjacency(jaxpr, ())
+        assert isinstance(adj, AxisAdjacency)
+        assert adj.axes == ()
+        assert not adj.conservative
+
+    def test_dense_recurrent_matmul_is_identity_times_full(self):
+        # tanh_rnn's own shape: the leading axis is a size-1 batch axis and must
+        # stay `identity`, otherwise K would carry a wasted factor of `batch`.
+        adj = analyze_position_adjacency(_dense_rnn_jaxpr((1, 4)), (1, 4))
+        assert not adj.conservative
+        assert adj.reason == ''
+        assert len(adj.axes) == 2
+        np.testing.assert_array_equal(adj.axes[0], _identity_pattern(1))
+        np.testing.assert_array_equal(adj.axes[1], _full_pattern(4))
+
+    def test_batch_axis_stays_identity_when_larger_than_one(self):
+        adj = analyze_position_adjacency(_dense_rnn_jaxpr((3, 4)), (3, 4))
+        assert not adj.conservative
+        np.testing.assert_array_equal(adj.axes[0], _identity_pattern(3))
+        np.testing.assert_array_equal(adj.axes[1], _full_pattern(4))
+
+    def test_no_mixing_equation_is_identity_everywhere(self):
+        # two_state_rnn's shape: the v/a coupling is hand-written arithmetic,
+        # so no position-mixing equation exists at all.
+        jaxpr = _jaxpr(
+            lambda v, a: (0.9 * v - 0.1 * a, 0.95 * a + v),
+            jnp.zeros((1, 3)), jnp.zeros((1, 3)),
+        )
+        adj = analyze_position_adjacency(jaxpr, (1, 3))
+        assert not adj.conservative
+        np.testing.assert_array_equal(adj.axes[0], _identity_pattern(1))
+        np.testing.assert_array_equal(adj.axes[1], _identity_pattern(3))
+
+    def test_sparse_adjacency_is_the_pattern_transposed(self):
+        # forward is y = x @ W, so h_p depends on h_q iff W[q, p] != 0.
+        dense = _sparse_pattern(6)
+        adj = analyze_position_adjacency(_sparse_rnn_jaxpr(dense), (6,))
+        assert not adj.conservative
+        assert len(adj.axes) == 1
+        np.testing.assert_array_equal(adj.axes[0], (dense != 0).T)
+        # and it is genuinely not the untransposed pattern (guards the direction)
+        assert not np.array_equal(dense != 0, (dense != 0).T)
+
+    def test_sparse_adjacency_ignores_stored_numeric_zeros(self):
+        # the pattern is a *static* structure; a stored zero is still an edge.
+        dense = _sparse_pattern(5)
+        csr = brainevent.CSR.fromdense(jnp.asarray(dense))
+        zeros = jnp.zeros_like(csr.data)
+        jaxpr = _jaxpr(
+            lambda h: braintrace.sparse_matmul(h, zeros, sparse_mat=csr),
+            jnp.zeros((5,)),
+        )
+        adj = analyze_position_adjacency(jaxpr, (5,))
+        np.testing.assert_array_equal(adj.axes[0], (dense != 0).T)
+
+
+class TestConservativeFallbacks:
+    """Every case where the analysis must widen to all-to-all, and say why."""
+
+    def _assert_conservative(self, adj, varshape, needle):
+        assert adj.conservative
+        assert needle in adj.reason, adj.reason
+        for axis, d in zip(adj.axes, varshape):
+            np.testing.assert_array_equal(axis, _full_pattern(d))
+
+    def test_two_mixing_equations(self):
+        w1 = jnp.ones((4, 4))
+        w2 = jnp.ones((4, 4))
+        jaxpr = _jaxpr(
+            lambda h: braintrace.matmul(jnp.tanh(braintrace.matmul(h, w1)), w2),
+            jnp.zeros((1, 4)),
+        )
+        self._assert_conservative(
+            analyze_position_adjacency(jaxpr, (1, 4)), (1, 4), 'more than one'
+        )
+
+    def test_unregistered_mixing_primitive(self):
+        w = jnp.ones((4, 4))
+        jaxpr = _jaxpr(lambda h: jnp.tanh(h @ w), jnp.zeros((1, 4)))
+        self._assert_conservative(
+            analyze_position_adjacency(jaxpr, (1, 4)), (1, 4), 'dot_general'
+        )
+
+    def test_non_elementwise_equation_on_the_hidden_path(self):
+        # a reduction couples every position without being a "mixing" primitive
+        jaxpr = _jaxpr(lambda h: h * 0.9 + jnp.sum(h), jnp.zeros((1, 4)))
+        self._assert_conservative(
+            analyze_position_adjacency(jaxpr, (1, 4)), (1, 4), 'reduce_sum'
+        )
+
+    def test_reshape_on_the_hidden_path(self):
+        # a reshape relabels the axes an axis-indexed pattern is attached to
+        jaxpr = _jaxpr(
+            lambda h: jnp.reshape(jnp.reshape(h, (4, 1)) * 0.5, (1, 4)),
+            jnp.zeros((1, 4)),
+        )
+        self._assert_conservative(
+            analyze_position_adjacency(jaxpr, (1, 4)), (1, 4), 'reshape'
+        )
+
+    def test_control_flow_on_the_hidden_path(self):
+        jaxpr = _jaxpr(
+            lambda h: jax.lax.cond(True, lambda z: z * 2., lambda z: z * 3., h),
+            jnp.zeros((1, 4)),
+        )
+        self._assert_conservative(
+            analyze_position_adjacency(jaxpr, (1, 4)), (1, 4), 'cond'
+        )
+
+    def test_scan_hiding_a_registered_mixing_equation(self):
+        # a single dot inside a length-L scan transfers A^L, not A: the
+        # registered rule would be wrong, so the scan alone forces conservative.
+        w = jnp.ones((4, 4))
+
+        def body(carry, _):
+            return braintrace.matmul(carry, w), None
+
+        jaxpr = _jaxpr(
+            lambda h: jax.lax.scan(body, h, None, length=3)[0], jnp.zeros((1, 4))
+        )
+        self._assert_conservative(
+            analyze_position_adjacency(jaxpr, (1, 4)), (1, 4), 'scan'
+        )
+
+    def test_mixing_output_shape_differs_from_varshape(self):
+        # y is not the group's position layout, so the rule's axis indices do
+        # not refer to the group's axes
+        w = jnp.ones((4, 7))
+        jaxpr = _jaxpr(lambda h: braintrace.matmul(h, w), jnp.zeros((1, 4)))
+        self._assert_conservative(
+            analyze_position_adjacency(jaxpr, (1, 4)), (1, 4), 'shape'
+        )
+
+    def test_every_result_covers_the_true_dependency(self):
+        """The soundness property, read against a *differentiated* reference.
+
+        Comparing an all-ones matrix with anything is vacuously true, so the
+        reference here is the real thing: the nonzero pattern of the transition's
+        own Jacobian, obtained by differentiating the same function the analysis
+        read symbolically. Every case is checked in the direction that can
+        actually fail — the returned pattern must **cover** the true dependency.
+
+        The ``tightness`` column then says what the coverage costs, which is
+        what separates "sound" from "sound but useless":
+
+        - ``'exact'``   the analysis reproduced the Jacobian's own pattern;
+        - ``'lossy'``   the fallback fired *and* retained edges that do not
+          exist, so the strict-superset assertion has teeth;
+        - ``'free'``    the fallback fired but this transition really is
+          all-to-all, so widening cost nothing. Kept to document that a
+          conservative result is not the same claim as an imprecise one.
+        """
+        w_full = jnp.ones((4, 4))
+        dense = _sparse_pattern(6)
+        csr = brainevent.CSR.fromdense(jnp.asarray(dense))
+        data = jnp.asarray(csr.data)
+
+        cases = [
+            # (label, transition fn, varshape, conservative?, tightness)
+            ('reduce_sum', lambda h: h * 0.9 + jnp.sum(h), (1, 4), True, 'free'),
+            ('dot_general', lambda h: jnp.tanh(h @ w_full), (1, 4), True, 'free'),
+            ('cond', lambda h: jax.lax.cond(
+                True, lambda z: z * 2., lambda z: z * 3., h), (1, 4), True, 'lossy'),
+            ('reshape', lambda h: jnp.reshape(
+                jnp.reshape(h, (4, 1)) * 0.5, (1, 4)), (1, 4), True, 'lossy'),
+            ('sparse', lambda h: jnp.tanh(
+                braintrace.sparse_matmul(h, data, sparse_mat=csr)), (6,), False, 'exact'),
+            ('dense', lambda h: jnp.tanh(
+                braintrace.matmul(h, w_full)), (1, 4), False, 'exact'),
+        ]
+        for label, fn, varshape, conservative, tightness in cases:
+            adj = analyze_position_adjacency(_jaxpr(fn, jnp.zeros(varshape)), varshape)
+            got = flat_adjacency(adj.axes)
+            assert adj.conservative == conservative, (
+                f'{label}: expected conservative={conservative}, got {adj.reason!r}')
+            # differentiate at a generic point so no entry vanishes by accident
+            with brainstate.random.seed_context(3):
+                h0 = brainstate.random.randn(*varshape)
+            jac = jax.jacobian(lambda h: jnp.ravel(fn(h)))(h0)
+            true_dep = np.abs(np.asarray(jac).reshape(got.shape)) > 1e-6
+            assert np.any(true_dep), f'{label}: the reference Jacobian is empty'
+            assert np.all(got >= true_dep), f'{label}: analysis lost a dependency'
+            if tightness == 'lossy':
+                assert np.any(got > true_dep), (
+                    f'{label}: expected the fallback to over-retain, but it was '
+                    f'exact — the fixture no longer exercises the widening')
+            elif tightness == 'exact':
+                np.testing.assert_array_equal(got, true_dep, err_msg=label)
+
+
+# -----------------------------------------------------------------------------
+# closure
+# -----------------------------------------------------------------------------
+
+class TestCloseAdjacency:
+
+    def test_n_equals_one_is_the_identity(self):
+        # SnAp-1 retains the instantaneous pattern only -- no propagation.
+        axes = (_full_pattern(4),)
+        closed = close_adjacency(axes, 1)
+        np.testing.assert_array_equal(closed[0], _identity_pattern(4))
+
+    def test_n_equals_two_is_identity_or_adjacency(self):
+        a = _sparse_pattern(6) != 0
+        closed = close_adjacency((a,), 2)
+        np.testing.assert_array_equal(closed[0], a | _identity_pattern(6))
+
+    def test_closure_is_monotone_in_n(self):
+        a = _sparse_pattern(7, density=0.25, seed=3) != 0
+        prev = close_adjacency((a,), 1)[0]
+        for n in range(2, 10):
+            cur = close_adjacency((a,), n)[0]
+            assert np.all(cur >= prev), f'closure shrank at n={n}'
+            prev = cur
+
+    def test_closure_saturates_and_is_then_a_fixed_point(self):
+        a = _sparse_pattern(7, density=0.25, seed=3) != 0
+        big = close_adjacency((a,), 64)[0]
+        for n in (65, 128):
+            np.testing.assert_array_equal(close_adjacency((a,), n)[0], big)
+
+    def test_identity_axis_never_grows(self):
+        axes = (_identity_pattern(3), _full_pattern(4))
+        for n in (1, 2, 5, 50):
+            np.testing.assert_array_equal(close_adjacency(axes, n)[0],
+                                          _identity_pattern(3))
+
+    def test_zero_or_negative_n_rejected(self):
+        with pytest.raises(ValueError):
+            close_adjacency((_full_pattern(2),), 0)
+
+    def test_many_parallel_paths_do_not_wrap(self):
+        """A path *count* that is a multiple of 256 must still read reachable.
+
+        The closure is a reachability question, not a counting one. Accumulating
+        it in a narrow integer type answers the counting question and then
+        thresholds it, so a pair joined by exactly 256 parallel two-hop paths
+        wraps to zero and is reported unreachable — SnAp would then drop that
+        influence from the neighbourhood, silently, with no diagnostic and no
+        change to K.
+        """
+        fan = 256
+        size = fan + 2
+        a = np.zeros((size, size), dtype=bool)
+        for m in range(fan):
+            a[m + 1, 0] = True          # 0 -> each of the fan-out positions
+            a[size - 1, m + 1] = True   # each of them -> the far position
+        closed = close_adjacency((a,), 3)[0]
+        assert closed[size - 1, 0], 'a 256-fold two-hop path was lost to wraparound'
+        np.testing.assert_array_equal(closed, _matrix_closure(a, 3))
+
+    def test_factorised_closure_contains_the_flat_closure(self):
+        # The per-axis (Kronecker) form is EXACT when at most one axis is
+        # non-identity, and a conservative superset otherwise. Both halves are
+        # asserted here, because the superset direction is the soundness
+        # property and the exactness condition is what the shipped rules rely on.
+        # Pure cyclic shifts, deliberately WITHOUT self-loops: a reflexive axis
+        # pattern makes A^k monotone in k and the factorisation exact, so the
+        # strict case only appears once an axis can move without staying put.
+        a0 = np.roll(np.eye(3, dtype=bool), 1, axis=1)
+        a1 = np.roll(np.eye(2, dtype=bool), 1, axis=1)
+
+        # two non-identity axes: superset, and strictly so for some n
+        strict_somewhere = False
+        for n in (2, 3, 4):
+            factorised = flat_adjacency(close_adjacency((a0, a1), n))
+            flat = _matrix_closure(flat_adjacency((a0, a1)), n)
+            assert np.all(factorised >= flat), f'factorised closure lost an edge at n={n}'
+            strict_somewhere |= bool(np.any(factorised > flat))
+        assert strict_somewhere, 'fixture does not exercise the strict case'
+
+        # one non-identity axis: exact
+        for n in (1, 2, 3, 4, 9):
+            axes = (_identity_pattern(3), a1)
+            factorised = flat_adjacency(close_adjacency(axes, n))
+            flat = _matrix_closure(flat_adjacency(axes), n)
+            np.testing.assert_array_equal(factorised, flat)
+
+
+class TestFlatAdjacency:
+
+    def test_kron_order_matches_c_order_flat_indexing(self):
+        a0 = np.array([[1, 0], [1, 1]], dtype=bool)
+        a1 = np.array([[1, 1, 0], [0, 1, 0], [0, 0, 1]], dtype=bool)
+        flat = flat_adjacency((a0, a1))
+        shape = (2, 3)
+        for p in itertools.product(*[range(d) for d in shape]):
+            for q in itertools.product(*[range(d) for d in shape]):
+                pi = np.ravel_multi_index(p, shape)
+                qi = np.ravel_multi_index(q, shape)
+                want = a0[p[0], q[0]] and a1[p[1], q[1]]
+                assert bool(flat[pi, qi]) == bool(want)
+
+    def test_no_axes_is_the_one_by_one_identity(self):
+        np.testing.assert_array_equal(flat_adjacency(()), np.ones((1, 1), dtype=bool))
+
+
+# -----------------------------------------------------------------------------
+# the neighbourhood index
+# -----------------------------------------------------------------------------
+
+class TestBuildSnapPattern:
+
+    def test_self_is_always_the_first_neighbour(self):
+        dense = _sparse_pattern(6)
+        pat = build_snap_pattern(_sparse_rnn_jaxpr(dense), (6,), 3)
+        np.testing.assert_array_equal(pat.neighbours[:, 0], np.arange(6))
+        assert np.all(pat.valid[:, 0])
+
+    def test_neighbours_agree_with_the_closed_flat_adjacency(self):
+        dense = _sparse_pattern(6)
+        pat = build_snap_pattern(_sparse_rnn_jaxpr(dense), (6,), 3)
+        flat = flat_adjacency(pat.axes)
+        for p in range(pat.num_position):
+            listed = set(int(q) for q, ok in zip(pat.neighbours[p], pat.valid[p]) if ok)
+            # ``flat[r, p]`` reads "r depends on p"; the trace slot anchored at p
+            # has to cover the positions p *influences*, which is column p. See
+            # TestNeighbourhoodDirection below for a fixture where the two differ.
+            expected = set(np.flatnonzero(flat[:, p]).tolist())
+            assert listed == expected
+
+    def test_padded_slots_repeat_self_and_are_marked_invalid(self):
+        dense = _sparse_pattern(6)
+        pat = build_snap_pattern(_sparse_rnn_jaxpr(dense), (6,), 2)
+        for p in range(pat.num_position):
+            for k in range(pat.num_neighbour):
+                if not pat.valid[p, k]:
+                    # a dummy index that is always in range, so a gather on it
+                    # can never read out of bounds
+                    assert pat.neighbours[p, k] == p
+
+    def test_neighbour_rows_have_no_duplicate_valid_entries(self):
+        dense = _sparse_pattern(6)
+        pat = build_snap_pattern(_sparse_rnn_jaxpr(dense), (6,), 3)
+        for p in range(pat.num_position):
+            valid = pat.neighbours[p][pat.valid[p]]
+            assert len(set(valid.tolist())) == len(valid)
+
+    def test_n_equals_one_degenerates_to_a_single_neighbour(self):
+        # SnAp-1 == the un-widened per-parameter trace
+        pat = build_snap_pattern(_dense_rnn_jaxpr((1, 4)), (1, 4), 1)
+        assert pat.num_neighbour == 1
+        np.testing.assert_array_equal(pat.neighbours[:, 0], np.arange(4))
+
+    def test_dense_rnn_saturates_at_n_two(self):
+        pat1 = build_snap_pattern(_dense_rnn_jaxpr((1, 4)), (1, 4), 1)
+        pat2 = build_snap_pattern(_dense_rnn_jaxpr((1, 4)), (1, 4), 2)
+        pat3 = build_snap_pattern(_dense_rnn_jaxpr((1, 4)), (1, 4), 3)
+        assert (pat1.num_neighbour, pat2.num_neighbour, pat3.num_neighbour) == (1, 4, 4)
+        assert pat2.num_neighbour == pat2.num_position  # saturated
+        np.testing.assert_array_equal(pat2.valid, np.ones((4, 4), dtype=bool))
+
+    def test_no_mixing_gives_one_neighbour_at_every_n(self):
+        jaxpr = _jaxpr(lambda h: 0.9 * h, jnp.zeros((1, 3)))
+        for n in (1, 2, 5, 17):
+            pat = build_snap_pattern(jaxpr, (1, 3), n)
+            assert pat.num_neighbour == 1
+            assert not pat.conservative
+
+    def test_sparse_k_sequence_is_exact_and_monotone(self):
+        dense = _sparse_pattern(6, density=0.25, seed=1)
+        jaxpr = _sparse_rnn_jaxpr(dense)
+        a = (dense != 0).T
+        ks = []
+        for n in range(1, 8):
+            pat = build_snap_pattern(jaxpr, (6,), n)
+            # K is the widest *influence* set, i.e. the largest column sum of the
+            # closure. On this fixture the row maxima happen to agree, so the
+            # column is spelled out rather than left to coincidence.
+            want = int(_matrix_closure(a, n).sum(axis=0).max())
+            assert pat.num_neighbour == want, f'n={n}'
+            ks.append(pat.num_neighbour)
+        assert ks == sorted(ks), ks
+        assert ks[0] == 1
+        assert ks[-1] == 6  # saturates on this fixture
+
+    def test_neighbourhoods_are_nested_in_n(self):
+        dense = _sparse_pattern(6, density=0.25, seed=1)
+        jaxpr = _sparse_rnn_jaxpr(dense)
+        prev = None
+        for n in range(1, 8):
+            pat = build_snap_pattern(jaxpr, (6,), n)
+            cur = [
+                set(int(q) for q, ok in zip(pat.neighbours[p], pat.valid[p]) if ok)
+                for p in range(pat.num_position)
+            ]
+            if prev is not None:
+                for p, (a_set, b_set) in enumerate(zip(prev, cur)):
+                    assert a_set <= b_set, f'neighbourhood shrank at n={n}, p={p}'
+            prev = cur
+
+    def test_scalar_varshape_pattern(self):
+        jaxpr = _jaxpr(lambda h: h * 0.9, jnp.zeros(()))
+        pat = build_snap_pattern(jaxpr, (), 4)
+        assert pat.num_position == 1
+        assert pat.num_neighbour == 1
+        np.testing.assert_array_equal(pat.neighbours, np.zeros((1, 1), dtype=pat.neighbours.dtype))
+
+    def test_conservative_flag_and_reason_propagate(self):
+        w = jnp.ones((4, 4))
+        jaxpr = _jaxpr(lambda h: jnp.tanh(h @ w), jnp.zeros((1, 4)))
+        pat = build_snap_pattern(jaxpr, (1, 4), 2)
+        assert isinstance(pat, SnapPattern)
+        assert pat.conservative
+        assert pat.reason
+        assert pat.num_neighbour == 4
+
+    def test_budget_guard_raises_with_the_numbers(self):
+        w = jnp.ones((64, 64))
+        jaxpr = _jaxpr(lambda h: braintrace.matmul(h, w), jnp.zeros((1, 64)))
+        with pytest.raises(NotSupportedError) as exc:
+            build_snap_pattern(jaxpr, (1, 64), 2, max_jacobian_elements=1024)
+        msg = str(exc.value)
+        assert '64' in msg and 'sparse_n' in msg
+
+    def test_budget_guard_admits_what_fits(self):
+        w = jnp.ones((8, 8))
+        jaxpr = _jaxpr(lambda h: braintrace.matmul(h, w), jnp.zeros((1, 8)))
+        # P*(K*S)**2 = 8 * 64 = 512
+        pat = build_snap_pattern(jaxpr, (1, 8), 2, max_jacobian_elements=1024)
+        assert pat.num_neighbour == 8
+
+    def test_budget_guard_counts_the_block_jacobian_not_the_trace(self):
+        """The ceiling is on ``P*(K*S)**2``, which is the dominant allocation.
+
+        A ``P*K`` budget is linear in the widening and so cannot see the term
+        that actually blows up: the widened block Jacobian is ``P*(K*S)**2``.
+        The fixture below saturates at ``K = P = 8``, where ``P*K = 64`` but
+        ``P*K**2 = 512`` — a budget of 100 must reject it.
+        """
+        w = jnp.ones((8, 8))
+        jaxpr = _jaxpr(lambda h: braintrace.matmul(h, w), jnp.zeros((1, 8)))
+        with pytest.raises(NotSupportedError) as exc:
+            build_snap_pattern(jaxpr, (1, 8), 2, max_jacobian_elements=100)
+        assert '512' in str(exc.value)
+
+    def test_budget_guard_charges_for_states_per_position(self):
+        """``num_state`` enters squared, so a multi-state group costs ``S**2``."""
+        w = jnp.ones((8, 8))
+        jaxpr = _jaxpr(lambda h: braintrace.matmul(h, w), jnp.zeros((1, 8)))
+        build_snap_pattern(jaxpr, (1, 8), 2, num_state=1, max_jacobian_elements=512)
+        with pytest.raises(NotSupportedError) as exc:
+            build_snap_pattern(jaxpr, (1, 8), 2, num_state=2, max_jacobian_elements=512)
+        assert '2048' in str(exc.value)  # 8 * (8 * 2) ** 2
+
+
+# -----------------------------------------------------------------------------
+# the direction of the neighbourhood
+# -----------------------------------------------------------------------------
+
+class TestNeighbourhoodDirection:
+    """A trace slot covers what its anchor *influences*, not what it reads from.
+
+    On an undirected (or symmetric-by-accident) graph the two readings coincide
+    and every size-based check -- K, saturation, nestedness -- passes under
+    either one. The fixture here is a strict shift, whose in- and out-neighbours
+    are disjoint apart from the anchor itself, so only membership separates them.
+    Getting this backwards is not a relabelling: it fills the trace with
+    positions whose contribution to the anchor's gradient is exactly zero, and
+    the error curve in ``n`` then stays flat until the neighbourhood saturates.
+    """
+
+    @staticmethod
+    def _shift_pattern(n_rec):
+        # dense[q, r] != 0 means h_new[r] reads h[q], so this is q -> q+1
+        dense = np.zeros((n_rec, n_rec), dtype='float32')
+        dense[np.arange(n_rec), (np.arange(n_rec) + 1) % n_rec] = 1.0
+        return dense
+
+    def test_neighbours_run_downstream_of_the_anchor(self):
+        n_rec = 6
+        jaxpr = _sparse_rnn_jaxpr(self._shift_pattern(n_rec))
+        for n in (1, 2, 3, 4):
+            pat = build_snap_pattern(jaxpr, (n_rec,), n)
+            assert pat.num_neighbour == n, f'n={n}'
+            for p in range(n_rec):
+                listed = set(int(q) for q, ok in zip(pat.neighbours[p], pat.valid[p]) if ok)
+                downstream = {(p + k) % n_rec for k in range(n)}
+                upstream = {(p - k) % n_rec for k in range(n)}
+                assert listed == downstream, f'n={n}, p={p}'
+                if n > 1:  # the two only coincide at the anchor itself
+                    assert listed != upstream
+
+    def test_adjacency_reads_as_dependency(self):
+        # the convention the direction argument rests on: A[p, q] is "p depends
+        # on q", so the shift q -> q+1 has to show up as A[q + 1, q]. `pat.axes`
+        # is the closure, and at n=2 that is exactly `I | A`.
+        n_rec = 5
+        pat = build_snap_pattern(_sparse_rnn_jaxpr(self._shift_pattern(n_rec)), (n_rec,), 2)
+        flat = flat_adjacency(pat.axes)
+        for q in range(n_rec):
+            assert flat[q, q]
+            assert flat[(q + 1) % n_rec, q]
+            assert not flat[q, (q + 1) % n_rec]

--- a/braintrace/_op/__init__.py
+++ b/braintrace/_op/__init__.py
@@ -43,6 +43,8 @@ from ._registries import (
     ETP_RULES_INIT_DRTRL,
     ETP_RULES_INIT_PP,
     ETP_RULES_PP_X_REPR,
+    ETP_RULES_SNAP_ADJACENCY,
+    ETP_RULES_SNAP_ANCHOR,
     ETP_RULES_XY_TO_DW,
     ETP_RULES_DT_TO_T,
     ETP_TRAINABLE_INVARS_FNS,
@@ -52,12 +54,14 @@ from ._registries import (
     GRADIENT_ENABLED_PRIMITIVES,
     get_fast_path_rules,
     get_pp_x_repr,
+    get_snap_adjacency_rule,
     get_trainable_invars,
     get_x_invar_index,
     get_y_outvar_index,
     is_batched_primitive,
     is_etp_enable_gradient_primitive,
     is_etp_primitive,
+    is_snap_anchored,
 )
 from .conv import _etp_conv_impl
 from .conv import conv, etp_conv_p
@@ -96,6 +100,10 @@ __all__ = [
     'get_fast_path_rules',
     'ETP_RULES_PP_X_REPR',
     'get_pp_x_repr',
+    'ETP_RULES_SNAP_ANCHOR',
+    'is_snap_anchored',
+    'ETP_RULES_SNAP_ADJACENCY',
+    'get_snap_adjacency_rule',
 
     # primitives
     'etp_mm_p',

--- a/braintrace/_op/_primitive.py
+++ b/braintrace/_op/_primitive.py
@@ -41,6 +41,8 @@ from ._registries import (
     ETP_RULES_INIT_DRTRL,
     ETP_RULES_INIT_PP,
     ETP_RULES_PP_X_REPR,
+    ETP_RULES_SNAP_ADJACENCY,
+    ETP_RULES_SNAP_ANCHOR,
     ETP_RULES_XY_TO_DW,
     ETP_RULES_DT_TO_T,
     ETP_TRAINABLE_INVARS_FNS,
@@ -136,6 +138,8 @@ class ETPPrimitive(Primitive):
         init_pp: Callable[..., Any] | None = None,
         fast_path: FastPathRules | None = None,
         pp_x_repr: Callable[..., Any] | None = None,
+        snap_anchor: Callable[..., Any] | None = None,
+        snap_adjacency: Callable[..., Any] | None = None,
     ) -> None:
         """Install multiple ETP rules in one call.
 
@@ -164,6 +168,20 @@ class ETPPrimitive(Primitive):
             the operand the op is linear in (e.g. ``etp_emb_p`` filters the
             one-hot encoding of its integer indices); ``None`` leaves the
             IO-dim trace filtering the raw ``x``. Default ``None``.
+        snap_anchor : Callable, optional
+            SnAp-n anchor declaration ``eqn_params -> bool``. Registered into
+            :data:`ETP_RULES_SNAP_ANCHOR`. Declares that the primitive's trace
+            layout keeps, for every slot, one well-defined hidden position the
+            slot's instantaneous term lands on -- the precondition for widening
+            the trailing state axis into a ``(neighbour, state)`` axis.
+            ``None`` (the default) leaves the primitive **unanchored**, so
+            ``recurrence_scope='sparse_n'`` rejects it loudly.
+        snap_adjacency : Callable, optional
+            SnAp-n position-adjacency rule ``(eqn_params, size) -> pattern``.
+            Registered into :data:`ETP_RULES_SNAP_ADJACENCY`. Supply it only
+            when the primitive's cross-position coupling is fully determined by
+            static equation parameters; ``None`` (the default) makes the
+            position analysis conservative for this primitive. Default ``None``.
         """
         if dt_to_t is not None:
             ETP_RULES_DT_TO_T[self] = dt_to_t
@@ -177,6 +195,10 @@ class ETPPrimitive(Primitive):
             ETP_FAST_PATH_RULES[self] = fast_path
         if pp_x_repr is not None:
             ETP_RULES_PP_X_REPR[self] = pp_x_repr
+        if snap_anchor is not None:
+            ETP_RULES_SNAP_ANCHOR[self] = snap_anchor
+        if snap_adjacency is not None:
+            ETP_RULES_SNAP_ADJACENCY[self] = snap_adjacency
 
 
 def register_primitive(

--- a/braintrace/_op/_registries.py
+++ b/braintrace/_op/_registries.py
@@ -85,6 +85,10 @@ __all__ = [
     'get_solve_drtrl_rule',
     'ETP_RULES_PP_X_REPR',
     'get_pp_x_repr',
+    'ETP_RULES_SNAP_ANCHOR',
+    'is_snap_anchored',
+    'ETP_RULES_SNAP_ADJACENCY',
+    'get_snap_adjacency_rule',
 ]
 
 ETP_PRIMITIVES: set = set()
@@ -401,3 +405,92 @@ def get_pp_x_repr(primitive) -> Optional[Callable]:
         not register one (the trace then filters the raw ``x``).
     """
     return ETP_RULES_PP_X_REPR.get(primitive)
+
+
+ETP_RULES_SNAP_ANCHOR: Dict[Primitive, Callable] = {}
+r"""Optional SnAp-n *anchor* declaration, ``eqn.params -> bool``.
+
+SnAp-n (``recurrence_scope='sparse_n'``) widens the trace's trailing
+``num_state`` axis into a ``(neighbour, state)`` axis. That substitution is
+meaningful only if every trace slot has one well-defined hidden *position*
+its instantaneous term lands on -- its **anchor** -- so that the widened
+slot ``(k, a)`` can mean "influence of this slot on ``h[nbr[anchor, k], a]``".
+
+The anchor is a property of the primitive's **trace layout**, not of its
+parameter: a spatially shared convolution kernel is still anchored, because
+its trace keeps one kernel-shaped slot per spatial output position and
+defers the spatial sum to solve time. ``etp_einsum_p`` with a *shared* axis
+is not: its trace has no slot for the shared axis and ``dt_to_t`` sums the
+hidden signal over that axis, so distinct shared-axis positions are already
+collapsed into one slot and per-position influence is unrepresentable.
+
+Unregistered primitives are treated as **not anchored** (default deny), so a
+third-party primitive is rejected loudly under ``sparse_n`` rather than
+silently mis-traced; ``diagonal`` and ``coupled`` remain available to it.
+Queried through :func:`is_snap_anchored`.
+"""
+
+
+def is_snap_anchored(primitive, params: Optional[Dict] = None) -> bool:
+    """Return True iff *primitive* declares a SnAp-n trace anchor.
+
+    Parameters
+    ----------
+    primitive : Primitive
+        The ETP primitive to look up.
+    params : dict, optional
+        The equation parameters. Passed to the declaration so a primitive whose
+        anchor depends on the equation (e.g. ``etp_einsum_p``, anchored only
+        when the equation has no shared axis) can decide per call site.
+        Default ``None`` (an empty parameter mapping).
+
+    Returns
+    -------
+    bool
+        ``True`` when the primitive declared an anchor that accepts *params*;
+        ``False`` when it registered no declaration at all (default deny) or
+        its declaration rejected this equation.
+    """
+    rule = ETP_RULES_SNAP_ANCHOR.get(primitive)
+    if rule is None:
+        return False
+    return bool(rule(params or {}))
+
+
+ETP_RULES_SNAP_ADJACENCY: Dict[Primitive, Callable] = {}
+r"""Optional SnAp-n *position adjacency* rule, ``(eqn.params, size) -> pattern``.
+
+Returns the boolean ``(size, size)`` one-step dependency pattern this
+primitive induces on the **last** axis of the hidden group's ``varshape``
+(``pattern[p, q]`` is ``True`` iff ``h_p^t`` may depend on ``h_q^{t-1}``
+through this equation), or ``None`` to decline -- the analysis then widens to
+all-to-all.
+
+Only primitives whose position coupling is fully determined by static
+equation parameters register one: ``etp_mm``/``etp_mv`` (dense: all-to-all on
+the last axis) and ``etp_sp_mm``/``etp_sp_mv`` (the static sparsity pattern,
+*transposed*, since the forward is ``y = x @ W``). Everything else -- conv,
+einsum, ``dot_general``, grouped, LoRA -- is deliberately unregistered: the
+tempting "mixing happens on the last axis" rule is unsound for them (an
+einsum such as ``btn,tu->bun`` mixes a middle axis, ``dot_general`` exposes
+arbitrary contraction dimensions, convolution mixes spatial axes as well as
+channels). Queried through :func:`get_snap_adjacency_rule`.
+"""
+
+
+def get_snap_adjacency_rule(primitive) -> Optional[Callable]:
+    """Return the SnAp-n position-adjacency rule for *primitive*, or ``None``.
+
+    Parameters
+    ----------
+    primitive : Primitive
+        The ETP primitive to look up.
+
+    Returns
+    -------
+    Callable or None
+        Rule ``(eqn_params, size) -> numpy.ndarray | None`` producing the
+        boolean ``(size, size)`` last-axis dependency pattern, or ``None`` if
+        the primitive registered no rule (the analysis is then conservative).
+    """
+    return ETP_RULES_SNAP_ADJACENCY.get(primitive)

--- a/braintrace/_op/_registries_test.py
+++ b/braintrace/_op/_registries_test.py
@@ -33,7 +33,12 @@ from braintrace._op import (
     ETP_RULES_DT_TO_T,
     GRADIENT_ENABLED_PRIMITIVES,
     etp_conv_p,
+    etp_einsum_p,
     etp_elemwise_p,
+    etp_emb_p,
+    etp_emb_v_p,
+    etp_gmm_p,
+    etp_gmv_p,
     etp_lora_mm_p,
     etp_lora_mv_p,
     etp_mm_p,
@@ -41,9 +46,11 @@ from braintrace._op import (
     etp_sp_mm_p,
     etp_sp_mv_p,
     get_fast_path_rules,
+    get_snap_adjacency_rule,
     is_batched_primitive,
     is_etp_enable_gradient_primitive,
     is_etp_primitive,
+    is_snap_anchored,
 )
 from braintrace._op._primitive import register_primitive
 from braintrace._op._registries import (
@@ -249,3 +256,87 @@ class TestBatchedCounterparts:
         pu2 = register_primitive('etp_test_ctr_u3', lambda x, w: x @ w, batched=False)
         with pytest.raises(ValueError, match='batched'):
             register_batched_counterpart(pu1, pu2)
+
+
+class TestSnapAnchorDeclarations:
+    """The SnAp-n anchor capability: default deny, explicit opt-in.
+
+    ``recurrence_scope='sparse_n'`` widens the trailing state axis of every
+    trace leaf into a ``(neighbour, state)`` axis. That is only meaningful when
+    each trace slot has one hidden position its instantaneous term lands on --
+    the *anchor*. The capability is declared by the primitive rather than
+    assumed by the algorithm, and an undeclared primitive is rejected loudly.
+    """
+
+    ANCHORED = (
+        etp_mm_p, etp_mv_p, etp_gmm_p, etp_gmv_p, etp_sp_mm_p, etp_sp_mv_p,
+        etp_elemwise_p, etp_lora_mm_p, etp_lora_mv_p, etp_conv_p,
+    )
+
+    @pytest.mark.parametrize('primitive', ANCHORED, ids=lambda p: p.name)
+    def test_declared_anchored(self, primitive):
+        assert is_snap_anchored(primitive, {})
+
+    def test_unregistered_primitive_defaults_to_not_anchored(self):
+        fresh = register_primitive('etp_test_snap_unanchored', lambda x, w: x @ w)
+        assert not is_snap_anchored(fresh, {})
+
+    def test_plain_non_etp_primitive_is_not_anchored(self):
+        assert not is_snap_anchored(Primitive('not_etp_test_snap'), {})
+
+    def test_embedding_is_left_undeclared(self):
+        # A recorded limitation, not an oversight: the embedding trace layout
+        # was not analysed in P3, so sparse_n must refuse it rather than guess.
+        assert not is_snap_anchored(etp_emb_p, {})
+        assert not is_snap_anchored(etp_emb_v_p, {})
+
+    def test_einsum_anchor_is_conditional_on_the_equation(self):
+        # no shared axis -> laid out like a dense matmul, anchored
+        assert is_snap_anchored(etp_einsum_p, {'equation': 'bk,kn->bn'})
+        assert is_snap_anchored(etp_einsum_p, {'equation': 'bgk,gkn->bgn'})
+        # a shared axis is summed away by dt_to_t and has no trace slot
+        assert not is_snap_anchored(etp_einsum_p, {'equation': 'btk,kn->btn'})
+
+    def test_missing_params_are_tolerated(self):
+        assert is_snap_anchored(etp_mm_p)
+        assert not is_snap_anchored(etp_einsum_p)
+
+
+class TestSnapAdjacencyRules:
+    """Only primitives whose coupling is fully static register an adjacency rule."""
+
+    def test_dense_registers_all_to_all(self):
+        rule = get_snap_adjacency_rule(etp_mm_p)
+        assert rule is not None
+        pattern = rule({}, 3)
+        assert pattern.shape == (3, 3)
+        assert pattern.all()
+        assert get_snap_adjacency_rule(etp_mv_p) is rule
+
+    def test_sparse_registers_a_rule(self):
+        assert get_snap_adjacency_rule(etp_sp_mm_p) is not None
+        assert get_snap_adjacency_rule(etp_sp_mv_p) is not None
+
+    @pytest.mark.parametrize(
+        'primitive',
+        [etp_conv_p, etp_einsum_p, etp_gmm_p, etp_gmv_p, etp_lora_mm_p,
+         etp_lora_mv_p, etp_elemwise_p, etp_emb_p],
+        ids=lambda p: p.name,
+    )
+    def test_everything_else_is_deliberately_unregistered(self, primitive):
+        # Anchored (mostly) but conservative: "the mixing happens on the last
+        # axis" is unsound for conv (spatial mixing), einsum (`btn,tu->bun`
+        # mixes a middle axis) and grouped/LoRA layouts.
+        assert get_snap_adjacency_rule(primitive) is None
+
+    def test_sparse_rule_declines_a_non_square_structure(self):
+        import brainevent
+        import jax.numpy as jnp
+        import numpy as np
+
+        dense = np.zeros((4, 5), dtype=np.float32)
+        dense[0, 0] = 1.0
+        csr = brainevent.CSR.fromdense(jnp.asarray(dense))
+        rule = get_snap_adjacency_rule(etp_sp_mv_p)
+        assert rule({'sparse_mat': csr}, 5) is None
+        assert rule({'sparse_mat': None}, 5) is None

--- a/braintrace/_op/conv.py
+++ b/braintrace/_op/conv.py
@@ -758,7 +758,35 @@ etp_conv_p = register_primitive(
     trainable_invars_fn=_conv_trainable_invars,
     x_invar_index=0,
 )
+def _conv_snap_anchor(eqn_params: dict) -> bool:
+    """Declare the SnAp-n trace anchor for ``etp_conv``.
+
+    The kernel is *shared* across spatial positions, but the anchor is a
+    property of the trace layout, not of the parameter: the D-RTRL trace keeps
+    one kernel-shaped slot per spatial output position
+    (``(batch, *spatial_out, *kernel, S)``) and defers the spatial sum to
+    :func:`_conv_solve_drtrl`. Every slot therefore has exactly one output
+    position its instantaneous term lands on.
+
+    ``etp_conv`` registers no ``snap_adjacency`` rule: a receptive-field
+    adjacency is derivable in principle but is not attempted here, so a
+    convolutional group takes the conservative all-to-all pattern.
+
+    Parameters
+    ----------
+    eqn_params : dict
+        The equation parameters (unused).
+
+    Returns
+    -------
+    bool
+        Always ``True``.
+    """
+    return True
+
+
 etp_conv_p.register_etp_rules(
+    snap_anchor=_conv_snap_anchor,
     dt_to_t=_conv_dt_to_t,
     xy_to_dw=_conv_xy_to_dw,
     init_drtrl=_conv_init_drtrl,

--- a/braintrace/_op/dense.py
+++ b/braintrace/_op/dense.py
@@ -110,6 +110,7 @@ from typing import Any
 
 import jax
 import jax.numpy as jnp
+import numpy as np
 import brainunit as u
 
 from ._primitive import register_primitive
@@ -518,6 +519,50 @@ _DENSE_FAST_PATH = FastPathRules(
 )
 
 
+def _dense_snap_anchor(eqn_params: dict) -> bool:
+    """Declare the SnAp-n trace anchor for ``etp_mm`` / ``etp_mv``.
+
+    The D-RTRL trace is weight-shaped ``(..., in, out, S)``: slot ``[i, o]``
+    carries the influence of ``W[i, o]``, whose instantaneous term lands on
+    output position ``o`` and nowhere else. The anchor is therefore the ``out``
+    axis, unconditionally.
+
+    Parameters
+    ----------
+    eqn_params : dict
+        The equation parameters (unused; the anchor does not depend on them).
+
+    Returns
+    -------
+    bool
+        Always ``True``.
+    """
+    return True
+
+
+def _dense_snap_adjacency(eqn_params: dict, size: int) -> np.ndarray:
+    """Position adjacency induced by a dense recurrent ``y = x @ W``.
+
+    Every output position reads every input position, so the last-axis
+    dependency pattern is all-to-all. The *other* ``varshape`` axes (a batch
+    axis, say) are untouched by the matmul and stay ``identity`` -- that split
+    is applied by the caller, not here.
+
+    Parameters
+    ----------
+    eqn_params : dict
+        The equation parameters (unused).
+    size : int
+        Length of the hidden group's last ``varshape`` axis.
+
+    Returns
+    -------
+    numpy.ndarray
+        The all-ones ``(size, size)`` boolean pattern.
+    """
+    return np.ones((size, size), dtype=bool)
+
+
 etp_mm_p = register_primitive(
     'etp_mm',
     _etp_matmul_impl,
@@ -531,6 +576,8 @@ etp_mm_p.register_etp_rules(
     init_drtrl=_mm_init_drtrl,
     init_pp=_mm_init_pp,
     fast_path=_DENSE_FAST_PATH,
+    snap_anchor=_dense_snap_anchor,
+    snap_adjacency=_dense_snap_adjacency,
 )
 
 
@@ -675,6 +722,8 @@ etp_mv_p.register_etp_rules(
     init_drtrl=_mv_init_drtrl,
     init_pp=_mv_init_pp,
     fast_path=_DENSE_FAST_PATH,
+    snap_anchor=_dense_snap_anchor,
+    snap_adjacency=_dense_snap_adjacency,
 )
 register_batched_counterpart(etp_mv_p, etp_mm_p)
 

--- a/braintrace/_op/einsum.py
+++ b/braintrace/_op/einsum.py
@@ -227,7 +227,38 @@ def _einsum_init_pp(x_var: Any, y_var: Any, weight_vars: dict[str, Any],
     return jnp.zeros((*y_var.aval.shape, num_hidden_state), dtype=y_var.aval.dtype)
 
 
+def _einsum_snap_anchor(eqn_params: dict) -> bool:
+    """Declare the SnAp-n trace anchor for ``etp_einsum`` -- conditionally.
+
+    The trace allocated by :func:`_einsum_init_drtrl` is weight-shaped and has
+    **no slot for a shared axis**, and :func:`_einsum_dt_to_t` sums the hidden
+    signal over the shared axes before applying it. So for an equation such as
+    ``btk,kn->btn`` the distinct ``t`` positions are already collapsed into one
+    trace slot: no per-position anchor exists, and widening the trailing state
+    axis cannot represent per-``t`` influence at any ``n``.
+
+    Without a shared axis (``bk,kn->bn``, ``bgk,gkn->bgn``, ...) the trace is
+    laid out exactly like the dense / grouped case and the anchor is the output
+    axis.
+
+    Parameters
+    ----------
+    eqn_params : dict
+        The equation parameters; ``equation`` holds the einsum spec.
+
+    Returns
+    -------
+    bool
+        ``True`` iff the equation has no shared axis.
+    """
+    equation = eqn_params.get('equation')
+    if equation is None:
+        return False
+    return not parse_etp_einsum(equation).shared
+
+
 etp_einsum_p.register_etp_rules(
+    snap_anchor=_einsum_snap_anchor,
     dt_to_t=_einsum_dt_to_t,
     xy_to_dw=_einsum_xy_to_dw,
     init_drtrl=_einsum_init_drtrl,

--- a/braintrace/_op/elemwise.py
+++ b/braintrace/_op/elemwise.py
@@ -414,7 +414,29 @@ etp_elemwise_p = register_primitive(
     trainable_invars_fn=_elem_trainable_invars,
     x_invar_index=None,
 )
+def _elemwise_snap_anchor(eqn_params: dict) -> bool:
+    """Declare the SnAp-n trace anchor for ``etp_elemwise``.
+
+    The D-RTRL trace is allocated straight from the hidden group's
+    ``varshape``: slot ``p`` carries the influence of the elementwise weight at
+    position ``p``, whose instantaneous term lands on that same position. The
+    anchor is the position itself.
+
+    Parameters
+    ----------
+    eqn_params : dict
+        The equation parameters (unused).
+
+    Returns
+    -------
+    bool
+        Always ``True``.
+    """
+    return True
+
+
 etp_elemwise_p.register_etp_rules(
+    snap_anchor=_elemwise_snap_anchor,
     dt_to_t=_elemwise_dt_to_t,
     xy_to_dw=_elemwise_xy_to_dw,
     init_drtrl=_elemwise_init_drtrl,

--- a/braintrace/_op/grouped.py
+++ b/braintrace/_op/grouped.py
@@ -228,7 +228,29 @@ etp_gmm_p = register_primitive(
     trainable_invars_fn=_gmm_trainable_invars,
     x_invar_index=0,
 )
+def _grouped_snap_anchor(eqn_params: dict) -> bool:
+    """Declare the SnAp-n trace anchor for ``etp_gmm`` / ``etp_gmv``.
+
+    The trace keeps the group axis and the per-group output axis
+    (``(..., G, K, N, S)``), so slot ``[g, k, n]`` carries the influence of
+    ``W[g, k, n]``, whose instantaneous term lands on output position
+    ``(g, n)`` alone.
+
+    Parameters
+    ----------
+    eqn_params : dict
+        The equation parameters (unused).
+
+    Returns
+    -------
+    bool
+        Always ``True``.
+    """
+    return True
+
+
 etp_gmm_p.register_etp_rules(
+    snap_anchor=_grouped_snap_anchor,
     dt_to_t=_gmm_dt_to_t,
     xy_to_dw=_gmm_xy_to_dw,
     init_drtrl=_gmm_init_drtrl,
@@ -316,6 +338,7 @@ etp_gmv_p = register_primitive(
     x_invar_index=0,
 )
 etp_gmv_p.register_etp_rules(
+    snap_anchor=_grouped_snap_anchor,
     dt_to_t=_gmv_dt_to_t,
     xy_to_dw=_gmv_xy_to_dw,
     init_drtrl=_gmv_init_drtrl,

--- a/braintrace/_op/lora.py
+++ b/braintrace/_op/lora.py
@@ -538,7 +538,29 @@ etp_lora_mm_p = register_primitive(
     trainable_invars_fn=_lora_trainable_invars,
     x_invar_index=0,
 )
+def _lora_snap_anchor(eqn_params: dict) -> bool:
+    """Declare the SnAp-n trace anchor for ``etp_lora_mm`` / ``etp_lora_mv``.
+
+    The trace ``'lora_b'`` is *effective-weight* shaped ``(..., in, out, S)``
+    -- the low-rank factors are recombined only at solve time by
+    :func:`_lora_solve_drtrl` -- so the anchor is the effective weight's ``out``
+    axis, exactly as for a dense matmul.
+
+    Parameters
+    ----------
+    eqn_params : dict
+        The equation parameters (unused).
+
+    Returns
+    -------
+    bool
+        Always ``True``.
+    """
+    return True
+
+
 etp_lora_mm_p.register_etp_rules(
+    snap_anchor=_lora_snap_anchor,
     dt_to_t=_lora_mm_dt_to_t,
     xy_to_dw=_lora_xy_to_dw,
     init_drtrl=_lora_mm_init_drtrl,
@@ -559,6 +581,7 @@ etp_lora_mv_p = register_primitive(
     x_invar_index=0,
 )
 etp_lora_mv_p.register_etp_rules(
+    snap_anchor=_lora_snap_anchor,
     dt_to_t=_lora_mv_dt_to_t,
     xy_to_dw=_lora_xy_to_dw,
     init_drtrl=_lora_mv_init_drtrl,

--- a/braintrace/_op/sparse.py
+++ b/braintrace/_op/sparse.py
@@ -94,10 +94,11 @@ path, which threads :math:`f'` correctly when a transform hook is present.
 
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, Optional
 
 import jax
 import jax.numpy as jnp
+import numpy as np
 import brainunit as u
 import brainevent
 
@@ -423,6 +424,70 @@ def _sp_mv_init_pp(x_var: Any, y_var: Any, weight_vars: dict[str, Any],
 
 
 # ---------------------------------------------------------------------------
+# SnAp-n declarations
+# ---------------------------------------------------------------------------
+
+def _sp_snap_anchor(eqn_params: dict) -> bool:
+    """Declare the SnAp-n trace anchor for ``etp_sp_mm`` / ``etp_sp_mv``.
+
+    The D-RTRL trace is ``(nnz, S)``-shaped: entry ``p`` carries the influence
+    of the stored weight at structural coordinate ``(row(p), col(p))``, whose
+    instantaneous term lands on output position ``col(p)`` and nowhere else.
+    The anchor is that column map -- an index map rather than an array axis,
+    which is equally sufficient for the widening.
+
+    Parameters
+    ----------
+    eqn_params : dict
+        The equation parameters (unused; the anchor does not depend on them).
+
+    Returns
+    -------
+    bool
+        Always ``True``.
+    """
+    return True
+
+
+def _sp_snap_adjacency(eqn_params: dict, size: int) -> Optional[np.ndarray]:
+    """Position adjacency induced by a recurrent ``y = x @ sparse(W)``.
+
+    The forward is ``y = x @ W``, so ``h_p`` depends on ``h_q`` iff
+    ``W[q, p] != 0`` -- the structural pattern **transposed**. The pattern is
+    read from the *static* ``sparse_mat`` equation parameter with the stored
+    data replaced by ones, so it reflects the sparse structure and is unaffected
+    by which stored entries happen to be numerically zero.
+
+    Parameters
+    ----------
+    eqn_params : dict
+        The equation parameters; ``sparse_mat`` holds the
+        :class:`_HashableSparseMat`-wrapped structure.
+    size : int
+        Length of the hidden group's last ``varshape`` axis. A structure that
+        is not ``(size, size)`` cannot be a within-group transition.
+
+    Returns
+    -------
+    numpy.ndarray or None
+        The boolean ``(size, size)`` pattern, or ``None`` to decline (the
+        caller then widens to all-to-all).
+    """
+    mat = _unwrap_sparse_mat(eqn_params.get('sparse_mat'))
+    if mat is None or tuple(getattr(mat, 'shape', ())) != (size, size):
+        return None
+    try:
+        dense = np.asarray(mat.with_data(jnp.ones_like(mat.data)).todense())
+    except Exception:  # noqa: BLE001 - any failure to materialise means "decline"
+        # A structure whose pattern cannot be read concretely at compile time
+        # (an exotic representation, a traced index array) must not be guessed
+        # at: declining yields the conservative all-to-all pattern, which is
+        # sound, where a guess could silently under-approximate.
+        return None
+    return (dense != 0).T
+
+
+# ---------------------------------------------------------------------------
 # Primitive registration
 # ---------------------------------------------------------------------------
 
@@ -438,6 +503,8 @@ etp_sp_mm_p.register_etp_rules(
     xy_to_dw=_sp_xy_to_dw,
     init_drtrl=_sp_mm_init_drtrl,
     init_pp=_sp_mm_init_pp,
+    snap_anchor=_sp_snap_anchor,
+    snap_adjacency=_sp_snap_adjacency,
 )
 
 etp_sp_mv_p = register_primitive(
@@ -452,6 +519,8 @@ etp_sp_mv_p.register_etp_rules(
     xy_to_dw=_sp_xy_to_dw,
     init_drtrl=_sp_mv_init_drtrl,
     init_pp=_sp_mv_init_pp,
+    snap_anchor=_sp_snap_anchor,
+    snap_adjacency=_sp_snap_adjacency,
 )
 register_batched_counterpart(etp_sp_mv_p, etp_sp_mm_p)
 

--- a/docs/specs/2026-07-25-algorithm-axes-roadmap.md
+++ b/docs/specs/2026-07-25-algorithm-axes-roadmap.md
@@ -146,12 +146,22 @@ naming the two that exist today:
 SnAp-n is therefore a *generalisation of an existing knob* rather than a new
 representation invented from scratch, which is what makes P3 tractable.
 
-**Open design question for P3.** Both existing values end up producing a
-per-position block-diagonal Jacobian; they differ in what enters the transition
-before the block diagonal is taken. SnAp-n instead parameterises the *n-step
-influence* that is retained. Whether `coupled` lands on a particular `n`, or
-stays a sibling value beside the `n` scale, is a design decision P3 must settle
-explicitly — this document does not assume it maps onto one.
+**Settled in P3: `coupled` *is* SnAp-1, and `diagonal` sits below the scale.**
+The open question was whether `coupled` lands on a point of the `n` scale or
+stays a sibling beside it. It lands on `n = 1`: SnAp-1 keeps only the
+instantaneous term `∂h_p/∂θ_p` and propagates it through the *self* block of
+`D`, which is exactly what `coupled` computes once the recurrent mixing
+primitive is in the transition and the per-position block diagonal is taken.
+`SnAp(model, n=1)` therefore canonicalises to `recurrence_scope='coupled'`
+rather than being a second spelling of it
+(`snap_n_test.py::TestCoordinates::test_snap_1_canonicalises_to_the_coupled_coordinate`).
+
+`diagonal` is *not* SnAp-0 or any other point on the scale. It deletes the
+recurrent mixing primitive from the transition *before* differentiating, so it
+is not a sparsification of `J = ∂h/∂θ` at all — it is a different transition
+operator. The scale runs `coupled` (= SnAp-1) → `sparse_n(2)` → … →
+`sparse_n(≥ diameter)` (= full within-group RTRL = BPTT); `diagonal` sits beside
+its lower end, cheaper and structurally different.
 
 ### Axis 4 — `learning_signal` (where the signal comes from)
 
@@ -205,6 +215,13 @@ so the table cannot drift from the code.
 | `OSTLRecurrent` | per_param | jacobian | **coupled** | symmetric | none | — |
 | `OSTLFeedforward` | io_factorized | (scalar_leak, jacobian) | diagonal | symmetric | none | (1e-6, 1e-6) |
 | `EProp` | per_param | jacobian | diagonal | symmetric \| random_feedback | **kappa** | — |
+| `SnAp(n≥2)` | per_param | jacobian | **sparse_n**(n) | symmetric | none | — |
+| `SnAp(n=1)` | per_param | jacobian | **coupled** | symmetric | none | — |
+
+`SnAp` was added in P3; its two rows are pinned by
+`snap_n_test.py::TestCoordinates` rather than by the P2 preset table, because
+`n = 1` canonicalises onto `OSTLRecurrent`'s coordinate and the preset table
+asserts a bijection between presets and coordinates.
 
 Two entries were corrected during P2. Under `io_factorized` the recursion is a
 **pair**: the x-side (presynaptic input trace) never involves a Jacobian, so the
@@ -322,7 +339,9 @@ into an engine-specific structure. The lifecycle contract the spec actually care
 about (base concrete, engines chain via `super()` as their last statement, no
 silent degradation) is unchanged.
 
-### P3 — SnAp-n: generalise `recurrence_scope`
+### P3 — SnAp-n: generalise `recurrence_scope` — **done**
+
+Spec: [`2026-07-25-p3-snap-n.md`](2026-07-25-p3-snap-n.md).
 
 Menick et al. 2021. Derive the n-step influence sparsity pattern automatically
 from the compiler's jaxpr hidden→hidden reachability graph — the thing a
@@ -350,6 +369,62 @@ today's coupled path, and add the intermediate sparse representation for
   only to assert the influence matrix `dh^t/dθ` itself when localising a
   divergence between trace and learning signal — optional debugging aid.)
 - Measured memory curve, monotone in n.
+
+**Delivered.** `braintrace/_compiler/position_graph.py` (per-axis adjacency
+analysis, closure, neighbourhood index, budget guard), the `snap_anchor`
+capability in `_op/_registries.py` plus its nine per-primitive declarations,
+`HiddenGroup.snap` / `.trace_state_width` / `widened_block_jacobian` /
+`widen_instant_term` / `gather_learning_signal` in `_compiler/hidden_group.py`,
+the widened-trace plumbing in `_algorithm/param_dim_vjp.py`, two guardrails in
+`_algorithm/vjp_base.py`, the `sparse_n` axis value and its matrix rules in
+`_algorithm/axes.py`, three new oracles (`sparse_ring_rnn`,
+`sparse_ring_two_state_rnn`, `rolled_tail_rnn`), and the `braintrace.SnAp`
+preset.
+
+122 new tests: `_algorithm/snap_n_test.py` (48 acceptance),
+`_compiler/position_graph_test.py` (41), plus 10 in `hidden_group_test.py`,
+10 in `_registries_test.py` and 13 in `axes_test.py`.
+
+Both curves, measured on `sparse_ring_rnn(n_rec=6)` (diameter 5) through
+`chunked_online_param_gradients(chunk_size=3)`, T=8, against the BPTT oracle on
+the ETP parameter only:
+
+| n | K | trace scalars | rel. deviation from BPTT |
+|---|---|---|---|
+| 1 | 1 | 12 | 2.32e-01 |
+| 2 | 2 | 24 | 4.96e-03 |
+| 3 | 3 | 36 | 5.93e-04 |
+| 4 | 4 | 48 | 2.22e-04 |
+| 5 | 5 | 60 | 8.03e-08 |
+| 6 | 6 | 72 | 8.03e-08 |
+| 7 | 6 | 72 | 8.03e-08 |
+
+Memory is exactly linear in `K` and saturates with it; accuracy is monotone and
+reaches round-off at `n = diameter`. A *dense* recurrent weight has diameter 1
+and saturates at `n = 2`, which is why the ring — and not `tanh_rnn` — is the
+reference model for the scale.
+
+Two deviations from the spec. First, the widening hooks live at the innermost
+consumers in `param_dim_vjp.py` rather than behind the
+`vjp_base._transform_trace_inputs` hook the spec proposed: the `df` widening and
+the learning-signal gather need the `HiddenGroup` they belong to, and the base
+hook does not have it without threading group identity through a signature that
+every engine shares. Second, `n = 1` canonicalises to `recurrence_scope='coupled'`
+instead of `sparse_n` with `sparse_n=1`; the spec left this open, and collapsing
+it keeps one coordinate per rule (see Axis 3 above).
+
+**Adversarial review.** An independent review of the finished implementation
+raised twelve findings; the ones that changed code were a soundness blocker in
+the reachability closure (integer overflow under-approximating the
+neighbourhood), the budget being charged against the trace rather than the block
+Jacobian that dominates it, the anchor check lapsing at `n = 1`, a missing
+guard on the public `compile_etrace_graph` entry point, and a diagnostic whose
+"the gradient stays correct" wording over-claimed. On the test side it added an
+independent masked-RTRL oracle for the interior orders, gradient execution for
+all eleven anchored primitives at a saturating order, and replaced two
+tautological assertions. Lessons 26–30 record what generalises; F-31 in the
+limitations list records the one behaviour that was confirmed as a pre-existing
+property rather than a P3 regression.
 
 ### P4 — UORO, three-factor and DNI
 
@@ -438,8 +513,10 @@ statistical class.
 ## Lessons learned during implementation
 
 Items 1–9 were recorded during P1, against commit `bc153da`; items 10–17 during
-P2, against `156d058`. These are the things the roadmap got wrong or could not
-have known, kept here because later phases rest on them.
+P2, against `156d058`; items 18–30 during P3, against `100b5be` (18–25 while
+implementing, 26–30 while working through the adversarial review). These are the
+things the roadmap got wrong or could not have known, kept here because later
+phases rest on them.
 
 1. **The instrument was the defect, not the compiler.** P1 was scoped as
    compiler work on multi-timescale and heterogeneous populations. Every one of
@@ -606,3 +683,165 @@ have known, kept here because later phases rest on them.
     correction and a refactor cannot land together, or neither can be verified.
     It is recorded in the findings list with a reproduction and pinned by a test
     that asserts the current, biased behaviour.
+
+### From P3
+
+18. **An approximation whose error does not fall when you spend more memory on
+    it is not "converging slowly" — it is wired backwards.** The first working
+    SnAp-n produced a flat error curve: `2.3167e-01` at every `n` from 1 to 4,
+    then exactly round-off at `n = 5`. Every structural test passed. The cause
+    was the direction of the neighbourhood: `A[p, q]` reads "h_p depends on
+    h_q", so the trace slot anchored at `p` must cover **column** `p` of the
+    closure — the positions `p` *influences* — and the code took the row. On a
+    directed graph the row is the set `p` reads *from*, whose contribution to
+    `p`'s own parameter gradient is exactly zero, so the trace paid the full
+    `K`-fold widening and bought nothing until the neighbourhood saturated and
+    the two sets coincided.
+
+    What makes this worth an item is that *no size-based test can see it*. `K`,
+    monotonicity, nestedness, saturation, padding validity and the memory curve
+    are all identical under either orientation, and the graph fixtures in use
+    were symmetric often enough that even the flat-adjacency cross-check passed.
+    Only membership on a strictly directed fixture separates them, which is now
+    `position_graph_test.py::TestNeighbourhoodDirection`. Generalising: when an
+    axis is supposed to trade memory for accuracy, plot accuracy against the
+    knob *before* trusting any single-point assertion — a two-point check at the
+    endpoints would have shown "SnAp-1 differs from BPTT" and "saturated SnAp
+    equals BPTT", both true here, both passing, with the entire interior wrong.
+
+19. **A whole-tree comparison against BPTT measures the truncation window, not
+    the learning rule.** Under chunking, a model's *plain* (non-ETP) parameters
+    receive exactly truncated BPTT — they are carried by no trace, so they
+    truncate by construction at every coordinate of every axis. On the ring at
+    `chunk_size=1` the plain input projection alone contributes `4.5e-01` to the
+    tree-wide relative deviation while the ETP weight is exact to `7e-08`. This
+    cost the longest debugging session of P3, chasing a "saturated SnAp is not
+    BPTT" failure that was never a failure. BPTT comparisons now restrict to
+    `spec.etp_param_keys` (`snap_n_test._rel_etp`). Algorithm-vs-algorithm
+    comparisons deliberately stay on the *full* tree: two rules at the same
+    window truncate identically, so agreeing everywhere is the stronger claim.
+
+20. **A recurrent oracle without a self-edge cannot see `recurrence_scope` at
+    all.** The first sparse ring used `offsets=(1,)`, a pure cycle. Then
+    `∂h_p/∂h_p = 0`, the per-position block of the recurrent Jacobian is
+    identically zero, and `diagonal` and `coupled` return *bit-identical*
+    gradients — so the negative control that was supposed to prove the axis has
+    content proved nothing. Fixed by defaulting both ring oracles to
+    `offsets=(0, 1)`, which restores a `3.68e-02` separation and does not change
+    `K(n)`. This is lesson 10 with a new mechanism: for a scope axis, what the
+    model must supply is a non-zero *self* block, not merely recurrence.
+
+21. **The widened trace needed zero per-primitive changes, and the reason is
+    worth keeping.** `sparse_n` replaces the trace's trailing `num_state` axis
+    `S` with a `(neighbour, state)` axis of width `M = K·S`, and not one of the
+    nine ETP primitives' rules was touched. Two existing properties make that
+    work: `_comp_recurrent_legacy` vmaps the state axes away before calling
+    `dt_to_t`, so per-primitive rules never see the widened axis; and `dt_to_t`
+    already implements each primitive's anchor map (hidden position → trace
+    slot), which is exactly the map the widening needs. The fast paths
+    (`fp.recurrent` / `instant` / `solve` / `chunk`) index the state axis by
+    einsum letter and are therefore generic in its size. P4's `random_projection`
+    should check whether the same two properties buy it the same freedom before
+    proposing to touch kernels.
+
+22. **A capability the compiler cannot infer must be declared, and must default
+    to deny.** `sparse_n` is only meaningful if every ETP relation anchors on a
+    single hidden position — a trace slot has to have one well-defined position
+    its instantaneous term lands on. `etp_einsum` with a shared axis, and the
+    embedding ops, have no such position, and nothing in their shapes reveals
+    that. So `snap_anchor` is a declared per-primitive capability whose default
+    is *no anchor*, and `sparse_n` raises naming the offending primitive and
+    pointing at `coupled` / `diagonal`. Inferring it would have been silently
+    wrong for exactly the primitives that matter; cf. lesson 15.
+
+23. **An ETP output reshaped before it reaches the hidden state severs the
+    relation, and the compiler only warns.** The grouped-matmul fixture first
+    declared a flat `(1, n_rec)` hidden state and reshaped the `etp_gmm` output
+    into it. The compiler discovered *zero* ETP relations, emitted a warning
+    ("y shape=(1, 2, 3) not broadcastable with hidden shape=(1, 6)"), and the
+    test passed while exercising nothing. Fixed by shaping the hidden state
+    `(1, G, K)` and reshaping the *input* instead. A warning is not a failure:
+    what caught it was the structural pin on `primitives`, which was `()`.
+
+24. **`@pytest.mark.parametrize` does not parametrize a `unittest.TestCase`
+    method.** pytest collects the method once and never binds the parameter. A
+    test that reads as covering nine primitives covered none. Converted to an
+    explicit loop over the fixture dict. Worth stating alongside lesson 8: this
+    repository mixes `TestCase` classes and bare pytest classes in the same
+    file, so the decorator's applicability changes from class to class.
+
+25. **Report the conservative and the degenerate case; do not just handle
+    them.** The adjacency analysis factorises per axis (`A = ⊗ A_axis`), which
+    is exact when at most one axis is non-identity and a strict superset
+    otherwise — safe, but it silently costs memory, so it emits
+    `SNAP_PATTERN_CONSERVATIVE` with the reason. The `K == 1` case matters more:
+    it is legitimate on a model with no cross-position coupling, and it is also
+    exactly what a silently failing analysis produces, so it emits
+    `SNAP_PATTERN_DEGENERATE` rather than quietly computing `coupled` under a
+    `sparse_n` label. One tooling note for reading these back:
+    `compile_etrace_graph` opens its own nested `diagnostic_context()`, so an
+    outer reporter sees nothing — the records are on `graph.diagnostics`.
+
+### From P3's adversarial review
+
+The implementation above passed its own acceptance suite before this review ran.
+These five are what a hostile second reading found anyway, which is the argument
+for running one.
+
+26. **`bool @ bool` saturates; `uint8 @ uint8` counts paths and wraps.** The
+    reachability closure `A^k` was computed on `uint8` for compactness. NumPy's
+    boolean matmul accumulates with logical-or, so it saturates at `True`; the
+    integer one accumulates with `+` and wraps modulo 256. A position pair
+    joined by exactly 256 parallel two-hop paths therefore reported
+    **unreachable** — a *subset* of the true neighbourhood, which is the one
+    error direction this analysis may never have, and the one no existing test
+    could see because every fixture had a handful of paths, not hundreds. Fixed
+    by keeping the closure boolean throughout; pinned by
+    `test_many_parallel_paths_do_not_wrap`, which builds a 256-fold fan
+    deliberately. The general form: a *conservative* analysis has an asymmetric
+    failure cost, so its arithmetic must be chosen for the direction it may err
+    in, not for its width.
+
+27. **Budget the allocation that actually dominates, and name it in the error.**
+    The first guard capped the *trace* at `P·K·S` scalars. The term that
+    actually bounds usable `n` is the widened block Jacobian `Dg`, at
+    `P·(K·S)²` — quadratic in the same knob. The constant became
+    `DEFAULT_MAX_JACOBIAN_ELEMENTS = 2^24`, which admits `P=K=256, S=1` at
+    64 MiB and rejects `P=K=512` at 512 MiB, and the message prints the computed
+    element count and names the three ways out (smaller `n`, `coupled`, or a
+    larger explicit ceiling). A limit whose message does not say what was
+    measured is a limit users work around by guessing.
+
+28. **A coordinate cannot always carry its own provenance.** `SnAp(n=1)`
+    canonicalises to `recurrence_scope='coupled'` (lesson 18's finding), and
+    `coupled` is legal on models with no anchored primitive — so the anchor
+    check, keyed on the coordinate, silently stopped applying at exactly the
+    order where a user is most likely to be comparing SnAp against something
+    else. The preset now records `_requested_snap_order` alongside the config
+    and the check keys on either. Whenever a public entry point *narrows* to a
+    shared internal coordinate, ask what the narrowing threw away that a
+    validation still needs.
+
+29. **Endpoints are not evidence about the interior; write the interior's own
+    oracle.** Saturated SnAp equals BPTT and SnAp-1 equals `OSTLRecurrent`,
+    both pinned — and both are statements about the *ends* of the scale. The
+    interior got a hand-written masked-RTRL recursion in float64 numpy
+    (`influence = mask * (influence @ Dᵀ + instant)`) whose mask is derived
+    independently of the compiler's, and orders 2, 3 and 4 match it to `<1e-6`
+    while a deliberately narrower reference misses by `1.2e-1`. Note the
+    discrimination is one-sided on a forward-only ring — a wider reference still
+    matches, because widening only adds strictly-downstream positions that
+    cannot feed back — so the test documents that rather than asserting a
+    symmetry the model does not have.
+
+30. **"Correct" needs a subject.** The conservative-widening diagnostic said
+    "the gradient stays correct". True of the *pattern* — a superset never drops
+    a real dependency — but it reads as a promise about the returned gradient,
+    and that promise is false whenever the group's `y → hidden` tail relabels
+    positions: there, full within-group RTRL is **not** BPTT, and the saturated
+    rule is further from BPTT than the cheaper ones (1.30 vs 1.03 relative
+    deviation on the `roll`-tail probe, against `1.3e-07` for the same model
+    with the roll removed). The wording now says the *approximation* is not
+    degraded and points at F-31 in the limitations list, where the pair and its
+    control are recorded. Every axis in this roadmap describes what a trace
+    retains; none of them can describe what the trace's index does not denote.

--- a/docs/specs/2026-07-25-known-limitations.md
+++ b/docs/specs/2026-07-25-known-limitations.md
@@ -56,6 +56,7 @@ resolution, never that a test stopped being run.
 | F-28 | `EProp(feedback='random')` assumes a single, direct readout whose width equals the HiddenGroup's own | active, **documented scope boundary** | `e_prop.py:117-122` states it: the hooks only see `∂L/∂h`, which has no visibility into a separate readout layer's width, so the projection matrix is square |
 | F-29 | `pp_prop(decay_or_rank=1)` is a genuine approximation | **active, misattributed as approximate** — rank 1 means decay 0, so the presynaptic EMA collapses to the exact current input | `tests/approx_correctness_test.py::test_rank1_pp_prop_is_degenerate_on_a_recurrent_only_relation` pins both sides |
 | F-30 | the IO-dim f-side de-biasing correction is indexed by `update()` call count, not by trace-step count, so it is exact only for single-step input | active, **preserved deliberately** — fixing it moves `pp_prop` / `OSTLFeedforward` gradients | `io_dim_vjp_test.py::TestBiasCorrectionTimeIndex`, both the structural claim and the finite-window consequence |
+| F-31 | on a hidden group whose `y -> hidden` tail is not position-preserving, *no* within-group scope reaches BPTT — saturated SnAp / full within-group RTRL included | active, **structural** — pre-P3, affects every `recurrence_scope`; the compiler detects the tail and warns | `_algorithm/snap_n_test.py::TestConservativeFallbackEndToEnd::test_a_relabelling_tail_defeats_saturation_and_says_so`, against the `roll=0` control; measured below |
 | F-SCAN / F-SCAN-WEIGHT | weight inside control flow raised `KeyError` | resolved | `_compiler/base_test.py::TestCheckUnsupportedOp::test_error_message_identifies_weight_variable` |
 | F-SINGLESTEP | naive single-step summation does not equal BPTT even for an exact algorithm | active as a property; documented | `online_param_gradients_singlestep_naive`' docstring; used deliberately as the maximally-sensitive window in `oracle_test.py` |
 
@@ -135,6 +136,56 @@ Not fixed in P2: the phase's acceptance criterion is that no preset's gradients
 move, and this correction is on `pp_prop`'s and `OSTLFeedforward`'s hot path.
 The P2 golden values in `data/p2_golden.npz` therefore freeze the biased
 numbers on purpose. A fix belongs in its own change, with its own goldens.
+
+## Notes on F-31
+
+The per-parameter eligibility trace indexes hidden units by *position within a
+hidden group*. Every `recurrence_scope` coordinate — `diagonal`, `coupled`,
+`sparse_n` — is a statement about which positions a parameter's influence is
+retained for. That vocabulary presumes the group's positions survive the trip
+from the mixing primitive's output back into the hidden state. When they do not,
+the trace cannot represent the influence at all, and widening the neighbourhood
+does not help: the missing term is not a neighbour that was dropped, it is a
+relabelling the representation has no slot for.
+
+Reproduced on a dense tanh RNN (`n_in=3`, `n_rec=5`, `T=8`, chunk 2, ETP
+parameters only) whose recurrent pre-activation is rolled by one position before
+it re-enters `h` — `h^t = tanh(x @ win + roll(matmul(h^{t-1}, w), 1))`. The
+position graph of the mixing primitive alone has diameter 1, so `n = 2` already
+saturates and the un-rolled control is the same model with `roll` deleted:
+
+| algorithm | rel. deviation from BPTT, **with** the roll | control, **without** |
+|---|---|---|
+| `D_RTRL` (diagonal) | 1.0329 | 0.4041 |
+| `OSTLRecurrent` (coupled) | 1.0452 | 0.2836 |
+| `SnAp(n=2)` (saturated) | 1.3031 | **1.29e-07** |
+| `SnAp(n=4)` (saturated) | 1.3031 | 1.29e-07 |
+
+The control column is what gives the first column its meaning: with a
+position-preserving tail, saturation *is* BPTT to float32 round-off while the
+cheaper scopes are genuinely approximate — the axis behaves exactly as the
+roadmap claims. Add the roll and the ordering collapses: the most expensive
+coordinate is now the least accurate of the three, because retaining more
+positions buys nothing when every position is mislabelled.
+
+Two things follow, and only the second is a defect:
+
+1. **It is detected, not silent.** The position analysis rejects the `slice`
+   equation `roll` lowers to, widens to all-to-all, and emits
+   `SNAP_PATTERN_CONSERVATIVE`. Nothing here is assumed and later violated.
+2. **The diagnostic's wording was wrong, and was fixed in P3.** It read "the
+   gradient stays correct", which is true of the *pattern* (a superset never
+   drops a real dependency) but reads as a claim about the returned gradient.
+   It now says the approximation is not degraded and points here. The warning
+   is emitted for the SnAp path only; the same tail degrades `diagonal` and
+   `coupled` too, without any warning at all, because those coordinates never
+   ask for a position graph.
+
+Not fixed: representing a non-position-preserving tail would require the trace
+to carry the tail's own permutation alongside the neighbourhood, which is a
+change to the trace layout rather than to any one algorithm. Until then, the
+usable statement is the one in `SnAp`'s docstring: saturation equals BPTT on a
+single-group model with an **elementwise** `y -> hidden` tail.
 
 ## Mapping from the `AGENTS.md` prose list
 

--- a/docs/specs/2026-07-25-p3-snap-n.md
+++ b/docs/specs/2026-07-25-p3-snap-n.md
@@ -1,0 +1,659 @@
+# P3 — SnAp-n: generalise `recurrence_scope`
+
+Status: spec, revised after review
+Roadmap: [`2026-07-25-algorithm-axes-roadmap.md`](2026-07-25-algorithm-axes-roadmap.md) § P3
+Baseline: commit `100b5be` (P2 landed)
+Target release: 0.3.0
+
+## Goal
+
+Turn `recurrence_scope` from a two-valued knob into the SnAp-*n* scale of
+Menick et al. 2021, with the *n*-step influence sparsity pattern **derived by
+the compiler** from the model's own hidden→hidden structure rather than
+declared by the user.
+
+The deliverable is the scale plus the two-sided squeeze that proves it lands on
+the right endpoints: at the cheap end it reproduces today's coordinates
+bit-for-bit, at the expensive end it reproduces the exact within-group
+influence matrix.
+
+## The design question the roadmap deferred
+
+The roadmap says, verbatim:
+
+> Both existing values end up producing a per-position block-diagonal Jacobian;
+> they differ in what enters the transition before the block diagonal is taken.
+> SnAp-n instead parameterises the *n-step influence* that is retained. Whether
+> `coupled` lands on a particular `n`, or stays a sibling value beside the `n`
+> scale, is a design decision P3 must settle explicitly.
+
+**It settles as: `coupled` *is* SnAp-1, exactly, and `diagonal` sits below the
+scale.** The derivation, in the repository's own terms.
+
+Write the influence matrix `J^t_{θ,u} = ∂h^t_u / ∂θ` over hidden units
+`u = (position p, state a)`. RTRL is `J^t = D^t J^{t-1} + I^t`, with `D^t` the
+hidden→hidden Jacobian and `I^t` the instantaneous term. SnAp-*n* fixes `J`'s
+sparsity to the pattern of `I` propagated `n-1` times through `D`, and masks
+every update back onto it.
+
+For a weight `W[i,o]` the instantaneous pattern is `{(W[i,o], h_o)}` — the
+parameter's trace slot is anchored at output position `o` and nothing else.
+That is *precisely* the shape of today's per-parameter trace: `etrace_bwg[key]`
+has shape `(*param_shape, num_state)`, and the position index is the
+parameter's own output index. **The `per_param` trace is already the SnAp-1
+representation** — for every primitive whose trace carries such an anchor,
+which is a real precondition and is treated as one (§ The anchor contract).
+
+Propagate the SnAp-1 mask through one step:
+
+```
+J_new[i, o, p=o] = Σ_q D[o, q] · J_old[i, o, q]
+                 = D[o, o] · J_old[i, o, o]      (J_old lives only on q = o)
+```
+
+so SnAp-1's recursion multiplies by `D[o,o]` — the **per-position block
+diagonal of the full `D`**. That is exactly `block_diagonal_last_dim`, i.e.
+exactly what `recurrence_scope='coupled'` computes today.
+
+`diagonal` is a different thing. It does not take the block diagonal of the
+true `D`; it deletes the recurrent mixing primitive from the transition
+*before* differentiating (`_eval_eqn`'s ETP boundary skip), so the `D[o,o]` it
+multiplies by is missing every contribution routed through the recurrent
+weight — including the self-coupling `W[o,o]` that SnAp-1 keeps. It is the
+e-prop / RFLO approximation, strictly below SnAp-1.
+
+Measured, so it is not merely argued (`tanh_rnn`, T=8, `chunk_size=2`, the
+finite-window path F-23 requires):
+
+| comparison | relative deviation |
+|---|---|
+| `D_RTRL` (`diagonal`) vs BPTT | 6.18e-02 |
+| `OSTLRecurrent` (`coupled`) vs BPTT | 6.18e-02 |
+| `D_RTRL` vs `OSTLRecurrent` | **6.27e-04** |
+| hand-written full RTRL vs BPTT | 7.96e-08 (float32 round-off) |
+
+The last row is the instrument check for the far end of the squeeze: on a
+single-hidden-group model, full RTRL and BPTT are the same gradient, so
+`oracle.py`'s `bptt_param_gradients` is a valid reference for SnAp-∞ and no
+separate full-RTRL reference has to ship. The third row is what gives the near
+end content: the two existing scopes are distinguishable on this path by
+6.27e-04, three orders above the 1e-6 axis threshold lesson 5 mandates.
+
+**Consequence for the roadmap's acceptance list.** Its criterion 1 reads
+"`n = 1` equals the current `D_RTRL` element-wise". That was written under the
+assumption `n = 1` ↔ `diagonal`, which the derivation above contradicts. It is
+restated in § Acceptance as two criteria: `diagonal` (untouched default) still
+equals today's `D_RTRL`, and `sparse_n(1)` equals today's `OSTLRecurrent`.
+
+**Consequence for `is_diagonal_recurrence`.** The roadmap says "replace the
+boolean `is_diagonal_recurrence` with an n-valued scope". P3 does **not** do
+that, and the reason is the same finding: the boolean and the scale answer
+different questions. `is_diagonal_recurrence` answers *is this transition
+position-diagonal, so that the cheap column-sum Jacobian is exact?* — a
+property of the transition jaxpr, still needed to choose between
+`jacrev_last_dim` and materialising the full Jacobian. The scale answers *how
+many steps of influence does the trace retain?*. Collapsing them would re-merge
+the two things this phase exists to separate. The boolean stays; the scale is a
+new, separate field.
+
+## Scope
+
+**In:**
+
+1. `recurrence_scope='sparse_n'` with its `sparse_n: int` coefficient accepted
+   by `ETraceConfig`, canonicalising `n = 1` onto `'coupled'`, plus the
+   matrix rules that constrain it.
+2. A compile-time **position-adjacency analysis**: per hidden group, which
+   positions can influence which in one step, derived from the group's own
+   transition jaxpr; and its *n*-step closure into a neighbourhood index.
+   Precise for two operator families, **conservative everywhere else**.
+3. The **anchor contract** as a declared per-primitive capability, so a
+   primitive whose trace layout cannot carry the widening is rejected loudly
+   rather than silently mis-traced.
+4. `HiddenGroup` carries the resulting pattern and produces the widened
+   transition operator it implies.
+5. `ParamDimVjpAlgorithm` runs the widened trace — allocation, recursion,
+   instantaneous term and solve — **without a single per-primitive kernel
+   change**.
+6. A `braintrace.SnAp` preset, coordinates asserted against the roadmap table.
+7. The two-sided squeeze, the storage curve, and the degeneracy pins.
+
+**Out**, each rejected with an error naming why:
+
+- `trace_factorization='io_factorized'` + `sparse_n`. The x-side factor is
+  indexed by input position and carries no hidden index at all, so widening
+  would have to land entirely on `ε_f`; that is a real and reachable design but
+  it changes the `_solve_weight_gradients` contraction on the engine whose
+  whole point is `O(I+O)` memory. Matrix rule.
+- `sparse_n` inside a **descended scan**, for the same reason `coupled` is
+  rejected there today (P2 § scope boundaries): `scan_descent.py` analyses body
+  transitions with `include_recurrent_mixing=False` unconditionally. The
+  existing guard is extended rather than duplicated.
+- **Cross-*group* SnAp.** The full hidden-unit graph spans hidden groups as
+  well as positions within one; retaining influence across groups needs
+  `∂h_g^t / ∂h_{g'}^{t-1}`, which the compiler never computes — ETP mixing is
+  the *boundary* between groups by construction, and the trace, the executor
+  and the solve are all keyed per group. This phase is the within-group scale
+  only. It is why the far end of the squeeze is stated as *within-group* RTRL
+  and why its test asserts a structural precondition rather than picking a
+  convenient model (§ Acceptance 3).
+- A receptive-field adjacency rule for `conv_general_dilated` / `etp_conv`, and
+  any precise rule for `dot_general` / `etp_einsum` / `etp_gmm` / `etp_lora_*`.
+  All take the conservative pattern. See § The adjacency analysis for why the
+  obvious "mixing happens on the last axis" rule is unsound.
+
+## The representation
+
+### The widened state axis
+
+The whole of SnAp-*n* reduces to one substitution: **the trace's trailing
+`num_state` axis becomes a `(neighbour, state)` axis.**
+
+For a hidden group with `varshape` `V` (`P = prod(V)` positions), `S` states,
+and an *n*-step neighbourhood of width `K`:
+
+| object | today | under `sparse_n` |
+|---|---|---|
+| trace leaf | `(…, S)` | `(…, M)`, `M = K·S` |
+| `hid2hid` Jacobian | `(*V, S, S)` | `(*V, M, M)` |
+| `df` | `(*V, S)` | `(*V, M)` |
+| learning signal | `(*V, S)` | `(*V, M)` |
+
+Index `m = k·S + a` means "the influence on `h[nbr[p, k], a]`", where
+`nbr[p, k]` is the `k`-th member of position `p`'s neighbourhood and
+`nbr[p, 0] = p` always. At `K = 1` every shape is today's shape and every
+formula below reduces to today's formula.
+
+This is why P3 changes no ETP kernel. Every per-primitive rule —
+`init_drtrl`, `xy_to_dw`, `dt_to_t`, `instant_drtrl`, `solve_drtrl`, the
+closed-form `FastPathRules`, the chunk kernel — is generic in the size of the
+trailing state axis: `num_state` reaches them only as a `== 1` shortcut, and
+the conv / sparse / LoRA rules see one state slice at a time through the
+algorithm's outer `vmap`. Feeding them `M` instead of `S` is the entire
+integration.
+
+That genericity is a fact about the *kernels*, verified by reading them. It is
+**not** the same as the trace *layout* being able to carry the widening, which
+is a separate precondition:
+
+### The anchor contract
+
+The widening is meaningful only if the trace has, for each of its slots, one
+well-defined hidden position that the slot's instantaneous term lands on. Call
+that the **anchor**. `ε[..., p, m]` then means "influence of this parameter
+slot (anchored at `p`) on `h[nbr[p,k], a]`", and:
+
+- the instantaneous term is nonzero only at `k = 0`;
+- the solve contracts slot `m` against `dL/dh[nbr[p,k], a]`.
+
+Most shipped primitives have an anchor, including ones where the parameter is
+*shared* across positions — the anchor is a property of the **trace layout**,
+not of the parameter. Convolution's kernel is spatially shared, but its trace
+keeps one kernel-shaped slot per spatial output position and defers the spatial
+sum to `_conv_solve_drtrl`, so every slot is anchored. LoRA's trace is
+effective-weight shaped with a dedicated `solve_drtrl`; its anchor is the
+output axis. `etp_elemwise` allocates from `group.varshape` directly.
+
+`etp_einsum` with a **shared** axis does not. `_einsum_init_drtrl` allocates a
+weight-shaped trace with no slot for the shared axis, and `_einsum_dt_to_t`
+sums the hidden signal over that axis before applying it
+(`einsum.py: jnp.sum(hidden_dim, axis=shared_axes)`). For `btk,kn->btn`
+distinct `t` positions are *already* collapsed into one slot, so widening the
+trailing axis cannot represent per-`t` influence — SnAp-1 and saturation are
+both unrepresentable. This is invisible in the existing einsum equality tests,
+which run on the full-window oracle that is documented blind to trace
+correctness (F-23).
+
+So the anchor is **declared by the primitive, not assumed by the algorithm**:
+
+```python
+etp_mm_p.register_etp_rules(..., snap_anchor=lambda eqn_params: True)
+etp_einsum_p.register_etp_rules(
+    ..., snap_anchor=lambda p: not parse_etp_einsum(p['equation']).shared)
+```
+
+`snap_anchor` defaults to **`False`**. A relation whose primitive has not
+declared one raises at `compile_graph` with a message naming the primitive, the
+relation, and the fact that `diagonal` / `coupled` remain available. Default-
+deny is the safe direction (lesson 15: a configuration that cannot be honoured
+must fail loudly) and it puts the capability in the operator protocol beside
+`FastPathRules.applicable` and `chunk` — a third-party primitive declares its
+own, so this is not an algorithm-side primitive whitelist and removal
+criterion 1 still holds.
+
+Declared `True` in P3: `etp_mm`, `etp_mv`, `etp_gmm`, `etp_gmv`, `etp_sp_mm`,
+`etp_sp_mv`, `etp_elemwise`, `etp_lora_mm`, `etp_lora_mv`, `etp_conv`.
+Declared conditionally: `etp_einsum` (no shared axis). Left at the default:
+`etp_emb`, `etp_emb_v` — not analysed in this phase, recorded as a limitation.
+
+A second precondition rides along: `df` is the *diagonal* of the `y → hidden`
+map only when that map is elementwise; otherwise the all-ones jvp returns its
+row sums (`vjp_graph_executor._compute_hid2weight_jacobian`, the `[ KEY ]`
+note). Saturation cannot be exact when that tail is non-elementwise. This is a
+pre-existing approximation shared by both engines, not something P3 introduces,
+but the saturation criterion must be run on a model where it does not bite and
+must say so.
+
+### The four widened quantities
+
+Let `Jf` be the group's **full** cross-position Jacobian, shape
+`(P, S, P, S)` after reshaping — the array `block_diagonal_last_dim` already
+materialises today and then throws most of away. Let `valid[p, k]` mark
+padded neighbourhood slots (§ Padding).
+
+**1. Transition operator.**
+
+```
+Dg[p, k, a, k', b] = Jf[nbr[p,k], a, nbr[p,k'], b] · valid[p,k] · valid[p,k']
+```
+
+reshaped to `(*V, M, M)`. A double gather on the position axes of `Jf`.
+
+**2. Recursion** — unchanged code, new shapes:
+
+```
+ε_new[..., p, (k,a)] = Σ_{k',b} Dg[p, (k,a), (k',b)] · ε[..., p, (k',b)] + inst
+                     = Σ_{q ∈ N(p), b} ∂h[nbr[p,k],a]/∂h[q,b] · ∂h[q,b]/∂θ[...,p]
+```
+
+which is RTRL restricted to the neighbourhood — the SnAp truncation, verbatim.
+
+**3. Instantaneous term.** Under the anchor contract it is zero for `k ≠ 0`. It
+is realised by **zero-padding `df`**, not by padding each primitive's output:
+every instantaneous kernel is linear in `df`, so
+
+```
+df_wide = concat([df, zeros(*V, (K-1)·S)], axis=-1)
+```
+
+produces exactly the padded instantaneous term through the unmodified kernel.
+This is the single trick that keeps the per-primitive rules untouched.
+
+**4. Solve.** The learning signal is gathered onto the same index:
+
+```
+sig[p, (k,a)] = dL/dh[nbr[p,k], a] · valid[p,k]
+```
+
+and the existing contraction `Σ_m ε[..., p, m] · sig[p, m]` then computes
+`Σ_{q ∈ N(p), a} ∂h[q,a]/∂θ[...,p] · ∂L/∂h[q,a]` — the SnAp gradient.
+
+**Saturation, stated precisely.** When `K = P`, `nbr[p,k] = k` and every slot
+is valid: `Dg[p] = Jf` for every `p`, the trace carries
+`ε[..., p, (q,a)] = ∂h[q,a]/∂θ[..., p]` in full, and the solve contracts it
+against the whole signal. That is **full within-group RTRL**. It equals the
+true total gradient — and hence BPTT — exactly when the model's global
+hidden→hidden Jacobian is block-diagonal with respect to the compiler's
+grouping, since no cross-group block ever enters any group's `Jf`. The
+sufficient structural condition the acceptance test asserts is that the
+compiled graph has exactly one hidden group.
+
+### Padding
+
+Neighbourhoods are not uniform in size (a sparse adjacency gives some positions
+fewer neighbours), but the arrays must be rectangular. `K = max_p |N(p)|`;
+short rows are padded with the dummy index `p` itself and `valid[p,k] = False`.
+A masked slot has a zero row *and* column in `Dg` and a zero instantaneous
+term, so its trace value is zero for all time and contributes nothing to the
+solve. The mask is applied to `Dg` and to `sig`, so no invalid entry can leak
+through either the recursion or the contraction.
+
+## The adjacency analysis
+
+### What is derived
+
+Per hidden group, a boolean `A[p, q]` = "`h_p^t` may depend on `h_q^{t-1}`".
+The *n*-step neighbourhood is `N_n(p) ⊇ {q : (⋁_{k=0..n-1} A^k)[p, q]}`, always
+containing `p` (the `k = 0` term). `⊇` rather than `=` is deliberate: the
+representation is allowed to over-approximate, and § Per-axis factorisation
+says exactly when it does.
+
+**Soundness direction.** An over-approximation is safe: a superset
+neighbourhood costs memory and moves the coordinate *towards* exact, never
+away. An under-approximation would silently compute a different rule than the
+one requested — lesson 15's failure mode — so every uncertain case widens to
+all-to-all, and every widening emits a diagnostic naming the equation that
+caused it.
+
+### Per-axis factorisation
+
+`A` is represented **per axis of `varshape`**, as one square boolean pattern
+per axis with `A = ⊗ A_axis`. This is not an optimisation:
+
+- `tanh_rnn`'s hidden state is `(1, n_rec)` — the leading axis is a batch axis.
+  A flat all-to-all pattern would make `K = batch · n_rec` and waste a factor of
+  `batch` on couplings that are structurally impossible. The per-axis form gives
+  `(identity, full)` and `K = n_rec`.
+- The closure and the neighbour index both factor, so the closure runs on
+  `d`-sized matrices rather than `P`-sized ones.
+
+**The factorised closure is exact when at most one axis is non-identity, and a
+conservative superset otherwise.** `A^k = ⊗ A_i^k`, but
+`⋁_k (⊗_i A_i^k) ⊆ ⊗_i (⋁_k A_i^k)` with the inclusion generally strict — the
+right-hand side admits combinations that use `j` steps on one axis and `k ≠ j`
+on another. Every precise rule shipped here produces at most one non-identity
+axis, so on those the factorisation is exact; the conservative rule is
+all-`full`, where the distinction cannot arise. The inclusion direction is the
+safe one, and a unit test asserts containment rather than equality.
+
+### The rules
+
+The analysis walks the group's **transition jaxpr**. A precise pattern is
+returned only when *all* of the following hold; otherwise the pattern is
+`full` on every axis, with a diagnostic naming which condition failed:
+
+1. Exactly one position-mixing equation is reachable from the hidden invar,
+   using the classification `_eval_eqn` already applies (`is_etp_primitive`
+   minus `is_etp_enable_gradient_primitive`, plus
+   `_RECURRENT_WEIGHT_MIXING_PRIMITIVES`).
+2. That equation is at the **top level** of the transition jaxpr, and the
+   transition contains **no control-flow equation at all** (`scan`, `while`,
+   `cond`) and no call-like equation (`pjit`, `remat`, `custom_*_call`)
+   reachable from the hidden invar. A single static `dot` inside a length-`L`
+   scan executes `L` times and its transfer is `A^L`, not `A`; `cond` needs a
+   branch union; `while` needs a fixed point. `_jaxpr_mixes_from` answers
+   *whether* mixing occurs, not *what* its transfer matrix is, so none of these
+   can be composed with today's machinery.
+3. Its primitive has a **registered adjacency rule**.
+4. Its output `y` shape equals the group's `varshape`, and every equation on
+   the path from that output to the group's outvars is shape-preserving and
+   elementwise. Without this, a transpose, reshape, reduction or gather between
+   the mixing op and the hidden state can relabel or re-mix the axes, and an
+   axis-indexed pattern derived at the op would be attached to the wrong axis
+   of the group. `_simplify_hid2hid_tracer` filters on shape and layer
+   membership, never on axis provenance, so nothing upstream guarantees this.
+
+Registered adjacency rules — deliberately only two families, both with fixed,
+inspectable semantics:
+
+- **`etp_mm` / `etp_mv`** (`y = x @ W`, `W` of shape `(I, O)`) →
+  `identity` on every axis but the last, `full` on the last.
+- **`etp_sp_mm` / `etp_sp_mv`** → the sparsity pattern itself, read from the
+  equation's static `sparse_mat` parameter — **transposed**. The forward is
+  `y = x @ W`, so `h_p` depends on `h_q` iff `W[q, p] ≠ 0`, i.e.
+  `A = pattern.T`. The parameter is a `_HashableSparseMat` wrapper, so the
+  rule unwraps it, materialises the boolean pattern once at compile time, and
+  validates that it is square (a non-square recurrent weight cannot be a
+  within-group transition and falls back conservatively).
+  This is the one rule that produces a **finely graded** scale: with a random
+  sparse recurrent weight `K` grows smoothly with `n` up to saturation, which
+  is SnAp's own setting. The pattern is a *static equation parameter*, not
+  trainable data, so reading it is structural — no value inspection, no
+  dependence on which stored entries happen to be numerically zero.
+
+Everything else — `dot_general`, `conv_general_dilated`, `etp_conv`,
+`etp_einsum`, `etp_gmm`, `etp_gmv`, `etp_lora_*`, `etp_emb*` — is conservative.
+The tempting rule "the mixing happens on the last axis" is **unsound** for
+them: an einsum equation such as `btn,tu->bun` mixes a middle axis while
+leaving the last one intact, `dot_general` exposes arbitrary contraction
+dimensions, and convolution mixes spatial axes as well as channels. Being
+conservative costs memory on those models and nothing else. Convolution's
+receptive field is the case where the scale would be most finely graded and is
+the named follow-up.
+
+### Where it runs
+
+In `_compiler/position_graph.py`, called from
+`JaxprEvalForHiddenGroup._post_check` once per group, with the resulting
+pattern stored on the `HiddenGroup`. It runs only when the requested scope
+needs it (`n ≥ 2`); `diagonal` and `coupled` groups carry `None` and every
+existing code path is untouched.
+
+## Axis and API surface
+
+### `ETraceConfig`
+
+`recurrence_scope='sparse_n'` leaves `_UNIMPLEMENTED`. Canonicalisation and
+matrix rules:
+
+- **canonicalisation** — `sparse_n == 1` rewrites to
+  `recurrence_scope='coupled', sparse_n=None`. One coordinate, one spelling
+  (the P2 principle). `coupled` keeps the established name.
+- **rule 2** (existing) already requires a `jacobian` recursion for any
+  non-`diagonal` scope; `sparse_n` inherits it.
+- **rule 7** (existing) already pairs the `sparse_n` coefficient with its axis
+  value in both directions.
+- **rule 9** (new) — `sparse_n` requires `trace_factorization='per_param'`.
+- **rule 10** (new) — `sparse_n` must be an `int ≥ 1`; `bool` is rejected
+  (`_check_decay` sets the precedent). There is no "infinity" spelling: any `n`
+  at or above the group's diameter saturates, and saturation is a property of
+  the model, not of the vocabulary.
+
+### `HiddenGroup`
+
+Two additions, no removals:
+
+- `snap: Optional[SnapPattern] = None` — a frozen dataclass holding `n`, the
+  per-axis patterns, the neighbour index `(P, K)`, the validity mask `(P, K)`,
+  `K`, and whether the pattern was conservative.
+- `trace_state_width: int` property — `K · num_state` when `snap` is set, else
+  `num_state`.
+
+`diagonal_jacobian` dispatches on `snap`: when set, it materialises the full
+Jacobian and gathers `Dg`; otherwise unchanged. Because the dispatch lives
+there, `vjp_graph_executor._compute_hid2hid_jacobian` — including its
+descended-scan `vmap` branch — needs no change.
+
+### `ParamDimVjpAlgorithm`
+
+Six reads of `group.num_state` become `group.trace_state_width`:
+
+| site | what it sizes |
+|---|---|
+| `_init_param_dim_state` (`param_dim_vjp.py:122`) | trace allocation |
+| `_apply_relation_step` → `fp.recurrent` (`:423`) | fast recurrence |
+| `_apply_relation_step` → `_comp_recurrent_legacy` (`:426`) | legacy recurrence |
+| `_update_param_dim_etrace_chunked` → `suffix_products` (`:504`) | chunk products |
+| `_update_param_dim_etrace_chunked` → `fp.chunk` (`:516`) | chunk kernel |
+| `_solve_param_dim_weight_gradients` (`:672`) | the `== 1` solve shortcut |
+
+Plus one behavioural addition: `_solve_weight_gradients` gathers the learning
+signal onto the neighbour index before calling into the solve.
+
+`trace_dtype` casting and the singleton-batch re-insertion logic are rank-based
+and stay valid unchanged.
+
+The `== 1` shortcuts are the hazard here, and `S = 1, K > 1` is the
+configuration that exercises every one of them — it is a named test case, not a
+hoped-for coincidence.
+
+### `vjp_base`: one trace-input transform
+
+P2 rewrote the hidden Jacobians in `_substitute_hidden_jacobians`, gated by
+`_substitutes_hidden_jacobians`, and wrapped the fused stepper only when that
+gate was on. `sparse_n` keeps `temporal_recursion='jacobian'`, so that gate is
+**off** — placing `df` widening beside the substitution would silently skip the
+fused multi-step path entirely, which is the majority path for
+`ParamDimVjpAlgorithm` at `chunked_trace=False` and every IO-dim coordinate.
+
+So the two rewrites merge into one hook:
+
+```python
+def _transform_trace_inputs(self, xs, dfs, jacs) -> tuple: ...
+
+@property
+def _transforms_trace_inputs(self) -> bool:
+    return self._substitutes_hidden_jacobians or self._widens_for_snap
+```
+
+called at exactly three sites — the fused stepper wrapper and the two
+`_update_etrace_data` paths — with the engines' internal steppers left
+unwrapped, so every path transforms exactly once. This is P2's lesson 13
+structure, generalised rather than duplicated.
+
+### Preset
+
+`braintrace/_algorithm/snap_n.py`, a sibling module beside `ostl.py` /
+`e_prop.py` / `d_rtrl.py`:
+
+```python
+braintrace.SnAp(model, n=2, vjp_method='multi-step')
+```
+
+a thin factory over `ETraceConfig(recurrence_scope='sparse_n', sparse_n=n)`, in
+the style P2 established. `SnAp(model, n=1)` constructs the `coupled`
+coordinate and is therefore `OSTLRecurrent`'s coordinate — asserted, not
+assumed. Its docstring states plainly that the pattern is conservative for
+every primitive outside the two registered families and that the scale is
+within-group.
+
+### Roadmap coordinate table
+
+| Algorithm | factorization | recursion | recurrence_scope | signal | filter |
+|---|---|---|---|---|---|
+| `SnAp(n=1)` | per_param | jacobian | **coupled** | symmetric | none |
+| `SnAp(n≥2)` | per_param | jacobian | **sparse_n** (`sparse_n=n`) | symmetric | none |
+
+## Acceptance
+
+Every gradient criterion names a **finite-window** oracle path
+(`chunked_online_param_gradients`, `chunk_size < T`). The full-window
+multi-step path returns BPTT for every algorithm regardless of coordinates
+(F-23), so a criterion phrased there would be vacuous — roadmap lesson 2.
+
+Every gradient criterion also carries a **structural pin**: the compiled `K`,
+`M = K·S`, the relation's primitive, whether the pattern was conservative, and
+the number of hidden groups. Without them a criterion can pass at `K = 1` while
+believing it tested the scale — the review's sharpest point, and a direct
+descendant of lesson 4.
+
+1. **Regression, cheap end.** `recurrence_scope='diagonal'` still equals the
+   frozen `D_RTRL` golden values element-wise. The P2 golden set already covers
+   this; P3 adds no new capture, it just must not move.
+2. **Near end of the squeeze.** `SnAp(n=1)` equals today's `OSTLRecurrent`
+   element-wise, and its config is the `coupled` coordinate. Guarded by
+   `assert_gradients_differ(D_RTRL, OSTLRecurrent) ≥ 1e-6` on the same path, so
+   the comparison has content — measured at 6.27e-04.
+3. **Far end of the squeeze.** On a model with **exactly one hidden group**
+   (asserted structurally in the test, not chosen quietly) and an elementwise
+   `y → hidden` tail, `SnAp(n)` at saturation equals `bptt_param_gradients` to
+   float32 round-off (1e-6 relative). Pinned by `K == P` and
+   `assert_gradients_differ(SnAp(n=1), BPTT)`, so the far end is not trivially
+   reachable. Repeated at chunk sizes 1, `T-1`, and a non-divisor of `T`, and
+   on both trace-update implementations (`chunked_trace` True and False).
+4. **Nestedness, not accuracy.** `N_n(p) ⊆ N_{n+1}(p)` for every `p` and every
+   `n`, and the saturated pattern is a fixed point. The *gradient error* curve
+   in `n` is **reported, not asserted**: nested masks do not imply monotone
+   error, because a newly retained path can overshoot terms the truncation was
+   previously cancelling against, so a correct implementation may legitimately
+   produce a non-monotone curve and a hand-picked model could make a wrong one
+   look monotone.
+5. **Trace-state storage** (renamed from "memory"). Summed trace-leaf element
+   counts are non-decreasing in `n`, and the **exact `K` sequence** is asserted
+   for the sparse model rather than only its monotonicity. Storage of the
+   transition operator `Dg` (`P·K²·S²`) is budgeted separately (§ Risks 2) —
+   the trace metric is not a memory metric and is not presented as one.
+6. **Model-agnostic.** The scale runs, at saturation, on a primitive with no
+   closed-form fast path (LoRA), pinned by the relation's primitive so the test
+   cannot pass having silently taken the dense path. Every primitive that
+   declares `snap_anchor=True` gets at least a width-level test that its
+   allocated trace is `K·S` wide.
+7. **Anchor rejection.** `etp_einsum` with a shared axis raises at
+   `compile_graph` under `sparse_n`, with a message naming the primitive; the
+   same model still compiles under `diagonal` and `coupled`.
+8. **Degeneracy pins.** `sparse_n` on `two_state_rnn` — whose v/a coupling is
+   hand-written arithmetic, not an ETP op, so no mixing equation exists and
+   `K = 1` at every `n` — equals `coupled` equals `D_RTRL`, *and* the analysis
+   is asserted to have returned `identity` for a structural reason rather than
+   by defaulting. Lesson 10: a pair that starts differing is as much a
+   regression as one that stops.
+9. **Conservative fallbacks fire where they should.** Two mixing equations,
+   nested control flow, an unregistered mixing primitive, and a non-elementwise
+   tail each produce the all-`full` pattern *and* the diagnostic.
+10. **Illegal combinations** raise readable errors naming the legal pairings:
+    `io_factorized` + `sparse_n`, `sparse_n` + `scalar_leak`, `sparse_n=0`,
+    `sparse_n=True`, `sparse_n` inside a descended scan.
+11. **Coordinates asserted** against the table above, so it cannot drift.
+
+## Test plan
+
+Written before the implementation. Test files are **siblings** of the module
+under test, per `AGENTS.md` rule 9 — never a `tests/` directory. (P2's
+`_algorithm/tests/` predates this and is left alone; P3 adds nothing to it.)
+
+`braintrace/_compiler/position_graph_test.py` — pure, no gradients:
+
+- `tanh_rnn` → `(identity, full)`; `K == n_rec`, not `batch · n_rec`.
+- no mixing equation → `identity` everywhere, `K == 1` at every `n`.
+- sparse recurrent weight → the pattern equals `sparse_mat`'s pattern
+  **transposed**; the exact `K` sequence in `n`; saturation at `P`.
+- two mixing equations / nested control flow / unregistered primitive /
+  non-elementwise tail → all-`full` + the diagnostic (one case each).
+- closure is monotone and idempotent past saturation; the factorised closure
+  **contains** the flat closure (containment, not equality — § Per-axis).
+- `nbr[p, 0] == p` always; padded slots are marked invalid.
+
+`braintrace/_compiler/hidden_group_test.py` — additions:
+
+- `K = 1` reproduces today's `block_diagonal_last_dim` output bit-for-bit; the
+  scale's identity element is exact, not approximately exact.
+- `K = P`, all valid → `Dg[p] == Jf` for every `p`.
+- a masked slot has a zero row and column in `Dg`.
+
+`braintrace/_algorithm/snap_n_test.py` — criteria 2–9, each carrying
+`assert_model_is_live` (lesson 4) and, where it asserts a difference,
+`assert_gradients_differ`. Includes the `S = 1, K > 1` case that exercises every
+former `num_state == 1` shortcut, and the three-trace-path agreement check.
+
+`braintrace/_algorithm/axes_test.py` — canonicalisation `n=1 → coupled`, rules
+9/10, `describe()` round-trip.
+
+`braintrace/_op/*_test.py` — one `snap_anchor` declaration test per primitive.
+
+New oracle model: a recurrent sparse RNN
+(`h^t = tanh(x @ W_in + sparse_matmul(h^{t-1}, w, sparse_mat=CSR))`).
+**Verified constructible before this spec was written**: the compiler discovers
+one hidden group with `varshape (N,)`, and under `include_recurrent_mixing=True`
+the transition contains `etp_sp_mv` carrying `sparse_mat` as a static equation
+parameter.
+
+## Risks
+
+1. **The far end is not exact for the wrong reason.** Saturation is exact only
+   under two preconditions — single hidden group (no cross-group block) and an
+   elementwise `y → hidden` tail (so `df` is a diagonal, not row sums). Both are
+   pre-existing properties of the compiler, not new. Mitigation: criterion 3
+   asserts the first structurally and runs on a model that satisfies the second;
+   the hand-written full-RTRL check measured 7.96e-08 against BPTT on exactly
+   that model before any of this was written.
+
+2. **`Dg` is `O(P·K²·S²)` to store.** The gather materialises the full Jacobian
+   first, exactly as `coupled` does today, so the *peak* is unchanged from the
+   existing coupled path — but the stored operator at saturation is `P³S²`.
+   Affordable for the small dense groups this targets, unaffordable for a large
+   one. Mitigation: document the bound beside `block_diagonal_last_dim`'s
+   existing note and emit a diagnostic when `P·K²·S²` crosses a threshold. A
+   matrix-free per-position `vmap(jacrev)` trades it for compute and is the
+   named follow-up.
+
+3. **The scale is two-point on most models.** With convolution, einsum,
+   `dot_general` and LoRA all conservative, and dense matmul saturating at
+   `n = 2`, only the sparse family is finely graded. That is an honest
+   consequence of the soundness requirement, not an oversight — but it means
+   the phase's headline must claim *derived, conservative-by-default* patterns
+   rather than general automatic receptive-field inference. Criteria 4 and 5
+   name the sparse model as their subject precisely because it is the one where
+   the intermediate range is non-empty.
+
+4. **A widened trace silently degrades to `K = 1`.** If the analysis returns
+   `identity` where it should not, the user asks for `sparse_n` and receives
+   `coupled` — lesson 15 again. Degeneracy is *legitimate* on some models
+   (criterion 8), so it cannot simply raise. Mitigation: `SnAp` emits a
+   diagnostic naming the group whenever `K = 1` at `n ≥ 2`, criterion 8 asserts
+   the diagnostic fires on exactly the models where degeneracy is expected, and
+   every gradient criterion pins `K` structurally.
+
+5. **The unified trace-input transform is applied twice, or zero times.** The
+   gate now has two independent sources. Mitigation: the three-call-site
+   structure P2 settled on, plus a test that all three trace paths agree to
+   round-off under `sparse_n` *and* that `diagonal` gradients are unchanged
+   bit-for-bit (criterion 1 catches a stray transform on the default path).
+
+## Out of scope
+
+Everything the roadmap assigns to P4 and P5. `update_schedule`, UORO,
+`modulatory`, `bootstrapped` and the benchmark suite are untouched. The F-30
+IO-dim bias-correction defect stays unfixed and stays pinned by its existing
+test, and `etp_einsum`'s shared-axis trace layout is **not** redesigned here —
+lesson 17: a numerical correction does not ride along inside a phase whose
+acceptance is that specific gradients do not move.


### PR DESCRIPTION
## Summary

Adds `recurrence_scope='sparse_n'` and the `braintrace.SnAp` preset — SnAp-n
(Menick et al., 2021), the interpolation between the cheap and the exact end of
the recurrence-scope axis.

The point of doing this in a compiler rather than a library: the n-step
influence sparsity pattern is **derived**, not declared. `position_graph.py`
reads the hidden group's transition jaxpr, extracts the one-step position
adjacency from the recurrent mixing primitive, closes it `n-1` times, and hands
back the retained neighbourhood. The trace's trailing `num_state` axis `S`
widens to a `(neighbour, state)` axis of width `M = K·S`, and not one of the
nine ETP primitive rules needed changing.

Both ends of the scale turned out to be in the codebase already: `n=1`
canonicalises to `recurrence_scope='coupled'` (`OSTLRecurrent`'s rule), and any
`n` at or above a group's position-graph diameter saturates to full within-group
RTRL. `diagonal` sits *below* the scale rather than on it.

## Measured

`sparse_ring_rnn(n_rec=6)` (diameter 5), `chunk_size=3`, `T=8`, against the BPTT
oracle on the ETP parameter:

| n | K | trace scalars | rel. deviation from BPTT |
|---|---|---|---|
| 1 | 1 | 12 | 2.32e-01 |
| 2 | 2 | 24 | 4.96e-03 |
| 3 | 3 | 36 | 5.93e-04 |
| 4 | 4 | 48 | 2.22e-04 |
| 5 | 5 | 60 | 8.03e-08 |
| 6 | 6 | 72 | 8.03e-08 |

Memory exactly linear in `K` and saturating with it; accuracy monotone, reaching
round-off at `n = diameter`.

## Safety properties

- **`snap_anchor` is declared per primitive and defaults to deny.** A trace slot
  must have one well-defined hidden position its instantaneous term lands on.
  Nine primitives declare it; `etp_emb` and shared-axis `etp_einsum` are
  rejected with a message naming the legal scopes.
- **Unreadable adjacency widens, and says so.** An unregistered mixing
  primitive, more than one mixing equation, control flow, or a
  non-position-preserving tail all fall back to all-to-all with
  `SNAP_PATTERN_CONSERVATIVE`. `K == 1` emits `SNAP_PATTERN_DEGENERATE` rather
  than quietly computing `coupled` under a `sparse_n` label.
- **The reachability closure is boolean throughout.** An integer closure counts
  paths and wraps, which would under-approximate the neighbourhood — the one
  error direction a conservative analysis may never have.
- **The widened block Jacobian is budgeted** at `P·(K·S)²` elements, with
  `snap_max_jacobian_elements` to raise it deliberately.

## Tests

122 new tests; full suite 2388 passed, `mypy braintrace` clean.

Acceptance is a two-sided squeeze — `n=1` equals `OSTLRecurrent` element-wise
and saturation equals BPTT, both through the finite-window oracle since the
full-window path is blind to every axis (F-23) — plus:

- an independent hand-written **masked-RTRL** reference for the interior orders
  (`n = 2,3,4` match to `<1e-6`; a deliberately narrower reference misses by
  `1.2e-1`), because the endpoints are no evidence about the middle;
- all **eleven** anchored primitives executed at a saturating order on both the
  fast and legacy solve paths;
- a strictly directed fixture pinning that the neighbourhood runs *downstream*
  of its anchor — the orientation no size-based assertion can see.

## Also

Documents **F-31** in the known-limitations list: on a hidden group whose
`y → hidden` tail relabels positions, no within-group scope reaches BPTT,
saturated SnAp included, and the saturated rule is *further* from BPTT than the
cheaper ones (1.30 vs 1.03, against 1.3e-07 for the same model with the
relabelling removed). Pre-existing and structural — it hits `diagonal` and
`coupled` identically — detected and warned about rather than silent. The
conservative diagnostic previously read "the gradient stays correct", which is
true of the pattern but over-claims about the returned gradient; it now says the
approximation is not degraded and points at F-31.

Roadmap lessons 18–30 record what generalises, including the five findings an
adversarial review of the finished implementation turned up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
