### PR TITLE
Convert remaining Google-style docstrings to NumPy style

### DIFF
--- a/braintrace/_algorithm/_common.py
+++ b/braintrace/_algorithm/_common.py
@@ -208,19 +208,18 @@ def _reset_state_in_a_dict(
     Reset the values in a dictionary of states to zero.
 
     This function iterates over a dictionary of states and resets each state's
-    value to a zero array. The shape of the zero array is determined by the
-    original shape of the state's value and the specified batch size.
+    value to a zero array, modifying ``state_dict`` in place. The shape of the
+    zero array is determined by the original shape of the state's value and the
+    specified batch size.
 
-    Args:
-        state_dict (Dict[Any, brainstate.State]): A dictionary where keys are any
-            type and values are brainstate.State objects. Each state's value will be
-            reset to a zero array.
-        batch_size (Optional[int]): The size of the batch. If provided, the
-            zero array will include a batch dimension; otherwise, it will not.
-
-    Returns:
-        None: The function modifies the state_dict in place, resetting each
-        state's value to a zero array.
+    Parameters
+    ----------
+    state_dict : Dict[Any, brainstate.State]
+        A dictionary where keys are any type and values are brainstate.State
+        objects. Each state's value will be reset to a zero array.
+    batch_size : int, optional
+        The size of the batch. If provided, the zero array will include a batch
+        dimension; otherwise, it will not.
     """
     for k, v in state_dict.items():
         state_dict[k].value = jax.tree.map(partial(_zeros_like_batch_or_not, batch_size), v.value)
@@ -238,17 +237,21 @@ def _zeros_like_batch_or_not(
     of the input array `x`. If a batch size is provided, the zeros array will
     include an additional batch dimension at the beginning.
 
-    Args:
-        batch_size (Optional[int]): The size of the batch. If provided, the
-            zeros array will include a batch dimension. If None, the zeros
-            array will have the same shape as `x`.
-        x (jax.Array): The input array whose shape and data type are used as
-            a reference for creating the zeros array.
+    Parameters
+    ----------
+    batch_size : int, optional
+        The size of the batch. If provided, the zeros array will include a
+        batch dimension. If None, the zeros array will have the same shape
+        as `x`.
+    x : jax.Array
+        The input array whose shape and data type are used as a reference for
+        creating the zeros array.
 
-    Returns:
-        jax.Array: A zeros array with the same shape and data type as the
-        input array, optionally including a batch dimension if `batch_size`
-        is provided.
+    Returns
+    -------
+    jax.Array
+        A zeros array with the same shape and data type as the input array,
+        optionally including a batch dimension if `batch_size` is provided.
     """
     if batch_size is not None:
         assert isinstance(batch_size, int), 'The batch size should be an integer. '
@@ -271,18 +274,22 @@ def _batched_zeros_like(
     states. If a batch size is provided, the zeros array will also include
     a batch dimension.
 
-    Args:
-        batch_size (Optional[int]): The size of the batch. If None, the
-            batch dimension is not included.
-        num_state (int): The number of hidden states, which determines the
-            size of the additional dimension in the zeros array.
-        x (jax.Array): The input array whose shape is used as a reference
-            for creating the zeros array.
+    Parameters
+    ----------
+    batch_size : int, optional
+        The size of the batch. If None, the batch dimension is not included.
+    num_state : int
+        The number of hidden states, which determines the size of the
+        additional dimension in the zeros array.
+    x : jax.Array
+        The input array whose shape is used as a reference for creating the
+        zeros array.
 
-    Returns:
-        jax.Array: A zeros array with the same shape as the input array,
-        extended by the number of hidden states, and optionally including
-        a batch dimension.
+    Returns
+    -------
+    jax.Array
+        A zeros array with the same shape as the input array, extended by the
+        number of hidden states, and optionally including a batch dimension.
     """
     if batch_size is None:
         return u.math.zeros((*x.shape, num_state), x.dtype)
@@ -298,13 +305,18 @@ def _sum_dim(xs: jax.Array, axis: int = -1) -> Any:
     within a PyTree structure. It is useful for reducing the dimensionality of
     arrays by aggregating values along the specified axis.
 
-    Args:
-        xs (jax.Array): A PyTree of arrays where each array will have its last
-                        dimension summed.
+    Parameters
+    ----------
+    xs : jax.Array
+        A PyTree of arrays where each array will have its last dimension summed.
+    axis : int, optional
+        The axis to sum over. Defaults to ``-1`` (the last dimension).
 
-    Returns:
-        jax.Array: A PyTree with the same structure as the input, where each array
-                   has been reduced by summing over its last dimension.
+    Returns
+    -------
+    jax.Array
+        A PyTree with the same structure as the input, where each array has
+        been reduced by summing over its last dimension.
     """
     return jax.tree.map(lambda x: u.math.sum(x, axis=axis), xs)
 
@@ -390,14 +402,18 @@ def _route_grads_by_path(
     into ``per_path``, then wrap with ``_wrap_leaves_as_pytree`` and merge into
     ``target_dict`` via ``_update_dict``.
 
-    Args:
-        relation: HiddenParamOpRelation — provides ``trainable_paths`` and
-            ``trainable_leaf_indices``.
-        per_key_grads: Dict[str, Array] — gradient contributions keyed by
-            trainable invar name (e.g. ``'weight'``, ``'lora_b'``).
-        weight_vals: Dict[Path, PyTree] — current ParamState pytree values;
-            used as the structure template for ``_wrap_leaves_as_pytree``.
-        target_dict: Dict[Path, PyTree] — accumulation target, modified in place.
+    Parameters
+    ----------
+    relation : HiddenParamOpRelation
+        Provides ``trainable_paths`` and ``trainable_leaf_indices``.
+    per_key_grads : Dict[str, jax.Array]
+        Gradient contributions keyed by trainable invar name (e.g.
+        ``'weight'``, ``'lora_b'``).
+    weight_vals : Dict[Path, PyTree]
+        Current ParamState pytree values; used as the structure template for
+        ``_wrap_leaves_as_pytree``.
+    target_dict : Dict[Path, PyTree]
+        Accumulation target, modified in place.
     """
     per_path: Dict[Any, Dict[int, jax.Array]] = {}
     for key, grad in per_key_grads.items():
@@ -420,12 +436,16 @@ def _update_dict(
     If the key exists, then add the value to the existing value.
     Otherwise, create a new key-value pair.
 
-    Args:
-      the_dict: The dictionary.
-      key: The key.
-      value: The value.
-      error_when_no_key: bool, whether to raise an error when the key does not exist.
-
+    Parameters
+    ----------
+    the_dict : Dict
+        The dictionary.
+    key : Any
+        The key.
+    value : PyTree
+        The value.
+    error_when_no_key : bool, optional
+        Whether to raise an error when the key does not exist.
     """
     if key not in the_dict:
         if error_when_no_key:

--- a/braintrace/_algorithm/graph_executor.py
+++ b/braintrace/_algorithm/graph_executor.py
@@ -193,19 +193,14 @@ class ETraceGraphExecutor:
 
         This method is crucial for constructing the graph used in the eligibility trace
         algorithm, which is essential for calculating weight spatial gradients and the
-        hidden state Jacobian.
+        hidden state Jacobian. It initializes the compiled graph attribute of the
+        instance.
 
         Parameters
         ----------
         *args
             Positional arguments for the model, which may include inputs, parameters, or
             other necessary data required for graph compilation.
-
-        Returns
-        -------
-        None
-            This method does not return any value. It initializes the compiled graph
-            attribute of the instance.
         """
 
         # invalidate cached mappings on recompilation

--- a/braintrace/_algorithm/io_dim_vjp.py
+++ b/braintrace/_algorithm/io_dim_vjp.py
@@ -83,23 +83,30 @@ def _format_decay_and_rank(decay_or_rank: Any) -> Tuple[float, int]:
     If the input is an integer, it is treated as the number of ranks, and the decay factor
     is calculated.
 
-    Args:
-        decay_or_rank (float or int): The decay factor (a float in ``[0, 1)``) or the
-                                      number of approximation ranks (a positive integer).
+    Parameters
+    ----------
+    decay_or_rank : float or int
+        The decay factor (a float in ``[0, 1)``) or the number of approximation
+        ranks (a positive integer).
 
-    Returns:
-        Tuple[float, int]: A tuple containing the decay factor and the number of approximation ranks.
+    Returns
+    -------
+    tuple of (float, int)
+        A tuple containing the decay factor and the number of approximation ranks.
 
-    Raises:
-        ValueError: If the input is neither a float nor an integer, or if the float is not in the range [0, 1),
-                    or if the integer is not greater than 0.
+    Raises
+    ------
+    ValueError
+        If the input is neither a float nor an integer, or if the float is not
+        in the range [0, 1), or if the integer is not greater than 0.
 
-    Notes:
-        The lower bound is inclusive so that ``temporal_recursion='none'`` is
-        expressible as a float. It introduces no new numerical regime: decay 0
-        was already reachable as ``decay_or_rank=1`` (rank 1 -> decay 0), and the
-        bias correction's exponent ``running_index + 1`` is always >= 1, so
-        ``0 ** k`` is 0 and the correction factor is exactly 1.
+    Notes
+    -----
+    The lower bound is inclusive so that ``temporal_recursion='none'`` is
+    expressible as a float. It introduces no new numerical regime: decay 0
+    was already reachable as ``decay_or_rank=1`` (rank 1 -> decay 0), and the
+    bias correction's exponent ``running_index + 1`` is always >= 1, so
+    ``0 ** k`` is 0 and the correction factor is exactly 1.
     """
     # number of approximation rank and the decay factor
     if isinstance(decay_or_rank, float):
@@ -122,15 +129,20 @@ def _format_decays(decay_or_rank: Any) -> Tuple[float, float]:
     either a float decay in ``[0, 1)`` or an integer rank ``>= 1`` mapping
     through ``decay = (rank - 1) / (rank + 1)``.
 
-    Args:
-        decay_or_rank: A scalar or a two-entry sequence.
+    Parameters
+    ----------
+    decay_or_rank : Any
+        A scalar or a two-entry sequence.
 
-    Returns:
-        Tuple[float, float]: The x-side and f-side decays.
+    Returns
+    -------
+    tuple of (float, float)
+        The x-side and f-side decays.
 
-    Raises:
-        ValueError: If a pair does not have exactly two entries, or an entry is
-            out of range.
+    Raises
+    ------
+    ValueError
+        If a pair does not have exactly two entries, or an entry is out of range.
     """
     if isinstance(decay_or_rank, (tuple, list)):
         if len(decay_or_rank) != 2:
@@ -153,14 +165,20 @@ def _expon_smooth(old: Any, new: Any, decay: Any) -> Any:
     with the new value. If the new value is None, the function returns the old
     value scaled by the decay factor.
 
-    Args:
-        old: The old value to be smoothed.
-        new: The new value to be incorporated into the smoothing. If None, only
-             the old value scaled by the decay factor is returned.
-        decay: The decay factor, a float between 0 and 1, that determines the
-               weight of the old value in the smoothing process.
+    Parameters
+    ----------
+    old : Any
+        The old value to be smoothed.
+    new : Any
+        The new value to be incorporated into the smoothing. If None, only the
+        old value scaled by the decay factor is returned.
+    decay : Any
+        The decay factor, a float between 0 and 1, that determines the weight
+        of the old value in the smoothing process.
 
-    Returns:
+    Returns
+    -------
+    Any
         The smoothed value, which is a combination of the old and new values
         weighted by the decay factor.
     """
@@ -214,19 +232,23 @@ def _init_IO_dim_state(
     the df, and records the target paths of the weight x if it is used
     repeatedly in the graph.
 
-    Args:
-        etrace_xs (Dict[ETraceX_Key, brainstate.State]): A dictionary to store the
-            eligibility trace states for the weight x, keyed by ETraceX_Key.
-        etrace_dfs (Dict[ETraceDF_Key, brainstate.State]): A dictionary to store the
-            eligibility trace states for the differential functions, keyed by
-            ETraceDF_Key.
-        relation (HiddenParamOpRelation): The relation object containing
-            information about the weights and hidden groups involved in the
-            computation.
+    Parameters
+    ----------
+    etrace_xs : Dict[ETraceX_Key, brainstate.State]
+        A dictionary to store the eligibility trace states for the weight x,
+        keyed by ETraceX_Key.
+    etrace_dfs : Dict[ETraceDF_Key, brainstate.State]
+        A dictionary to store the eligibility trace states for the differential
+        functions, keyed by ETraceDF_Key.
+    relation : HiddenParamOpRelation
+        The relation object containing information about the weights and hidden
+        groups involved in the computation.
 
-    Raises:
-        ValueError: If a relation with the same key has already been added to
-            the eligibility trace states.
+    Raises
+    ------
+    ValueError
+        If a relation with the same key has already been added to the
+        eligibility trace states.
     """
     # For the relation
     #
@@ -333,25 +355,31 @@ def _update_IO_dim_etrace_scan_fn(
     They are equal for every shipped preset; the split exists so an asymmetric
     coordinate is expressible.
 
-    Args:
-        hist_etrace_vals (Tuple[Dict[ETraceX_Key, jax.Array], Dict[ETraceDF_Key, jax.Array]]):
-            A tuple containing dictionaries of historical eligibility trace
-            values for the weight x and df, keyed by ETraceX_Key and
-            ETraceDF_Key, respectively.
-        jacobians (Tuple[Dict[ETraceX_Key, jax.Array], Dict[ETraceDF_Key, jax.Array], Sequence[jax.Array]]):
-            A tuple containing dictionaries of current Jacobian values for the
-            weight x and df, and a sequence of hidden group Jacobians.
-        hid_weight_op_relations (Sequence[HiddenParamOpRelation]):
-            A sequence of HiddenParamOpRelation objects representing the
-            relationships between hidden parameters and operations.
-        decay (float): The decay factor used in the low-pass filter, a value
-            between 0 and 1.
+    Parameters
+    ----------
+    hist_etrace_vals : Tuple[Dict[ETraceX_Key, jax.Array], Dict[ETraceDF_Key, jax.Array]]
+        A tuple containing dictionaries of historical eligibility trace values
+        for the weight x and df, keyed by ETraceX_Key and ETraceDF_Key,
+        respectively.
+    jacobians : Tuple[Dict[ETraceX_Key, jax.Array], Dict[ETraceDF_Key, jax.Array], Sequence[jax.Array]]
+        A tuple containing dictionaries of current Jacobian values for the
+        weight x and df, and a sequence of hidden group Jacobians.
+    hid_weight_op_relations : Sequence[HiddenParamOpRelation]
+        A sequence of HiddenParamOpRelation objects representing the
+        relationships between hidden parameters and operations.
+    decay_x : float
+        The decay factor applied to the presynaptic input trace in the low-pass
+        filter, a value between 0 and 1.
+    decay_f : float
+        The decay factor applied to the Jacobian-propagated output trace in the
+        low-pass filter, a value between 0 and 1.
 
-    Returns:
-        Tuple[Dict[ETraceX_Key, jax.Array], Dict[ETraceDF_Key, jax.Array]]:
-            A tuple containing dictionaries of updated eligibility trace values
-            for the weight x and df, keyed by ETraceX_Key and ETraceDF_Key,
-            respectively.
+    Returns
+    -------
+    Tuple[Dict[ETraceX_Key, jax.Array], Dict[ETraceDF_Key, jax.Array]]
+        A tuple containing dictionaries of updated eligibility trace values for
+        the weight x and df, keyed by ETraceX_Key and ETraceDF_Key,
+        respectively.
     """
     # --- the data --- #
 
@@ -507,33 +535,34 @@ def _solve_IO_dim_weight_gradients(
 
     This function calculates the weight gradients by utilizing the eligibility trace data and the
     hidden-to-hidden Jacobians. It applies a correction factor to avoid exponential smoothing bias
-    at the beginning of the computation.
+    at the beginning of the computation, and updates the ``dG_weights`` dictionary in place.
 
-    Args:
-        hist_etrace_data (Tuple[Dict[ETraceX_Key, jax.Array], Dict[ETraceDF_Key, jax.Array]]):
-            A tuple containing dictionaries of historical eligibility trace values for the weight x
-            and differential functions (df), keyed by ETraceX_Key and ETraceDF_Key, respectively.
-        dG_weights (Dict[Path, dG_Weight]):
-            A dictionary to store the computed weight gradients, keyed by the path of the weight.
-        dG_hidden_groups (Sequence[jax.Array]):
-            A sequence of hidden group Jacobians, with the same length as the total number of hidden groups.
-        weight_hidden_relations (Sequence[HiddenParamOpRelation]):
-            A sequence of HiddenParamOpRelation objects representing the relationships between hidden
-            parameters and operations.
-        weight_vals (Dict[Path, WeightVals]):
-            A dictionary containing the current values of the weights, keyed by their paths.
-        running_index (int):
-            The current index in the running sequence, used to compute the correction factor.
-            See F-30 in ``docs/specs/2026-07-25-known-limitations.md``: this counts
-            ``update()`` calls, not trace steps, so the correction is exact only for
-            single-step input.
-        decay_f (float):
-            The f-side decay factor used in the exponential smoothing process, a value
-            in ``[0, 1)``. Only the f-side is corrected: the x-side low-pass has no
-            ``(1 - alpha)`` input weight and therefore no warm-up bias to undo.
-
-    Returns:
-        None: The function updates the dG_weights dictionary in place with the computed weight gradients.
+    Parameters
+    ----------
+    hist_etrace_data : Tuple[Dict[ETraceX_Key, jax.Array], Dict[ETraceDF_Key, jax.Array]]
+        A tuple containing dictionaries of historical eligibility trace values for the weight x
+        and differential functions (df), keyed by ETraceX_Key and ETraceDF_Key, respectively.
+    dG_weights : Dict[Path, dG_Weight]
+        A dictionary to store the computed weight gradients, keyed by the path of the weight.
+    dG_hidden_groups : Sequence[jax.Array]
+        A sequence of hidden group Jacobians, with the same length as the total number of hidden groups.
+    weight_hidden_relations : Sequence[HiddenParamOpRelation]
+        A sequence of HiddenParamOpRelation objects representing the relationships between hidden
+        parameters and operations.
+    weight_vals : Dict[Path, WeightVals]
+        A dictionary containing the current values of the weights, keyed by their paths.
+    running_index : int
+        The current index in the running sequence, used to compute the correction factor.
+        See F-30 in ``docs/specs/2026-07-25-known-limitations.md``: this counts
+        ``update()`` calls, not trace steps, so the correction is exact only for
+        single-step input.
+    decay_f : float
+        The f-side decay factor used in the exponential smoothing process, a value
+        in ``[0, 1)``. Only the f-side is corrected: the x-side low-pass has no
+        ``(1 - alpha)`` input weight and therefore no warm-up bias to undo.
+    fast_solve : bool, optional
+        Whether to use the per-primitive fast contraction instead of the legacy
+        vmap path.
     """
     # Bias correction for exponential smoothing
     #   ε_f^t = α ε_f^{t-1} + (1-α) x_t  =>  E[ε_f^t] = x · (1 - α^{t+1})
@@ -908,8 +937,10 @@ class IODimVjpAlgorithm(ETraceVjpAlgorithm):
 
             This is the protocol method that should be implemented in the subclass.
 
-        Returns:
-            ETraceVals, the eligibility trace data.
+        Returns
+        -------
+        ETraceVals
+            The eligibility trace data.
         """
         etrace_xs = {k: v.value for k, v in self.etrace_xs.items()}
         etrace_dfs = {k: v.value for k, v in self.etrace_dfs.items()}
@@ -928,8 +959,10 @@ class IODimVjpAlgorithm(ETraceVjpAlgorithm):
 
             This is the protocol method that should be implemented in the subclass.
 
-        Args:
-            hist_etrace_vals: ETraceVals, the eligibility trace data.
+        Parameters
+        ----------
+        hist_etrace_vals : ETraceVals
+            The eligibility trace data.
         """
         #
         # For any operation:
@@ -989,25 +1022,31 @@ class IODimVjpAlgorithm(ETraceVjpAlgorithm):
         trace values along with current Jacobians to compute the updated eligibility
         traces according to the algorithm's update rules.
 
-        Args:
-            running_index: Optional[int]
-                The current timestep index. Used for decay correction factors.
-            hist_etrace_vals: Tuple[Dict[ETraceX_Key, jax.Array], Dict[ETraceDF_Key, jax.Array]]
-                The eligibility trace values from the previous timestep, containing:
-                - Dictionary mapping weight inputs to their trace values
-                - Dictionary mapping differential functions to their trace values
-            hid2weight_jac_single_or_multi_times: Hid2WeightJacobian
-                The current hidden-to-weight Jacobians at time t (or t-1 depending on vjp_method).
-            hid2hid_jac_single_or_multi_times: HiddenGroupJacobian
-                The current hidden-to-hidden Jacobians for propagating gradients.
-            weight_vals: WeightVals
-                The current values of the model weights.
+        Parameters
+        ----------
+        running_index : int, optional
+            The current timestep index. Used for decay correction factors.
+        hist_etrace_vals : Tuple[Dict[ETraceX_Key, jax.Array], Dict[ETraceDF_Key, jax.Array]]
+            The eligibility trace values from the previous timestep, containing:
 
-        Returns:
-            Tuple[Dict[ETraceX_Key, jax.Array], Dict[ETraceDF_Key, jax.Array]]:
-                Updated eligibility trace values for both input traces and differential
-                function traces, computed according to the exponential smoothing rules
-                of the algorithm.
+            - Dictionary mapping weight inputs to their trace values.
+            - Dictionary mapping differential functions to their trace values.
+        hid2weight_jac_single_or_multi_times : Hid2WeightJacobian
+            The current hidden-to-weight Jacobians at time t (or t-1 depending on vjp_method).
+        hid2hid_jac_single_or_multi_times : HiddenGroupJacobian
+            The current hidden-to-hidden Jacobians for propagating gradients.
+        weight_vals : WeightVals
+            The current values of the model weights.
+        input_is_multi_step : bool
+            Whether the Jacobian inputs span multiple time steps, selecting the
+            scan path over the single-step path.
+
+        Returns
+        -------
+        Tuple[Dict[ETraceX_Key, jax.Array], Dict[ETraceDF_Key, jax.Array]]
+            Updated eligibility trace values for both input traces and differential
+            function traces, computed according to the exponential smoothing rules
+            of the algorithm.
         """
         #
         # "running_index":
@@ -1076,24 +1115,28 @@ class IODimVjpAlgorithm(ETraceVjpAlgorithm):
         where ϵ represents the eligibility traces and ∂L/∂h are the gradients of
         the loss with respect to hidden states.
 
-        Args:
-            running_index: int
-                The current timestep index, used for correction factor calculation.
-            etrace_h2w_at_t: Tuple[Dict[ETraceX_Key, jax.Array], Dict[ETraceDF_Key, jax.Array]]
-                The eligibility trace data at the current timestep, containing:
-                - Dictionary mapping weight inputs to their trace values
-                - Dictionary mapping differential functions to their trace values
-            dl_to_hidden_groups: Sequence[jax.Array]
-                Gradients of the loss with respect to each hidden group/state.
-            weight_vals: Dict[Path, PyTree]
-                Current values of the model weights.
-            dl_to_nonetws_at_t: Dict[Path, PyTree]
-                Gradients for non-eligibility trace weights computed through standard backprop.
-            dl_to_etws_at_t: Optional[Dict[Path, PyTree]]
-                Optional additional gradients for eligibility trace weights.
+        Parameters
+        ----------
+        running_index : int
+            The current timestep index, used for correction factor calculation.
+        etrace_h2w_at_t : Tuple[Dict[ETraceX_Key, jax.Array], Dict[ETraceDF_Key, jax.Array]]
+            The eligibility trace data at the current timestep, containing:
 
-        Returns:
-            Dict[Path, jax.Array]: Computed gradients for all weights in the model.
+            - Dictionary mapping weight inputs to their trace values.
+            - Dictionary mapping differential functions to their trace values.
+        dl_to_hidden_groups : Sequence[jax.Array]
+            Gradients of the loss with respect to each hidden group/state.
+        weight_vals : Dict[Path, PyTree]
+            Current values of the model weights.
+        dl_to_nonetws_at_t : Dict[Path, PyTree]
+            Gradients for non-eligibility trace weights computed through standard backprop.
+        dl_to_etws_at_t : Dict[Path, PyTree], optional
+            Optional additional gradients for eligibility trace weights.
+
+        Returns
+        -------
+        Dict[Path, jax.Array]
+            Computed gradients for all weights in the model.
         """
 
         #

--- a/braintrace/_algorithm/param_dim_vjp.py
+++ b/braintrace/_algorithm/param_dim_vjp.py
@@ -166,23 +166,30 @@ def _update_param_dim_etrace_scan_fn(
     trace values by applying vector-Jacobian products and incorporating the current
     Jacobian values.
 
-    Args:
-        hist_etrace_vals (Dict[ETraceWG_Key, jax.Array]): A dictionary containing
-            historical eligibility trace values for the weight gradients, keyed by
-            ETraceWG_Key.
-        jacobians (Tuple[Dict[ETraceX_Key, jax.Array], Dict[ETraceDF_Key, jax.Array], Sequence[jax.Array]]):
-            A tuple containing dictionaries of current Jacobian values for the weight x
-            and df, and a sequence of hidden group Jacobians.
-        weight_path_to_vals (Dict[Path, PyTree]): A dictionary mapping weight paths to
-            their corresponding PyTree values.
-        hidden_param_op_relations: A sequence of HiddenParamOpRelation objects representing
-            the relationships between hidden parameters and operations.
-        mode (brainstate.mixin.Mode): The mode indicating whether batching is enabled.
+    Parameters
+    ----------
+    hist_etrace_vals : Dict[ETraceWG_Key, jax.Array]
+        A dictionary containing historical eligibility trace values for the
+        weight gradients, keyed by ETraceWG_Key.
+    jacobians : Tuple[Dict[ETraceX_Key, jax.Array], Dict[ETraceDF_Key, jax.Array], Sequence[jax.Array]]
+        A tuple containing dictionaries of current Jacobian values for the weight x
+        and df, and a sequence of hidden group Jacobians.
+    weight_path_to_vals : Dict[Path, PyTree]
+        A dictionary mapping weight paths to their corresponding PyTree values.
+    hidden_param_op_relations : Any
+        A sequence of HiddenParamOpRelation objects representing the
+        relationships between hidden parameters and operations.
+    fast_solve : bool, optional
+        Whether to use the per-primitive fast contraction instead of the legacy
+        vmap path.
+    trace_dtype : DTypeLike, optional
+        Optional dtype override for the updated trace values.
 
-    Returns:
-        Tuple[Dict[ETraceWG_Key, jax.Array], None]: A tuple containing a dictionary of
-        updated eligibility trace values for the weight gradients, keyed by ETraceWG_Key,
-        and None.
+    Returns
+    -------
+    Tuple[Dict[ETraceWG_Key, jax.Array], None]
+        A tuple containing a dictionary of updated eligibility trace values for
+        the weight gradients, keyed by ETraceWG_Key, and None.
     """
     # --- the data --- #
 
@@ -833,21 +840,27 @@ def _solve_param_dim_weight_gradients(
 
     This function calculates the weight gradients by utilizing the eligibility trace data and the
     hidden-to-hidden Jacobians. It applies a correction factor to avoid exponential smoothing bias
-    at the beginning of the computation.
+    at the beginning of the computation, and updates the ``dG_weights`` dictionary in place.
 
-    Args:
-        hist_etrace_data (Dict[ETraceWG_Key, PyTree]): A dictionary containing historical eligibility
-            trace data for the weight gradients, keyed by ETraceWG_Key.
-        dG_weights (Dict[Path, dG_Weight]): A dictionary to store the computed weight gradients,
-            keyed by the path of the weight.
-        dG_hidden_groups (Sequence[jax.Array]): A sequence of hidden group gradients, with the same
-            length as the total number of hidden groups.
-        weight_hidden_relations (Sequence[HiddenParamOpRelation]): A sequence of HiddenParamOpRelation
-            objects representing the relationships between hidden parameters and operations.
-        mode (brainstate.mixin.Mode): The mode indicating whether batching is enabled.
-
-    Returns:
-        None: The function updates the dG_weights dictionary in place with the computed weight gradients.
+    Parameters
+    ----------
+    hist_etrace_data : Dict[ETraceWG_Key, PyTree]
+        A dictionary containing historical eligibility trace data for the weight
+        gradients, keyed by ETraceWG_Key.
+    dG_weights : Dict[Path, dG_Weight]
+        A dictionary to store the computed weight gradients, keyed by the path
+        of the weight.
+    dG_hidden_groups : Sequence[jax.Array]
+        A sequence of hidden group gradients, with the same length as the total
+        number of hidden groups.
+    weight_hidden_relations : Sequence[HiddenParamOpRelation]
+        A sequence of HiddenParamOpRelation objects representing the
+        relationships between hidden parameters and operations.
+    weight_vals : Dict[Path, PyTree]
+        Current ParamState pytree values, used as the structure template.
+    fast_solve : bool, optional
+        Whether to use the per-primitive fast contraction instead of the legacy
+        vmap path.
     """
     # update the etrace weight gradients
     temp_data: Dict[Path, PyTree] = dict()
@@ -902,13 +915,20 @@ def _remove_units(xs_maybe_quantity: PyTree) -> Any:
     with the same structure but without units. It also returns a function that can be used to restore the
     original units to the unitless PyTree.
 
-    Args:
-        xs_maybe_quantity (PyTree): A PyTree structure containing quantities with units.
+    Parameters
+    ----------
+    xs_maybe_quantity : PyTree
+        A PyTree structure containing quantities with units.
 
-    Returns:
-        Tuple[PyTree, Callable]: A tuple containing:
-            - A PyTree with the same structure as the input, but with units removed from each quantity.
-            - A function that takes a unitless PyTree and restores the original units to it.
+    Returns
+    -------
+    Tuple[PyTree, Callable]
+        A tuple containing:
+
+        - A PyTree with the same structure as the input, but with units removed
+          from each quantity.
+        - A function that takes a unitless PyTree and restores the original
+          units to it.
     """
     leaves, treedef = jax.tree.flatten(xs_maybe_quantity, is_leaf=u.math.is_quantity)
     new_leaves, units = [], []
@@ -1228,11 +1248,13 @@ class ParamDimVjpAlgorithm(ETraceVjpAlgorithm):
         This is an internal method used in the parameter dimension eligibility trace algorithm
         to access the current trace state for updates and gradient calculations.
 
-        Returns:
-            Dict[ETraceWG_Key, jax.Array]: A dictionary mapping eligibility trace keys to
-                their current values. Each key represents a specific trace component
-                (typically involving a parameter and hidden state relationship), and
-                the corresponding value represents the accumulated eligibility trace.
+        Returns
+        -------
+        Dict[ETraceWG_Key, jax.Array]
+            A dictionary mapping eligibility trace keys to their current values.
+            Each key represents a specific trace component (typically involving a
+            parameter and hidden state relationship), and the corresponding value
+            represents the accumulated eligibility trace.
         """
         return {
             k: v.value
@@ -1252,14 +1274,12 @@ class ParamDimVjpAlgorithm(ETraceVjpAlgorithm):
         stores traces in a single dictionary rather than separate ones for inputs
         and differential functions.
 
-        Args:
-            etrace_vals: Dict[ETraceWG_Key, jax.Array]
-                Dictionary mapping eligibility trace keys to their updated values.
-                Each key represents a specific parameter-hidden state relationship,
-                and the value represents the updated eligibility trace value.
-
-        Returns:
-            None
+        Parameters
+        ----------
+        etrace_vals : Dict[ETraceWG_Key, jax.Array]
+            Dictionary mapping eligibility trace keys to their updated values.
+            Each key represents a specific parameter-hidden state relationship,
+            and the value represents the updated eligibility trace value.
         """
         for x, val in etrace_vals.items():
             self.etrace_bwg[x].value = val
@@ -1313,23 +1333,29 @@ class ParamDimVjpAlgorithm(ETraceVjpAlgorithm):
         combines them with current Jacobians to compute updated traces according to the
         parameter-dimension approximation approach.
 
-        Args:
-            running_index: Optional[int]
-                Current timestep counter, used for correcting exponential smoothing bias.
-            hist_etrace_vals: Dict[ETraceWG_Key, PyTree]
-                Dictionary containing historical eligibility trace values from previous timestep.
-                Keys are tuples identifying parameter-hidden state relationships.
-            hid2weight_jac_single_or_multi_times: Hid2WeightJacobian
-                Jacobians of hidden states with respect to weights at the current timestep.
-                Contains input gradients and differential function gradients.
-            hid2hid_jac_single_or_multi_times: HiddenGroupJacobian
-                Jacobians between hidden states (recurrent connections) at the current timestep.
-            weight_vals: Dict[Path, PyTree]
-                Dictionary mapping paths to current weight values in the model.
+        Parameters
+        ----------
+        running_index : int, optional
+            Current timestep counter, used for correcting exponential smoothing bias.
+        hist_etrace_vals : Dict[ETraceWG_Key, PyTree]
+            Dictionary containing historical eligibility trace values from previous timestep.
+            Keys are tuples identifying parameter-hidden state relationships.
+        hid2weight_jac_single_or_multi_times : Hid2WeightJacobian
+            Jacobians of hidden states with respect to weights at the current timestep.
+            Contains input gradients and differential function gradients.
+        hid2hid_jac_single_or_multi_times : HiddenGroupJacobian
+            Jacobians between hidden states (recurrent connections) at the current timestep.
+        weight_vals : Dict[Path, PyTree]
+            Dictionary mapping paths to current weight values in the model.
+        input_is_multi_step : bool
+            Whether the Jacobian inputs span multiple time steps, selecting the
+            scan (or chunked) path over the single-step path.
 
-        Returns:
-            Dict[ETraceWG_Key, PyTree]: Updated eligibility trace values dictionary with the
-                same structure as hist_etrace_vals but containing new values for the current timestep.
+        Returns
+        -------
+        Dict[ETraceWG_Key, PyTree]
+            Updated eligibility trace values dictionary with the same structure as
+            ``hist_etrace_vals`` but containing new values for the current timestep.
         """
 
         jacobians = (
@@ -1383,24 +1409,27 @@ class ParamDimVjpAlgorithm(ETraceVjpAlgorithm):
         Where ε represents the eligibility traces and ∂L/∂h are the gradients of the loss
         with respect to hidden states.
 
-        Args:
-            running_index: int
-                Current timestep counter used for bias correction.
-            etrace_h2w_at_t: Dict[ETraceWG_Key, PyTree]
-                Eligibility trace values at the current timestep, mapping parameter-hidden
-                state relationship keys to trace values.
-            dl_to_hidden_groups: Sequence[jax.Array]
-                Gradients of the loss with respect to hidden states at the current timestep.
-            weight_vals: Dict[WeightID, PyTree]
-                Current values of all weights in the model.
-            dl_to_nonetws_at_t: Dict[Path, PyTree]
-                Gradients of non-eligibility trace parameters at the current timestep.
-            dl_to_etws_at_t: Optional[Dict[Path, PyTree]]
-                Optional additional gradients for eligibility trace parameters at the
-                current timestep.
+        Parameters
+        ----------
+        running_index : int
+            Current timestep counter used for bias correction.
+        etrace_h2w_at_t : Dict[ETraceWG_Key, PyTree]
+            Eligibility trace values at the current timestep, mapping parameter-hidden
+            state relationship keys to trace values.
+        dl_to_hidden_groups : Sequence[jax.Array]
+            Gradients of the loss with respect to hidden states at the current timestep.
+        weight_vals : Dict[Path, PyTree]
+            Current values of all weights in the model.
+        dl_to_nonetws_at_t : Dict[Path, PyTree]
+            Gradients of non-eligibility trace parameters at the current timestep.
+        dl_to_etws_at_t : Dict[Path, PyTree], optional
+            Optional additional gradients for eligibility trace parameters at the
+            current timestep.
 
-        Returns:
-            Dict[Path, PyTree]: Dictionary mapping parameter paths to their gradient values.
+        Returns
+        -------
+        Dict[Path, PyTree]
+            Dictionary mapping parameter paths to their gradient values.
         """
         # `trace_filter`: low-pass the raw trace before it is contracted with the
         # learning signal. Applied elementwise (`jax.tree.map` over the trace's

--- a/braintrace/_algorithm/vjp_base.py
+++ b/braintrace/_algorithm/vjp_base.py
@@ -1240,11 +1240,16 @@ class ETraceVjpAlgorithm(ETraceAlgorithm):
         Implementations must apply `jax.lax.stop_gradient` to their estimate, or
         the online loss will train the synthesiser through the wrong path.
 
-        Args:
-            exit_hiddens: Hidden-path-keyed window-exit values, `h^exit`.
-            aux: Per-call auxiliary data from `_get_update_aux`.
+        Parameters
+        ----------
+        exit_hiddens : Any
+            Hidden-path-keyed window-exit values, `h^exit`.
+        aux : Any
+            Per-call auxiliary data from `_get_update_aux`.
 
-        Returns:
+        Returns
+        -------
+        dict or None
             A hidden-path-keyed mapping of cotangents shaped like the
             corresponding entry of `exit_hiddens`, or `None` for "no injection"
             (the default, and the zero-cost path: no second pass runs).
@@ -1254,19 +1259,25 @@ class ETraceVjpAlgorithm(ETraceAlgorithm):
     def _exit_cotangent_grads(self, grads_wo_etrace: tuple, exit_cotangent: Any) -> tuple:
         """Build the pass-2 cotangent tuple: zero everywhere but the exit hiddens.
 
-        Args:
-            grads_wo_etrace: The incoming `(dg_out, dg_hiddens, dg_oth_states)`
-                triple, used purely as a shape/unit/dtype template so the result
-                flattens to the same tree the transposed jaxpr expects.
-            exit_cotangent: The hidden-path-keyed synthetic cotangents.
+        Parameters
+        ----------
+        grads_wo_etrace : tuple
+            The incoming `(dg_out, dg_hiddens, dg_oth_states)` triple, used
+            purely as a shape/unit/dtype template so the result flattens to the
+            same tree the transposed jaxpr expects.
+        exit_cotangent : Any
+            The hidden-path-keyed synthetic cotangents.
 
-        Returns:
+        Returns
+        -------
+        tuple
             A triple with the same structure as `grads_wo_etrace`.
 
-        Raises:
-            ValueError: If a synthetic cotangent's shape does not match the
-                hidden cotangent it replaces, or if it is keyed by a path that is
-                not a hidden state.
+        Raises
+        ------
+        ValueError
+            If a synthetic cotangent's shape does not match the hidden cotangent
+            it replaces, or if it is keyed by a path that is not a hidden state.
         """
         dg_out, dg_hiddens, dg_oth = grads_wo_etrace
 
@@ -1340,15 +1351,19 @@ class ETraceVjpAlgorithm(ETraceAlgorithm):
         should override this and read whatever they stashed on `self` during
         their own `update()` override, at this exact call site.
 
-        Returns:
+        Returns
+        -------
+        Any
             Any pytree (or `None`). Appended to the `args` tuple seen by
             `_compute_learning_signal` (see below); never forwarded to the
             model's forward call.
 
-        Raises:
-            RuntimeError: If `learning_signal='modulatory'` but no modulator was
-                supplied. Falling back to the symmetric signal there would
-                silently compute a different learning rule.
+        Raises
+        ------
+        RuntimeError
+            If `learning_signal='modulatory'` but no modulator was supplied.
+            Falling back to the symmetric signal there would silently compute a
+            different learning rule.
         """
         if self.config.learning_signal != 'modulatory':
             return None
@@ -1446,25 +1461,30 @@ class ETraceVjpAlgorithm(ETraceAlgorithm):
         different time than replacing a boundary signal. See
         :meth:`_inject_exit_cotangent`.
 
-        Args:
-            dl_to_hidden_from_autodiff: Sequence of per-hidden-group gradients produced
-                by reverse-AD inside `_update_fn_bwd`.
-            args: The `*args` tuple passed to the most recent `update()` call,
-                with the per-call auxiliary data from `_get_update_aux` appended
-                as the trailing element. Subclasses that override
-                `_get_update_aux` can pull their auxiliary tensor from there;
-                subclasses that don't (the default `None`) can ignore `args`
-                entirely, as this implementation does.
+        Parameters
+        ----------
+        dl_to_hidden_from_autodiff : Sequence[jax.Array]
+            Sequence of per-hidden-group gradients produced by reverse-AD inside
+            `_update_fn_bwd`.
+        args : tuple
+            The `*args` tuple passed to the most recent `update()` call, with the
+            per-call auxiliary data from `_get_update_aux` appended as the
+            trailing element. Subclasses that override `_get_update_aux` can pull
+            their auxiliary tensor from there; subclasses that don't (the default
+            `None`) can ignore `args` entirely, as this implementation does.
 
-        Returns:
+        Returns
+        -------
+        Sequence[jax.Array]
             Sequence of per-hidden-group gradient arrays, one per HiddenGroup. Must
             match the shape and length of ``dl_to_hidden_from_autodiff``.
 
-        Raises:
-            RuntimeError: If ``learning_signal='random_feedback'`` but no
-                projection was allocated. Returning the symmetric signal there
-                would quietly compute a *different rule* than the one
-                configured.
+        Raises
+        ------
+        RuntimeError
+            If ``learning_signal='random_feedback'`` but no projection was
+            allocated. Returning the symmetric signal there would quietly compute
+            a *different rule* than the one configured.
         """
         # `bootstrapped` leaves the boundary signal exactly alone -- its whole
         # effect is the extra cotangent injected at the window *exit*, which
@@ -1567,17 +1587,23 @@ class ETraceVjpAlgorithm(ETraceAlgorithm):
                                               + \frac{\partial L^t}{\partial W^t}
 
 
-        Args:
-          running_index: Optional[int], the running index.
-          etrace_h2w_at_t: Any, the eligibility trace data (which track the hidden-to-weight Jacobian)
-              that have accumulated util the time ``t``.
-          dl_to_hidden_groups: Dict[HiddenOutVar, jax.Array], the gradients of the loss-to-hidden
-              at the time ``t``.
-          weight_vals: Dict[WeightID, PyTree], the weight values.
-          dl_to_nonetws_at_t: List[PyTree], the gradients of the loss-to-non-etrace parameters
-              at the time ``t``, i.e., :math:``\partial L^t / \partial W^t``.
-          dl_to_etws_at_t: List[PyTree], the gradients of the loss-to-etrace parameters
-              at the time ``t``, i.e., :math:``\partial L^t / \partial W^t``.
+        Parameters
+        ----------
+        running_index : int, optional
+            The running index.
+        etrace_h2w_at_t : Any
+            The eligibility trace data (which track the hidden-to-weight Jacobian)
+            that have accumulated util the time ``t``.
+        dl_to_hidden_groups : Dict[HiddenOutVar, jax.Array]
+            The gradients of the loss-to-hidden at the time ``t``.
+        weight_vals : Dict[WeightID, PyTree]
+            The weight values.
+        dl_to_nonetws_at_t : List[PyTree]
+            The gradients of the loss-to-non-etrace parameters at the time ``t``,
+            i.e., :math:``\partial L^t / \partial W^t``.
+        dl_to_etws_at_t : List[PyTree]
+            The gradients of the loss-to-etrace parameters at the time ``t``,
+            i.e., :math:``\partial L^t / \partial W^t``.
         """
         raise NotImplementedError
 
@@ -1625,15 +1651,25 @@ class ETraceVjpAlgorithm(ETraceAlgorithm):
 
             This is the protocol method that should be implemented in the subclass.
 
-        Args:
-          running_index: Optional[int], the running index.
-          etrace_vals_util_t_1: ETraceVals, the history eligibility trace data that have accumulated util :math:`t-1`.
-          hid2weight_jac_single_or_multi_times: ETraceVals, the current eligibility trace data at the time :math:`t`.
-          hid2hid_jac_single_or_multi_times: The data for computing the hidden-to-hidden Jacobian at the time :math:`t`.
-          weight_vals: Dict[WeightID, PyTree], the weight values.
+        Parameters
+        ----------
+        running_index : int, optional
+            The running index.
+        etrace_vals_util_t_1 : ETraceVals
+            The history eligibility trace data that have accumulated util :math:`t-1`.
+        hid2weight_jac_single_or_multi_times : ETraceVals
+            The current eligibility trace data at the time :math:`t`.
+        hid2hid_jac_single_or_multi_times : Sequence[jax.Array]
+            The data for computing the hidden-to-hidden Jacobian at the time :math:`t`.
+        weight_vals : Dict[WeightID, PyTree]
+            The weight values.
+        input_is_multi_step : bool
+            Whether the Jacobian inputs span multiple time steps.
 
-        Returns:
-          ETraceVals, the updated eligibility trace data that have accumulated util :math:`t`.
+        Returns
+        -------
+        ETraceVals
+            The updated eligibility trace data that have accumulated util :math:`t`.
         """
         raise NotImplementedError
 
@@ -1645,8 +1681,10 @@ class ETraceVjpAlgorithm(ETraceAlgorithm):
 
             This is the protocol method that should be implemented in the subclass.
 
-        Returns:
-            ETraceVals, the eligibility trace data.
+        Returns
+        -------
+        ETraceVals
+            The eligibility trace data.
         """
         raise NotImplementedError
 
@@ -1658,7 +1696,9 @@ class ETraceVjpAlgorithm(ETraceAlgorithm):
 
             This is the protocol method that should be implemented in the subclass.
 
-        Args:
-          etrace_vals: ETraceVals, the eligibility trace data.
+        Parameters
+        ----------
+        etrace_vals : ETraceVals
+            The eligibility trace data.
         """
         raise NotImplementedError

--- a/braintrace/_algorithm/vjp_graph_executor.py
+++ b/braintrace/_algorithm/vjp_graph_executor.py
@@ -102,11 +102,16 @@ class VjpResiduals:
     """
     The residuals for storing the backward pass data in a VJP function.
 
-    Args:
-      jaxpr: The jaxpr for the backward pass.
-      in_tree: The input tree structure.
-      out_tree: The output tree structure.
-      consts: The constants for the backward pass.
+    Parameters
+    ----------
+    jaxpr : Any
+        The jaxpr for the backward pass.
+    in_tree : Any
+        The input tree structure.
+    out_tree : Any
+        The output tree structure.
+    consts : Any
+        The constants for the backward pass.
     """
 
     def __init__(
@@ -269,10 +274,14 @@ class ETraceVjpGraphExecutor(ETraceGraphExecutor):
         """
         Computing the weight x and df values for the spatial gradients.
 
-        Args:
-            intermediate_values: The intermediate values of the model.
+        Parameters
+        ----------
+        intermediate_values : Dict[Var, jax.Array]
+            The intermediate values of the model.
 
-        Returns:
+        Returns
+        -------
+        tuple
             The weight x and df values.
 
         Notes
@@ -401,10 +410,14 @@ class ETraceVjpGraphExecutor(ETraceGraphExecutor):
         """
         Computing the hidden group-to-hidden group Jacobian according to the given intermediate values.
 
-        Args:
-            intermediate_values: The intermediate values of the model.
+        Parameters
+        ----------
+        intermediate_values : Dict[Var, jax.Array]
+            The intermediate values of the model.
 
-        Returns:
+        Returns
+        -------
+        HiddenGroupJacobian
             The hidden group-to-hidden group Jacobian.
         """
 

--- a/braintrace/_compiler/graph.py
+++ b/braintrace/_compiler/graph.py
@@ -68,11 +68,15 @@ def order_hidden_group_index(
     matches its position in the sequence. This validation is important for maintaining
     the correct ordering of hidden groups in the eligibility trace compilation process.
 
-    Args:
-        hidden_groups (Sequence[HiddenGroup]): A sequence of HiddenGroup objects to validate.
+    Parameters
+    ----------
+    hidden_groups : Sequence[HiddenGroup]
+        A sequence of HiddenGroup objects to validate.
 
-    Raises:
-        AssertionError: If any hidden group's index doesn't match its position in the sequence.
+    Raises
+    ------
+    AssertionError
+        If any hidden group's index doesn't match its position in the sequence.
     """
     for i, group in enumerate(hidden_groups):
         assert group.index == i, f"Hidden group index {group.index} should be equal to its position {i}."
@@ -257,14 +261,20 @@ def compiler_context(name: str):
     This function manages the context for compiling eligibility trace graphs, ensuring
     that recursive graph compilations are detected and handled appropriately.
 
-    Args:
-        name (str): The name of the compiler to be added to the context.
+    Parameters
+    ----------
+    name : str
+        The name of the compiler to be added to the context.
 
-    Yields:
-        None: This context manager does not yield any value.
+    Yields
+    ------
+    None
+        This context manager does not yield any value.
 
-    Raises:
-        NotImplementedError: If a recursive call to "compile_graph" is detected.
+    Raises
+    ------
+    NotImplementedError
+        If a recursive call to "compile_graph" is detected.
     """
     try:
         # add the compiler to the context

--- a/braintrace/_compiler/hidden_group.py
+++ b/braintrace/_compiler/hidden_group.py
@@ -505,21 +505,26 @@ def jacrev_last_dim(
     with respect to the last dimension of the input 'hid_vals'. It uses
     JAX's vector-Jacobian product (vjp) and vmap for efficient computation.
 
-    Args:
-        fn (Callable[[...], jax.Array]): The function for which to compute
-            the Jacobian. It should take a JAX array as input and return
-            a JAX array.
-        hid_vals (jax.Array): The input values for which to compute the
-            Jacobian. The last dimension is considered as the dimension
-            of interest.
+    Parameters
+    ----------
+    fn : Callable[..., jax.Array]
+        The function for which to compute the Jacobian. It should take a JAX
+        array as input and return a JAX array.
+    hid_vals : jax.Array
+        The input values for which to compute the Jacobian. The last dimension
+        is considered as the dimension of interest.
 
-    Returns:
-        jax.Array: The Jacobian matrix. Its shape is (*varshape, num_state, num_state),
-        where varshape is the shape of the input excluding the last dimension,
-        and num_state is the size of the last dimension.
+    Returns
+    -------
+    jax.Array
+        The Jacobian matrix. Its shape is ``(*varshape, num_state, num_state)``,
+        where ``varshape`` is the shape of the input excluding the last
+        dimension, and ``num_state`` is the size of the last dimension.
 
-    Raises:
-        AssertionError: If the number of input and output states are not the same.
+    Raises
+    ------
+    AssertionError
+        If the number of input and output states are not the same.
     """
     new_hid_vals, f_vjp = jax.vjp(fn, hid_vals)
     num_state = new_hid_vals.shape[-1]
@@ -977,12 +982,18 @@ class HiddenToHiddenGroupTracer(NamedTuple):
     plain ``set`` iteration follows memory-address hashes for jaxpr ``Var``
     objects.
 
-    Attributes:
-        hidden_invar (Var): The input variable representing the hidden state.
-        connected_hidden_outvars (Dict[Var, None]): Ordered set of output variables representing the connected hidden states.
-        other_invars (Dict[Var, None]): Ordered set of other input variables involved in the tracing.
-        invar_needed_in_oth_eqns (Dict[Var, None]): Ordered set of variables needed in other equations for trace analysis.
-        trace (List[JaxprEqn]): A list of JAX equations representing the trace of operations.
+    Attributes
+    ----------
+    hidden_invar : Var
+        The input variable representing the hidden state.
+    connected_hidden_outvars : Dict[Var, None]
+        Ordered set of output variables representing the connected hidden states.
+    other_invars : Dict[Var, None]
+        Ordered set of other input variables involved in the tracing.
+    invar_needed_in_oth_eqns : Dict[Var, None]
+        Ordered set of variables needed in other equations for trace analysis.
+    trace : List[JaxprEqn]
+        A list of JAX equations representing the trace of operations.
     """
     hidden_invar: Var
     connected_hidden_outvars: Dict[Var, None]
@@ -1014,13 +1025,22 @@ class Hidden2GroupTransition(NamedTuple):
     the connected output hidden states, and the JAX program representation (jaxpr) that
     defines the transition.
 
-    Attributes:
-        hidden_invar (Var): The input variable representing the hidden state at the previous time step.
-        hidden_path (Path): The path to the hidden state in the model hierarchy.
-        connected_hidden_outvars (List[Var]): A list of output variables representing the connected hidden states at the current time step.
-        connected_hidden_paths (List[Path]): A list of paths to the connected hidden states in the model hierarchy.
-        transition_jaxpr (Jaxpr): The JAX program representation for computing the hidden state transitions.
-        other_invars (List[Var]): A list of other input variables required for evaluating the transition_jaxpr.
+    Attributes
+    ----------
+    hidden_invar : Var
+        The input variable representing the hidden state at the previous time step.
+    hidden_path : Path
+        The path to the hidden state in the model hierarchy.
+    connected_hidden_outvars : List[Var]
+        A list of output variables representing the connected hidden states at
+        the current time step.
+    connected_hidden_paths : List[Path]
+        A list of paths to the connected hidden states in the model hierarchy.
+    transition_jaxpr : Jaxpr
+        The JAX program representation for computing the hidden state transitions.
+    other_invars : List[Var]
+        A list of other input variables required for evaluating the
+        ``transition_jaxpr``.
     """
 
     # the hidden state h_i^{t-1}
@@ -1049,13 +1069,19 @@ class Hidden2GroupTransition(NamedTuple):
         """
         Computing the hidden state transitions :math:`h^t = f(h_i^t, x)`.
 
-        Args:
-          old_hidden_val: The old hidden state value.
-          other_input_vals: The input values.
-          return_index: index of the hidden state to return.
+        Parameters
+        ----------
+        old_hidden_val : jax.Array
+            The old hidden state value.
+        other_input_vals : PyTree
+            The input values.
+        return_index : int, optional
+            Index of the hidden state to return.
 
-        Returns:
-          The new hidden state values.
+        Returns
+        -------
+        list of jax.Array or jax.Array
+            The new hidden state values.
         """
         new_hidden_vals = jax.core.eval_jaxpr(self.transition_jaxpr, other_input_vals, old_hidden_val)
         if return_index is not None:
@@ -1111,15 +1137,23 @@ def _simplify_hid2hid_tracer(
     """
     Simplifying the hidden-to-hidden state tracer.
 
-    Args:
-        tracer: The hidden-to-hidden state tracer.
-        hidden_invar_to_path: The mapping from the hidden input variable to the hidden state path.
-        hidden_outvar_to_path: The mapping from the hidden output variable to the hidden state path.
-        path_to_state: The mapping from the hidden state path to the state.
-        debug_info: The debug info threaded from the source model jaxpr onto the
-            simplified transition jaxpr (avoids the missing-DebugInfo deprecation).
+    Parameters
+    ----------
+    tracer : HiddenToHiddenGroupTracer
+        The hidden-to-hidden state tracer.
+    hidden_invar_to_path : dict
+        The mapping from the hidden input variable to the hidden state path.
+    hidden_outvar_to_path : dict
+        The mapping from the hidden output variable to the hidden state path.
+    path_to_state : dict
+        The mapping from the hidden state path to the state.
+    debug_info : optional
+        The debug info threaded from the source model jaxpr onto the simplified
+        transition jaxpr (avoids the missing-DebugInfo deprecation).
 
-    Returns:
+    Returns
+    -------
+    Hidden2GroupTransition or None
         The hidden-to-hidden state transition.
     """
     #
@@ -1208,23 +1242,35 @@ class JaxprEvalForHiddenGroup(JaxprEvaluation):
     """
     Evaluating the jaxpr for extracting the hidden state ``hidden-to-hidden`` relationships.
 
-    Args:
-        jaxpr: The jaxpr for the model.
-        hidden_outvar_to_invar: The mapping from the hidden output variable to the hidden input variable.
-        weight_invars: The weight input variables.
-        invar_to_hidden_path: The mapping from the weight input variable to the hidden state path.
-        outvar_to_hidden_path: The mapping from the hidden output variable to the hidden state path.
-        path_to_state: The mapping from the hidden state path to the state.
-        include_recurrent_mixing: Whether recurrent ETP mixing primitives are
-            traced into the hidden-to-hidden transition jaxpr.
-        sparse_n: SnAp order for ``recurrence_scope='sparse_n'``; ``None``
-            (default) leaves every group's ``snap`` pattern unset.
-        control_flow: The :class:`~braintrace.ControlFlowPolicy` governing
-            opaque control-flow handling (see ``base.check_unsupported_op``).
-        descended_scan_eqn_ids: ``id()`` values of scan equations rewritten by
-            structured scan descent; those equations are skipped by this walker.
-        descended_hidden_paths: Hidden-state paths covered by descended scan
-            bodies; excluded from the zero-recurrence fallback grouping.
+    Parameters
+    ----------
+    jaxpr : Jaxpr
+        The jaxpr for the model.
+    hidden_outvar_to_invar : dict
+        The mapping from the hidden output variable to the hidden input variable.
+    weight_invars : set
+        The weight input variables.
+    invar_to_hidden_path : dict
+        The mapping from the weight input variable to the hidden state path.
+    outvar_to_hidden_path : dict
+        The mapping from the hidden output variable to the hidden state path.
+    path_to_state : dict
+        The mapping from the hidden state path to the state.
+    include_recurrent_mixing : bool
+        Whether recurrent ETP mixing primitives are traced into the
+        hidden-to-hidden transition jaxpr.
+    sparse_n : int or None, optional
+        SnAp order for ``recurrence_scope='sparse_n'``; ``None`` (default)
+        leaves every group's ``snap`` pattern unset.
+    control_flow : ControlFlowPolicy
+        The :class:`~braintrace.ControlFlowPolicy` governing opaque
+        control-flow handling (see ``base.check_unsupported_op``).
+    descended_scan_eqn_ids : frozenset of int
+        ``id()`` values of scan equations rewritten by structured scan descent;
+        those equations are skipped by this walker.
+    descended_hidden_paths : set of Path
+        Hidden-state paths covered by descended scan bodies; excluded from the
+        zero-recurrence fallback grouping.
     """
     __module__ = 'braintrace'
 
@@ -1901,14 +1947,19 @@ def group_merging(groups, version: int = 1) -> List[frozenset[HiddenOutVar]]:
     any common hidden states. The merging process is controlled by the specified
     version of the algorithm.
 
-    Args:
-        groups: A list of hidden groups, where each group is a collection of
-            hidden states represented as frozensets.
-        version: An integer specifying the version of the merging algorithm to use.
-            Default is 1. Version 0 and 1 are supported, with version 1 being
-            more efficient and readable.
+    Parameters
+    ----------
+    groups : list
+        A list of hidden groups, where each group is a collection of hidden
+        states represented as frozensets.
+    version : int, optional
+        An integer specifying the version of the merging algorithm to use.
+        Default is 1. Version 0 and 1 are supported, with version 1 being
+        more efficient and readable.
 
-    Returns:
+    Returns
+    -------
+    list of frozenset
         A list of merged hidden groups, where each group is a frozenset of
         HiddenOutVar objects. The groups are merged based on shared hidden states.
     """
@@ -1979,41 +2030,62 @@ def find_hidden_groups_from_jaxpr(
     """
     Find hidden groups from the jaxpr.
 
-    Args:
-        jaxpr: The jaxpr for the model.
-        hidden_outvar_to_invar: Mapping from hidden output variable to hidden input variable.
-        weight_invars: Set of weight input variables.
-        invar_to_hidden_path: Mapping from weight input variable to hidden state path.
-        outvar_to_hidden_path: Mapping from hidden output variable to hidden state path.
-        path_to_state: Mapping from hidden state path to state.
-        include_recurrent_mixing: Whether to trace recurrent ETP *mixing* primitives
-            (``etp_mv``/``etp_mm``/``etp_conv``) into the hidden-to-hidden
-            transition jaxpr.
+    Parameters
+    ----------
+    jaxpr : Jaxpr
+        The jaxpr for the model.
+    hidden_outvar_to_invar : dict
+        Mapping from hidden output variable to hidden input variable.
+    weight_invars : set
+        Set of weight input variables.
+    invar_to_hidden_path : dict
+        Mapping from weight input variable to hidden state path.
+    outvar_to_hidden_path : dict
+        Mapping from hidden output variable to hidden state path.
+    path_to_state : dict
+        Mapping from hidden state path to state.
+    include_recurrent_mixing : bool, optional
+        Whether to trace recurrent ETP *mixing* primitives
+        (``etp_mv``/``etp_mm``/``etp_conv``) into the hidden-to-hidden
+        transition jaxpr.
 
-            - ``False`` (default, "without recurrence"): these primitives are
-              treated as boundaries and excluded, so the transition keeps only
-              element-wise (and non-ETP) state-to-state paths. The recurrent
-              weight's temporal credit is carried by its eligibility trace. This
-              keeps the recurrent Jacobian ``D^t`` contractive and the trace
-              bounded (the standard D-RTRL / e-prop diagonal approximation).
-            - ``True`` ("with recurrence"): the mixing primitives are traced into
-              the transition, so ``D^t`` carries the full per-step recurrent
-              coupling. The resulting (coupled) Jacobian is extracted per
-              position via :func:`block_diagonal_last_dim` (selected automatically
-              by :attr:`HiddenGroup.is_diagonal_recurrence`).
-        control_flow: The :class:`~braintrace.ControlFlowPolicy` governing how
-            opaque control-flow equations touching hidden states are handled
-            (``'opaque-fwd'`` keeps a weight-free while/scan/cond as an opaque
-            forward node; ``'error'`` raises as before Phase 3).
-        descended_scan_eqn_ids: ``id()`` values of scan equations rewritten by
-            structured scan descent (Phase 4); skipped by this walker.
-        descended_hidden_paths: Hidden-state paths covered by descended scan
-            bodies; excluded from the zero-recurrence fallback grouping.
+        - ``False`` (default, "without recurrence"): these primitives are
+          treated as boundaries and excluded, so the transition keeps only
+          element-wise (and non-ETP) state-to-state paths. The recurrent
+          weight's temporal credit is carried by its eligibility trace. This
+          keeps the recurrent Jacobian ``D^t`` contractive and the trace
+          bounded (the standard D-RTRL / e-prop diagonal approximation).
+        - ``True`` ("with recurrence"): the mixing primitives are traced into
+          the transition, so ``D^t`` carries the full per-step recurrent
+          coupling. The resulting (coupled) Jacobian is extracted per
+          position via :func:`block_diagonal_last_dim` (selected automatically
+          by :attr:`HiddenGroup.is_diagonal_recurrence`).
+    sparse_n : int or None, optional
+        SnAp order for ``recurrence_scope='sparse_n'``; ``None`` (default)
+        leaves every group's ``snap`` pattern unset.
+    snap_max_jacobian_elements : int, optional
+        Ceiling on each hidden group's widened block Jacobian,
+        ``P * (K * S) ** 2`` elements. Configurations exceeding it are
+        refused with :class:`~braintrace.NotSupportedError`.
+    control_flow : ControlFlowPolicy, optional
+        The :class:`~braintrace.ControlFlowPolicy` governing how opaque
+        control-flow equations touching hidden states are handled
+        (``'opaque-fwd'`` keeps a weight-free while/scan/cond as an opaque
+        forward node; ``'error'`` raises as before Phase 3).
+    descended_scan_eqn_ids : frozenset of int, optional
+        ``id()`` values of scan equations rewritten by structured scan descent
+        (Phase 4); skipped by this walker.
+    descended_hidden_paths : frozenset of Path, optional
+        Hidden-state paths covered by descended scan bodies; excluded from the
+        zero-recurrence fallback grouping.
 
-    Returns:
+    Returns
+    -------
+    tuple
         A tuple containing:
-        - Sequence of HiddenGroup objects
-        - PrettyDict mapping hidden state paths to hidden groups
+
+        - Sequence of HiddenGroup objects.
+        - PrettyDict mapping hidden state paths to hidden groups.
     """
     evaluator = JaxprEvalForHiddenGroup(
         jaxpr=jaxpr,

--- a/braintrace/_compiler/hidden_pertubation.py
+++ b/braintrace/_compiler/hidden_pertubation.py
@@ -219,37 +219,47 @@ class JaxprEvalForHiddenPerturbation(JaxprEvaluation):
     """
     Adding perturbations to the hidden states in the jaxpr, and replacing the hidden states with the perturbed states.
 
-    Args:
-        closed_jaxpr: The closed jaxpr for the model.
-        outvar_to_hidden_path: The mapping from the outvar to the state id.
-        hidden_outvar_to_invar: The mapping from the hidden output variable to the hidden input variable.
-        weight_invars: The weight input variables.
-        invar_to_hidden_path: The mapping from the weight input variable to the hidden state path.
-        control_flow: The :class:`~braintrace.ControlFlowPolicy` governing
-            opaque control-flow handling.
-        descended_scan_eqn_ids: ``id()`` values of scan equations rewritten
-            by structured scan descent (Phase 4); exempt from the
-            unsupported-op checks.
+    Parameters
+    ----------
+    closed_jaxpr : ClosedJaxpr
+        The closed jaxpr for the model.
+    outvar_to_hidden_path : dict
+        The mapping from the outvar to the state id.
+    hidden_outvar_to_invar : dict
+        The mapping from the hidden output variable to the hidden input variable.
+    weight_invars : set
+        The weight input variables.
+    invar_to_hidden_path : dict
+        The mapping from the weight input variable to the hidden state path.
+    control_flow : ControlFlowPolicy
+        The :class:`~braintrace.ControlFlowPolicy` governing opaque
+        control-flow handling.
+    descended_scan_eqn_ids : frozenset of int
+        ``id()`` values of scan equations rewritten by structured scan descent
+        (Phase 4); exempt from the unsupported-op checks.
 
-    Returns:
+    Returns
+    -------
+    HiddenPerturbation
         The revised closed jaxpr with the perturbations.
 
-    Notes:
-        A hidden-producing ``while`` equation gets special treatment: every
-        ``Var`` input of the loop is detached with ``stop_gradient`` in the
-        perturbed jaxpr (JAX has no transpose rule for ``while``, so an
-        undetached loop would make the VJP of the perturbed step
-        untraceable). The perturbation add ``h = fresh + p`` stays *outside*
-        the detach, so the loop's *own* hidden group keeps an exact per-step
-        learning signal ``dL/dp``. Consequence: any *reverse-mode* path
-        through the loop body within the same step contributes zero — the
-        loop's temporal credit is carried instead by the forward-computed
-        hidden-to-hidden Jacobian ``D^t`` (see
-        ``hidden_group.jacfwd_last_dim``), but a parameter or *other* hidden
-        group whose only same-step path to the loss crosses the loop (e.g.
-        an upstream layer feeding the loop) receives a ZERO learning signal.
-        A WARNING-level ``CONTROL_FLOW_OPAQUE_FWD`` diagnostic
-        (``site='perturbation'``) records every detach.
+    Notes
+    -----
+    A hidden-producing ``while`` equation gets special treatment: every
+    ``Var`` input of the loop is detached with ``stop_gradient`` in the
+    perturbed jaxpr (JAX has no transpose rule for ``while``, so an
+    undetached loop would make the VJP of the perturbed step
+    untraceable). The perturbation add ``h = fresh + p`` stays *outside*
+    the detach, so the loop's *own* hidden group keeps an exact per-step
+    learning signal ``dL/dp``. Consequence: any *reverse-mode* path
+    through the loop body within the same step contributes zero — the
+    loop's temporal credit is carried instead by the forward-computed
+    hidden-to-hidden Jacobian ``D^t`` (see
+    ``hidden_group.jacfwd_last_dim``), but a parameter or *other* hidden
+    group whose only same-step path to the loss crosses the loop (e.g.
+    an upstream layer feeding the loop) receives a ZERO learning signal.
+    A WARNING-level ``CONTROL_FLOW_OPAQUE_FWD`` diagnostic
+    (``site='perturbation'``) records every detach.
     """
     __module__ = 'braintrace'
 
@@ -513,23 +523,32 @@ def add_hidden_perturbation_in_jaxpr(
     """
     Adding perturbations to the hidden states in the jaxpr, and replacing the hidden states with the perturbed states.
 
-    Args:
-        closed_jaxpr: The closed jaxpr for the model.
-        outvar_to_hidden_path: The mapping from the outvar to the state id.
-        hidden_outvar_to_invar: The mapping from the hidden output variable to the hidden input variable.
-        weight_invars: The weight input variables.
-        invar_to_hidden_path: The mapping from the weight input variable to the hidden state path.
-        path_to_state: The mapping from the hidden state path to the state.
-        control_flow: The :class:`~braintrace.ControlFlowPolicy` governing
-            opaque control-flow handling. Under the default policy a
-            hidden-producing ``while`` is kept and its inputs are detached
-            in the perturbed jaxpr (see
-            :class:`JaxprEvalForHiddenPerturbation`).
-        descended_scan_eqn_ids: ``id()`` values of scan equations rewritten
-            by structured scan descent (Phase 4); exempt from the
-            unsupported-op checks.
+    Parameters
+    ----------
+    closed_jaxpr : ClosedJaxpr
+        The closed jaxpr for the model.
+    hidden_outvar_to_invar : dict
+        The mapping from the hidden output variable to the hidden input variable.
+    weight_invars : set
+        The weight input variables.
+    invar_to_hidden_path : dict
+        The mapping from the weight input variable to the hidden state path.
+    outvar_to_hidden_path : dict
+        The mapping from the outvar to the state id.
+    path_to_state : dict
+        The mapping from the hidden state path to the state.
+    control_flow : ControlFlowPolicy, optional
+        The :class:`~braintrace.ControlFlowPolicy` governing opaque
+        control-flow handling. Under the default policy a hidden-producing
+        ``while`` is kept and its inputs are detached in the perturbed jaxpr
+        (see :class:`JaxprEvalForHiddenPerturbation`).
+    descended_scan_eqn_ids : frozenset of int, optional
+        ``id()`` values of scan equations rewritten by structured scan descent
+        (Phase 4); exempt from the unsupported-op checks.
 
-    Returns:
+    Returns
+    -------
+    HiddenPerturbation
         The revised closed jaxpr with the perturbations.
     """
     return JaxprEvalForHiddenPerturbation(

--- a/braintrace/_compiler/module_info.py
+++ b/braintrace/_compiler/module_info.py
@@ -150,18 +150,25 @@ def abstractify_model(
     Abstracts a model into a stateful representation suitable for compilation and state extraction.
 
     This function ensures that the model is an instance of `brainstate.nn.Module` and compiles it into a
-    stateful function. It retrieves the model's states and checks for consistency between the 
+    stateful function. It retrieves the model's states and checks for consistency between the
     compiled states and the retrieved states.
 
-    Args:
-        model (brainstate.nn.Module): The model to be abstracted. It must be an instance of `brainstate.nn.Module`.
-        *model_args: Positional arguments to be passed to the model during compilation.
-        **model_kwargs: Keyword arguments to be passed to the model during compilation.
+    Parameters
+    ----------
+    model : brainstate.nn.Module
+        The model to be abstracted. It must be an instance of `brainstate.nn.Module`.
+    *model_args : Any
+        Positional arguments to be passed to the model during compilation.
+    **model_kwargs : Any
+        Keyword arguments to be passed to the model during compilation.
 
-    Returns:
-        Tuple[brainstate.transform.StatefulFunction, Dict[Path, brainstate.State]]:
-            - A stateful function representing the compiled model.
-            - A dictionary of the model's retrieved states with their paths.
+    Returns
+    -------
+    tuple of (brainstate.transform.StatefulFunction, dict)
+        A two-element tuple containing:
+
+        - A stateful function representing the compiled model.
+        - A dictionary of the model's retrieved states with their paths.
     """
     assert isinstance(model, brainstate.nn.Module), (
         "The model should be an instance of brainstate.nn.Module. "

--- a/braintrace/_grad_exponential.py
+++ b/braintrace/_grad_exponential.py
@@ -107,11 +107,6 @@ class GradExpon(brainstate.nn.Module):
         grads : PyTree
             The new gradients to incorporate into the accumulated gradients.
             Must match the pytree structure of the accumulator.
-
-        Returns
-        -------
-        None
-            The ``self.gradients`` attribute is updated in place.
         """
         self.gradients.value = jax.tree.map(
             lambda x, y: x * self.decay + y,

--- a/braintrace/_input_data.py
+++ b/braintrace/_input_data.py
@@ -34,8 +34,10 @@ class ETraceInputData:
         """
         Initializes an instance of ETraceInputData.
 
-        Args:
-            data (Any): The data to be stored in the instance.
+        Parameters
+        ----------
+        data : Any
+            The data to be stored in the instance.
         """
         self.data = data
 
@@ -43,8 +45,10 @@ class ETraceInputData:
         """
         Flattens the data for processing with JAX's tree utilities.
 
-        Returns:
-            tuple: A tuple containing the flattened data and an empty auxiliary data structure.
+        Returns
+        -------
+        tuple
+            A tuple containing the flattened data and an empty auxiliary data structure.
         """
         return (self.data,), ()
 
@@ -53,12 +57,17 @@ class ETraceInputData:
         """
         Reconstructs an instance of ETraceInputData from flattened data.
 
-        Args:
-            aux: Auxiliary data structure, not used in this implementation.
-            data: The flattened data to be reconstructed into an instance.
+        Parameters
+        ----------
+        aux : Any
+            Auxiliary data structure, not used in this implementation.
+        data : Any
+            The flattened data to be reconstructed into an instance.
 
-        Returns:
-            ETraceInputData: An instance of ETraceInputData with the provided data.
+        Returns
+        -------
+        ETraceInputData
+            An instance of ETraceInputData with the provided data.
         """
         return cls(*data)
 
@@ -136,15 +145,20 @@ def split_input_data_types(*args: Any) -> tuple[dict[int, SingleStepData], dict[
     Splits input data into dictionaries based on their type, distinguishing between
     SingleStepData and MultiStepData instances.
 
-    Args:
-        *args: Variable length argument list, expected to contain instances of SingleStepData
-               or MultiStepData, or other data types.
+    Parameters
+    ----------
+    *args : Any
+        Variable length argument list, expected to contain instances of SingleStepData
+        or MultiStepData, or other data types.
 
-    Returns:
-        tuple: A tuple containing three elements:
-            - A dictionary mapping indices to SingleStepData instances.
-            - A dictionary mapping indices to MultiStepData instances.
-            - A JAX tree structure definition of the input data.
+    Returns
+    -------
+    tuple
+        A tuple containing three elements:
+
+        - A dictionary mapping indices to SingleStepData instances.
+        - A dictionary mapping indices to MultiStepData instances.
+        - A JAX tree structure definition of the input data.
     """
     leaves, tree_def = jax.tree.flatten(args, is_leaf=is_input)
     data_at_single_step = dict()
@@ -164,15 +178,22 @@ def merge_data(tree_def: Any, *args: dict[int, Any]) -> Any:
     """
     Merges multiple dictionaries of data into a single structure based on a JAX tree definition.
 
-    Args:
-        tree_def: The JAX tree structure definition used to unflatten the data.
-        *args: Variable length argument list, expected to contain dictionaries of data to be merged.
+    Parameters
+    ----------
+    tree_def : Any
+        The JAX tree structure definition used to unflatten the data.
+    *args : dict
+        Variable length argument list, expected to contain dictionaries of data to be merged.
 
-    Returns:
+    Returns
+    -------
+    Any
         The merged data structure, reconstructed using the provided JAX tree definition.
 
-    Raises:
-        ValueError: If any expected data index is missing in the merged data.
+    Raises
+    ------
+    ValueError
+        If any expected data index is missing in the merged data.
     """
     data = dict()
     for arg in args:
@@ -187,15 +208,20 @@ def get_single_step_data(*args: Any) -> Any:
     """
     Extracts and returns data corresponding to a single time step from the provided input data.
 
-    This function processes input data, which may include instances of SingleStepData and 
+    This function processes input data, which may include instances of SingleStepData and
     MultiStepData, and returns a structure where MultiStepData is reduced to a single time step.
 
-    Args:
-        *args: Variable length argument list, expected to contain instances of SingleStepData,
-               MultiStepData, or other data types.
+    Parameters
+    ----------
+    *args : Any
+        Variable length argument list, expected to contain instances of SingleStepData,
+        MultiStepData, or other data types.
 
-    Returns:
-        The processed data structure, where MultiStepData instances are reduced to a single time step.
+    Returns
+    -------
+    Any
+        The processed data structure, where MultiStepData instances are reduced to a single
+        time step.
     """
     leaves, tree_def = jax.tree.flatten(args, is_leaf=is_input)
     leaves_processed = []
@@ -218,12 +244,16 @@ def has_multistep_data(*args: Any) -> bool:
     This function processes the input data, which may include instances of SingleStepData,
     MultiStepData, or other data types, and checks if any of the data is of type MultiStepData.
 
-    Args:
-        *args: Variable length argument list, expected to contain instances of SingleStepData,
-               MultiStepData, or other data types.
+    Parameters
+    ----------
+    *args : Any
+        Variable length argument list, expected to contain instances of SingleStepData,
+        MultiStepData, or other data types.
 
-    Returns:
-        bool: True if any of the input data is an instance of MultiStepData, False otherwise.
+    Returns
+    -------
+    bool
+        True if any of the input data is an instance of MultiStepData, False otherwise.
     """
     leaves, _ = jax.tree.flatten(args, is_leaf=is_input)
     return any(isinstance(leaf, MultiStepData) for leaf in leaves)

--- a/braintrace/_misc.py
+++ b/braintrace/_misc.py
@@ -39,11 +39,15 @@ def _remove_quantity(tree: Any) -> Any:
     """
     Remove the quantity from the tree.
 
-    Args:
-      tree: The tree.
+    Parameters
+    ----------
+    tree : Any
+        The tree.
 
-    Returns:
-      The tree without the quantity.
+    Returns
+    -------
+    Any
+        The tree without the quantity.
     """
 
     def fn(x: Any) -> Any:

--- a/braintrace/_op/elemwise.py
+++ b/braintrace/_op/elemwise.py
@@ -121,11 +121,16 @@ def _elemwise_dt_to_t(hidden_dim: Any, trace: dict[str, Any], *,
     This is invoked per hidden-state slice; both operands share shape
     ``(*y_shape,)``.
 
-    Args:
-        hidden_dim: Cotangent :math:`\partial h / \partial y`, shape matches weight.
-        trace: ``{'weight': ...}``, array of the same shape.
+    Parameters
+    ----------
+    hidden_dim : Any
+        Cotangent :math:`\partial h / \partial y`, shape matches weight.
+    trace : dict
+        ``{'weight': ...}``, array of the same shape.
 
-    Returns:
+    Returns
+    -------
+    dict
         ``{'weight': hidden_dim ⊙ trace['weight']}``.
     """
     return {'weight': trace['weight'] * hidden_dim}
@@ -153,15 +158,22 @@ def _elemwise_xy_to_dw(x: Any, hidden_dim: Any, weights: dict[str, Any], *,
     leading axes (e.g. a batch axis under :class:`brainstate.mixin.Batching`),
     which the unbatched VJP would reject as a shape mismatch.
 
-    Args:
-        x: Unused (``x_invar_index=None``).
-        hidden_dim: Cotangent :math:`\partial h / \partial y`. Shape matches the
-            weight, optionally with extra leading axes (e.g. a batch axis).
-        weights: Dict with key 'weight' (the raw weight mantissa).
-        weight_fn: Element-wise function applied inside the primitive. When
-            ``None``, behaves as identity.
+    Parameters
+    ----------
+    x : Any
+        Unused (``x_invar_index=None``).
+    hidden_dim : Any
+        Cotangent :math:`\partial h / \partial y`. Shape matches the weight,
+        optionally with extra leading axes (e.g. a batch axis).
+    weights : dict
+        Dict with key 'weight' (the raw weight mantissa).
+    weight_fn : WeightFn or None, optional
+        Element-wise function applied inside the primitive. When ``None``,
+        behaves as identity.
 
-    Returns:
+    Returns
+    -------
+    dict
         ``{'weight': hidden_dim ⊙ weight_fn'(w)}``, or
         ``{'weight': hidden_dim}`` when ``weight_fn is None``.
     """
@@ -199,18 +211,26 @@ def _elemwise_init_drtrl(x_var: Any, y_var: Any, weight_vars: dict[str, Any],
     instantaneous term ``df`` (shape ``(*group.varshape, n_state)``) so the scan
     carry stays well-typed.
 
-    Args:
-        x_var: Unused (``x_invar_index=None``).
-        y_var: Output variable descriptor with shape.
-        weight_vars: Dict with key 'weight'. Only its dtype is consulted
-            (unused otherwise); falls back to ``y_var``'s dtype alone when
-            ``None`` (e.g. direct unit tests).
-        num_hidden_state: Number of hidden states :math:`n_{\text{state}}`.
-        group: The owning :class:`HiddenGroup`. When supplied, its (possibly
-            batched) ``varshape`` is used for the trace leading axes; falls back
-            to ``y_var`` shape when ``None`` (e.g. direct unit tests).
+    Parameters
+    ----------
+    x_var : Any
+        Unused (``x_invar_index=None``).
+    y_var : Any
+        Output variable descriptor with shape.
+    weight_vars : dict
+        Dict with key 'weight'. Only its dtype is consulted (unused otherwise);
+        falls back to ``y_var``'s dtype alone when ``None`` (e.g. direct unit
+        tests).
+    num_hidden_state : int
+        Number of hidden states :math:`n_{\text{state}}`.
+    group : Any, optional
+        The owning :class:`HiddenGroup`. When supplied, its (possibly batched)
+        ``varshape`` is used for the trace leading axes; falls back to ``y_var``
+        shape when ``None`` (e.g. direct unit tests).
 
-    Returns:
+    Returns
+    -------
+    dict
         ``{'weight': zeros(*leading_shape, n_state)}``.
 
     Notes
@@ -245,7 +265,9 @@ def _elemwise_init_pp(x_var: Any, y_var: Any, weight_vars: dict[str, Any],
     leading axes come from ``group.varshape`` so the trace carries the batch
     axis under :class:`brainstate.mixin.Batching`.
 
-    Returns:
+    Returns
+    -------
+    Array
         Single array of shape ``(*leading_shape, n_state)``.
     """
     leading = tuple(group.varshape) if group is not None else tuple(y_var.aval.shape)

--- a/braintrace/_state_managment.py
+++ b/braintrace/_state_managment.py
@@ -43,10 +43,6 @@ def assign_dict_state_values(
     write : bool, optional
         A flag indicating whether to assign (`True`) or restore (`False`) the values.
         Defaults to `True`.
-
-    Returns
-    --------
-    None
     """
     if set(states.keys()) != set(state_values.keys()):
         raise ValueError('The keys of states and state_values must be the same.')
@@ -82,10 +78,6 @@ def assign_state_values_v2(
     write : bool, optional
         A flag indicating whether to assign (`True`) or restore (`False`) the values.
         Defaults to `True`.
-
-    Returns
-    --------
-    None
     """
     if set(states.keys()) != set(state_values.keys()):
         raise ValueError(

--- a/examples/004-feedforward-conv-snn.py
+++ b/examples/004-feedforward-conv-snn.py
@@ -113,21 +113,35 @@ class Trainer(object):
     including accuracy calculation, batch evaluation, and epoch-wise training/testing.
     Subclasses should implement the `batch_train` method for specific training algorithms.
 
-    Args:
-        target (brainstate.nn.Module): The neural network model to be trained.
-        opt (braintools.optim.Optimizer): Optimizer for updating model parameters.
-        train_loader (Iterable): DataLoader for training data.
-        test_loader (Iterable): DataLoader for test data.
-        x_fun (Callable): Function to preprocess input data batches.
-        n_epoch (int, optional): Number of training epochs. Default is 30.
+    Parameters
+    ----------
+    target : brainstate.nn.Module
+        The neural network model to be trained.
+    opt : braintools.optim.Optimizer
+        Optimizer for updating model parameters.
+    train_loader : Iterable
+        DataLoader for training data.
+    test_loader : Iterable
+        DataLoader for test data.
+    x_fun : Callable
+        Function to preprocess input data batches.
+    n_epoch : int, optional
+        Number of training epochs. Default is 30.
 
-    Attributes:
-        train_loader (Iterable): Training data loader.
-        test_loader (Iterable): Test data loader.
-        x_fun (Callable): Input preprocessing function.
-        target (brainstate.nn.Module): The model being trained.
-        opt (braintools.optim.Optimizer): Optimizer instance.
-        n_epoch (int): Number of epochs to train.
+    Attributes
+    ----------
+    train_loader : Iterable
+        Training data loader.
+    test_loader : Iterable
+        Test data loader.
+    x_fun : Callable
+        Input preprocessing function.
+    target : brainstate.nn.Module
+        The model being trained.
+    opt : braintools.optim.Optimizer
+        Optimizer instance.
+    n_epoch : int
+        Number of epochs to train.
     """
 
     def __init__(


### PR DESCRIPTION
## Summary

`AGENTS.md` mandates NumPy-doc for all public classes, methods and functions, and `docs/conf.py` renders through `sphinx.ext.napoleon`. Sixteen modules still carried Google-style `Args:` / `Returns:` / `Raises:` / `Attributes:` / `Notes:` sections, so their parameter tables rendered inconsistently against the rest of the API reference.

This converts every remaining Google-style section to NumPy-doc: underlined headers and `name : type` entries. Multi-item return values become reST bullet lists so Sphinx renders them rather than collapsing them into the surrounding paragraph.

`Returns` sections whose only content is `None` are dropped. Where such a section carried real information — in-place mutation of an argument, or the attribute a method initialises — that information moves into the extended summary rather than being lost.

## Drift corrected while reformatting

Three docstrings no longer matched their signatures:

- `_update_IO_dim_etrace_scan_fn` documented a single `decay`; the function takes `decay_x` and `decay_f`.
- `_update_param_dim_etrace_scan_fn` and `_solve_param_dim_weight_gradients` documented a `mode` parameter that no longer exists; they take `fast_solve` (plus `trace_dtype` and `weight_vals` respectively).

Undocumented parameters already present in the signatures are filled in along the way (`input_is_multi_step`, `fast_solve`, `sparse_n`, `snap_max_jacobian_elements`, `axis`), reusing the wording already used for those parameters elsewhere in the codebase.

## Verification

- `python -m pytest braintrace/_compiler braintrace/_op braintrace/_algorithm/graph_executor_test.py braintrace/_algorithm/io_dim_vjp_test.py braintrace/_algorithm/param_dim_vjp_test.py -q -x` — 1156 passed
- `python -m pytest braintrace/_docs_examples_test.py braintrace/_input_data_test.py braintrace/_misc_test.py braintrace/_state_managment_test.py braintrace/_grad_exponential_test.py -q` — 60 passed
- `python -m compileall braintrace examples` — clean
- Repo-wide scan confirms no Google-style section headers and no `Returns -> None` sections remain

Docstring-only change; no runtime behaviour is affected.

## Summary by Sourcery

Standardize remaining API and internal docstrings to NumPy style while keeping behavior unchanged.

Enhancements:
- Document new and existing configuration flags and arguments (e.g., fast_solve, input_is_multi_step, sparse_n, snap_max_jacobian_elements, axis) across algorithm and compiler utilities.

Documentation:
- Convert multiple modules’ Google-style docstrings to NumPy-style parameter, returns, raises, attributes, and notes sections for consistent Sphinx rendering.
- Clarify and complete several parameter and return descriptions, including previously undocumented arguments and corrected names in VJP and eligibility-trace helpers.