### PR TITLE
fix(nn): reject Embedding's unsupported options at construction (E-04)

### DIFF
--- a/braintrace/nn/_embedding.py
+++ b/braintrace/nn/_embedding.py
@@ -15,19 +15,232 @@
 
 from __future__ import annotations
 
+from typing import Callable, Optional, Union
+
 import brainstate
 import brainunit as u
 import jax.numpy as jnp
 
 from braintrace._op import embedding
-from braintrace._typing import ArrayLike
+from braintrace._typing import ArrayLike, Size
 
 __all__ = ['Embedding']
 
 
+def _reject_unsupported_options(
+    max_norm: Optional[float],
+    freeze: bool,
+    scale_grad_by_freq: bool,
+    padding_idx: Optional[int],
+) -> None:
+    """Raise if any option outside the ETP ``embedding`` primitive is enabled.
+
+    ``max_norm`` and ``freeze`` wrap the lookup in ``stop_gradient``;
+    ``scale_grad_by_freq`` and ``padding_idx`` live in the ``brainstate``
+    parent's ``custom_vjp`` backward rule, which the ETP ``embedding``
+    primitive replaces outright. None of the four is visible to the
+    online-learning trace machinery, so honouring them silently would diverge
+    from the ``brainstate`` semantics rather than reproduce them.
+
+    Shared by :meth:`Embedding.__init__` and :meth:`Embedding.update` so that
+    the unsupported set and its message cannot drift apart. The constructor is
+    the gate that matters; ``update`` re-checks because these are plain public
+    attributes a caller can still assign after construction.
+
+    Parameters
+    ----------
+    max_norm : float or None
+        The ``max_norm`` option. Unsupported unless ``None``.
+    freeze : bool
+        The ``freeze`` option. Unsupported unless ``False``.
+    scale_grad_by_freq : bool
+        The ``scale_grad_by_freq`` option. Unsupported unless ``False``.
+    padding_idx : int or None
+        The ``padding_idx`` option. Unsupported unless ``None``.
+
+    Raises
+    ------
+    NotImplementedError
+        If any argument is set to a value other than its default. The message
+        names every offending option and its value, in the fixed order
+        ``max_norm``, ``freeze``, ``scale_grad_by_freq``, ``padding_idx``.
+    """
+    offenders = []
+    if max_norm is not None:
+        offenders.append(f'max_norm={max_norm!r}')
+    if freeze:
+        offenders.append(f'freeze={freeze!r}')
+    if scale_grad_by_freq:
+        offenders.append(f'scale_grad_by_freq={scale_grad_by_freq!r}')
+    if padding_idx is not None:
+        offenders.append(f'padding_idx={padding_idx!r}')
+    if not offenders:
+        return
+    raise NotImplementedError(
+        f'braintrace.nn.Embedding does not support: {", ".join(offenders)}. '
+        'These modify the lookup or its gradient outside the ETP primitive '
+        'that online learning traces. Use braintrace.nn.Embedding with '
+        'default values for max_norm, freeze, scale_grad_by_freq and '
+        'padding_idx, or use brainstate.nn.Embedding if you do not need '
+        'online-learning traces.'
+    )
+
+
 class Embedding(brainstate.nn.Embedding):
