### PR TITLE
Fix Tutorial hierarchy and landing pages with native RST

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -30,13 +30,8 @@
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
 
-import html
 import os
-import re
 import sys
-from pathlib import Path
-
-from markupsafe import Markup
 
 sys.path.insert(0, os.path.abspath('../'))
 sys.path.insert(0, os.path.abspath('./'))
@@ -192,99 +187,3 @@ napoleon_use_rtype = False
 # Keep NumPy-style ``Attributes`` sections as field-list documentation.
 # ``autoclass :members:`` remains the single owner of member targets.
 napoleon_use_ivar = True
-
-
-_TUTORIAL_GROUP_PATTERN = re.compile(
-    r"^\.\. braintrace-tutorial-group: (?P<title>.+)\n"
-    r"   :members: (?P<members>.+)$",
-    re.MULTILINE,
-)
-
-
-def _tutorial_groups():
-    """Read Tutorial group declarations from the root index."""
-    source = Path(__file__).with_name("index.rst").read_text(encoding="utf-8")
-    return tuple(
-        (
-            match.group("title").strip(),
-            tuple(
-                member.strip()
-                for member in match.group("members").split("|")
-                if member.strip()
-            ),
-        )
-        for match in _TUTORIAL_GROUP_PATTERN.finditer(source)
-    )
-
-
-def _tutorial_item_pattern(member):
-    """Return the sidebar-item pattern for one rendered document title."""
-    escaped = re.escape(html.escape(member))
-    return re.compile(
-        r'<li class="[^"]*\btoctree-l1\b[^"]*">'
-        r"(?:(?!</li>).)*?"
-        r"<a\b[^>]*>" + escaped + r"</a>"
-        r"(?:(?!</li>).)*?</li>",
-        re.DOTALL,
-    )
-
-
-def _group_tutorial_toctree(toctree_html, groups):
-    """Group a flat Tutorial sidebar without client-side assets."""
-    grouped = str(toctree_html)
-    for title, members in reversed(groups):
-        matches = [
-            _tutorial_item_pattern(member).search(grouped)
-            for member in members
-        ]
-        if not matches or any(match is None for match in matches):
-            continue
-        items = [match for match in matches if match is not None]
-        if [match.start() for match in items] != sorted(
-            match.start() for match in items
-        ):
-            continue
-
-        start, end = items[0].start(), items[-1].end()
-        children = grouped[start:end]
-        children = re.sub(r"\btoctree-l1\b", "toctree-l2", children)
-        is_active = " current" in children
-        active = " current active" if is_active else ""
-        open_state = " open" if is_active else ""
-        wrapper = (
-            f'<li class="toctree-l1 braintrace-tutorial-group'
-            f' has-children{active}">'
-            f"<details{open_state}>"
-            "<summary>"
-            f'<span class="caption-text">{html.escape(title)}</span>'
-            '<span class="toctree-toggle" role="presentation">'
-            '<i class="fa-solid fa-chevron-down"></i>'
-            "</span>"
-            "</summary>"
-            f'<ul class="nav bd-sidenav">{children}</ul>'
-            "</details>"
-            "</li>"
-        )
-        grouped = grouped[:start] + wrapper + grouped[end:]
-    return Markup(grouped)
-
-
-def _group_tutorial_sidebar(app, pagename, templatename, context, doctree):
-    """Wrap the theme's root sidebar generator with Tutorial grouping."""
-    generate_toctree_html = context.get("generate_toctree_html")
-    if generate_toctree_html is None:
-        return
-    groups = _tutorial_groups()
-
-    def generate_grouped_toctree(*args, **kwargs):
-        rendered = generate_toctree_html(*args, **kwargs)
-        if kwargs.get("kind") == "sidebar" and kwargs.get("startdepth") == 0:
-            return _group_tutorial_toctree(rendered, groups)
-        return rendered
-
-    context["generate_toctree_html"] = generate_grouped_toctree
-
-
-def setup(app):
-    """Register BrainTrace documentation hooks."""
-    app.connect("html-page-context", _group_tutorial_sidebar, priority=900)

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -175,36 +175,15 @@ differentiable ecosystem for full-scale brain simulation.
    quickstart/concepts.ipynb
 
 
-.. Tutorial grouping metadata is consumed by docs/conf.py. The toctree below
-.. remains the only owner of the actual document links.
-
-.. braintrace-tutorial-group: Online Training
-   :members: RNN Online Learning | SNN Online Learning
-
-.. braintrace-tutorial-group: Algorithm Tutorials
-   :members: D-RTRL: diagonal online gradient learning | pp_prop: input/output-factorized online gradients
-
-.. braintrace-tutorial-group: Foundations
-   :members: ETP Operator Fundamentals | braintrace.nn Layers | Hidden State Management
-
-.. braintrace-tutorial-group: Compiler & Runtime
-   :members: Graph Compilation | Visualization
-
-
 .. toctree::
    :hidden:
