### PR TITLE
docs: complete Algorithms API reference

### DIFF
--- a/braintrace/_algorithm/base.py
+++ b/braintrace/_algorithm/base.py
@@ -59,20 +59,25 @@ class EligibilityTrace(brainstate.ShortTermState):
 
 
 class ETraceAlgorithm(brainstate.nn.Module):
-    r"""
-    The base class for the eligibility trace algorithm.
+    r"""Provide the base interface for eligibility-trace algorithms.
 
     Parameters
     ----------
     model : brainstate.nn.Module
         The model function, which receives the input arguments and returns the model output.
+    graph_executor : ETraceGraphExecutor
+        The executor used to evaluate the compiled eligibility-trace graph.
     name : str, optional
         The name of the etrace algorithm.
 
     Attributes
     ----------
-    graph : ETraceGraphExecutor
-        The etrace graph.
+    graph : ETraceGraph
+        The compiled eligibility-trace graph.
+    executor : ETraceGraphExecutor
+        The executor associated with ``graph``.
+    report : CompilationReport
+        Structured diagnostics produced by graph compilation.
     param_states : Dict[Hashable, brainstate.ParamState]
         The weight states.
     hidden_states : Dict[Hashable, brainstate.HiddenState]

--- a/braintrace/_algorithm/d_rtrl.py
+++ b/braintrace/_algorithm/d_rtrl.py
@@ -23,28 +23,68 @@ __all__ = [
 
 
 class D_RTRL(ParamDimVjpAlgorithm):
-    r"""
-    The Diagonal RTRL (D-RTRL) online gradient computation algorithm.
+    r"""Compute online gradients with the Diagonal RTRL preset.
 
     ``D_RTRL`` is the canonical name for the parameter-dimension eligibility
-    trace algorithm implemented by :py:class:`ParamDimVjpAlgorithm`. It computes
+    trace algorithm implemented by :class:`ParamDimVjpAlgorithm`. It computes
     the gradients of the weights with the diagonal approximation and the
     parameter dimension complexity, following the learning rule:
 
-    $$
-    \begin{aligned}
-    &\boldsymbol{\epsilon}^t \approx \mathbf{D}^t \boldsymbol{\epsilon}^{t-1}+\operatorname{diag}\left(\mathbf{D}_f^t\right) \otimes \mathbf{x}^t \\
-    & \nabla_{\boldsymbol{\theta}} \mathcal{L}=\sum_{t^{\prime} \in \mathcal{T}} \frac{\partial \mathcal{L}^{t^{\prime}}}{\partial \mathbf{h}^{t^{\prime}}} \circ \boldsymbol{\epsilon}^{t^{\prime}}
-    \end{aligned}
-    $$
+    .. math::
+
+        \begin{aligned}
+        \boldsymbol{\epsilon}^t
+        &\approx \mathbf{D}^t \boldsymbol{\epsilon}^{t-1}
+        + \operatorname{diag}(\mathbf{D}_f^t) \otimes \mathbf{x}^t, \\
+        \nabla_{\boldsymbol{\theta}} \mathcal{L}
+        &= \sum_{t^{\prime} \in \mathcal{T}}
+        \frac{\partial \mathcal{L}^{t^{\prime}}}
+        {\partial \mathbf{h}^{t^{\prime}}}
+        \circ \boldsymbol{\epsilon}^{t^{\prime}}.
+        \end{aligned}
 
     This formulation follows the D-RTRL estimator presented by Wang et al.
     [1]_ and the original RTRL construction of Williams and Zipser [2]_.
 
-    This subclass inherits all behavior from :py:class:`ParamDimVjpAlgorithm`
-    without modification; it exists to provide the canonical ``D_RTRL`` name. See
-    :py:class:`ParamDimVjpAlgorithm` for the full parameter list and a usage
-    example.
+    Parameters
+    ----------
+    model : brainstate.nn.Module
+        Recurrent model whose ETP-routed parameters are trained online.
+    name : str, optional
+        Name of the algorithm instance.
+    vjp_method : {'single-step', 'multi-step'}, optional
+        VJP window used to compute the learning signal.
+    fast_solve : bool, optional
+        Whether to use closed-form per-primitive contractions when available.
+    trace_dtype : dtype, optional
+        Storage dtype for supported fast-path eligibility traces.
+    chunked_trace : bool, optional
+        Whether multi-step inputs use the closed-form chunked trace roll.
+    control_flow : ControlFlowPolicy, optional
+        Control-flow canonicalization policy used during graph compilation.
+    config : ETraceConfig, optional
+        Learning-rule coordinates. ``None`` uses the D-RTRL preset.
+    random_feedback_key : jax.Array, optional
+        Key for fixed random-feedback projections requested by ``config``.
+    snap_max_jacobian_elements : int, optional
+        Maximum permitted size of each SnAp widened block Jacobian.
+
+    See Also
+    --------
+    ParamDimVjpAlgorithm
+        Parameter-dimensional engine implementing this preset.
+
+    Examples
+    --------
+    .. code-block:: python
+
+        >>> import brainstate
+        >>> import braintrace
+        >>>
+        >>> model = braintrace.nn.ValinaRNNCell(2, 4, activation='tanh')
+        >>> x0 = brainstate.random.randn(2)
+        >>> learner = braintrace.compile(model, braintrace.D_RTRL, x0)
+        >>> y = learner.update(x0)
 
     References
     ----------

--- a/braintrace/_algorithm/e_prop.py
+++ b/braintrace/_algorithm/e_prop.py
@@ -129,8 +129,15 @@ class EProp(ParamDimVjpAlgorithm):
         ``feedback='random'``; ignored otherwise.
     name : str, optional
         Name of the algorithm instance.
-    vjp_method, fast_solve
-        Forwarded verbatim to :class:`~braintrace.D_RTRL`.
+    vjp_method : {'single-step', 'multi-step'}, optional
+        VJP window used to compute the learning signal.
+    fast_solve : bool, optional
+        Whether to use closed-form per-primitive contractions when available.
+    **kwargs : Any
+        Additional options forwarded to
+        :class:`~braintrace.ParamDimVjpAlgorithm`, including ``trace_dtype``,
+        ``chunked_trace``, ``control_flow``, ``config``, and
+        ``snap_max_jacobian_elements``.
 
     Raises
     ------

--- a/braintrace/_algorithm/io_dim_vjp.py
+++ b/braintrace/_algorithm/io_dim_vjp.py
@@ -668,12 +668,15 @@ class IODimVjpAlgorithm(ETraceVjpAlgorithm):
     model : brainstate.nn.Module
         The model function, which receives the input arguments and returns the
         model output.
-    decay_or_rank : float or int
+    decay_or_rank : float, int, or tuple of two floats or ints
         Parameterization of the exponential smoothing factor. A float in
         :math:`(0, 1)` is used directly as the decay. A positive integer
         :math:`r` is converted to :math:`\alpha=(r-1)/(r+1)`. The integer form
         does not allocate :math:`r` separate trace factors; both forms use the
-        same input/output-factorized trace structure.
+        same input/output-factorized trace structure. A two-item tuple
+        configures the input- and output-side factors separately.
+    name : str, optional
+        Name of the eligibility-trace algorithm.
     vjp_method : str, optional
         The method for computing the VJP. It should be either ``"single-step"``
         or ``"multi-step"``.
@@ -683,15 +686,20 @@ class IODimVjpAlgorithm(ETraceVjpAlgorithm):
         - ``"multi-step"``: the VJP is computed at multiple time steps, i.e.,
           :math:`\partial L^t/\partial h^{t-k}`, where :math:`k` is determined by
           the data input.
+    fast_solve : bool, optional
+        Whether to use the closed-form per-primitive contractions when
+        available. The default is ``True``.
     control_flow : ControlFlowPolicy, optional
         Policy governing control-flow canonicalization (cond if-conversion,
         scan unrolling, structured scan descent, ...) during graph
         compilation. ``None`` (default) uses
         ``ControlFlowPolicy()``.
-    name : str, optional
-        The name of the etrace algorithm.
-    mode : braintrace.mixin.Mode, optional
-        The computing mode, indicating the batching information.
+    config : ETraceConfig, optional
+        Learning-rule coordinates. ``None`` uses the input/output-factorized
+        preset derived from ``decay_or_rank``.
+    random_feedback_key : jax.Array, optional
+        Key used to initialize fixed random-feedback projections when the
+        selected config requests them.
 
     Notes
     -----

--- a/braintrace/_algorithm/ostl.py
+++ b/braintrace/_algorithm/ostl.py
@@ -93,8 +93,24 @@ class OSTLRecurrent(ParamDimVjpAlgorithm):
     ----------
     model : brainstate.nn.Module
         The recurrent SNN whose weights are trained online.
-    name, vjp_method, fast_solve : optional
-        Forwarded verbatim to :class:`~braintrace.ParamDimVjpAlgorithm`.
+    name : str, optional
+        Name of the algorithm instance.
+    vjp_method : {'single-step', 'multi-step'}, optional
+        VJP window used to compute the learning signal.
+    fast_solve : bool, optional
+        Whether to use closed-form per-primitive contractions when available.
+    trace_dtype : dtype, optional
+        Storage dtype for supported fast-path eligibility traces.
+    chunked_trace : bool, optional
+        Whether multi-step inputs use the closed-form chunked trace roll.
+    control_flow : ControlFlowPolicy, optional
+        Control-flow canonicalization policy used during graph compilation.
+    config : ETraceConfig, optional
+        Learning-rule coordinates. ``None`` uses the OSTL recurrent preset.
+    random_feedback_key : jax.Array, optional
+        Key for fixed random-feedback projections requested by ``config``.
+    snap_max_jacobian_elements : int, optional
+        Maximum permitted size of each SnAp widened block Jacobian.
 
     Examples
     --------
@@ -166,8 +182,12 @@ class OSTLFeedforward(pp_prop):
         Exponential-smoothing factor of the IO-dim trace. The tiny default makes
         the temporal contribution negligible, matching the 'without-H' regime. A
         float must lie in ``[0, 1)``; an int is read as an approximation rank.
-    name, vjp_method, fast_solve : optional
-        Forwarded verbatim to :class:`~braintrace.pp_prop`.
+    name : str, optional
+        Name of the algorithm instance.
+    **kwargs : Any
+        Additional options forwarded to :class:`~braintrace.pp_prop`, including
+        ``vjp_method``, ``fast_solve``, ``control_flow``, ``config``, and
+        ``random_feedback_key``.
 
     Notes
     -----

--- a/braintrace/_algorithm/param_dim_vjp.py
+++ b/braintrace/_algorithm/param_dim_vjp.py
@@ -963,6 +963,8 @@ class ParamDimVjpAlgorithm(ETraceVjpAlgorithm):
     model : brainstate.nn.Module
         The model function, which receives the input arguments and returns the
         model output.
+    name : str, optional
+        Name of the eligibility-trace algorithm.
     vjp_method : str, optional
         The method for computing the VJP. It should be either ``"single-step"``
         or ``"multi-step"``.
@@ -972,6 +974,12 @@ class ParamDimVjpAlgorithm(ETraceVjpAlgorithm):
         - ``"multi-step"``: the VJP is computed at multiple time steps, i.e.,
           :math:`\partial L^t/\partial h^{t-k}`, where :math:`k` is determined by
           the data input.
+    fast_solve : bool, optional
+        Whether to use the closed-form per-primitive contractions when
+        available. The default is ``True``.
+    trace_dtype : dtype, optional
+        Storage dtype for supported fast-path eligibility traces. ``None``
+        preserves the native dtype.
     chunked_trace : bool, optional
         When ``True`` (default) and the input spans multiple time steps, the
         eligibility-trace roll over the window is computed in closed form —
@@ -994,10 +1002,15 @@ class ParamDimVjpAlgorithm(ETraceVjpAlgorithm):
         scan unrolling, structured scan descent, ...) during graph
         compilation. ``None`` (default) uses
         ``ControlFlowPolicy()``.