+    r"""A lookup table whose gather is routed through the ETP ``embedding`` op.
+
+    Drop-in replacement for :class:`brainstate.nn.Embedding` that performs the
+    table lookup with :func:`braintrace.embedding`, which is what makes the
+    table eligible for online-learning trace computation. Indices of any rank
+    are accepted; rank 2 and above are folded into one flat axis before the op
+    (the rank-guarded primitive takes only scalar or ``(batch,)`` indices) and
+    the output is unfolded back to ``(*indices.shape, *embedding_size)``.
+
+    Four of the parent's options are **accepted for signature compatibility but
+    not supported, and are rejected by the constructor**: ``max_norm``,
+    ``freeze``, ``scale_grad_by_freq`` and ``padding_idx``. Each modifies the
+    lookup or its gradient outside the ETP primitive that online learning
+    traces, so there is no way to honour them without diverging from the
+    ``brainstate`` semantics. They are part of the signature so that code
+    written against :class:`brainstate.nn.Embedding` fails with a clear message
+    at the constructor call rather than with a ``TypeError`` about an unexpected
+    keyword — or, as before this validation moved, with a deferred failure at
+    the first forward pass, which under ``jit`` can be far from the mistake.
+
+    Parameters
+    ----------
+    num_embeddings : int
+        Size of the embedding dictionary. Must be non-negative.
+    embedding_size : int or sequence of int
+        Size of each embedding vector.
+    embedding_init : Callable or ArrayLike, optional
+        Initializer for the lookup table, of shape
+        ``(num_embeddings, *embedding_size)``. Default is ``LecunUniform()``.
+    padding_idx : int, optional
+        Accepted but **not supported**; anything other than ``None`` raises
+        ``NotImplementedError`` from the constructor. Zeroing the gradient of
+        one row happens in the parent's backward rule, which the ETP primitive
+        replaces.
+    max_norm : float, optional
+        Accepted but **not supported**; anything other than ``None`` raises
+        ``NotImplementedError`` from the constructor. Renormalizing rows
+        inserts a ``stop_gradient`` the trace machinery cannot see through.
+    norm_type : float, optional
+        The p of the p-norm used by ``max_norm``. Supported in the sense that
+        it is accepted and stored, but inert: it only has an effect together
+        with ``max_norm``, which is rejected. Default is ``2.0``.
+    scale_grad_by_freq : bool, optional
+        Accepted but **not supported**; ``True`` raises
+        ``NotImplementedError`` from the constructor. The inverse-frequency
+        scaling lives in the parent's backward rule, which the ETP primitive
+        replaces. Default is ``False``.
+    freeze : bool, optional
+        Accepted but **not supported**; ``True`` raises
+        ``NotImplementedError`` from the constructor. Freezing wraps the table
+        in ``stop_gradient``, which removes the very gradient path online
+        learning traces. Default is ``False``.
+    name : str, optional
+        Name of the module.
+    param_type : type, optional
+        Parameter state type. Default is ``brainstate.ParamState``.
+
+    Attributes
+    ----------
+    weight : brainstate.ParamState
+        The learnable table, of shape ``(num_embeddings, *embedding_size)``.
+
+    Raises
+    ------
+    NotImplementedError
+        From the constructor, if ``max_norm``, ``freeze``,
+        ``scale_grad_by_freq`` or ``padding_idx`` is set to a non-default
+        value. The message names every offending option.
+
+    See Also
+    --------
+    braintrace.embedding : The ETP primitive this layer wraps.
+    brainstate.nn.Embedding : The upstream layer, which supports all options.
+
+    Examples
+    --------
+    Look up rows of the table:
+
+    .. code-block:: python
+
+        >>> import jax.numpy as jnp
+        >>> import braintrace
+        >>> layer = braintrace.nn.Embedding(10, 4)
+        >>> layer(jnp.array([0, 3, 3])).shape
+        (3, 4)
+
+    Index arrays of rank 2 or higher are folded and unfolded automatically:
+
+    .. code-block:: python
+
+        >>> import jax.numpy as jnp
+        >>> import braintrace
+        >>> layer = braintrace.nn.Embedding(10, 4)
+        >>> layer(jnp.array([[0, 1, 2], [3, 4, 5]])).shape
+        (2, 3, 4)
+
+    An unsupported option fails at the constructor, not at the forward pass:
+
+    .. code-block:: python
+
+        >>> import braintrace
+        >>> braintrace.nn.Embedding(10, 4, freeze=True)
+        Traceback (most recent call last):
+            ...
+        NotImplementedError: braintrace.nn.Embedding does not support: freeze=True. ...
+    """
+
     __module__ = 'braintrace.nn'