-   :maxdepth: 1
+   :maxdepth: 2
    :caption: Tutorial
 
-   tutorials/rnn_online_learning.ipynb
-   tutorials/snn_online_learning.ipynb
-   tutorials/drtrl.ipynb
-   tutorials/pp_prop.ipynb
-   tutorials/five_primitive_functions.ipynb
-   tutorials/neural_network_layers.ipynb
-   tutorials/hidden_states.ipynb
-   tutorials/graph_compilation.ipynb
-   tutorials/visualization.ipynb
+   tutorials/online_training.rst
+   tutorials/algorithm_tutorials.rst
+   tutorials/foundations.rst
+   tutorials/compiler_runtime.rst
 
 
 .. toctree::

--- a/docs/tutorials/algorithm_tutorials.rst
+++ b/docs/tutorials/algorithm_tutorials.rst
@@ -1,0 +1,59 @@
+Algorithm Tutorials
+===================
+
+Study the approximation carried by each algorithm before treating its output
+as a gradient estimate. Both chapters use a matched MiniGRU task so the
+algorithmic difference remains the main variable.
+
+.. note::
+
+   Read :doc:`../quickstart/concepts` first. The chapters assume that you
+   understand ETP selection and the role of hidden-state recurrences.
+
+Choose an algorithm
+-------------------
+
+.. grid:: 1 1 2 2
+   :gutter: 2
+
+   .. grid-item-card:: D-RTRL
+      :link: drtrl
+      :link-type: doc
+
+      Follow diagonal recurrent traces across a sequence and examine when the
+      approximation can differ from BPTT.
+
+   .. grid-item-card:: pp_prop
+      :link: pp_prop
+      :link-type: doc
+
+      Follow input/output-factorized traces and the contraction that turns
+      those factors into parameter gradients.
+
+Compare the algorithms
+----------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 34 44
+
+   * - Chapter
+     - Trace structure
+     - Primary question
+   * - :doc:`D-RTRL <drtrl>`
+     - Parameter-shaped trace with a diagonal hidden-Jacobian approximation
+     - What recurrent influence is retained, and why can it differ from BPTT?
+   * - :doc:`pp_prop <pp_prop>`
+     - Separate input and output factors
+     - How does factorization change trace propagation and gradient assembly?
+
+For a first pass, read D-RTRL before pp_prop. Neither chapter establishes
+universal equality with BPTT; each states the regime and checks appropriate to
+its approximation.
+
+.. toctree::
+   :hidden:
+   :maxdepth: 1
+
+   drtrl.ipynb
+   pp_prop.ipynb

--- a/docs/tutorials/compiler_runtime.rst
+++ b/docs/tutorials/compiler_runtime.rst
@@ -1,0 +1,52 @@
+Compiler & Runtime
+==================
+
+Inspect what BrainTrace compiled before interpreting an online-learning result.
+These chapters connect model structure to hidden groups, ETP relations, and
+compiler diagnostics.
+
+Inspect the runtime
+-------------------
+
+.. grid:: 1 1 2 2
+   :gutter: 2
+
+   .. grid-item-card:: Graph Compilation
+      :link: graph_compilation
+      :link-type: doc
+
+      Compile a recurrent model, inspect its ETP graph, and use
+      :func:`braintrace.compile_etrace_graph` when an algorithm wrapper is not
+      required.
+
+   .. grid-item-card:: Visualization
+      :link: visualization
+      :link-type: doc
+
+      Read ``learner.report`` and ``learner.graph`` to inspect included,
+      excluded, and grouped model state.
+
+Diagnostic workflow
+-------------------
+
+1. Compile the smallest representative input and confirm that compilation
+   completes without errors.
+2. Check the discovered hidden groups and their state paths.
+3. Compare ETP weights with excluded or non-temporal weights.
+4. Inspect each weight-primitive-hidden relation rather than relying only on
+   relation counts.
+5. Resolve structural diagnostics before evaluating an algorithm's learning
+   behavior.
+
+.. important::
+
+   Graphs and reports establish what the compiler selected. They do not, by
+   themselves, demonstrate that an approximate learning rule matches BPTT or
+   produces a valid descent direction.
+
+.. toctree::
+   :hidden:
+   :maxdepth: 1
+
+   graph_compilation.ipynb
+   visualization.ipynb