-    name : str, optional
-        The name of the etrace algorithm.
-    mode : braintrace.mixin.Mode, optional
-        The computing mode, indicating the batching behavior.
+    config : ETraceConfig, optional
+        Learning-rule coordinates. ``None`` uses the parameter-dimensional
+        preset.
+    random_feedback_key : jax.Array, optional
+        Key used to initialize fixed random-feedback projections when the
+        selected config requests them.
+    snap_max_jacobian_elements : int, optional
+        Maximum number of elements permitted in each SnAp widened block
+        Jacobian. The default is ``16777216``.
 
     Notes
     -----
@@ -1071,7 +1084,7 @@ class ParamDimVjpAlgorithm(ETraceVjpAlgorithm):
         >>>
         >>> model = RNN()
         >>> x0 = brainstate.random.randn(1)
-        >>> # ``braintrace.D_RTRL`` is an alias of ``ParamDimVjpAlgorithm``; one call
+        >>> # ``D_RTRL`` is the concrete parameter-dimensional preset; one call
         >>> # initialises states, builds the trace graph, and returns a learner.
         >>> learner = braintrace.compile(model, braintrace.D_RTRL, x0)
         >>> y = learner(x0)             # forward pass + eligibility-trace update

--- a/braintrace/_algorithm/pp_prop.py
+++ b/braintrace/_algorithm/pp_prop.py
@@ -33,12 +33,33 @@ class pp_prop(IODimVjpAlgorithm):
     on the RTRL construction of Williams and Zipser [2]_.
 
     This subclass inherits all behavior from :class:`IODimVjpAlgorithm` without