-    __doc__ = (brainstate.nn.Embedding.__doc__ or '').replace('brainstate', 'braintrace')
+
+    def __init__(
+        self,
+        num_embeddings: int,
+        embedding_size: Size,
+        embedding_init: Union[Callable, ArrayLike] = brainstate.nn.init.LecunUniform(),
+        padding_idx: Optional[int] = None,
+        max_norm: Optional[float] = None,
+        norm_type: float = 2.0,
+        scale_grad_by_freq: bool = False,
+        freeze: bool = False,
+        name: Optional[str] = None,
+        param_type: type = brainstate.ParamState,
+    ):
+        """Build the table and reject the options this layer cannot trace.
+
+        The parent constructor runs first so that its own argument validation
+        keeps producing the more specific diagnosis where it has one — an
+        out-of-range ``padding_idx`` is still the parent's ``ValueError``, not
+        an "unsupported option" report, because being out of range is a
+        different mistake.
+
+        Every argument is forwarded to :class:`brainstate.nn.Embedding`
+        unchanged and is documented on the class docstring above.
+
+        Raises
+        ------
+        NotImplementedError
+            If ``max_norm``, ``freeze``, ``scale_grad_by_freq`` or
+            ``padding_idx`` is set to a non-default value.
+        """
+        super().__init__(
+            num_embeddings=num_embeddings,
+            embedding_size=embedding_size,
+            embedding_init=embedding_init,
+            padding_idx=padding_idx,
+            max_norm=max_norm,
+            norm_type=norm_type,
+            scale_grad_by_freq=scale_grad_by_freq,
+            freeze=freeze,
+            name=name,
+            param_type=param_type,
+        )
+        _reject_unsupported_options(
+            self.max_norm, self.freeze, self.scale_grad_by_freq, self.padding_idx
+        )
 
     def update(self, indices: ArrayLike) -> ArrayLike:
         """Look up embeddings through the ETP ``embedding`` primitive.
@@ -38,10 +251,12 @@ class Embedding(brainstate.nn.Embedding):
         rank-guarded primitive accepts only scalar or ``(batch,)`` indices)
         and the output is unfolded to ``(*indices.shape, features)``.
 
-        ``max_norm``, ``freeze``, ``scale_grad_by_freq``, and ``padding_idx``
-        modify the lookup or its gradient outside the primitive that online
-        learning traces, so they raise ``NotImplementedError`` instead of
-        silently diverging from the ``brainstate`` semantics.
+        The unsupported-option check is re-run here, not only in
+        ``__init__``. ``max_norm``, ``freeze``, ``scale_grad_by_freq`` and
+        ``padding_idx`` are plain public attributes that the parent
+        constructor assigns directly, so a caller can still enable one after
+        construction (``layer.freeze = True``); without this second gate that
+        would silently produce the wrong semantics instead of an error.
 
         Parameters
         ----------
@@ -56,21 +271,13 @@ class Embedding(brainstate.nn.Embedding):
         Raises
         ------
         NotImplementedError
-            If the layer was constructed with ``max_norm``, ``freeze``,
-            ``scale_grad_by_freq``, or ``padding_idx``.
+            If ``max_norm``, ``freeze``, ``scale_grad_by_freq`` or
+            ``padding_idx`` was enabled by assignment after construction.
+            Passing one to the constructor raises there instead.
         """
-        if (
-            self.max_norm is not None
-            or self.freeze
-            or self.scale_grad_by_freq
-            or self.padding_idx is not None
-        ):
-            raise NotImplementedError(
-                'braintrace.nn.Embedding does not support max_norm, freeze, '
-                'scale_grad_by_freq, or padding_idx: they modify the lookup '
-                'or its gradient outside the ETP primitive that online '
-                'learning requires.'
-            )
+        _reject_unsupported_options(
+            self.max_norm, self.freeze, self.scale_grad_by_freq, self.padding_idx
+        )
         indices = jnp.asarray(indices)
         table = self.weight.value
         if indices.ndim <= 1:

--- a/braintrace/nn/_embedding_test.py
+++ b/braintrace/nn/_embedding_test.py
@@ -51,17 +51,6 @@ class TestEmbedding:
         assert 'etp_emb' in prims
         assert 'gather' not in prims
 