--- a/docs/tutorials/foundations.rst
+++ b/docs/tutorials/foundations.rst
@@ -1,0 +1,73 @@
+Foundations
+===========
+
+Build the conceptual path from an ETP-marked operation to the hidden state it
+influences. These chapters explain the contracts that determine whether a
+parameter participates in online learning.
+
+Choose a foundation
+-------------------
+
+.. grid:: 1 1 3 3
+   :gutter: 2
+
+   .. grid-item-card:: ETP Operator Fundamentals
+      :link: five_primitive_functions
+      :link-type: doc
+
+      Use the five public ETP operators with batching, physical units, JIT,
+      gradients, and ``vmap``.
+
+   .. grid-item-card:: braintrace.nn Layers
+      :link: neural_network_layers
+      :link-type: doc
+
+      Compose ETP-aware layers and understand operation-based parameter
+      selection and relation boundaries.
+
+   .. grid-item-card:: Hidden State Management
+      :link: hidden_states
+      :link-type: doc
+
+      Define, initialize, reset, and inspect the hidden-state groups discovered
+      by the compiler.
+
+Recommended sequence
+--------------------
+
+.. list-table::
+   :header-rows: 1
+   :widths: 12 30 58
+
+   * - Step
+     - Chapter
+     - Use it to
+   * - 1
+     - :doc:`ETP Operator Fundamentals <five_primitive_functions>`
+     - Select trainable operations and verify unit and JAX-transform behavior.
+   * - 2
+     - :doc:`braintrace.nn Layers <neural_network_layers>`
+     - Assemble recurrent models without violating parameter-to-hidden relation
+       boundaries.
+   * - 3
+     - :doc:`Hidden State Management <hidden_states>`
+     - Control state structure and understand how the compiler forms hidden
+       groups.
+
+Where to look first
+-------------------
+
+- Unexpected units, batching, or transform behavior: start with
+  :doc:`five_primitive_functions`.
+- A weight is excluded or marked non-temporal: inspect the relation-boundary
+  discussion in :doc:`neural_network_layers`.
+- State shapes, grouping, initialization, or reset behavior are unclear: use
+  :doc:`hidden_states`.
+
+.. toctree::
+   :hidden:
+   :maxdepth: 1
+
+   five_primitive_functions.ipynb
+   neural_network_layers.ipynb
+   hidden_states.ipynb

--- a/docs/tutorials/online_training.rst
+++ b/docs/tutorials/online_training.rst
@@ -1,0 +1,52 @@
+Online Training
+===============
+
+Take a model from definition to an executable online-learning workflow. These
+chapters use compact tasks to make state handling, trace updates, and training
+behavior inspectable.
+
+.. note::
+
+   Complete :doc:`../quickstart/quickstart` and
+   :doc:`../quickstart/concepts` first if you have not yet compiled a
+   BrainTrace model.
+
+Choose a workflow
+-----------------
+
+.. grid:: 1 1 2 2
+   :gutter: 2
+
+   .. grid-item-card:: RNN Online Learning
+      :link: rnn_online_learning
+      :link-type: doc
+
+      Train a GRU on the copying task with D-RTRL, then compare the online
+      workflow with a BPTT baseline.
+
+      **Best for:** continuous hidden states and sequence-memory tasks.
+
+   .. grid-item-card:: SNN Online Learning
+      :link: snn_online_learning
+      :link-type: doc
+
+      Build a recurrent LIF network, train it with ES-D-RTRL, and inspect how
+      factorized traces differ from D-RTRL.
+
+      **Best for:** spike-based dynamics, surrogate gradients, and physical
+      units.
+
+What both workflows establish
+-----------------------------
+
+- how model state is initialized and reset between sequences;
+- where :func:`braintrace.compile` enters the training pipeline;
+- how repeated updates are executed with compiled stateful transforms; and
+- which conclusions are specific to the demonstrated task and approximation.
+
+.. toctree::
+   :hidden:
+   :maxdepth: 1
+
+   rnn_online_learning.ipynb
+   snn_online_learning.ipynb


### PR DESCRIPTION
## Summary

- replace the theme-dependent Tutorial HTML rewrite with native nested RST toctrees
- add four stable second-level Tutorial group pages
- enrich the group pages with tutorial cards, reading guidance, comparisons, and diagnostic workflows
- remove the custom `html-page-context` grouping hook
- add no custom CSS, JavaScript, or template override

## Validation

- strict Sphinx HTML build completed with `-n -W`
- warning log is empty
- generated navigation retains native `toctree-l1` and `toctree-l2` nesting
- linked cards and API cross-references resolve successfully
- BrainX-generated assets are not included

## Summary by Sourcery

Replace theme-dependent tutorial sidebar grouping with native reStructuredText tutorial hierarchy and landing pages.

New Features:
- Introduce four second-level tutorial group landing pages under the tutorials section with structured guidance and comparisons.

Enhancements:
- Remove the custom html-page-context hook and associated sidebar HTML rewriting logic from the Sphinx configuration in favor of native toctree nesting.

Documentation:
- Restructure the tutorials section into a nested RST toctree with new group landing pages containing tutorial cards, reading guidance, and workflows.