-    modification; it exists to provide the canonical ``pp_prop`` name. See
-    :class:`IODimVjpAlgorithm` for the full parameter list.
+    modification; it exists to provide the canonical ``pp_prop`` name.
+
+    Parameters
+    ----------
+    model : brainstate.nn.Module
+        Recurrent model whose ETP-routed parameters are trained online.
+    decay_or_rank : float, int, or tuple of two floats or ints
+        Exponential-smoothing decay, integer rank parameterization, or separate
+        input/output-side settings.
+    name : str, optional
+        Name of the algorithm instance.
+    vjp_method : {'single-step', 'multi-step'}, optional
+        VJP window used to compute the learning signal.
+    fast_solve : bool, optional
+        Whether to use closed-form per-primitive contractions when available.
+    control_flow : ControlFlowPolicy, optional
+        Control-flow canonicalization policy used during graph compilation.
+    config : ETraceConfig, optional
+        Learning-rule coordinates. ``None`` derives the pp-prop preset from
+        ``decay_or_rank``.
+    random_feedback_key : jax.Array, optional
+        Key for fixed random-feedback projections requested by ``config``.
 
     See Also
     --------
-    IODimVjpAlgorithm : The implementing class with the full parameter list.
+    IODimVjpAlgorithm
+        Input/output-factorized engine implementing this preset.
 
     Notes
     -----

--- a/braintrace/_algorithm/snap_n.py
+++ b/braintrace/_algorithm/snap_n.py
@@ -109,8 +109,11 @@ class SnAp(ParamDimVjpAlgorithm):
         ``P * (K * S) ** 2`` elements. Raising it is how a deliberately large
         neighbourhood is admitted; the default rejects roughly half a gigabyte
         per operator. Forwarded to the compiler.
-    **kwargs
-        Forwarded verbatim to :class:`~braintrace.ParamDimVjpAlgorithm`.
+    **kwargs : Any
+        Additional options forwarded to
+        :class:`~braintrace.ParamDimVjpAlgorithm`, including ``trace_dtype``,
+        ``chunked_trace``, ``control_flow``, ``config``, and
+        ``random_feedback_key``.
 
     Attributes
     ----------

--- a/braintrace/_algorithm/vjp_base.py
+++ b/braintrace/_algorithm/vjp_base.py
@@ -188,9 +188,7 @@ def expand_modulator_to_group(
 
 
 class ETraceVjpAlgorithm(ETraceAlgorithm):
-    r"""
-    The base class for the eligibility trace algorithm supporting the VJP gradient
-    computation (reverse-mode differentiation).
+    r"""Provide VJP-based eligibility-trace gradient computation.
 
     The term ``VJP`` comes from two aspects. First, this module is designed to be
     compatible with JAX's VJP mechanism, so the gradient is computed according to the
@@ -223,6 +221,15 @@ class ETraceVjpAlgorithm(ETraceAlgorithm):
         scan unrolling, structured scan descent, ...) during graph
         compilation. ``None`` (default) uses
         ``ControlFlowPolicy()``.
+    config : ETraceConfig, optional
+        Learning-rule coordinates. ``None`` uses the subclass's preset
+        coordinate.
+    random_feedback_key : jax.Array, optional
+        Key used to initialize fixed random-feedback projections when
+        ``config.learning_signal='random_feedback'``.
+    snap_max_jacobian_elements : int, optional
+        Maximum number of elements permitted in each SnAp widened block
+        Jacobian. The default is ``16777216``.
 
     Notes
     -----