-    def test_unsupported_features_rejected(self):
-        idx = jnp.array([0], dtype=jnp.int32)
-        with pytest.raises(NotImplementedError):
-            braintrace.nn.Embedding(10, 4, max_norm=1.0)(idx)
-        with pytest.raises(NotImplementedError):
-            braintrace.nn.Embedding(10, 4, freeze=True)(idx)
-        with pytest.raises(NotImplementedError):
-            braintrace.nn.Embedding(10, 4, scale_grad_by_freq=True)(idx)
-        with pytest.raises(NotImplementedError):
-            braintrace.nn.Embedding(10, 4, padding_idx=0)(idx)
-
     def test_gradient_flows_to_table(self):
         layer = braintrace.nn.Embedding(10, 4)
         idx = jnp.array([2, 2], dtype=jnp.int32)
@@ -73,3 +62,125 @@ class TestEmbedding:
 
     def test_exported_from_nn(self):
         assert 'Embedding' in braintrace.nn.__all__
+
+
+class TestEmbeddingUnsupportedOptions:
+    """E-04: the four unsupported options are rejected by ``__init__``.
+
+    Before this fix the constructor accepted all four and ``update()`` raised,
+    so the failure surfaced at the first forward pass -- under ``jit``,
+    arbitrarily far from the line that passed the option.
+    """
+
+    @pytest.mark.parametrize(
+        'kwargs, named',
+        [
+            ({'max_norm': 1.0}, 'max_norm'),
+            ({'freeze': True}, 'freeze'),
+            ({'scale_grad_by_freq': True}, 'scale_grad_by_freq'),
+            ({'padding_idx': 0}, 'padding_idx'),
+        ],
+    )
+    def test_each_option_raises_at_construction(self, kwargs, named):
+        with pytest.raises(NotImplementedError) as exc:
+            braintrace.nn.Embedding(10, 4, **kwargs)
+        assert named in str(exc.value)
+
+    def test_message_names_every_offender_and_no_others(self):
+        with pytest.raises(NotImplementedError) as exc:
+            braintrace.nn.Embedding(
+                10, 4, freeze=True, padding_idx=2, scale_grad_by_freq=True)
+        # The offenders appear with their values, in the fixed declaration
+        # order; the option that was left at its default is not reported.
+        msg = str(exc.value)
+        offenders = msg.split('does not support: ', 1)[1].split('.', 1)[0]
+        assert offenders == 'freeze=True, scale_grad_by_freq=True, padding_idx=2'
+
+    def test_failure_is_at_init_not_at_first_call(self):
+        """The regression: no forward pass is needed to provoke the error.
+
+        The old behaviour was for this constructor to return an object and for
+        the error to appear only when that object was called. If the layer is
+        ever constructed here, ``pytest.raises`` fails and the regression is
+        caught.
+        """
+        with pytest.raises(NotImplementedError):
+            braintrace.nn.Embedding(10, 4, max_norm=1.0)
+
+    def test_jitted_forward_is_never_reached(self):
+        """Under ``jit`` the old failure fired at trace time, not construction.
+
+        Construct inside the jitted callable's *builder*, so that if the layer
+        constructed successfully the error could only come from the traced
+        call. Asserting the callable was never invoked pins the timing.
+        """
+        called = []
+
+        def build_and_run(idx):
+            layer = braintrace.nn.Embedding(10, 4, scale_grad_by_freq=True)
+            called.append(True)
+            return layer(idx)
+
+        with pytest.raises(NotImplementedError):
+            brainstate.transform.jit(build_and_run)(jnp.array([0, 1], dtype=jnp.int32))
+        assert called == [], 'construction should have raised before the lookup'
+
+    def test_explicit_defaults_construct_and_run(self):
+        layer = braintrace.nn.Embedding(
+            10, 4,
+            max_norm=None,
+            freeze=False,
+            scale_grad_by_freq=False,
+            padding_idx=None,
+        )
+        idx = jnp.array([1, 5], dtype=jnp.int32)
+        np.testing.assert_allclose(layer(idx), layer.weight.value[idx], atol=1e-6)
+
+    def test_norm_type_is_not_in_the_unsupported_set(self):
+        # `norm_type` only matters together with `max_norm`, which is rejected,
+        # so it stays accepted and inert rather than joining the rejected set.
+        layer = braintrace.nn.Embedding(10, 4, norm_type=1.0)
+        assert layer(jnp.array([0], dtype=jnp.int32)).shape == (1, 4)
+
+    def test_parent_value_error_still_wins_for_out_of_range_padding_idx(self):
+        # An out-of-range index is a different mistake from an unsupported
+        # feature; the parent's more specific diagnosis must not be masked.
+        with pytest.raises(ValueError) as exc:
+            braintrace.nn.Embedding(10, 4, padding_idx=99)
+        assert not isinstance(exc.value, NotImplementedError)
+
+    @pytest.mark.parametrize(
+        'attr, value',
+        [
+            ('max_norm', 1.0),
+            ('freeze', True),
+            ('scale_grad_by_freq', True),
+            ('padding_idx', 0),
+        ],
+    )
+    def test_post_init_mutation_is_still_caught_by_update(self, attr, value):
+        """``update()``'s check is not dead code.
+
+        These are plain public attributes assigned by the parent constructor,
+        so a caller can enable one after construction. Dropping the check in
+        ``update()`` would make that silently produce the wrong semantics.
+        """
+        layer = braintrace.nn.Embedding(10, 4)
+        setattr(layer, attr, value)
+        with pytest.raises(NotImplementedError) as exc:
+            layer(jnp.array([0], dtype=jnp.int32))
+        assert attr in str(exc.value)
+
+    def test_from_pretrained_rejects_its_default_freeze(self):
+        # `from_pretrained` defaults to `freeze=True`, so it now fails at the
+        # `from_pretrained` call rather than at the first forward pass.
+        w = jnp.arange(12, dtype=jnp.float32).reshape(4, 3)
+        with pytest.raises(NotImplementedError) as exc:
+            braintrace.nn.Embedding.from_pretrained(w)
+        assert 'freeze' in str(exc.value)
+
+    def test_from_pretrained_works_with_freeze_disabled(self):
+        w = jnp.arange(12, dtype=jnp.float32).reshape(4, 3)
+        layer = braintrace.nn.Embedding.from_pretrained(w, freeze=False)
+        out = layer(jnp.array([1], dtype=jnp.int32))
+        np.testing.assert_allclose(out, w[jnp.array([1])], atol=1e-6)

