### PR TITLE
Replace id(eqn) warning dedup with settled-fixpoint buffering

### DIFF
--- a/braintrace/_compiler/canonicalize.py
+++ b/braintrace/_compiler/canonicalize.py
@@ -217,6 +217,33 @@ def _is_etp_eqn(eqn: JaxprEqn) -> bool:
     return is_etp_primitive(eqn.primitive)
 
 
+# A buffered :func:`~braintrace._compiler.diagnostics.emit` call: the keyword
+# arguments are built where the decision is made and replayed verbatim once the
+# canonicalization fixpoint has settled. See ``_emit_pending``.
+_PendingDiagnostic = Dict[str, Any]
+
+
+def _emit_pending(pending: List[_PendingDiagnostic]) -> None:
+    """Emit buffered skip diagnostics collected by the final sweep.
+
+    Each canonicalization sweep copies through the equations it cannot rewrite,
+    so a sweep-time ``emit`` would fire once per fixpoint iteration for the same
+    equation. Instead every sweep *buffers* its skip diagnostics, the driver
+    keeps only the latest buffer, and this helper replays it once. The settling
+    sweep rewrote nothing, so it visited each surviving top-level equation
+    exactly once and its buffer holds exactly one entry per skipped equation —
+    no identity-keyed deduplication (and no reliance on equation objects staying
+    alive across sweeps) is needed.
+
+    Parameters
+    ----------
+    pending : list of dict
+        Keyword argument dicts for :func:`~braintrace._compiler.diagnostics.emit`.
+    """
+    for kwargs in pending:
+        emit(**kwargs)
+
+
 def if_convert_conds(
     closed_jaxpr: ClosedJaxpr,
     *,
@@ -290,21 +317,22 @@ def if_convert_conds(
     # Fixpoint loop: converting a cond can surface user ``jit`` equations
     # from its branches, and their inlined bodies can expose further conds.
     # Each iteration converts what is visible, then flattens surfaced jits;
-    # nesting depth is finite, so this terminates. ``skip_warned`` carries
-    # the equations already reported as skipped, so a relevant-but-unsafe
-    # cond warns once, not once per iteration.
+    # nesting depth is finite, so this terminates. Each sweep buffers (rather
+    # than emits) its skip diagnostics; only the settling sweep's buffer is
+    # emitted, so a relevant-but-unsafe cond warns once, not once per
+    # iteration. See ``_emit_pending``.
     result = closed_jaxpr
-    skip_warned: set = set()
+    pending: List[_PendingDiagnostic] = []
     while True:
-        converted, n_converted = _convert_conds_once(
+        converted, n_converted, pending = _convert_conds_once(
             result,
             weight_invars=weight_invars,
             hidden_invars=hidden_invars,
             hidden_outvars=hidden_outvars,
-            skip_warned=skip_warned,
             policy=policy,
         )
         if n_converted == 0:
+            _emit_pending(pending)
             return result
         result = inline_jit_calls(converted)
 
@@ -315,18 +343,19 @@ def _convert_conds_once(
     weight_invars: Container[Var],
     hidden_invars: Container[Var],
     hidden_outvars: Container[Var],
-    skip_warned: set,
     policy: ControlFlowPolicy = DEFAULT_CONTROL_FLOW_POLICY,
 ):
     """One conversion sweep over the top-level equations.
 
-    Returns ``(closed_jaxpr, n_converted)``; the input object itself when
-    nothing is converted.
+    Returns ``(closed_jaxpr, n_converted, pending)``; the input object itself
+    when nothing is converted. ``pending`` holds the skip diagnostics observed
+    by this sweep, buffered for the caller to emit once the fixpoint settles.
     """
     jaxpr = closed_jaxpr.jaxpr
     if not any(is_cond_primitive(eqn) for eqn in jaxpr.eqns):
-        return closed_jaxpr, 0
+        return closed_jaxpr, 0, []
 
+    pending: List[_PendingDiagnostic] = []
     extra_constvars: List[Var] = []
     extra_consts: List[Any] = []
     new_eqns: List[JaxprEqn] = []
@@ -454,18 +483,16 @@ def _convert_conds_once(
                         },
                     )
                     return
-                if id(eqn) not in skip_warned:
-                    skip_warned.add(id(eqn))
-                    emit(
-                        kind=DiagnosticKind.COND_CONVERSION_SKIPPED,
-                        level=DiagnosticLevel.WARNING,
-                        message=(
-                            f'An ETP-relevant cond ({reason}) was NOT '
-                            f'if-converted because {bad}; it stays opaque and '
-                            f'the existing control-flow restrictions apply.'
-                        ),
-                        context={'reason': bad, 'relevance': reason},
-                    )
+                pending.append(dict(
+                    kind=DiagnosticKind.COND_CONVERSION_SKIPPED,
+                    level=DiagnosticLevel.WARNING,
+                    message=(
+                        f'An ETP-relevant cond ({reason}) was NOT '
+                        f'if-converted because {bad}; it stays opaque and '
+                        f'the existing control-flow restrictions apply.'
+                    ),
+                    context={'reason': bad, 'relevance': reason},
+                ))
             # Not converted: keep the cond eqn (resolved when inside a branch).
             if subst is None:
                 new_eqns.append(eqn)
@@ -491,7 +518,7 @@ def _convert_conds_once(
         handle_eqn(eqn, lambda atom: atom, None)
 
     if n_converted == 0:
-        return closed_jaxpr, 0
+        return closed_jaxpr, 0, pending
 
     new_jaxpr = Jaxpr(
         constvars=list(jaxpr.constvars) + extra_constvars,
@@ -502,7 +529,7 @@ def _convert_conds_once(
         debug_info=jaxpr.debug_info,
     )
     result = ClosedJaxpr(new_jaxpr, list(closed_jaxpr.consts) + extra_consts)
-    return result, n_converted
+    return result, n_converted, pending
 
 
 # ---------------------------------------------------------------------------
@@ -608,20 +635,22 @@ def unroll_inner_scans(
     # Fixpoint: unrolling a scan can surface user ``jit`` equations and
     # nested scans from its body. Each sweep unrolls the visible top-level
     # scans, then flattens surfaced jits; nesting depth is finite, so this
-    # terminates. ``skip_warned`` carries the equations already reported, so
-    # a relevant-but-ineligible scan warns once, not once per sweep.
+    # terminates. Each sweep buffers (rather than emits) its skip
+    # diagnostics; only the settling sweep's buffer is emitted, so a
+    # relevant-but-ineligible scan warns once, not once per sweep. See
+    # ``_emit_pending``.
     result = closed_jaxpr
-    skip_warned: set = set()
+    pending: List[_PendingDiagnostic] = []
     while True:
-        converted, n_unrolled = _unroll_scans_once(
+        converted, n_unrolled, pending = _unroll_scans_once(
             result,
             weight_invars=weight_invars,
             hidden_invars=hidden_invars,
             hidden_outvars=hidden_outvars,
             policy=policy,
-            skip_warned=skip_warned,
         )
         if n_unrolled == 0:
+            _emit_pending(pending)
             return result
         result = inline_jit_calls(converted)
 
@@ -633,16 +662,18 @@ def _unroll_scans_once(
     hidden_invars: Container[Var],
     hidden_outvars: Container[Var],
     policy: ControlFlowPolicy,
-    skip_warned: set,
 ):
     """One unrolling sweep over the top-level equations.
 
-    Returns ``(closed_jaxpr, n_unrolled)``; the input object itself when
-    nothing is unrolled.
+    Returns ``(closed_jaxpr, n_unrolled, pending)``; the input object itself
+    when nothing is unrolled. ``pending`` holds the skip diagnostics observed
+    by this sweep, buffered for the caller to emit once the fixpoint settles.
     """
     jaxpr = closed_jaxpr.jaxpr
     if not any(is_scan_primitive(eqn) for eqn in jaxpr.eqns):
-        return closed_jaxpr, 0
+        return closed_jaxpr, 0, []
+
+    pending: List[_PendingDiagnostic] = []
 
     # Consumption of the original scan outvars, for dead-output elision.
     # Downstream equations keep referencing the original outvars (they are
@@ -882,41 +913,39 @@ def _unroll_scans_once(
             continue
         bad = _scan_static_ineligibility(eqn, policy)
         if bad is not None:
-            if id(eqn) not in skip_warned:
-                skip_warned.add(id(eqn))
-                # Matches the descent-eligibility rule in
-                # ``scan_descent._descent_blockers``: any positive-length
-                # scan beyond the limit descends, including when unrolling
-                # is disabled entirely (limit <= 0).
-                over_limit = eqn.params['length'] > policy.scan_unroll_limit
-                if over_limit and policy.scan_descent == 'auto':
-                    # An over-limit scan is no longer a dead end: the
-                    # scan-descent pass (Phase 4) picks it up downstream.
-                    emit(
-                        kind=DiagnosticKind.SCAN_UNROLL_SKIPPED,
-                        level=DiagnosticLevel.INFO,
-                        message=(
-                            f'An ETP-relevant scan ({reason}) was NOT '
-                            f'unrolled because {bad}; structured scan '
-                            f'descent will handle it (see '
-                            f'ControlFlowPolicy.scan_descent).'
-                        ),
-                        context={'reason': bad, 'relevance': reason},
-                    )
-                else:
-                    emit(
-                        kind=DiagnosticKind.SCAN_UNROLL_SKIPPED,
-                        level=DiagnosticLevel.WARNING,
-                        message=(
-                            f'An ETP-relevant scan ({reason}) was NOT '
-                            f'unrolled because {bad}; it stays opaque and '
-                            f'the existing control-flow restrictions apply. '
-                            f'Raise ControlFlowPolicy.scan_unroll_limit or '
-                            f'restructure the loop if its weights should '
-                            f'learn online.'
-                        ),
-                        context={'reason': bad, 'relevance': reason},
-                    )
+            # Matches the descent-eligibility rule in
+            # ``scan_descent._descent_blockers``: any positive-length
+            # scan beyond the limit descends, including when unrolling
+            # is disabled entirely (limit <= 0).
+            over_limit = eqn.params['length'] > policy.scan_unroll_limit
+            if over_limit and policy.scan_descent == 'auto':
+                # An over-limit scan is no longer a dead end: the
+                # scan-descent pass (Phase 4) picks it up downstream.
+                pending.append(dict(
+                    kind=DiagnosticKind.SCAN_UNROLL_SKIPPED,
+                    level=DiagnosticLevel.INFO,
+                    message=(
+                        f'An ETP-relevant scan ({reason}) was NOT '
+                        f'unrolled because {bad}; structured scan '
+                        f'descent will handle it (see '
+                        f'ControlFlowPolicy.scan_descent).'
+                    ),
+                    context={'reason': bad, 'relevance': reason},
+                ))
+            else:
+                pending.append(dict(
+                    kind=DiagnosticKind.SCAN_UNROLL_SKIPPED,
+                    level=DiagnosticLevel.WARNING,
+                    message=(
+                        f'An ETP-relevant scan ({reason}) was NOT '
+                        f'unrolled because {bad}; it stays opaque and '
+                        f'the existing control-flow restrictions apply. '
+                        f'Raise ControlFlowPolicy.scan_unroll_limit or '
+                        f'restructure the loop if its weights should '
+                        f'learn online.'
+                    ),
+                    context={'reason': bad, 'relevance': reason},
+                ))
             new_eqns.append(eqn)
             continue
         num_consts, num_carry = scan_num_consts_carry(eqn)
@@ -925,24 +954,22 @@ def _unroll_scans_once(
             v for v in eqn.invars[num_prefix:] if reaches_weight(v)
         ]
         if sliced_weight:
-            if id(eqn) not in skip_warned:
-                skip_warned.add(id(eqn))
-                emit(
-                    kind=DiagnosticKind.RELATION_EXCLUDED_SLICED_WEIGHT,
-                    level=DiagnosticLevel.WARNING,
-                    message=(
-                        f'An ETP-relevant scan ({reason}) was NOT unrolled '
-                        f'because it scans over a trainable weight (a '
-                        f'stacked parameter passed as xs). Each unrolled '
-                        f'iteration would consume a *slice* of the '
-                        f'parameter, which relation analysis cannot yet '
-                        f'attribute correctly. Pass per-iteration weights '
-                        f'as separate parameters, or keep the loop out of '
-                        f'online learning.'
-                    ),
-                    context={'relevance': reason,
-                             'n_sliced': len(sliced_weight)},
-                )
+            pending.append(dict(
+                kind=DiagnosticKind.RELATION_EXCLUDED_SLICED_WEIGHT,
+                level=DiagnosticLevel.WARNING,
+                message=(
+                    f'An ETP-relevant scan ({reason}) was NOT unrolled '
+                    f'because it scans over a trainable weight (a '
+                    f'stacked parameter passed as xs). Each unrolled '
+                    f'iteration would consume a *slice* of the '
+                    f'parameter, which relation analysis cannot yet '
+                    f'attribute correctly. Pass per-iteration weights '
+                    f'as separate parameters, or keep the loop out of '
+                    f'online learning.'
+                ),
+                context={'relevance': reason,
+                         'n_sliced': len(sliced_weight)},
+            ))
             new_eqns.append(eqn)
             continue
 
@@ -968,7 +995,7 @@ def _unroll_scans_once(
         )
 
     if n_unrolled == 0:
-        return closed_jaxpr, 0
+        return closed_jaxpr, 0, pending
 
     new_jaxpr = Jaxpr(
         constvars=list(jaxpr.constvars) + extra_constvars,
@@ -979,7 +1006,7 @@ def _unroll_scans_once(
         debug_info=jaxpr.debug_info,
     )
     result = ClosedJaxpr(new_jaxpr, list(closed_jaxpr.consts) + extra_consts)
-    return result, n_unrolled
+    return result, n_unrolled, pending
 
 
 # ---------------------------------------------------------------------------
@@ -1035,34 +1062,39 @@ def canonicalize_control_flow(
             f"policy.cond must be 'convert' or 'opaque', got {policy.cond!r}."
         )
 
+    # Each sweep buffers its skip diagnostics rather than emitting them; only
+    # the latest buffer per pass survives, and it is emitted once the joint
+    # fixpoint settles. The settling iteration ran both sweeps over the final
+    # jaxpr without rewriting anything, so its buffers hold exactly one entry
+    # per equation that stayed opaque. See ``_emit_pending``.
     result = closed_jaxpr
-    cond_skip_warned: set = set()
-    scan_skip_warned: set = set()
+    cond_pending: List[_PendingDiagnostic] = []
+    scan_pending: List[_PendingDiagnostic] = []
     while True:
         n_total = 0
         if policy.cond == 'convert':
-            converted, n = _convert_conds_once(
+            converted, n, cond_pending = _convert_conds_once(
                 result,
                 weight_invars=weight_invars,
                 hidden_invars=hidden_invars,
                 hidden_outvars=hidden_outvars,
-                skip_warned=cond_skip_warned,
                 policy=policy,
             )
             if n:
                 result = inline_jit_calls(converted)
                 n_total += n
         if policy.scan_unroll_limit > 0:
-            converted, n = _unroll_scans_once(
+            converted, n, scan_pending = _unroll_scans_once(
                 result,
                 weight_invars=weight_invars,
                 hidden_invars=hidden_invars,
                 hidden_outvars=hidden_outvars,
                 policy=policy,
-                skip_warned=scan_skip_warned,
             )
             if n:
                 result = inline_jit_calls(converted)
                 n_total += n
         if n_total == 0:
+            _emit_pending(cond_pending)
+            _emit_pending(scan_pending)
             return result

--- a/braintrace/_compiler/canonicalize_test.py
+++ b/braintrace/_compiler/canonicalize_test.py
@@ -1262,5 +1262,227 @@ class TestScanModelCompilation:
         assert any(jnp.any(jnp.abs(leaf) > 0) for leaf in leaves_scan)
 
 
+def _records_of(reporter, kind):
+    return [r for r in reporter.records() if r.kind is kind]
+
+
+def _warning_count(caught, needle):
+    return sum(needle in str(w.message) for w in caught)
+
+
+class TestSkipWarningDedup:
+    """Skip warnings are deduplicated per equation, not per message.
+
+    The canonicalization passes run to a fixpoint and copy through every
+    equation they cannot rewrite, so a naive implementation re-warns once per
+    sweep. The suppression must be exact in both directions: one record per
+    skipped equation regardless of how many sweeps run (no under-suppression),
+    and one record *per equation* even when two distinct equations produce
+    byte-identical messages (no over-suppression).
+    """
+
+    def test_two_distinct_unsafe_conds_each_warn_once(self):
+        # Both conds are relevant (they consume the weight invar) and unsafe
+        # for the same reason, so their messages are identical -- a
+        # message-keyed dedup would collapse them into one.
+        def f(x, w):
+            a = jax.lax.cond(
+                jnp.sum(x) > 1.,
+                lambda: jax.lax.while_loop(
+                    lambda v: jnp.sum(v) < 10., lambda v: v + 1., x),
+                lambda: braintrace.matmul(x, w),
+            )
+            b = jax.lax.cond(
+                jnp.sum(x) > 2.,
+                lambda: jax.lax.while_loop(
+                    lambda v: jnp.sum(v) < 20., lambda v: v + 2., x),
+                lambda: braintrace.matmul(x, w),
+            )
+            return a + b
+
+        closed = jax.make_jaxpr(f)(jnp.ones(3), jnp.eye(3))
+        with diagnostic_context() as reporter:
+            with pytest.warns(UserWarning) as caught:
+                conv = _convert(closed, weights=[closed.jaxpr.invars[1]])
+        assert _primitive_names(conv).count('cond') == 2
+        recs = _records_of(reporter, DiagnosticKind.COND_CONVERSION_SKIPPED)
+        assert len(recs) == 2
+        assert len({r.message for r in recs}) == 1  # identical messages
+        assert _warning_count(caught, 'NOT if-converted') == 2
+
+    def test_unsafe_cond_after_convertible_cond_warns_once(self):
+        # Mirror image of test_skipped_cond_warns_once_across_fixpoint_
+        # iterations: the unsafe cond sits AFTER the convertible one, so its
+        # position in the equation list shifts as the earlier cond expands.
+        @jax.jit
+        def jitted(a, w):
+            return jax.lax.cond(
+                jnp.max(a) > 2.,
+                lambda: braintrace.matmul(a, w),
+                lambda: a * 5.,
+            )
+
+        def f(x, w):
+            safe = jax.lax.cond(
+                jnp.sum(x) > 0.,
+                lambda: jitted(x, w),
+                lambda: x * 2.,
+            )
+            unsafe = jax.lax.cond(
+                jnp.sum(safe) > 1.,
+                lambda: jax.lax.while_loop(
+                    lambda v: jnp.sum(v) < 10., lambda v: v + 1., safe),
+                lambda: braintrace.matmul(safe, w),
+            )
+            return unsafe
+
+        closed = jax.make_jaxpr(f)(jnp.ones(3), jnp.eye(3))
+        with diagnostic_context() as reporter:
+            with pytest.warns(UserWarning) as caught:
+                conv = _convert(closed, weights=[closed.jaxpr.invars[1]])
+        assert _primitive_names(conv).count('cond') == 1
+        assert len(
+            _records_of(reporter, DiagnosticKind.COND_CONVERSION_SKIPPED)
+        ) == 1
+        assert _warning_count(caught, 'NOT if-converted') == 1
+
+    def _two_scan_jaxpr(self, len_a, len_b):
+        def f(w, h0, xs_a, xs_b):
+            def body(h, x):
+                return jnp.tanh(braintrace.matmul(x, w) + h), h
+            h1, _ = jax.lax.scan(body, h0, xs_a)
+            h2, _ = jax.lax.scan(body, h1, xs_b)
+            return h2
+
+        w = jnp.eye(3) * 0.5
+        h0 = jnp.zeros(3)
+        return jax.make_jaxpr(f)(
+            w, h0, jnp.ones((len_a, 3)), jnp.ones((len_b, 3))
+        )
+
+    def test_two_distinct_ineligible_scans_each_warn_once(self):
+        # Two over-limit scans of the SAME length: identical messages again.
+        closed = self._two_scan_jaxpr(5, 5)
+        with diagnostic_context() as reporter:
+            with pytest.warns(UserWarning) as caught:
+                conv = _unroll(
+                    closed,
+                    weights=[closed.jaxpr.invars[0]],
+                    policy=ControlFlowPolicy(scan_unroll_limit=3,
+                                             scan_descent='off'),
+                )
+        assert _primitive_names(conv).count('scan') == 2
+        recs = _records_of(reporter, DiagnosticKind.SCAN_UNROLL_SKIPPED)
+        assert len(recs) == 2
+        assert len({r.message for r in recs}) == 1
+        assert _warning_count(caught, 'NOT unrolled') == 2
+
+    @pytest.mark.parametrize('len_a,len_b', [(2, 5), (5, 2)])
+    def test_one_eligible_one_ineligible_warns_once(self, len_a, len_b):
+        # Either order: unrolling the eligible scan rewrites the equation list
+        # and shifts the ineligible one, but it must still warn exactly once
+        # across the resulting multi-sweep fixpoint.
+        closed = self._two_scan_jaxpr(len_a, len_b)
+        with diagnostic_context() as reporter:
+            with pytest.warns(UserWarning) as caught:
+                conv = _unroll(
+                    closed,
+                    weights=[closed.jaxpr.invars[0]],
+                    policy=ControlFlowPolicy(scan_unroll_limit=3,
+                                             scan_descent='off'),
+                )
+        assert _primitive_names(conv).count('scan') == 1
+        assert len(
+            _records_of(reporter, DiagnosticKind.SCAN_UNROLL_SKIPPED)
+        ) == 1
+        assert _warning_count(caught, 'NOT unrolled') == 1
+
+    def test_two_distinct_sliced_weight_scans_each_warn_once(self):
+        def f(ws, h0):
+            def body(h, w_t):
+                return jnp.tanh(braintrace.matmul(h, w_t)), h
+            h1, _ = jax.lax.scan(body, h0, ws)
+            h2, _ = jax.lax.scan(body, h1 * 0.5, ws)
+            return h2
+
+        ws = jnp.stack([jnp.eye(3)] * 2) * 0.5
+        closed = jax.make_jaxpr(f)(ws, jnp.ones(3))
+        with diagnostic_context() as reporter:
+            with pytest.warns(UserWarning) as caught:
+                conv = _unroll(closed, weights=[closed.jaxpr.invars[0]])
+        assert _primitive_names(conv).count('scan') == 2
+        assert len(_records_of(
+            reporter, DiagnosticKind.RELATION_EXCLUDED_SLICED_WEIGHT
+        )) == 2
+        assert _warning_count(caught, 'scans over a trainable weight') == 2
+
+    def test_joint_driver_reports_each_skip_once(self):
+        # An eligible scan drives several joint iterations (its body's cond
+        # only surfaces after unrolling); the opaque scan and the unsafe cond
+        # must each be reported exactly once.
+        def f(w, h0, xs_short, xs_long):
+            def body(h, x):
+                drive = jax.lax.cond(
+                    jnp.sum(x) > 0.,
+                    lambda: braintrace.matmul(x, w),
+                    lambda: x * 2.,
+                )
+                return jnp.tanh(drive + h), h
+
+            h1, _ = jax.lax.scan(body, h0, xs_short)
+            h2, _ = jax.lax.scan(body, h1, xs_long)
+            return jax.lax.cond(
+                jnp.sum(h2) > 1.,
+                lambda: jax.lax.while_loop(
+                    lambda v: jnp.sum(v) < 10., lambda v: v + 1., h2),
+                lambda: braintrace.matmul(h2, w),
+            )
+
+        closed = jax.make_jaxpr(f)(
+            jnp.eye(3) * 0.5, jnp.zeros(3), jnp.ones((2, 3)), jnp.ones((5, 3))
+        )
+        with diagnostic_context() as reporter:
+            with pytest.warns(UserWarning) as caught:
+                conv = canonicalize_control_flow(
+                    closed,
+                    weight_invars={closed.jaxpr.invars[0]},
+                    hidden_invars=set(),
+                    hidden_outvars=set(),
+                    policy=ControlFlowPolicy(scan_unroll_limit=3,
+                                             scan_descent='off'),
+                )
+        names = _primitive_names(conv)
+        assert names.count('scan') == 1
+        assert names.count('cond') == 1
+        assert len(
+            _records_of(reporter, DiagnosticKind.SCAN_UNROLL_SKIPPED)
+        ) == 1
+        assert len(
+            _records_of(reporter, DiagnosticKind.COND_CONVERSION_SKIPPED)
+        ) == 1
+        assert _warning_count(caught, 'NOT unrolled') == 1
+        assert _warning_count(caught, 'NOT if-converted') == 1
+
+    def test_skip_records_describe_the_final_jaxpr(self):
+        # The emitted record must survive to the settled jaxpr: the reported
+        # scan is still present as an opaque `scan` equation afterwards.
+        closed = self._two_scan_jaxpr(2, 5)
+        with diagnostic_context() as reporter:
+            with pytest.warns(UserWarning, match='NOT unrolled'):
+                conv = _unroll(
+                    closed,
+                    weights=[closed.jaxpr.invars[0]],
+                    policy=ControlFlowPolicy(scan_unroll_limit=3,
+                                             scan_descent='off'),
+                )
+        recs = _records_of(reporter, DiagnosticKind.SCAN_UNROLL_SKIPPED)
+        assert len(recs) == 1
+        assert recs[0].level is DiagnosticLevel.WARNING
+        n_opaque = sum(
+            eqn.primitive.name == 'scan' for eqn in conv.jaxpr.eqns
+        )
+        assert n_opaque == len(recs)
+
+
 if __name__ == '__main__':
     pytest.main([__file__, '-v'])

--- a/docs/specs/2026-08-07-e03-stable-warning-dedup-keys.md
+++ b/docs/specs/2026-08-07-e03-stable-warning-dedup-keys.md
@@ -1,0 +1,94 @@
+# E-03: stable warning dedup keys in `canonicalize.py`
+
+Issue: [#158](https://github.com/chaobrain/braintrace/issues/158)
+
+## Current keying
+
+`braintrace/_compiler/canonicalize.py` runs two canonicalization passes to a
+fixpoint (`if_convert_conds` / `unroll_inner_scans`, plus the joint driver
+`canonicalize_control_flow`). Each sweep (`_convert_conds_once`,
+`_unroll_scans_once`) walks the *top-level* equations of the current jaxpr,
+rewrites what it can, and copies through what it cannot. An equation that is
+ETP-relevant but not rewritable emits a warning:
+
+| site | warning | emitted from |
+| --- | --- | --- |
+| `_convert_conds_once` | `COND_CONVERSION_SKIPPED` — relevant cond, unsafe to if-convert | `handle_eqn` |
+| `_unroll_scans_once` | `SCAN_UNROLL_SKIPPED` — relevant scan, statically ineligible | top-level sweep loop |
+| `_unroll_scans_once` | `RELATION_EXCLUDED_SLICED_WEIGHT` — relevant, eligible scan whose `xs` reach a weight | top-level sweep loop |
+
+Because a skipped equation is copied through unchanged, every subsequent sweep
+sees it again and would warn again. The passes suppressed that with a
+`skip_warned: set` of `id(eqn)` values, threaded through the fixpoint loop (and
+through the joint driver as `cond_skip_warned` / `scan_skip_warned`).
+
+## The invariant it leans on
+
+`id()` is only unique among *live* objects. The dedup is correct only because
+the enclosing `Jaxpr`/`ClosedJaxpr` (or, for equations reached inside a `cond`
+branch, the branch `ClosedJaxpr` held by the parent equation's params) keeps
+every equation object alive for the whole fixpoint, so CPython cannot recycle
+an address onto a different equation. Nothing in the code says so. A refactor
+that drops the jaxpr reference between sweeps — or that keys off an equation
+built and discarded inside a sweep — would silently merge unrelated warnings.
+
+## Why the issue's suggested key does not work
+
+Keying on the equation's index within its jaxpr is *not* stable here: the sweep
+rebuilds the equation list every iteration, and rewriting one equation changes
+the index of every equation after it. Concretely, with an eligible scan
+followed by an ineligible one, sweep 1 warns at index 1; sweep 2 sees the
+unrolled body in place of the first scan, so the ineligible scan has moved to
+index *N* and warns a second time. (`test_skip_warning_once_across_fixpoint`
+covers exactly that shape.) Content-based keys are worse: two genuinely
+distinct equations with the same relevance/ineligibility reason produce
+byte-identical messages, so a content key would over-suppress.
+
+## Chosen fix — no key at all
+
+Remove the dedup set. Each `_once` sweep *buffers* its skip diagnostics instead
+of emitting them, and returns the buffer alongside the rewritten jaxpr. The
+fixpoint driver keeps only the most recent buffer per pass and emits it once,
+after the fixpoint has settled.
+
+That is correct because the settling sweep is by construction a sweep that
+rewrote nothing: it walked the final jaxpr's top-level equations, visiting each
+exactly once (no branch inlining happens when nothing is converted), so the
+final buffer holds exactly one entry per equation that survives
+canonicalization un-rewritten. This holds for the joint driver too — its last
+iteration is the one where both sweeps return zero rewrites, and both ran on
+the final jaxpr.
+
+Applied per site:
+
+- `_convert_conds_once`: drops the `skip_warned` parameter, returns
+  `(closed_jaxpr, n_converted, pending)`. `if_convert_conds` emits the last
+  `pending` before returning.
+- `_unroll_scans_once`: same, for both `SCAN_UNROLL_SKIPPED` and
+  `RELATION_EXCLUDED_SLICED_WEIGHT`. `unroll_inner_scans` emits the last
+  `pending` before returning.
+- `canonicalize_control_flow`: keeps the latest cond buffer and the latest scan
+  buffer, emits both when the joint fixpoint settles.
+
+A buffered entry is just the keyword dict for `diagnostics.emit`, built at
+detection time and replayed verbatim.
+
+### Behaviour deltas
+
+- Warning *count* per skipped equation is unchanged (exactly one).
+- Skip warnings now land after the pass's `INFO` rewrite records rather than
+  interleaved with them, and they describe the *final* jaxpr — if an equation's
+  ineligibility reason changes as the fixpoint proceeds, the reported reason is
+  the last one, which is the one the user is left with.
+
+## Tests
+
+`braintrace/_compiler/canonicalize_test.py` gains a `TestSkipWarningDedup`
+class asserting the dedup neither over- nor under-suppresses:
+
+- two *distinct* unsafe conds with identical messages emit two records (no
+  over-suppression), and stay at one record each across a multi-sweep fixpoint;
+- an ineligible scan placed *after* an eligible one (the ordering that breaks
+  an index key) warns exactly once;
+- two distinct ineligible scans with identical reasons emit two records;
+- the same, driven through `canonicalize_control_flow`.


### PR DESCRIPTION
## Problem

`braintrace/_compiler/canonicalize.py` deduplicated its control-flow skip
warnings (`COND_CONVERSION_SKIPPED`, `SCAN_UNROLL_SKIPPED`,
`RELATION_EXCLUDED_SLICED_WEIGHT`) with `skip_warned` sets keyed on `id(eqn)`.
The passes run to a fixpoint and copy through every equation they cannot
rewrite, so without dedup each skipped equation would warn once per sweep.

`id()` is unique only among *live* objects. The dedup was sound only because
the enclosing jaxpr (or, for equations inside a `cond` branch, the branch
`ClosedJaxpr` held on the parent equation's params) keeps every equation alive
for the whole fixpoint. Nothing said so; a refactor that dropped that reference
would silently merge unrelated warnings.

## Why not the index within the jaxpr

The issue suggests keying on the equation's index. That is not stable here:
every sweep rebuilds the equation list, and rewriting one equation shifts every
later index. With an eligible scan followed by an ineligible one, sweep 1 warns
at index 1 and sweep 2 finds the same equation at index *N* — a second warning.
The existing `test_skip_warning_once_across_fixpoint` is exactly that shape.
Content-based keys fail the other way: two genuinely distinct equations with the
same skip reason produce byte-identical messages, so a content key
over-suppresses.

## Fix

Drop the key entirely. `_convert_conds_once` / `_unroll_scans_once` now
*buffer* their skip diagnostics (as `emit` keyword dicts) and return them
alongside the rewritten jaxpr; `if_convert_conds`, `unroll_inner_scans` and
`canonicalize_control_flow` keep only the latest buffer per pass and replay it
via `_emit_pending` once the fixpoint settles.

This is correct because the settling sweep is by construction a sweep that
rewrote nothing: it walked the final jaxpr's top-level equations, visiting each
exactly once (no branch inlining happens when nothing is converted), so its
buffer holds exactly one entry per equation that survives canonicalization
un-rewritten. The joint driver's last iteration runs both sweeps over the final
jaxpr, so the same argument applies there.

Behaviour deltas: warning *count* per skipped equation is unchanged; skip
warnings now land after the pass's INFO rewrite records rather than interleaved
with them, and they describe the final jaxpr.

## Tests

New `TestSkipWarningDedup` in `braintrace/_compiler/canonicalize_test.py`
asserts the dedup neither over- nor under-suppresses:

- two distinct unsafe conds with identical messages emit two records;
- an unsafe cond placed *after* a convertible one (multi-sweep, index shifts)
  emits one;
- two distinct over-limit scans with identical messages emit two records;
- one eligible + one ineligible scan, in *both* orders, emits one record;
- two distinct sliced-weight scans emit two records;
- the joint driver reports the opaque scan and the unsafe cond once each.

Verified the new tests bite: temporarily emitting each sweep's buffer instead of
only the settled one fails 5 of the 8.

## Verification

```
$ python -m pytest braintrace/_compiler/ -x -q
561 passed, 78 warnings in 161.85s (0:02:41)

$ python -m mypy
Success: no issues found in 62 source files
```

Spec: `docs/specs/2026-08-07-e03-stable-warning-dedup-keys.md`

Closes #158

## Summary by Sourcery

Buffer and defer emission of control-flow skip diagnostics until canonicalization fixpoint settles, and add specification and tests to ensure per-equation, stable warning deduplication.

Enhancements:
- Replace id-based skip-warning deduplication in canonicalization passes with buffered diagnostics emitted once after the fixpoint settles.
- Introduce a helper to replay buffered diagnostics collected during canonicalization sweeps.

Documentation:
- Add a spec documenting stable warning deduplication keys and the new buffering strategy in canonicalization.

Tests:
- Add a dedicated test suite to verify skip warnings are emitted exactly once per skipped equation, including for multi-sweep fixpoints, identical messages, and the joint control-flow driver.