--- a/braintrace/_compile.py
+++ b/braintrace/_compile.py
@@ -142,12 +142,17 @@ def compile(
         need to be pre-initialized; ``compile`` always (re)initializes its states.
     algorithm : type, str or ETraceConfig
         An :class:`ETraceAlgorithm` subclass, a registered case-insensitive
-        name, e.g. ``'D_RTRL'``, ``'es_d_rtrl'``, ``'eprop'``,
-        ``'ostl_recurrent'``, ``'ostl_feedforward'``, or an
-        :class:`ETraceConfig` naming the learning-rule coordinate directly. A
-        config selects the engine through its ``trace_factorization`` and is
-        forwarded to the constructor, so any coordinate the compatibility
-        matrix admits can be compiled without a named preset.
+        name, or an :class:`ETraceConfig` naming the learning-rule coordinate
+        directly. Registered names are ``'d_rtrl'``, ``'pp_prop'``,
+        ``'es_d_rtrl'``, ``'esd_rtrl'``, ``'eprop'``, ``'e_prop'``,
+        ``'ostl_recurrent'``, ``'ostl_feedforward'``, ``'uoro'``,
+        ``'three_factor'``, and ``'dni'``. The aliases ``'es_d_rtrl'`` and
+        ``'esd_rtrl'`` select :class:`pp_prop`; ``'e_prop'`` selects
+        :class:`EProp`. :class:`SnAp` has no registered string name and must be
+        passed as a class. A config selects the engine through its
+        ``trace_factorization`` and is forwarded to the constructor, so any
+        coordinate admitted by the compatibility matrix can be compiled
+        without a named preset.
     *example_inputs
         Example call inputs (arrays / :class:`SingleStepData` /
         :class:`MultiStepData`) matching what ``learner.update(...)`` will
@@ -195,8 +200,10 @@ def compile(
         ``verbose`` is not in ``{0, 1, 2}``, or ``vmap=True`` without
         ``batch_size``.
     TypeError
-        If ``algorithm`` is neither an ``ETraceAlgorithm`` subclass nor a string,
-        or a required algorithm option (see below) is missing.
+        If ``algorithm`` is not an ``ETraceAlgorithm`` subclass, registered
+        string, or :class:`ETraceConfig`; if a required algorithm option is
+        missing; or if the same config is supplied both as ``algorithm`` and
+        through ``config=``.
     braintrace.CompilationError
         If no trainable weights are routed through ETP ops (nothing to learn
         online).
@@ -205,31 +212,24 @@ def compile(
     -----
     **Algorithm options.** ``**options`` are forwarded verbatim to the algorithm
     constructor. Required options have no default; omitting one raises
-    ``TypeError``. Authoritative descriptions live on each algorithm class.
+    ``TypeError``. The class pages are the authoritative source for accepted
+    options:
 
-    *Common (algorithm-dependent subset):*
+    - :class:`D_RTRL` for ``'d_rtrl'``.
+    - :class:`pp_prop` for ``'pp_prop'``, ``'es_d_rtrl'``, and ``'esd_rtrl'``.
+    - :class:`EProp` for ``'eprop'`` and ``'e_prop'``.
+    - :class:`OSTLRecurrent` for ``'ostl_recurrent'``.
+    - :class:`OSTLFeedforward` for ``'ostl_feedforward'``.
+    - :class:`UORO` for ``'uoro'``.
+    - :class:`ThreeFactor` for ``'three_factor'``.
+    - :class:`DNI` for ``'dni'``.
+    - :class:`SnAp` for class-only SnAp compilation.
 
-    - ``name`` (str) — module name.
-    - ``vjp_method`` (str, default ``'single-step'``) — loss→hidden VJP unrolling.
-    - ``fast_solve`` (bool, default ``True``) — fast linear solve for the
-      hidden→weight Jacobian.
-    - ``trace_dtype`` — eligibility-trace storage dtype.
-
-    *Per algorithm:*
-
-    - ``'D_RTRL'`` — ``vjp_method``, ``fast_solve``, ``trace_dtype``,
-      ``chunked_trace`` (bool, default ``True``: closed-form multi-step trace
-      roll via chunk factorization; see :class:`ParamDimVjpAlgorithm`),
-      ``name``.
-    - ``'es_d_rtrl'`` / ``'pp_prop'`` — ``decay_or_rank`` (**required**: float in
-      (0, 1) ⇒ decay, or int ≥ 1 ⇒ rank), ``vjp_method``, ``fast_solve``,
-      ``name``.
-    - ``'eprop'`` — ``feedback`` (default ``'symmetric'``), ``kappa_filter_decay``
-      (default ``0.0``), ``random_feedback_key`` (default ``None``),
-      ``vjp_method``, ``fast_solve``, ``name``.
-    - ``'ostl_recurrent'`` — ``vjp_method``, ``fast_solve``, ``trace_dtype``,
-      ``name``.
-    - ``'ostl_feedforward'`` — ``decay_or_rank`` (default ``1e-6``), ``name``.
+    Passing an algorithm class supports subclasses and avoids the string
+    registry. Passing :class:`ETraceConfig` selects
+    :class:`ParamDimVjpAlgorithm`, :class:`IODimVjpAlgorithm`, or
+    :class:`RandomProjectionVjpAlgorithm` from ``trace_factorization``. Do not
+    also pass ``config=`` in that case.
 
     Calling ``compile`` twice on the same model re-initializes its states.
 
@@ -263,9 +263,18 @@ def compile(
         >>>
         >>> model = RNN()
         >>> x0 = brainstate.random.randn(1, 3)   # (batch, features)
-        >>> # one call: initialise states, build the trace graph, return a learner
-        >>> learner = braintrace.compile(model, 'D_RTRL', x0, batch_size=1)
-        >>> y = learner.update(x0)               # forward pass + eligibility-trace update
+        >>> # Registered string: initialize states, build the graph, return a learner.
+        >>> by_name = braintrace.compile(model, 'd_rtrl', x0, batch_size=1)
+        >>> y = by_name.update(x0)
+        >>>
+        >>> # Algorithm classes, including SnAp, can be passed directly.
+        >>> by_class = braintrace.compile(
+        ...     model, braintrace.D_RTRL, x0, batch_size=1)
+        >>>
+        >>> # A config selects an engine from its trace factorization.
+        >>> config = braintrace.ETraceConfig()
+        >>> by_config = braintrace.compile(
+        ...     model, config, x0, batch_size=1)
     """
     cls = _resolve_algorithm(algorithm)
     if isinstance(algorithm, ETraceConfig):

--- a/docs/apis/algorithm_details/braintrace.DNI.rst
+++ b/docs/apis/algorithm_details/braintrace.DNI.rst
@@ -1,0 +1,10 @@
+﻿.. role:: hidden
+    :class: hidden-section
+.. currentmodule:: braintrace
+
+
+DNI
+===
+
+.. autoclass:: DNI(model, synthesizer=None, name=None, vjp_method='multi-step', fast_solve=True, trace_dtype=None, chunked_trace=True, control_flow=None, snap_max_jacobian_elements=16777216)
+    :members: graph, report, compile_graph, show_graph, update, init_etrace_state, reset_state, get_etrace_of, attach_synthesizer, group_signal_shapes

--- a/docs/apis/algorithm_details/braintrace.D_RTRL.rst
+++ b/docs/apis/algorithm_details/braintrace.D_RTRL.rst
@@ -1,0 +1,10 @@
+﻿.. role:: hidden
+    :class: hidden-section
+.. currentmodule:: braintrace
+
+
+D_RTRL
+======
+
+.. autoclass:: D_RTRL(model, name=None, vjp_method='single-step', fast_solve=True, trace_dtype=None, chunked_trace=True, control_flow=None, config=None, random_feedback_key=None, snap_max_jacobian_elements=16777216)
+    :members: graph, report, compile_graph, show_graph, update, init_etrace_state, reset_state, get_etrace_of

--- a/docs/apis/algorithm_details/braintrace.EProp.rst
+++ b/docs/apis/algorithm_details/braintrace.EProp.rst
@@ -1,0 +1,10 @@
+﻿.. role:: hidden
+    :class: hidden-section
+.. currentmodule:: braintrace
+
+
+EProp
+=====
+
+.. autoclass:: EProp(model, feedback='symmetric', kappa_filter_decay=0.0, random_feedback_key=None, name=None, vjp_method='single-step', fast_solve=True, **kwargs)
+    :members: graph, report, compile_graph, show_graph, update, init_etrace_state, reset_state, get_etrace_of

--- a/docs/apis/algorithm_details/braintrace.ETraceAlgorithm.rst
+++ b/docs/apis/algorithm_details/braintrace.ETraceAlgorithm.rst
@@ -1,0 +1,10 @@
+﻿.. role:: hidden
+    :class: hidden-section
+.. currentmodule:: braintrace
+
+
+ETraceAlgorithm
+===============
+
+.. autoclass:: ETraceAlgorithm(model, graph_executor, name=None)
+    :members: graph, report, compile_graph, show_graph, update, init_etrace_state, get_etrace_of

--- a/docs/apis/algorithm_details/braintrace.ETraceConfig.rst
+++ b/docs/apis/algorithm_details/braintrace.ETraceConfig.rst
@@ -1,0 +1,10 @@
+﻿.. role:: hidden
+    :class: hidden-section
+.. currentmodule:: braintrace
+
+
+ETraceConfig
+============
+
+.. autoclass:: ETraceConfig
+    :members:

--- a/docs/apis/algorithm_details/braintrace.ETraceVjpAlgorithm.rst
+++ b/docs/apis/algorithm_details/braintrace.ETraceVjpAlgorithm.rst
@@ -1,0 +1,10 @@
+﻿.. role:: hidden
+    :class: hidden-section
+.. currentmodule:: braintrace
+
+
+ETraceVjpAlgorithm
+==================
+
+.. autoclass:: ETraceVjpAlgorithm(model, name=None, vjp_method='single-step', control_flow=None, config=None, random_feedback_key=None, snap_max_jacobian_elements=16777216)
+    :members: graph, report, compile_graph, show_graph, update, init_etrace_state, get_etrace_of

--- a/docs/apis/algorithm_details/braintrace.EligibilityTrace.rst
+++ b/docs/apis/algorithm_details/braintrace.EligibilityTrace.rst
@@ -1,0 +1,10 @@
+﻿.. role:: hidden
+    :class: hidden-section
+.. currentmodule:: braintrace
+
+
+EligibilityTrace
+================
+
+.. autoclass:: EligibilityTrace
+    :members:

--- a/docs/apis/algorithm_details/braintrace.FixedRandomFeedback.rst
+++ b/docs/apis/algorithm_details/braintrace.FixedRandomFeedback.rst
@@ -1,0 +1,10 @@
+﻿.. role:: hidden
+    :class: hidden-section
+.. currentmodule:: braintrace
+
+
+FixedRandomFeedback
+===================
+
+.. autoclass:: FixedRandomFeedback
+    :members:

--- a/docs/apis/algorithm_details/braintrace.IODimVjpAlgorithm.rst
+++ b/docs/apis/algorithm_details/braintrace.IODimVjpAlgorithm.rst
@@ -1,0 +1,10 @@
+﻿.. role:: hidden
+    :class: hidden-section
+.. currentmodule:: braintrace
+
+
+IODimVjpAlgorithm
+=================
+
+.. autoclass:: IODimVjpAlgorithm(model, decay_or_rank, name=None, vjp_method='single-step', fast_solve=True, control_flow=None, config=None, random_feedback_key=None)
+    :members: graph, report, compile_graph, show_graph, update, init_etrace_state, reset_state, get_etrace_of

--- a/docs/apis/algorithm_details/braintrace.KappaFilter.rst
+++ b/docs/apis/algorithm_details/braintrace.KappaFilter.rst
@@ -1,0 +1,10 @@
+﻿.. role:: hidden
+    :class: hidden-section
+.. currentmodule:: braintrace
+
+
+KappaFilter
+===========
+
+.. autoclass:: KappaFilter
+    :members:

--- a/docs/apis/algorithm_details/braintrace.OSTLFeedforward.rst
+++ b/docs/apis/algorithm_details/braintrace.OSTLFeedforward.rst
@@ -1,0 +1,10 @@
+﻿.. role:: hidden
+    :class: hidden-section
+.. currentmodule:: braintrace
+
+
+OSTLFeedforward
+===============
+
+.. autoclass:: OSTLFeedforward(model, decay_or_rank=1e-06, name=None, **kwargs)
+    :members: graph, report, compile_graph, show_graph, update, init_etrace_state, reset_state, get_etrace_of

--- a/docs/apis/algorithm_details/braintrace.OSTLRecurrent.rst
+++ b/docs/apis/algorithm_details/braintrace.OSTLRecurrent.rst
@@ -1,0 +1,10 @@
+﻿.. role:: hidden
+    :class: hidden-section
+.. currentmodule:: braintrace
+
+
+OSTLRecurrent
+=============
+
+.. autoclass:: OSTLRecurrent(model, name=None, vjp_method='single-step', fast_solve=True, trace_dtype=None, chunked_trace=True, control_flow=None, config=None, random_feedback_key=None, snap_max_jacobian_elements=16777216)
+    :members: graph, report, compile_graph, show_graph, update, init_etrace_state, reset_state, get_etrace_of

--- a/docs/apis/algorithm_details/braintrace.ParamDimVjpAlgorithm.rst
+++ b/docs/apis/algorithm_details/braintrace.ParamDimVjpAlgorithm.rst
@@ -1,0 +1,10 @@
+﻿.. role:: hidden
+    :class: hidden-section
+.. currentmodule:: braintrace
+
+
+ParamDimVjpAlgorithm
+====================
+
+.. autoclass:: ParamDimVjpAlgorithm(model, name=None, vjp_method='single-step', fast_solve=True, trace_dtype=None, chunked_trace=True, control_flow=None, config=None, random_feedback_key=None, snap_max_jacobian_elements=16777216)
+    :members: graph, report, compile_graph, show_graph, update, init_etrace_state, reset_state, get_etrace_of

--- a/docs/apis/algorithm_details/braintrace.RandomProjectionVjpAlgorithm.rst
+++ b/docs/apis/algorithm_details/braintrace.RandomProjectionVjpAlgorithm.rst
@@ -1,0 +1,10 @@
+﻿.. role:: hidden
+    :class: hidden-section
+.. currentmodule:: braintrace
+
+
+RandomProjectionVjpAlgorithm
+============================
+
+.. autoclass:: RandomProjectionVjpAlgorithm(model, name=None, vjp_method='multi-step', fast_solve=True, control_flow=None, config=None, projection_key=42, projection_eps=1e-12, random_feedback_key=None, snap_max_jacobian_elements=16777216)
+    :members: graph, report, compile_graph, show_graph, update, init_etrace_state, reset_state, get_etrace_of

--- a/docs/apis/algorithm_details/braintrace.SnAp.rst
+++ b/docs/apis/algorithm_details/braintrace.SnAp.rst
@@ -1,0 +1,10 @@
+﻿.. role:: hidden
+    :class: hidden-section
+.. currentmodule:: braintrace
+
+
+SnAp
+====
+
+.. autoclass:: SnAp(model, n=2, name=None, vjp_method='single-step', fast_solve=True, snap_max_jacobian_elements=16777216, **kwargs)
+    :members: graph, report, compile_graph, show_graph, update, init_etrace_state, reset_state, get_etrace_of

--- a/docs/apis/algorithm_details/braintrace.SyntheticGradient.rst
+++ b/docs/apis/algorithm_details/braintrace.SyntheticGradient.rst
@@ -1,0 +1,10 @@
+﻿.. role:: hidden
+    :class: hidden-section
+.. currentmodule:: braintrace
+
+
+SyntheticGradient
+=================
+
+.. autoclass:: SyntheticGradient(group_shapes, hidden_width=None, scale=0.0, seed=0)
+    :members: param_values, states_dict, apply

--- a/docs/apis/algorithm_details/braintrace.ThreeFactor.rst
+++ b/docs/apis/algorithm_details/braintrace.ThreeFactor.rst
@@ -1,0 +1,10 @@
+﻿.. role:: hidden
+    :class: hidden-section
+.. currentmodule:: braintrace
+
+
+ThreeFactor
+===========
+
+.. autoclass:: ThreeFactor(model, name=None, vjp_method='single-step', modulator=None, fast_solve=True, trace_dtype=None, chunked_trace=True, control_flow=None, snap_max_jacobian_elements=16777216)
+    :members: graph, report, compile_graph, show_graph, update, init_etrace_state, reset_state, get_etrace_of

--- a/docs/apis/algorithm_details/braintrace.UORO.rst
+++ b/docs/apis/algorithm_details/braintrace.UORO.rst
@@ -1,0 +1,10 @@
+﻿.. role:: hidden
+    :class: hidden-section
+.. currentmodule:: braintrace
+
+
+UORO
+====
+
+.. autoclass:: UORO(model, name=None, vjp_method='multi-step', fast_solve=True, control_flow=None, projection_key=42, projection_eps=1e-12, random_feedback_key=None, snap_max_jacobian_elements=16777216)
+    :members: graph, report, compile_graph, show_graph, update, init_etrace_state, reset_state, get_etrace_of

--- a/docs/apis/algorithm_details/braintrace.compile.rst
+++ b/docs/apis/algorithm_details/braintrace.compile.rst
@@ -1,0 +1,9 @@
+﻿.. role:: hidden
+    :class: hidden-section
+.. currentmodule:: braintrace
+
+
+compile
+========
+
+.. autofunction:: compile

--- a/docs/apis/algorithm_details/braintrace.pp_prop.rst
+++ b/docs/apis/algorithm_details/braintrace.pp_prop.rst
@@ -1,0 +1,10 @@
+﻿.. role:: hidden
+    :class: hidden-section
+.. currentmodule:: braintrace
+
+
+pp_prop
+========
+
+.. autoclass:: pp_prop(model, decay_or_rank, name=None, vjp_method='single-step', fast_solve=True, control_flow=None, config=None, random_feedback_key=None)
+    :members: graph, report, compile_graph, show_graph, update, init_etrace_state, reset_state, get_etrace_of

--- a/docs/apis/algorithm_details/braintrace.train_synthetic_gradient.rst
+++ b/docs/apis/algorithm_details/braintrace.train_synthetic_gradient.rst
@@ -1,0 +1,9 @@
+﻿.. role:: hidden
+    :class: hidden-section
+.. currentmodule:: braintrace
+
+
+train_synthetic_gradient
+========================
+
+.. autofunction:: train_synthetic_gradient

--- a/docs/apis/algorithms.rst
+++ b/docs/apis/algorithms.rst
@@ -7,6 +7,31 @@ Online-Learning Algorithms
    :local:
    :depth: 1
 
+.. toctree::
+   :hidden:
+
+   algorithm_details/braintrace.compile
+   algorithm_details/braintrace.ETraceConfig
+   algorithm_details/braintrace.ETraceAlgorithm
+   algorithm_details/braintrace.ETraceVjpAlgorithm
+   algorithm_details/braintrace.EligibilityTrace
+   algorithm_details/braintrace.ParamDimVjpAlgorithm
+   algorithm_details/braintrace.D_RTRL
+   algorithm_details/braintrace.IODimVjpAlgorithm
+   algorithm_details/braintrace.pp_prop
+   algorithm_details/braintrace.SnAp
+   algorithm_details/braintrace.RandomProjectionVjpAlgorithm
+   algorithm_details/braintrace.UORO
+   algorithm_details/braintrace.ThreeFactor
+   algorithm_details/braintrace.DNI
+   algorithm_details/braintrace.SyntheticGradient
+   algorithm_details/braintrace.train_synthetic_gradient
+   algorithm_details/braintrace.EProp
+   algorithm_details/braintrace.OSTLRecurrent
+   algorithm_details/braintrace.OSTLFeedforward
+   algorithm_details/braintrace.FixedRandomFeedback
+   algorithm_details/braintrace.KappaFilter
+
 ``braintrace`` provides online-learning algorithms based on eligibility-trace
 propagation. They all share one interface: wrap a model, compile its graph,
 then call the learner as a drop-in replacement for the model's forward pass —
@@ -26,9 +51,7 @@ for a model and eagerly builds its eligibility-trace graph, returning a
 ready-to-``update`` learner in a single call.
 
 .. autosummary::
-   :toctree: generated/
    :nosignatures:
-   :template: classtemplate.rst
 
    compile
 
@@ -76,9 +99,7 @@ Pass a config wherever :func:`compile` accepts an algorithm name:
     )
 
 .. autosummary::
-   :toctree: generated/
    :nosignatures:
-   :template: classtemplate.rst
 
    ETraceConfig
 
@@ -92,9 +113,7 @@ concrete D-RTRL / ES-D-RTRL / SNN algorithms build on. :class:`EligibilityTrace`
 is the state these algorithms carry across time.
 
 .. autosummary::
-   :toctree: generated/
    :nosignatures:
-   :template: classtemplate.rst
 
    ETraceAlgorithm
    ETraceVjpAlgorithm
@@ -122,9 +141,7 @@ gradient-equivalent to BPTT outside the assumptions of that approximation.
    \circ \boldsymbol{\epsilon}^{t'}
 
 .. autosummary::
-   :toctree: generated/
    :nosignatures:
-   :template: classtemplate.rst
 
    ParamDimVjpAlgorithm
    D_RTRL
@@ -159,9 +176,7 @@ it does not allocate multiple rank factors.
    + (1 - \alpha) \operatorname{diag}(\mathbf{D}_f^t)
 
 .. autosummary::
-   :toctree: generated/
    :nosignatures:
-   :template: classtemplate.rst
 
    IODimVjpAlgorithm
    pp_prop
@@ -181,9 +196,7 @@ the method is most useful when the recurrent position graph is structurally
 sparse.
 
 .. autosummary::
-   :toctree: generated/
    :nosignatures:
-   :template: classtemplate.rst
 
    SnAp
 
@@ -197,9 +210,7 @@ variance for linear carrier storage. :class:`RandomProjectionVjpAlgorithm` is
 the shared engine for algorithms that use this factorization.
 
 .. autosummary::
-   :toctree: generated/
    :nosignatures:
-   :template: classtemplate.rst
 
    RandomProjectionVjpAlgorithm
    UORO
@@ -215,13 +226,15 @@ gradient to carry credit across finite online windows;
 :func:`train_synthetic_gradient` updates that predictor.
 
 .. autosummary::
-   :toctree: generated/
    :nosignatures:
-   :template: classtemplate.rst
 
    ThreeFactor
    DNI
    SyntheticGradient
+
+.. autosummary::
+   :nosignatures:
+
    train_synthetic_gradient
 
 
@@ -233,9 +246,7 @@ Paper-faithful algorithms tailored to spiking neural networks, all
 regime makes them exact); know the regime before relying on their gradients.
 
 .. autosummary::
-   :toctree: generated/
    :nosignatures:
-   :template: classtemplate.rst
 
    EProp
    OSTLRecurrent
@@ -245,9 +256,7 @@ Trace helpers reused across the SNN algorithms — a frozen random-feedback
 projection and an output-side low-pass filter:
 
 .. autosummary::
-   :toctree: generated/
    :nosignatures:
-   :template: classtemplate.rst
 
    FixedRandomFeedback
    KappaFilter

--- a/docs/examples/drtrl_examples.rst
+++ b/docs/examples/drtrl_examples.rst
@@ -6,19 +6,19 @@ diagonal RTRL implementation across several model and operator families.
 
 * `01-basics-integrator.py <https://github.com/chaobrain/braintrace/blob/main/examples/drtrl/01-basics-integrator.py>`__
   introduces the integrator workflow. API:
-  :doc:`D-RTRL </apis/generated/braintrace.D_RTRL>`.
+  :doc:`D-RTRL </apis/algorithm_details/braintrace.D_RTRL>`.
 * `02-batching-vmap.py <https://github.com/chaobrain/braintrace/blob/main/examples/drtrl/02-batching-vmap.py>`__
   uses per-sample ``vmap`` execution. API:
-  :doc:`compile </apis/generated/braintrace.compile>`.
+  :doc:`compile </apis/algorithm_details/braintrace.compile>`.
 * `03-batching-batched.py <https://github.com/chaobrain/braintrace/blob/main/examples/drtrl/03-batching-batched.py>`__
   uses batched primitives. API:
-  :doc:`compile </apis/generated/braintrace.compile>`.
+  :doc:`compile </apis/algorithm_details/braintrace.compile>`.
 * `04-vjp-single-step.py <https://github.com/chaobrain/braintrace/blob/main/examples/drtrl/04-vjp-single-step.py>`__
   demonstrates a single-step VJP. API:
-  :doc:`D-RTRL </apis/generated/braintrace.D_RTRL>`.
+  :doc:`D-RTRL </apis/algorithm_details/braintrace.D_RTRL>`.
 * `05-vjp-multi-step.py <https://github.com/chaobrain/braintrace/blob/main/examples/drtrl/05-vjp-multi-step.py>`__
   demonstrates a multi-step VJP. API:
-  :doc:`D-RTRL </apis/generated/braintrace.D_RTRL>`.
+  :doc:`D-RTRL </apis/algorithm_details/braintrace.D_RTRL>`.
 * `07-operator-lora.py <https://github.com/chaobrain/braintrace/blob/main/examples/drtrl/07-operator-lora.py>`__
   covers a low-rank recurrent operator. API:
   :doc:`LoRA </apis/generated/braintrace.nn.LoRA>`.
@@ -33,7 +33,7 @@ diagonal RTRL implementation across several model and operator families.
   :doc:`MiniGRU </apis/generated/braintrace.nn.MiniGRU>`.
 * `11-knob-fast-solve.py <https://github.com/chaobrain/braintrace/blob/main/examples/drtrl/11-knob-fast-solve.py>`__
   examines the ``fast_solve`` implementation option. API:
-  :doc:`D-RTRL </apis/generated/braintrace.D_RTRL>`.
+  :doc:`D-RTRL </apis/algorithm_details/braintrace.D_RTRL>`.
 
 Read the
 `D-RTRL examples README <https://github.com/chaobrain/braintrace/blob/main/examples/drtrl/README.md>`__
@@ -47,6 +47,6 @@ establish general gradient equivalence with BPTT.
 Related API
 -----------
 
-* :doc:`D-RTRL </apis/generated/braintrace.D_RTRL>`
+* :doc:`D-RTRL </apis/algorithm_details/braintrace.D_RTRL>`
 * :doc:`ETP Operators </apis/concepts>`
 * :doc:`Algorithm Reference </apis/algorithms>`

--- a/docs/examples/pp_prop_examples.rst
+++ b/docs/examples/pp_prop_examples.rst
@@ -9,28 +9,28 @@ Follow the numbered scripts in order:
 
 * `01-basics-lif-integrator.py <https://github.com/chaobrain/braintrace/blob/main/examples/pp_prop/01-basics-lif-integrator.py>`__
   introduces the LIF integrator. API:
-  :doc:`pp-prop </apis/generated/braintrace.pp_prop>`.
+  :doc:`pp-prop </apis/algorithm_details/braintrace.pp_prop>`.
 * `02-neurons-alif-dms.py <https://github.com/chaobrain/braintrace/blob/main/examples/pp_prop/02-neurons-alif-dms.py>`__
   applies an ALIF model to delayed matching-to-sample. API:
-  :doc:`pp-prop </apis/generated/braintrace.pp_prop>`.
+  :doc:`pp-prop </apis/algorithm_details/braintrace.pp_prop>`.
 * `03-neurons-gif-working-memory.py <https://github.com/chaobrain/braintrace/blob/main/examples/pp_prop/03-neurons-gif-working-memory.py>`__
   demonstrates a GIF working-memory model. API:
-  :doc:`pp-prop </apis/generated/braintrace.pp_prop>`.
+  :doc:`pp-prop </apis/algorithm_details/braintrace.pp_prop>`.
 * `04-neurons-coba-ei-rsnn.py <https://github.com/chaobrain/braintrace/blob/main/examples/pp_prop/04-neurons-coba-ei-rsnn.py>`__
   uses a conductance-based E/I recurrent SNN. API:
   :doc:`SignedWLinear </apis/generated/braintrace.nn.SignedWLinear>`.
 * `05-batching-vmap.py <https://github.com/chaobrain/braintrace/blob/main/examples/pp_prop/05-batching-vmap.py>`__
   uses per-sample ``vmap`` execution. API:
-  :doc:`compile </apis/generated/braintrace.compile>`.
+  :doc:`compile </apis/algorithm_details/braintrace.compile>`.
 * `06-batching-batched.py <https://github.com/chaobrain/braintrace/blob/main/examples/pp_prop/06-batching-batched.py>`__
   uses batched primitives. API:
-  :doc:`compile </apis/generated/braintrace.compile>`.
+  :doc:`compile </apis/algorithm_details/braintrace.compile>`.
 * `07-vjp-single-step.py <https://github.com/chaobrain/braintrace/blob/main/examples/pp_prop/07-vjp-single-step.py>`__
   demonstrates a single-step VJP. API:
-  :doc:`pp-prop </apis/generated/braintrace.pp_prop>`.
+  :doc:`pp-prop </apis/algorithm_details/braintrace.pp_prop>`.
 * `08-vjp-multi-step.py <https://github.com/chaobrain/braintrace/blob/main/examples/pp_prop/08-vjp-multi-step.py>`__
   demonstrates a multi-step VJP. API:
-  :doc:`pp-prop </apis/generated/braintrace.pp_prop>`.
+  :doc:`pp-prop </apis/algorithm_details/braintrace.pp_prop>`.
 * `09-operator-sparse.py <https://github.com/chaobrain/braintrace/blob/main/examples/pp_prop/09-operator-sparse.py>`__
   exercises a sparse recurrent operator. API:
   :doc:`SparseLinear </apis/generated/braintrace.nn.SparseLinear>`.
@@ -42,13 +42,13 @@ Follow the numbered scripts in order:
   :doc:`Conv2d </apis/generated/braintrace.nn.Conv2d>`.
 * `12-classification-neuromorphic.py <https://github.com/chaobrain/braintrace/blob/main/examples/pp_prop/12-classification-neuromorphic.py>`__
   provides a neuromorphic classification example. API:
-  :doc:`pp-prop </apis/generated/braintrace.pp_prop>`.
+  :doc:`pp-prop </apis/algorithm_details/braintrace.pp_prop>`.
 * `13-knob-decay-vs-rank.py <https://github.com/chaobrain/braintrace/blob/main/examples/pp_prop/13-knob-decay-vs-rank.py>`__
   compares trace decay with rank. API:
-  :doc:`pp-prop </apis/generated/braintrace.pp_prop>`.
+  :doc:`pp-prop </apis/algorithm_details/braintrace.pp_prop>`.
 * `14-knob-vjp-method-contrast.py <https://github.com/chaobrain/braintrace/blob/main/examples/pp_prop/14-knob-vjp-method-contrast.py>`__
   contrasts VJP methods. API:
-  :doc:`pp-prop </apis/generated/braintrace.pp_prop>`.
+  :doc:`pp-prop </apis/algorithm_details/braintrace.pp_prop>`.
 
 Read the
 `pp-prop examples README <https://github.com/chaobrain/braintrace/blob/main/examples/pp_prop/README.md>`__
@@ -60,6 +60,6 @@ suitability depends on the model dynamics and selected decay or rank.
 Related API
 -----------
 
-* :doc:`pp-prop </apis/generated/braintrace.pp_prop>`
+* :doc:`pp-prop </apis/algorithm_details/braintrace.pp_prop>`
 * :doc:`ETP Operators </apis/concepts>`
 * :doc:`Algorithm Reference </apis/algorithms>`

--- a/docs/examples/rnn_examples.rst
+++ b/docs/examples/rnn_examples.rst
@@ -22,6 +22,6 @@ workflow for the complete training sequence.
 Related API
 -----------
 
-* :doc:`D-RTRL </apis/generated/braintrace.D_RTRL>`
-* :doc:`SnAp </apis/generated/braintrace.SnAp>`
+* :doc:`D-RTRL </apis/algorithm_details/braintrace.D_RTRL>`
+* :doc:`SnAp </apis/algorithm_details/braintrace.SnAp>`
 * :doc:`Neural Network Layers </apis/nn>`

--- a/docs/examples/snn_examples.rst
+++ b/docs/examples/snn_examples.rst
@@ -10,10 +10,10 @@ Learning tasks
 
 * `000-lif-snn-for-nmnist.py <https://github.com/chaobrain/braintrace/blob/main/examples/000-lif-snn-for-nmnist.py>`__
   trains a recurrent LIF-delta SNN on framed N-MNIST events. API:
-  :doc:`pp-prop </apis/generated/braintrace.pp_prop>`.
+  :doc:`pp-prop </apis/algorithm_details/braintrace.pp_prop>`.
 * `001-gif-snn-for-dms.py <https://github.com/chaobrain/braintrace/blob/main/examples/001-gif-snn-for-dms.py>`__
   trains a GIF recurrent SNN on delayed matching-to-sample. API:
-  :doc:`pp-prop </apis/generated/braintrace.pp_prop>`.
+  :doc:`pp-prop </apis/algorithm_details/braintrace.pp_prop>`.
 * `002-coba-ei-rsnn.py <https://github.com/chaobrain/braintrace/blob/main/examples/002-coba-ei-rsnn.py>`__
   trains an excitatory/inhibitory recurrent SNN on an evidence-accumulation
   task with configurable current- or conductance-based synapses. API:
@@ -30,13 +30,13 @@ per-sample ``vmap`` execution:
 
 * `003-snn-memory-and-speed-evaluation-all.py <https://github.com/chaobrain/braintrace/blob/main/examples/003-snn-memory-and-speed-evaluation-all.py>`__
   runs the complete comparison. API:
-  :doc:`D-RTRL </apis/generated/braintrace.D_RTRL>`.
+  :doc:`D-RTRL </apis/algorithm_details/braintrace.D_RTRL>`.
 * `003-snn-memory-and-speed-evaluation-batched.py <https://github.com/chaobrain/braintrace/blob/main/examples/003-snn-memory-and-speed-evaluation-batched.py>`__
   uses batched state. API:
-  :doc:`compile </apis/generated/braintrace.compile>`.
+  :doc:`compile </apis/algorithm_details/braintrace.compile>`.
 * `003-snn-memory-and-speed-evaluation-vmap.py <https://github.com/chaobrain/braintrace/blob/main/examples/003-snn-memory-and-speed-evaluation-vmap.py>`__
   uses per-sample ``vmap`` execution. API:
-  :doc:`compile </apis/generated/braintrace.compile>`.
+  :doc:`compile </apis/algorithm_details/braintrace.compile>`.
 
 Use these scripts for implementation benchmarking, not as evidence that two
 algorithms have equivalent gradient accuracy.
@@ -47,7 +47,7 @@ workflow before moving to dataset-scale scripts.
 Related API
 -----------
 
-* :doc:`pp-prop </apis/generated/braintrace.pp_prop>`
-* :doc:`EProp </apis/generated/braintrace.EProp>`
-* :doc:`OSTLRecurrent </apis/generated/braintrace.OSTLRecurrent>`
+* :doc:`pp-prop </apis/algorithm_details/braintrace.pp_prop>`
+* :doc:`EProp </apis/algorithm_details/braintrace.EProp>`
+* :doc:`OSTLRecurrent </apis/algorithm_details/braintrace.OSTLRecurrent>`
 * :doc:`Neural Network Layers </apis/nn>`


### PR DESCRIPTION
## Summary

- add complete API detail pages for all public Algorithms classes and functions
- document explicit constructor signatures instead of `(*args, **kwargs)`
- expose curated methods for concrete online-learning algorithms
- document all supported `braintrace.compile` algorithm names and aliases
- update example links to the new algorithm detail pages

## Scope

- documentation and docstring changes only
- no runtime logic changes
- no `conf.py`, Tutorial, CSS, JavaScript, or test-file changes

## Verification

- `60 passed` in `braintrace/_compile_test.py`
- strict Sphinx HTML build completed with zero warnings
- AST comparison confirmed no executable Python changes after removing docstrings
- verified 19 class pages and 2 function pages

## Summary by Sourcery

Document the public online-learning algorithms and compile API more completely, including registered algorithm names, configuration behavior, and usage patterns.

Documentation:
- Expand docstrings for core algorithm and base classes to document full constructor parameters, configuration options, and attributes.
- Clarify braintrace.compile documentation with the complete set of registered algorithm names/aliases, config-based engine selection, and usage examples for passing names, classes, and configs.
- Add dedicated API reference detail pages for all public algorithm classes and key functions, and retarget existing example docs to link to these new detail pages.