### PR TITLE
Declare jax>=0.8.0 as a core dependency (#160)

### DIFF
--- a/braintrace/_version_test.py
+++ b/braintrace/_version_test.py
@@ -1,0 +1,170 @@
+# Copyright 2026 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Version string and install-metadata invariants.
+
+The metadata assertions here read the repository's ``pyproject.toml`` /
+``requirements.txt`` rather than ``importlib.metadata``: a source checkout
+routinely shadows an older installed distribution, so the installed
+``dist-info`` can describe a different release than the code under test.
+
+Both files ship in the sdist -- which is what downstream packagers build and run
+this suite from -- but not in the wheel, so each test skips when its file is
+absent. ``.github/`` is in neither artifact, so the CI cross-check skips outside
+a repo checkout.
+
+Rationale for the JAX floor: ``docs/specs/2026-08-07-e05-declare-jax-dependency.md``.
+"""
+
+import re
+import tomllib
+from pathlib import Path
+from typing import Optional, Tuple
+
+import pytest
+
+from braintrace._version import __version__, __version_info__
+
+#: Repository root as seen from an sdist/checkout layout (``<root>/braintrace``).
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+PYPROJECT = REPO_ROOT / 'pyproject.toml'
+REQUIREMENTS = REPO_ROOT / 'requirements.txt'
+CI_WORKFLOW = REPO_ROOT / '.github' / 'workflows' / 'CI.yml'
+
+#: Backend-selector extras that must keep requesting an accelerator-flavoured
+#: ``jax``. Adding a bare ``jax`` to the core dependency list must not degrade
+#: these into plain installs.
+BACKEND_EXTRAS = ('cpu', 'cuda12', 'cuda13', 'tpu')
+
+
+def _load_pyproject() -> dict:
+    if not PYPROJECT.is_file():
+        pytest.skip('pyproject.toml not available (wheel install)')
+    return tomllib.loads(PYPROJECT.read_text(encoding='utf-8'))
+
+
+def _jax_requirement(dependencies) -> Optional[str]:
+    """Return the requirement string naming the ``jax`` project, if any.
+
+    Matches the distribution name at the start of the requirement so that
+    ``jaxlib`` or ``jax-cuda12-plugin`` are not mistaken for it.
+    """
+    for dep in dependencies:
+        if re.match(r'^\s*jax\s*(\[|[<>=!~]|$)', dep):
+            return dep
+    return None
+
+
+def _floor(requirement: str) -> Tuple[int, ...]:
+    """Extract the ``>=`` floor of a requirement as a comparable tuple."""
+    match = re.search(r'>=\s*([0-9]+(?:\.[0-9]+)*)', requirement)
+    assert match is not None, f'no >= floor in {requirement!r}'
+    return tuple(int(part) for part in match.group(1).split('.'))
+
+
+class TestVersionString:
+    def test_version_info_matches_version(self):
+        assert __version_info__ == tuple(int(p) for p in __version__.split('.'))
+
+    def test_version_is_dotted_numeric(self):
+        # `[tool.setuptools.dynamic] version` reads this attribute verbatim, and
+        # `__version_info__` int-parses every component, so a suffix such as
+        # "0.3.0rc1" would raise at import time rather than at build time.
+        assert re.fullmatch(r'[0-9]+(\.[0-9]+)*', __version__), __version__
+
+    def test_pyproject_reads_this_module_for_its_version(self):
+        dynamic = _load_pyproject()['tool']['setuptools']['dynamic']
+        assert dynamic['version'] == {'attr': 'braintrace._version.__version__'}
+
+
+class TestJaxDependencyDeclaration:
+    """`jax` is imported directly by the package, so it must be declared (E-05).
+
+    Before this was declared, the floor was borrowed from ``brainevent``'s
+    metadata and could move without a braintrace commit.
+    """
+
+    def test_jax_is_a_core_dependency_with_a_floor(self):
+        deps = _load_pyproject()['project']['dependencies']
+        requirement = _jax_requirement(deps)
+        assert requirement is not None, f'jax missing from core dependencies: {deps}'
+        assert _floor(requirement) >= (0, 8, 0)
+
+    def test_declared_floor_matches_the_lowest_tested_jax(self):
+        """Metadata must not promise a version the CI matrix never runs.
+
+        This is E-05 stated as an assertion: lowering the matrix without
+        lowering the floor (or raising the floor without extending the matrix)
+        means the published range and the tested range have diverged.
+        """
+        if not CI_WORKFLOW.is_file():
+            pytest.skip('CI workflow not available outside a repo checkout')
+        text = CI_WORKFLOW.read_text(encoding='utf-8')
+        match = re.search(r'jax-version:\s*\[([^\]]*)\]', text)
+        assert match is not None, 'no jax-version matrix found in CI.yml'
+        # `""` means "latest" and carries no lower bound; non-numeric entries
+        # (a pre-release, say) are not comparable as dotted tuples.
+        versions = [
+            tuple(int(p) for p in raw.split('.'))
+            for raw in re.findall(r'"([^"]*)"', match.group(1))
+            if re.fullmatch(r'[0-9]+(\.[0-9]+)*', raw)
+        ]
+        assert versions, 'CI matrix pins no explicit JAX version'
+
+        deps = _load_pyproject()['project']['dependencies']
+        assert _floor(_jax_requirement(deps)) == min(versions)
+
+    def test_no_upper_cap_on_jax(self):
+        # A cap published today constrains JAX releases that do not exist yet,
+        # for every braintrace artifact already on PyPI. Breakage is answered
+        # with a targeted exclusion plus a fix instead.
+        requirement = _jax_requirement(_load_pyproject()['project']['dependencies'])
+        assert '<' not in requirement, requirement
+
+    def test_requirements_txt_states_the_same_floor(self):
+        if not REQUIREMENTS.is_file():
+            pytest.skip('requirements.txt not available (wheel install)')
+        lines = [
+            line.split('#')[0].strip()
+            for line in REQUIREMENTS.read_text(encoding='utf-8').splitlines()
+        ]
+        requirement = _jax_requirement([line for line in lines if line])
+        assert requirement is not None, 'jax missing from requirements.txt'
+
+        deps = _load_pyproject()['project']['dependencies']
+        assert _floor(requirement) == _floor(_jax_requirement(deps))
+
+
+class TestBackendExtrasSurviveTheCoreDependency:
+    """`braintrace[cuda12]` must still resolve to a CUDA-capable JAX.
+
+    Extras of the same distribution are additive, so the core `jax>=0.8.0`
+    intersects with `jax[cuda12]` rather than replacing it -- but only for as
+    long as the extras keep naming a backend.
+    """
+
+    @pytest.mark.parametrize('extra', BACKEND_EXTRAS)
+    def test_extra_requests_the_backend_flavoured_jax(self, extra):
+        optional = _load_pyproject()['project']['optional-dependencies']
+        assert optional[extra] == [f'jax[{extra}]']
+
+    def test_extras_do_not_restate_the_floor(self):
+        # The floor lives in exactly one place so it cannot drift; an extra that
+        # grew its own `>=` would be a second source of truth.
+        optional = _load_pyproject()['project']['optional-dependencies']
+        for extra in BACKEND_EXTRAS:
+            for dep in optional[extra]:
+                assert '>=' not in dep, (extra, dep)

--- a/docs/specs/2026-08-07-e05-declare-jax-dependency.md
+++ b/docs/specs/2026-08-07-e05-declare-jax-dependency.md
@@ -1,0 +1,227 @@
+# E-05: declare `jax` as a core dependency
+
+Issue: [#160](https://github.com/chaobrain/braintrace/issues/160)
+
+## What is missing
+
+`[project].dependencies` in `pyproject.toml` lists `brainstate`, `brainunit`,
+`brainevent`, `brainpy.state` and `braintools` — but not `jax`, which every
+module in the package imports directly (`braintrace/_compatible_imports.py:16`
+is the first line of the compiler's own compatibility layer). The package is
+therefore installable in a state where its own metadata never says which JAX it
+needs, and the version range CI actually exercises is invisible to a resolver.
+
+The decision is to declare it with a floor and no cap. This spec records the
+evidence for that floor, the argument against a cap, and what the change does
+(and does not do) to the existing accelerator extras.
+
+## Correcting the issue's premise
+
+The issue says `jax` "resolves transitively through `brainstate`". That is not
+where it comes from. `brainstate` 0.5.2's core requirements are `numpy`,
+`brainunit` and `brainevent`; it declares JAX **only under extras**
+(`jax[cpu]>=0.7.0; extra == "cpu"`, and the cuda12/cuda13/tpu equivalents).
+Installing `brainstate` without an extra installs no JAX at all.
+
+The dependencies that actually drag JAX in as a *core* requirement today are:
+
+| distribution | JAX requirement (core) |
+| --- | --- |
+| `brainevent` (declared `>=0.1.2`) | `jax>=0.8.0` |
+| `braintools` | `jax` (no floor) |
+| `brainpy.state` | `jax` (no floor) |
+| `brainstate` | none (extras only) |
+| `brainunit` | none (extras only) |
+
+So the floor a resolver sees today is `>=0.8.0`, and it holds only because
+`brainevent` happens to declare it. If `brainevent` relaxed that line, or if a
+future release dropped the constraint, braintrace's effective floor would move
+without a single braintrace commit. That is the real defect: the floor is not
+absent, it is *borrowed*.
+
+## The floor: `jax>=0.8.0`
+
+Three independent lines of evidence converge on 0.8.0.
+
+**1. It is the lowest version CI tests.** `.github/workflows/CI.yml:37`:
+
+```yaml
+jax-version: [ "0.8.0", "0.9.0", "0.10.0", "" ]  # "" means latest version
+```
+
+Four matrix entries run the full suite; 0.8.0 is the floor of that set. A
+declared floor below 0.8.0 would be an untested claim, which is precisely the
+failure mode the issue objects to.
+
+**2. Nothing in the source requires more than 0.8.0.** The JAX-facing
+compatibility code is written to span versions rather than pin one:
+
+- `scan_num_consts_carry` and `scan_params_add_ys`
+  (`braintrace/_compatible_imports.py:91-148`) handle the JAX 0.11 "flattree"
+  scan refactor — which removed the `num_consts` / `num_carry` scan params — by
+  *capability* detection (`if 'num_consts' in params`, `if 'ft_out' not in
+  params`), not by a version comparison. Both sides of each branch are live on
+  the tested range.
+- `new_jaxpr_eqn` is imported from `jax.extend.core` with a `jax.core` fallback
+  for the versions that still expose it there.
+- `stop_gradient_p` is imported from `jax._src.ad_util` with a trace-based
+  recovery path that raises an explicitly actionable `ImportError` if a future
+  JAX moves it.
+
+None of these needs a version newer than the CI floor, so the code does not
+push the floor above 0.8.0.
+
+**3. Nothing in the source supports less than 0.8.0 either.** Two version
+guards exist for older JAX — `jax.__version_info__ < (0, 6, 2)` in `new_var`
+and `< (0, 7, 0)` in `is_jit_primitive` (`_compatible_imports.py:66,73`). They
+are not evidence for a lower floor: no CI entry ever takes those branches, so
+the claim "braintrace works on JAX 0.6" is unverified. They are cheap
+defensive code, not a support commitment, and a floor is a commitment.
+
+`jax>=0.8.0` therefore adds **no new constraint to any install that works
+today** (the transitive floor from `brainevent` is already 0.8.0). What it
+changes is ownership: the floor becomes a braintrace decision, backed by the
+braintrace test matrix, instead of a side effect of a sibling package's
+metadata.
+
+## Why no upper cap
+
+A cap was considered and rejected.
+
+- **A cap published today is a claim about software that does not exist yet.**
+  Capping at the current latest (`<0.12`) forbids the next JAX minor for every
+  braintrace release already on PyPI, and makes a braintrace release a
+  prerequisite for adopting each JAX release. The failure it prevents (a
+  breaking JAX bump) is recoverable by a patch release; the failure it causes
+  (a stale published cap) is not, because old artifacts cannot be edited.
+- **The code is written to survive a bump.** Every JAX-version-sensitive site
+  is capability-detected or guarded by `try`/`except ImportError` with a
+  fallback, as enumerated above. The design assumption is already "JAX will
+  move"; a cap would contradict it.
+- **CI already detects the breakage a cap would guess at.** `CI.yml` runs on a
+  daily `schedule` (`cron: '0 0 * * *'`) with an unpinned `pip install jax`, so
+  a JAX release that breaks the compiler surfaces within 24 hours, against a
+  real failure rather than a pre-emptive guess.
+- **Caps on a leaf package poison a shared environment.** braintrace is one of
+  several JAX consumers a user installs alongside each other. An upper cap here
+  does not merely constrain braintrace; it constrains the whole environment's
+  JAX, and pip reports the resulting conflict against braintrace.
+
+If a specific JAX release is ever found to break braintrace, the answer is an
+exclusion for that release (`jax>=0.8.0,!=X.Y.Z`) plus a fix — targeted at the
+version that actually failed, not at every version after it.
+
+## Interaction with the accelerator extras
+
+This is the part worth stating explicitly, because it is the one place the
+change could plausibly do harm.
+
+```toml
+[project.optional-dependencies]
+cpu = ["jax[cpu]"]
+cuda12 = ["jax[cuda12]"]
+cuda13 = ["jax[cuda13]"]
+tpu = ["jax[tpu]"]
+```
+
+**Adding bare `jax>=0.8.0` to the core list does not change what these extras
+install.** Extras of the *same* distribution are **additive, not alternative**.
+When a user runs `pip install braintrace[cuda12]`, the resolver collects two
+requirements naming the one project `jax`:
+
+- `jax>=0.8.0` (core)
+- `jax[cuda12]` (extra)
+
+It intersects the version specifiers (`>=0.8.0`) and unions the extra sets
+(`{cuda12}`). Exactly one `jax` is installed, at a version satisfying the
+floor, with the `cuda12` extra's own requirements pulled in alongside it.
+
+The reason there is no CPU-vs-CUDA conflict to begin with is that **the
+accelerator choice is not encoded in the `jax` wheel**. From JAX 0.11's
+metadata:
+
+- `jax`'s *core* requirements already include `jaxlib` (plus `ml_dtypes`,
+  `numpy`, `opt_einsum`, `scipy`). A bare `jax` install is already runnable.
+- `jax[cuda12]` **adds** `jax-cuda12-plugin[with-cuda]`; `jax[cuda13]` adds the
+  cuda13 plugin; `jax[tpu]` adds `libtpu`.
+- `jax[cpu]` contributes **no** `Requires-Dist` line at all in 0.11 — the `cpu`
+  extra is empty and exists for symmetry. `jax[cpu]` is literally `jax`.
+
+So there is no "CPU build" of `jax` that a bare requirement could force a user
+onto. Backends are selected by *additional plugin packages*, which the extras
+still contribute unchanged. `braintrace[cuda12]` keeps getting the CUDA wheel.
+
+The `testing` and `dev` extras list `jax[cpu]` for the same reason and are
+unaffected by the same argument.
+
+### Why the floor is not repeated in the extras
+
+The extras stay unversioned (`jax[cuda12]`, not `jax[cuda12]>=0.8.0`). The core
+requirement already constrains the same distribution, so the floor applies to
+every install path including every extra. Writing it once means it cannot drift
+between the five places it would otherwise appear.
+
+## Changes
+
+1. `pyproject.toml` — add `"jax>=0.8.0"` to `[project].dependencies`.
+2. `requirements.txt` — already lists a bare `jax`; raise it to `jax>=0.8.0` so
+   the dev/CI install path states the same floor as the published metadata.
+   (This does not disturb CI's matrix: `CI.yml` installs `requirements-dev.txt`
+   and *then* `pip install jax==0.8.0`, which still satisfies `>=0.8.0`.)
+3. `setup.py` — no change. It carries no dependency list; it exists only as the
+   `build_py` shim that prunes the test payload from the wheel. All install
+   metadata lives in `pyproject.toml`.
+4. `requirements-dev.txt` / `requirements-doc.txt` — no change; both begin with
+   `-r requirements.txt` and inherit the floor.
+
+## Verification
+
+The built wheel's `METADATA` carries the requirement in the core (unconditional)
+block, with every extra unchanged:
+
+```
+Requires-Dist: jax>=0.8.0
+Requires-Dist: brainstate>=0.5.2
+...
+Requires-Dist: jax[cuda12]; extra == "cuda12"
+```
+
+The "does this force a CPU build?" question was answered by resolution rather
+than by reading, via `pip install --dry-run --report` against the built wheel
+with `[cuda12]`: the resolution installs `jax` / `jaxlib` 0.11.0 **plus**
+`jax-cuda12-plugin`, `jax-cuda12-pjrt` and five `nvidia-*-cu12` packages. The
+CUDA install path is intact.
+
+## Tests
+
+`braintrace/_version_test.py` (new — the module had no co-located test, against
+`AGENTS.md` rule 9) pins the invariants that would otherwise regress silently:
+
+- `__version__` / `__version_info__` agree, and `__version__` is what
+  `[tool.setuptools.dynamic]` reads.
+- `[project].dependencies` declares `jax` with a `>=` floor.
+- **The declared floor equals the lowest JAX in the CI matrix.** This is the
+  issue's actual complaint expressed as an assertion: if someone adds a lower
+  entry to the matrix, or raises the floor without extending the matrix, the
+  metadata and the tested range have diverged and the test fails.
+- `requirements.txt` states the same floor as `pyproject.toml`.
+- The accelerator extras still request `jax[<backend>]`, so a future edit
+  cannot quietly turn `braintrace[cuda12]` into a plain `jax` install.
+
+Both `pyproject.toml` and `requirements.txt` ship in the sdist (which is what
+downstream packagers run the suite from) but not in the wheel, so the file-based
+tests skip when the files are absent. The CI-matrix cross-check additionally
+skips outside a repo checkout, since `.github/` is in neither artifact.
+
+### Edge cases considered
+
+- **Wheel-only install** — no `pyproject.toml` next to the package; tests skip
+  rather than fail.
+- **Stale installed `dist-info`** — the tests deliberately read the repo's
+  `pyproject.toml` rather than `importlib.metadata`, because a source checkout
+  commonly shadows an older installed distribution and the metadata would
+  describe the wrong version.
+- **Matrix `""` entry** — the empty string means "latest" and is excluded from
+  the minimum computation.
+- **A future matrix entry with a pre-release or trailing suffix** — the parser
+  compares dotted numeric tuples and ignores non-numeric matrix values.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,16 @@ classifiers = [
     "Topic :: Software Development :: Libraries",
 ]
 dependencies = [
+    # JAX is imported directly throughout the package (the compiler's
+    # compatibility layer starts with `import jax`), so it is declared here
+    # rather than borrowed from a sibling package's metadata. The floor is the
+    # lowest version the CI matrix runs (`.github/workflows/CI.yml`); no upper
+    # cap is pinned, because every JAX-version-sensitive site in
+    # `_compatible_imports.py` is capability-detected rather than
+    # version-pinned, and a published cap cannot be relaxed for artifacts
+    # already on PyPI. Rationale in
+    # `docs/specs/2026-08-07-e05-declare-jax-dependency.md`.
+    "jax>=0.8.0",
     "brainstate>=0.5.2",
     "brainunit",
     "brainevent>=0.1.2",
@@ -82,6 +92,14 @@ dynamic = ["version"]
 "Source Code" = "https://github.com/chaobrain/braintrace"
 
 
+# Backend selectors. These stay unversioned on purpose: extras of the *same*
+# distribution are additive, not alternative, so the `jax>=0.8.0` floor in
+# `[project].dependencies` already applies here and stating it again in five
+# places would only let it drift. `braintrace[cuda12]` resolves to one `jax`
+# satisfying `>=0.8.0` *with* the `cuda12` extra, which is what pulls in
+# `jax-cuda12-plugin`; the bare core requirement cannot force a CPU build,
+# because the backend lives in additional plugin packages rather than in the
+# `jax` wheel itself.
 [project.optional-dependencies]
 cpu = ["jax[cpu]"]
 cuda12 = ["jax[cuda12]"]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-jax
+jax>=0.8.0
 numpy
 brainstate>=0.5.2
 brainunit


### PR DESCRIPTION
## The floor was borrowed, not absent

Every module in the package imports `jax` directly (`_compatible_imports.py`
opens with it), but `[project].dependencies` never declared it.

The issue says JAX "resolves transitively through `brainstate`". It does not —
`brainstate` 0.5.2 declares JAX **only under extras** (`jax[cpu]>=0.7.0; extra
== "cpu"`); its core deps are `numpy`, `brainunit`, `brainevent`. What actually
drags JAX in:

| distribution | JAX requirement (core) |
| --- | --- |
| `brainevent` (declared `>=0.1.2`) | `jax>=0.8.0` |
| `braintools` | `jax` (no floor) |
| `brainpy.state` | `jax` (no floor) |
| `brainstate`, `brainunit` | none (extras only) |

So the effective floor today is already `>=0.8.0` — but only because
`brainevent` happens to say so. That is the real defect: braintrace's floor
could move without a braintrace commit.

## Why 0.8.0

- **It is the lowest version CI runs.** `.github/workflows/CI.yml:37` —
  `jax-version: [ "0.8.0", "0.9.0", "0.10.0", "" ]`. A floor below that would be
  an untested claim, which is the failure mode the issue objects to.
- **Nothing in the source needs more.** The JAX 0.11 "flattree" scan refactor is
  absorbed by `scan_num_consts_carry` / `scan_params_add_ys` through *capability*
  detection (`if 'num_consts' in params`, `if 'ft_out' not in params`), not a
  version comparison; `new_jaxpr_eqn` and `stop_gradient_p` are `try`/`except
  ImportError` with fallbacks. Both sides of each branch are live on the tested
  range.
- **Nothing in the source supports less.** The `jax.__version_info__ < (0, 6, 2)`
  and `< (0, 7, 0)` guards in `new_var` / `is_jit_primitive` are cheap defensive
  code that no CI entry ever executes. An unverified branch is not a support
  commitment, and a floor is a commitment.

Net effect: `jax>=0.8.0` adds **no new constraint to any install that works
today**. It moves ownership of the floor from a sibling package's metadata to
the matrix that tests it.

## Why no upper cap

- A cap published today constrains JAX releases that do not exist yet, for every
  braintrace artifact already on PyPI — and old artifacts cannot be edited. It
  makes a braintrace release a prerequisite for adopting each JAX minor.
- The code is written to survive a bump (capability detection + import
  fallbacks); a cap would contradict its own design assumption.
- CI already catches what a cap would guess at: the daily `schedule` run does an
  unpinned `pip install jax`, so a breaking release surfaces within 24h.
- Caps on a leaf package poison a shared environment — braintrace is one of
  several JAX consumers a user installs together.

A specific bad release gets `!=X.Y.Z` plus a fix, not a blanket cap on
everything after it.

## The extras still work

This is the one place the change could plausibly do harm, so it was checked by
resolution rather than by reading. Extras of the *same* distribution are
**additive, not alternative**: `braintrace[cuda12]` gives pip both `jax>=0.8.0`
and `jax[cuda12]`, which intersect to one `jax` at a version `>=0.8.0` **with**
the cuda12 extra.

`pip install --dry-run --report` against the built wheel with `[cuda12]`:

```
jax    -> 0.11.0
jaxlib -> 0.11.0
cuda pkgs: jax-cuda12-pjrt, jax-cuda12-plugin, nvidia-cuda-cccl-cu12,
           nvidia-cuda-cupti-cu12, nvidia-cuda-nvcc-cu12, ... (7 total)
```

There is no CPU-only `jax` artifact a bare requirement could force a user onto —
`jax`'s core deps already include `jaxlib`, backends are *additional plugin
packages*, and in JAX 0.11 `jax[cpu]` contributes no `Requires-Dist` at all
(the `cpu` extra is empty). The extras deliberately stay unversioned so the
floor lives in exactly one place and cannot drift across five declarations.

## Built metadata

```
Requires-Dist: jax>=0.8.0
Requires-Dist: brainstate>=0.5.2
Requires-Dist: brainunit
Requires-Dist: brainevent>=0.1.2
Requires-Dist: brainpy.state
Requires-Dist: braintools
Provides-Extra: cuda12
Requires-Dist: jax[cuda12]; extra == "cuda12"
```

`twine check` PASSED.

## Also changed

- `requirements.txt` — bare `jax` raised to `jax>=0.8.0` so the dev/CI path
  states the published floor. CI is unaffected: it installs
  `requirements-dev.txt` and *then* `pip install jax==0.8.0`, which satisfies it.
- `setup.py` — **no change**. It carries no dependency list; it is only the
  `build_py` shim that prunes tests from the wheel.
- `requirements-dev.txt` / `requirements-doc.txt` — no change; both `-r
  requirements.txt` and inherit the floor.

## Tests

New `braintrace/_version_test.py` (the module had no co-located test, against
`AGENTS.md` rule 9), 12 tests. The load-bearing one asserts **the declared floor
equals `min(CI jax matrix)`** — the issue's complaint expressed as an assertion,
so lowering the matrix without lowering the floor (or raising the floor without
extending the matrix) fails. Plus: no upper cap, `requirements.txt` floor
matches `pyproject.toml`, each backend extra still requests `jax[<backend>]`,
extras carry no competing floor, and `__version__` / `__version_info__` /
`[tool.setuptools.dynamic]` agree.

The metadata tests read the repo's `pyproject.toml` rather than
`importlib.metadata` — a source checkout routinely shadows an older installed
dist-info, which would describe the wrong release. Both files ship in the sdist
(what downstream packagers run the suite from) but not the wheel, so they skip
when absent; `.github/` is in neither, so the matrix cross-check skips outside a
checkout.

Verified: 79 tests pass (`_version_test`, `_compatible_imports_test`,
`__init___test`), `python -m mypy` clean, wheel builds and still prunes
`_version_test.py`.

Spec: `docs/specs/2026-08-07-e05-declare-jax-dependency.md`

Closes #160

## Summary by Sourcery

Declare JAX as a core dependency with an explicit tested version floor and add safeguards to keep metadata, CI, and extras consistent over time.

Enhancements:
- Add an explicit core dependency on jax>=0.8.0 in project metadata and align the development requirements with the same floor.
- Document the rationale and constraints around the JAX dependency, including the absence of an upper cap and interaction with accelerator extras.

Documentation:
- Add a spec document explaining the decision to declare JAX as a core dependency, the chosen minimum version, and why no upper bound is set.

Tests:
- Introduce version and metadata invariants tests to ensure the declared JAX floor matches the CI matrix, no upper cap is added, requirements files stay aligned, and backend extras continue to request accelerator-specific JAX packages.