--- a/docs/specs/2026-08-07-e04-embedding-eager-validation.md
+++ b/docs/specs/2026-08-07-e04-embedding-eager-validation.md
@@ -1,0 +1,123 @@
+# E-04 — `Embedding` validates unsupported options at construction
+
+Status: proposed
+Scope: `braintrace/nn/_embedding.py`
+Backlog entry: E-04 in `2026-08-07-deferred-engineering-backlog.md`
+Issue: [#159](https://github.com/chaobrain/braintrace/issues/159)
+
+## The defect
+
+`braintrace.nn.Embedding` subclasses `brainstate.nn.Embedding` and inherits its
+constructor verbatim. That constructor accepts `padding_idx`, `max_norm`,
+`scale_grad_by_freq` and `freeze` and stores each as a plain instance
+attribute. `braintrace`'s `update()` then refuses all four:
+
+```python
+if (self.max_norm is not None or self.freeze
+        or self.scale_grad_by_freq or self.padding_idx is not None):
+    raise NotImplementedError(...)
+```
+
+So construction succeeds and the *first forward pass* fails. Under
+`brainstate.transform.jit` — the shape of every driver in this package — the
+first forward pass happens at trace time, arbitrarily far from the constructor
+call, inside a stack of transform frames. The traceback points at the trace, not
+at the line that passed the option.
+
+The unsupported set is right: all four modify the lookup or its gradient
+*outside* the ETP primitive that online learning traces (`max_norm` and `freeze`
+insert `stop_gradient`; `scale_grad_by_freq` and `padding_idx` live in the
+parent's `custom_vjp` backward rule, which the ETP `embedding` primitive
+replaces). Only the *timing* is wrong.
+
+## New behaviour
+
+`__init__` is overridden. It forwards every argument to the parent unchanged,
+then validates. Any of the four options set to a non-default value raises
+`NotImplementedError` from the constructor call itself.
+
+Validation runs *after* `super().__init__` so the parent keeps ownership of its
+own argument validation and its error messages continue to win where they are
+more specific. `padding_idx=99` on a 10-row table still raises the parent's
+`ValueError`, not our `NotImplementedError` — an out-of-range index is a
+different mistake from an unsupported feature, and the more precise diagnosis
+should be the one the user sees.
+
+### Error contract
+
+- Type: `NotImplementedError` — unchanged from the `update()` check, so any
+  existing `pytest.raises(NotImplementedError)` keeps passing.
+- Message: names *which* options were actually passed, then states why. E.g.
+  for `Embedding(10, 4, freeze=True, padding_idx=0)`:
+
+  ```
+  braintrace.nn.Embedding does not support: freeze=True, padding_idx=0. These
+  modify the lookup or its gradient outside the ETP primitive that online
+  learning traces. Use braintrace.nn.Embedding with default values for
+  max_norm, freeze, scale_grad_by_freq and padding_idx, or use
+  brainstate.nn.Embedding if you do not need online-learning traces.
+  ```
+
+  Options are listed in a fixed order (`max_norm`, `freeze`,
+  `scale_grad_by_freq`, `padding_idx`) so the message is deterministic. The
+  previous message named the whole unsupported set regardless of what was
+  passed; naming only the offenders is strictly more informative.
+
+### The `update()` check is kept, not deleted
+
+The issue text suggests the `update()` check becomes dead. It does not. The four
+options are **plain, public, mutable instance attributes** set by the parent
+constructor (`self.freeze = bool(freeze)` and friends) — verified empirically:
+
+```python
+layer = braintrace.nn.Embedding(10, 4)   # constructs fine
+layer.freeze = True                       # no descriptor, no guard
+layer(idx)                                # still reaches update() unsupported
+```
+
+Removing the `update()` check would therefore make post-init mutation silently
+produce wrong semantics (a frozen table that trains anyway, a `padding_idx` that
+receives gradient). The check stays as the second gate. `__init__` and
+`update()` share one `_reject_unsupported_options` helper so the set and the
+message cannot drift apart.
+
+### `from_pretrained`
+
+The inherited `from_pretrained` classmethod defaults to `freeze=True` and calls
+`cls(...)`, so `braintrace.nn.Embedding.from_pretrained(w)` now raises from the
+`from_pretrained` call instead of from the first forward pass. This is the same
+failure moved earlier — it already failed before, just later. Callers who want
+pretrained weights pass `freeze=False` explicitly, which works.
+
+## Docstring
+
+The class currently reuses the parent docstring with a `brainstate` →
+`braintrace` string substitution. That text documents `padding_idx` and
+`max_norm` as working features and demonstrates both in runnable examples that
+now raise. It is replaced with a docstring written for this class: the four
+options are documented as *accepted for signature compatibility with*
+`brainstate.nn.Embedding` *and rejected at construction*, with a `Raises`
+section and examples that only exercise the supported path.
+
+## Tests
+
+`braintrace/nn/_embedding_test.py` (already exists; extended).
+
+- Each of the four options raises `NotImplementedError` at construction — one
+  test per option, each asserting the message names that option.
+- Several at once: the message names every offender and no others.
+- **The regression that matters**: constructing raises, and no forward pass is
+  needed to provoke it. Asserted by constructing inside `pytest.raises` with no
+  call, and by a companion test that a `jit`-wrapped forward is never reached.
+- Explicit defaults (`max_norm=None`, `freeze=False`, `scale_grad_by_freq=False`,
+  `padding_idx=None`) construct and run a forward pass.
+- `norm_type` is *not* in the unsupported set and is accepted (it is inert
+  without `max_norm`).
+- Parent `ValueError` for an out-of-range `padding_idx` still wins.
+- Post-init mutation of each attribute is still caught by `update()`.
+- `from_pretrained` raises at the call with the default `freeze=True` and
+  succeeds with `freeze=False`.
+
+## Out of scope
+
+Implementing any of the four options. The unsupported set does not change.


### PR DESCRIPTION
## Problem

`braintrace.nn.Embedding` inherits `brainstate.nn.Embedding.__init__` verbatim, so `max_norm`, `freeze`, `scale_grad_by_freq` and `padding_idx` were **accepted at construction** and only refused by `update()`. Under `jit` the first forward pass is a trace, arbitrarily far from the line that passed the option, so the traceback pointed at the transform rather than at the mistake.

## Change

- **`__init__` is overridden** — it forwards every argument to the parent unchanged, then validates. The error now comes from the constructor call.
- Validation runs *after* `super().__init__` so the parent's more specific diagnoses still win: an out-of-range `padding_idx` is still its `ValueError`, not an "unsupported option" report. Being out of range is a different mistake from being unsupported.
- **The `update()` check is kept, not deleted.** The issue expected it to become dead code; it does not. The four options are plain public attributes the parent constructor assigns directly (`self.freeze = bool(freeze)`), so this still works and still has to be caught:

  ```python
  layer = braintrace.nn.Embedding(10, 4)   # constructs fine
  layer.freeze = True                       # no descriptor, no guard
  layer(idx)                                # reaches update() unsupported
  ```

  Dropping the check would make post-init mutation silently produce the wrong semantics (a frozen table that trains anyway). Both call sites share one `_reject_unsupported_options` helper so the set and the message cannot drift apart.
- The exception type is unchanged (`NotImplementedError`), and the message is strictly more informative: it names only the options *actually passed*, with their values, in a fixed order — the old message recited the whole unsupported set regardless.
- **Class docstring rewritten.** It previously reused the parent's text with a `brainstate` → `braintrace` substitution, which documented `padding_idx` and `max_norm` as working features and demonstrated both in runnable examples that raise. The four are now documented as accepted-for-signature-compatibility and rejected at construction, with a `Raises` section and examples that only exercise the supported path.

The unsupported set does not change.

### Note on `from_pretrained`

The inherited `from_pretrained` classmethod defaults to `freeze=True`, so `Embedding.from_pretrained(w)` now raises from the `from_pretrained` call instead of from the first forward pass. Same failure, moved earlier. `freeze=False` works and is covered by a test.

## Tests

`braintrace/nn/_embedding_test.py`, 16 new cases in `TestEmbeddingUnsupportedOptions`: each option at construction, several at once (exact offender list asserted), explicit defaults still construct and run, `norm_type` is *not* in the rejected set, the parent `ValueError` still wins, post-init mutation of each attribute still caught by `update()`, and `from_pretrained` both ways.

The regression that matters is pinned twice: once by constructing inside `pytest.raises` with no call at all, and once by building the layer inside a `brainstate.transform.jit`-wrapped callable and asserting the callable body past construction was **never reached**.

## Verification

```
$ python -m pytest braintrace/nn/ -x -q
........................................................................ [ 26%]
........................................................................ [ 53%]
........................................................................ [ 80%]
......................................................                   [100%]
270 passed, 1 warning in 165.65s (0:02:45)
```

(The one warning is a pre-existing `brainevent` numba/JAX-version notice from `_linear_test.py`, unrelated to this change.)

```
$ python -m mypy
Success: no issues found in 62 source files
```

Spec: `docs/specs/2026-08-07-e04-embedding-eager-validation.md`

Closes #159

## Summary by Sourcery

Validate unsupported Embedding options at construction time so misuse fails eagerly and consistently while preserving online-learning tracing semantics.

Bug Fixes:
- Raise NotImplementedError from Embedding.__init__ when unsupported options (max_norm, freeze, scale_grad_by_freq, padding_idx) are enabled, including when invoked via from_pretrained, instead of failing only on first forward pass.

Enhancements:
- Introduce a shared helper to check unsupported Embedding options from both construction and update, ensuring consistent error messages and preventing silent misbehaviour after post-init mutation.
- Rewrite braintrace.nn.Embedding’s docstring to accurately describe unsupported options, their error behaviour, and valid usage, including higher-rank index handling.

Documentation:
- Add a design spec documenting eager validation of unsupported Embedding options and its interaction with jit and online-learning traces.

Tests:
- Extend Embedding tests to cover constructor-time validation, combined option errors, behaviour under jit, explicit default values, norm_type acceptance, parent ValueError preservation, post-init mutation, and from_pretrained with both default and overridden freeze.