### PR TITLE
test: co-located tests for _typing.py and nn/__init__.py (E-06)

### DIFF
--- a/braintrace/_typing_test.py
+++ b/braintrace/_typing_test.py
@@ -26,6 +26,8 @@ pinning.
 Spec: ``docs/specs/2026-08-07-e06-colocated-tests.md``.
 """
 
+import typing
+
 import brainstate
 import numpy as np
 import pytest
@@ -277,8 +279,17 @@ def test_brainstate_aliases_are_reexported_not_redeclared(name):
 def test_size_union_is_what_as_size_tuple_documents():
     """Guard the premise of ``test_every_arm_of_the_declared_size_union_is_accepted``:
     if ``brainstate`` widens ``Size``, the union-coverage test above silently
-    stops covering the whole union."""
-    assert str(_typing.Size) == (
-        'typing.Union[int, typing.Sequence[int], numpy.integer, '
-        'typing.Sequence[numpy.integer]]'
-    )
+    stops covering the whole union.
+
+    Compared structurally, via :func:`typing.get_args`, rather than against the
+    union's rendering: ``str()`` of a union is not stable across the supported
+    Python range (3.11 renders ``typing.Union[A, B]``, 3.14 renders ``A | B``)
+    even though the union itself is unchanged. Member order is likewise a
+    property of how the alias was spelled upstream, so compare as a set.
+    """
+    assert frozenset(typing.get_args(_typing.Size)) == frozenset({
+        int,
+        typing.Sequence[int],
+        np.integer,
+        typing.Sequence[np.integer],
+    })

--- a/braintrace/_typing_test.py
+++ b/braintrace/_typing_test.py
@@ -1,0 +1,284 @@
+# Copyright 2026 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Tests for ``braintrace/_typing.py``.
+
+The module is almost entirely ``TypeAlias`` declarations, which have no runtime
+behaviour to test, plus one executable function: :func:`as_size_tuple`. That
+function is on the hot path of the public layer API -- every RNN cell in
+``braintrace/nn/_rnn.py`` and :class:`~braintrace.nn.LeakyRateReadout` route
+their ``in_size``/``out_size`` constructor arguments through it -- so its
+normalisation contract, and the exception type behind each rejection, are worth
+pinning.
+
+Spec: ``docs/specs/2026-08-07-e06-colocated-tests.md``.
+"""
+
+import brainstate
+import numpy as np
+import pytest
+
+from braintrace import _typing
+from braintrace._typing import as_size_tuple
+
+
+# ===========================================================================
+# Normalisation: the happy paths
+# ===========================================================================
+
+def test_scalar_int_becomes_one_tuple():
+    assert as_size_tuple(3) == (3,)
+
+
+def test_sequence_is_preserved_in_order():
+    assert as_size_tuple((2, 3, 4)) == (2, 3, 4)
+    assert as_size_tuple([2, 3, 4]) == (2, 3, 4)
+
+
+def test_result_is_a_plain_tuple_not_a_list_or_array():
+    assert type(as_size_tuple([2, 3])) is tuple
+
+
+@pytest.mark.parametrize(
+    'dtype', [np.int8, np.int16, np.int32, np.int64, np.uint8, np.uint32]
+)
+def test_numpy_integer_scalar_is_accepted(dtype):
+    assert as_size_tuple(dtype(5)) == (5,)
+
+
+def test_numpy_integer_array_is_accepted():
+    assert as_size_tuple(np.array([2, 3])) == (2, 3)
+
+
+@pytest.mark.parametrize(
+    'size',
+    [
+        3,  # int
+        np.int64(3),  # np.integer
+        (3, 4),  # Sequence[int]
+        (np.int64(3), np.int64(4)),  # Sequence[np.integer]
+    ],
+)
+def test_every_arm_of_the_declared_size_union_is_accepted(size):
+    """``Size`` is ``int | np.integer | Sequence[int] | Sequence[np.integer]``.
+
+    Each arm must survive normalisation, otherwise the annotation on the
+    callers (``size: Size``) promises more than the function delivers.
+    """
+    result = as_size_tuple(size)
+    assert isinstance(result, tuple)
+    assert all(type(s) is int for s in result)
+
+
+# ===========================================================================
+# The element-type contract: exactly ``int``, never ``np.integer``
+# ===========================================================================
+
+def test_numpy_scalars_are_downcast_to_builtin_int():
+    """The point of the helper is a concrete ``tuple[int, ...]``.
+
+    A ``np.int64`` compares equal to an ``int`` but is a different type, so an
+    ``isinstance``-based check would pass on a leaked numpy scalar. Compare the
+    type exactly.
+    """
+    result = as_size_tuple(np.int32(7))
+    assert result == (7,)
+    assert type(result[0]) is int
+    assert not isinstance(result[0], np.integer)
+
+
+def test_numpy_array_elements_are_downcast_to_builtin_int():
+    result = as_size_tuple(np.array([2, 3], dtype=np.int16))
+    assert [type(s) for s in result] == [int, int]
+
+
+def test_bool_is_accepted_as_an_int_subclass():
+    """``bool`` is a subclass of ``int``, so it takes the scalar branch.
+
+    Pinned as a fact, not endorsed: nothing rejects it, and it normalises to 1.
+    """
+    assert as_size_tuple(True) == (1,)
+    assert type(as_size_tuple(True)[0]) is int
+
+
+# ===========================================================================
+# Idempotence and the round-trip that motivates the helper
+# ===========================================================================
+
+@pytest.mark.parametrize('size', [3, np.int64(3), (2, 3), [2, 3], ()])
+def test_idempotent(size):
+    """``_rnn.py`` calls the helper on values a size setter already normalised.
+
+    Applying it twice must be indistinguishable from applying it once.
+    """
+    once = as_size_tuple(size)
+    assert as_size_tuple(once) == once
+
+
+def test_result_round_trips_through_a_brainstate_size_setter():
+    """The stated reason the helper exists.
+
+    ``brainstate``'s size getters are typed as the broad ``Size`` union, which
+    is not indexable to a type checker. Routing through ``as_size_tuple`` must
+    give a value that both assigns cleanly and reads back unchanged.
+    """
+    module = brainstate.nn.Module()
+    module.in_size = as_size_tuple(8)
+    module.out_size = as_size_tuple([4, 5])
+    assert module.in_size == (8,)
+    assert module.out_size == (4, 5)
+    assert as_size_tuple(module.out_size)[-1] == 5
+
+
+def test_trailing_dimension_lookup_works_on_the_result():
+    assert as_size_tuple((2, 3, 4))[-1] == 4
+    assert as_size_tuple(6)[-1] == 6
+
+
+# ===========================================================================
+# No validation: the helper normalises, it does not police
+# ===========================================================================
+
+def test_zero_is_accepted():
+    assert as_size_tuple(0) == (0,)
+    assert as_size_tuple((0, 3)) == (0, 3)
+
+
+def test_negative_is_accepted():
+    """No sign check. A negative size is nonsense as a shape, but rejecting it
+    is the layer's job, not the normaliser's; pinned so that adding a check
+    later is a visible, deliberate change."""
+    assert as_size_tuple(-1) == (-1,)
+    assert as_size_tuple([-1, 2]) == (-1, 2)
+
+
+@pytest.mark.parametrize('empty', [(), [], np.array([], dtype=np.int32)])
+def test_empty_sequence_gives_empty_tuple(empty):
+    """An empty size produces an empty tuple, which then makes ``size[-1]``
+    raise ``IndexError`` at the call site rather than here."""
+    assert as_size_tuple(empty) == ()
+
+
+def test_empty_result_makes_trailing_lookup_fail_at_the_call_site():
+    with pytest.raises(IndexError):
+        _ = as_size_tuple(())[-1]
+
+
+# ===========================================================================
+# Rejections, pinned by exception type
+# ===========================================================================
+
+@pytest.mark.parametrize('size', [3.0, 2.7, None, object()])
+def test_non_integer_scalar_raises_type_error(size):
+    """A bare ``float`` (integral or not) and ``None`` fall through the scalar
+    branch into ``tuple(int(s) for s in size)`` and fail as non-iterables.
+
+    Note in particular that ``3.0`` is *not* accepted despite being integral --
+    the scalar branch tests ``isinstance(..., (int, np.integer))`` only.
+    """
+    with pytest.raises(TypeError):
+        as_size_tuple(size)
+
+
+def test_zero_dimensional_numpy_array_raises_type_error():
+    """Divergence from ``brainstate.nn._module._format_size_arg``, pinned.
+
+    ``brainstate``'s own normaliser accepts a 0-d integer array
+    (``np.array(3)`` -> ``(3,)``); ``as_size_tuple`` does not, because a 0-d
+    array is neither ``int`` nor ``np.integer`` and iterating it raises. A 0-d
+    array is not a member of the declared ``Size`` union, and the ``brainstate``
+    layers that consume such a size fail the same way, so the divergence is
+    documented rather than fixed.
+    """
+    with pytest.raises(TypeError):
+        as_size_tuple(np.array(3))
+
+
+def test_nested_sequence_raises_type_error():
+    with pytest.raises(TypeError):
+        as_size_tuple(((1, 2), (3, 4)))
+
+
+def test_multidimensional_array_raises_type_error():
+    with pytest.raises(TypeError):
+        as_size_tuple(np.ones((2, 2), dtype=np.int32))
+
+
+def test_non_numeric_string_raises_value_error():
+    """A ``str`` is a ``Sequence``, so it reaches ``int()`` per character and
+    fails with ``ValueError`` -- a different exception type from the
+    non-iterable rejections above."""
+    with pytest.raises(ValueError):
+        as_size_tuple('ab')
+
+
+def test_float_array_raises_nothing_but_truncates():
+    """A float array is iterable and each element converts, so it is accepted.
+
+    Pinned alongside the scalar-float rejection to show the asymmetry: the
+    element path has no dtype check at all.
+    """
+    assert as_size_tuple(np.array([2.0, 3.0])) == (2, 3)
+
+
+# ===========================================================================
+# Sharp edges: pinned as facts, not endorsed
+# ===========================================================================
+
+@pytest.mark.parametrize(
+    'size, expected',
+    [
+        ((2.7,), (2,)),  # truncates toward zero, not rounds
+        ((-2.7,), (-2,)),  # ... in both directions
+        ((3.0, 4.0), (3, 4)),  # integral floats pass through silently
+    ],
+)
+def test_float_inside_a_sequence_is_silently_truncated(size, expected):
+    """There is no integral-float check on sequence elements: ``int()`` is
+    applied unconditionally, so ``2.7`` becomes ``2`` with no error or warning.
+    A caller that meant ``round`` gets a different layer width."""
+    assert as_size_tuple(size) == expected
+
+
+def test_numeric_string_is_iterated_character_by_character():
+    """``as_size_tuple('12')`` is ``(1, 2)``, not ``(12,)``.
+
+    A string satisfies the ``Sequence`` branch, so a size accidentally passed
+    as text produces a plausible-looking multi-dimensional size instead of an
+    error. This is the most surprising accepted input; pinned deliberately.
+    """
+    assert as_size_tuple('12') == (1, 2)
+    assert as_size_tuple('7') == (7,)
+
+
+# ===========================================================================
+# Alias identity
+# ===========================================================================
+
+@pytest.mark.parametrize('name', ['ArrayLike', 'DType', 'DTypeLike', 'Size'])
+def test_brainstate_aliases_are_reexported_not_redeclared(name):
+    """These four are re-exports. If one were ever re-declared locally it could
+    drift from ``brainstate.typing`` without any import error to flag it."""
+    assert getattr(_typing, name) is getattr(brainstate.typing, name)
+
+
+def test_size_union_is_what_as_size_tuple_documents():
+    """Guard the premise of ``test_every_arm_of_the_declared_size_union_is_accepted``:
+    if ``brainstate`` widens ``Size``, the union-coverage test above silently
+    stops covering the whole union."""
+    assert str(_typing.Size) == (
+        'typing.Union[int, typing.Sequence[int], numpy.integer, '
+        'typing.Sequence[numpy.integer]]'
+    )

--- a/braintrace/nn/__init___test.py
+++ b/braintrace/nn/__init___test.py
@@ -1,0 +1,248 @@
+# Copyright 2026 BrainX Ecosystem Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+# ==============================================================================
+
+"""Tests for the ``braintrace.nn`` package root (``braintrace/nn/__init__.py``).
+
+The module is a deprecation dispatcher: 8 names forward to :mod:`brainpy.state`
+and 40 to :mod:`brainstate.nn`, each with a :class:`DeprecationWarning` naming
+the replacement, and anything else raises :class:`AttributeError`.
+
+That final ``raise`` is the contract this file exists for. A module-level
+``__getattr__`` that falls off the end returns ``None``, so without it
+``braintrace.nn.Typo`` would silently *be* ``None`` and blow up much later,
+somewhere unrelated. ``braintrace/__init___test.py`` covers ``__dir__`` and two
+sample forwards from the package-root side; the dispatcher's own contract --
+every forwarded name, the warning text, the non-memoisation, and the
+fallthrough -- is pinned here.
+
+Spec: ``docs/specs/2026-08-07-e06-colocated-tests.md``.
+"""
+
+import warnings
+
+import brainpy.state
+import brainstate
+import pytest
+
+import braintrace.nn as nn
+
+
+# ===========================================================================
+# Forwarding: every deprecated name resolves, warns, and lands on the right object
+# ===========================================================================
+
+@pytest.mark.parametrize('name', nn._DEPRECATED_TO_BRAINPY_STATE)
+def test_brainpy_state_forward_warns_and_resolves(name):
+    with pytest.warns(DeprecationWarning) as record:
+        obj = getattr(nn, name)
+    assert obj is getattr(brainpy.state, name)
+    assert f'Use brainpy.state.{name} instead.' in str(record[0].message)
+    assert f'braintrace.nn.{name} is deprecated' in str(record[0].message)
+
+
+@pytest.mark.parametrize('name', nn._DEPRECATED_TO_BRAINSTATE_NN)
+def test_brainstate_nn_forward_warns_and_resolves(name):
+    with pytest.warns(DeprecationWarning) as record:
+        obj = getattr(nn, name)
+    assert obj is getattr(brainstate.nn, name)
+    assert f'Use brainstate.nn.{name} instead.' in str(record[0].message)
+    assert f'braintrace.nn.{name} is deprecated' in str(record[0].message)
+
+
+def test_marker_sentinel_the_deprecated_lists_are_not_empty():
+    # Guard against an emptied tuple making every parametrised test above
+    # vacuous (zero cases collected still counts as a green run).
+    assert len(nn._DEPRECATED_TO_BRAINPY_STATE) >= 8
+    assert len(nn._DEPRECATED_TO_BRAINSTATE_NN) >= 40
+
+
+def test_warning_is_attributed_to_the_caller_not_to_the_dispatcher():
+    """``stacklevel=2``. Without it the warning points at
+    ``braintrace/nn/__init__.py``, which tells the user nothing about which of
+    their lines to change."""
+    with pytest.warns(DeprecationWarning) as record:
+        _ = nn.ReLU
+    assert record[0].filename == __file__
+
+
+def test_forward_is_not_memoised():
+    """A second access must warn again.
+
+    ``__getattr__`` deliberately does not write the resolved object into the
+    module ``__dict__``: if it did, Python's normal attribute lookup would find
+    it from then on and every later caller -- in a different file, possibly a
+    different package -- would get no deprecation notice at all.
+    """
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter('always')
+        _ = nn.ReLU
+        _ = nn.ReLU
+    assert len(caught) == 2
+    assert 'ReLU' not in vars(nn)
+
+
+@pytest.mark.parametrize('name', nn.__all__)
+def test_real_exports_never_reach_the_dispatcher(name):
+    """``__all__`` names are bound at import time, so normal attribute lookup
+    finds them and ``__getattr__`` is never consulted. They must therefore
+    resolve without any warning."""
+    with warnings.catch_warnings():
+        warnings.simplefilter('error')
+        obj = getattr(nn, name)
+    assert obj is not None
+
+
+# ===========================================================================
+# The dispatch table itself
+# ===========================================================================
+
+def test_the_two_target_lists_are_disjoint():
+    """A name in both tuples would resolve via whichever branch runs first, and
+    the second entry would be unreachable -- and misleading, since it names a
+    different replacement package."""
+    overlap = set(nn._DEPRECATED_TO_BRAINPY_STATE) & set(nn._DEPRECATED_TO_BRAINSTATE_NN)
+    assert not overlap, f'name listed under two replacement packages: {sorted(overlap)}'
+
+
+def test_deprecated_names_do_not_shadow_real_exports():
+    """``__getattr__`` only runs when normal lookup fails, so a deprecated entry
+    that collides with an ``__all__`` name is dead code: the real class always
+    wins and no warning is ever emitted for it."""
+    deprecated = set(nn._DEPRECATED_TO_BRAINPY_STATE) | set(nn._DEPRECATED_TO_BRAINSTATE_NN)
+    collisions = deprecated & set(nn.__all__)
+    assert not collisions, f'deprecated entries shadowed by real exports: {sorted(collisions)}'
+
+
+@pytest.mark.parametrize(
+    'names', [nn._DEPRECATED_TO_BRAINPY_STATE, nn._DEPRECATED_TO_BRAINSTATE_NN]
+)
+def test_no_duplicates_within_a_list(names):
+    assert len(set(names)) == len(names)
+
+
+# ===========================================================================
+# __dir__
+# ===========================================================================
+
+def test_dir_is_exactly_all_plus_both_deprecated_lists():
+    expected = (
+        set(nn.__all__)
+        | set(nn._DEPRECATED_TO_BRAINPY_STATE)
+        | set(nn._DEPRECATED_TO_BRAINSTATE_NN)
+    )
+    assert set(dir(nn)) == expected
+
+
+def test_dir_is_sorted_and_duplicate_free():
+    names = dir(nn)
+    assert names == sorted(names)
+    assert len(set(names)) == len(names)
+
+
+def test_every_advertised_name_actually_resolves():
+    """``__dir__`` drives tab-completion and ``dir()``-based tooling. Every name
+    it advertises must be gettable, or completion offers names that raise."""
+    with warnings.catch_warnings():
+        warnings.simplefilter('ignore', DeprecationWarning)
+        unresolvable = [name for name in dir(nn) if not hasattr(nn, name)]
+    assert not unresolvable, f'advertised by __dir__ but not gettable: {unresolvable}'
+
+
+# ===========================================================================
+# The fallthrough (``__init__.py`` L119) -- the reason this file exists
+# ===========================================================================
+
+def test_unknown_name_raises_attribute_error():
+    with pytest.raises(AttributeError):
+        _ = nn.ThisNameDoesNotExist
+
+
+def test_unknown_name_does_not_silently_return_none():
+    """The regression the explicit ``raise`` prevents.
+
+    Delete the ``raise`` and ``__getattr__`` returns ``None`` implicitly; this
+    assertion is what tells the two apart, since a bare
+    ``pytest.raises(AttributeError)`` on a missing name would also pass against
+    a module that never defined ``__getattr__`` at all.
+    """
+    sentinel = object()
+    assert getattr(nn, 'ThisNameDoesNotExist', sentinel) is sentinel
+
+
+def test_fallthrough_message_names_the_module_and_the_attribute():
+    with pytest.raises(AttributeError) as excinfo:
+        _ = nn.ThisNameDoesNotExist
+    message = str(excinfo.value)
+    assert 'braintrace.nn' in message
+    assert 'ThisNameDoesNotExist' in message
+
+
+def test_fallthrough_does_not_warn():
+    """An unknown name is a typo, not a deprecation. Emitting a
+    ``DeprecationWarning`` on the way to the ``AttributeError`` would be
+    actively misleading."""
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter('always')
+        with pytest.raises(AttributeError):
+            _ = nn.ThisNameDoesNotExist
+    assert [w for w in caught if issubclass(w.category, DeprecationWarning)] == []
+
+
+def test_hasattr_is_false_for_an_unknown_name():
+    """``hasattr`` is ``True`` for anything that returns, including ``None``;
+    it only reports ``False`` because the fallthrough raises."""
+    assert not hasattr(nn, 'ThisNameDoesNotExist')
+
+
+def test_from_import_of_an_unknown_name_raises_import_error():
+    """``from ... import`` converts the dispatcher's ``AttributeError`` into an
+    ``ImportError``. Without the raise, the name would import as ``None``."""
+    with pytest.raises(ImportError):
+        from braintrace.nn import ThisNameDoesNotExist  # noqa: F401
+
+
+@pytest.mark.parametrize(
+    'name',
+    [
+        '__wrapped__',  # probed by inspect.signature / functools
+        '__deepcopy__',  # probed by copy.deepcopy
+        '__setstate__',  # probed by pickle (``object`` provides no default)
+        '_ipython_canary_method_should_not_exist_',  # probed by IPython completion
+    ],
+)
+def test_dunder_and_private_probes_raise(name):
+    """Protocol probes must fail, not resolve.
+
+    ``inspect``, ``copy``, ``pickle`` and REPL completion all test for optional
+    hooks with ``getattr``. A dispatcher that returned ``None`` for them would
+    hand each of those a non-callable hook, turning a clean "not supported" into
+    a ``TypeError`` from inside the stdlib.
+    """
+    with pytest.raises(AttributeError):
+        getattr(nn, name)
+
+
+@pytest.mark.parametrize('name', ['Sequential', 'Module'])
+def test_unlisted_brainstate_names_are_not_forwarded(name):
+    """The dispatcher is an allowlist, not a blanket ``brainstate.nn`` proxy.
+
+    ``Sequential`` and ``Module`` both exist in ``brainstate.nn`` but are not in
+    either deprecated tuple, so they reach the fallthrough. This is what keeps
+    ``braintrace.nn``'s surface a reviewed set rather than whatever
+    ``brainstate.nn`` happens to export today.
+    """
+    assert hasattr(brainstate.nn, name)
+    with pytest.raises(AttributeError):
+        getattr(nn, name)

--- a/docs/specs/2026-08-07-e06-colocated-tests.md
+++ b/docs/specs/2026-08-07-e06-colocated-tests.md
@@ -1,0 +1,114 @@
+# E-06 — co-located tests for `_typing.py` and `nn/__init__.py`
+
+Status: proposed
+Scope: `braintrace/_typing_test.py` (new), `braintrace/nn/__init___test.py` (new)
+Backlog entry: E-06 in `2026-08-07-deferred-engineering-backlog.md`
+Issue: [#161](https://github.com/chaobrain/braintrace/issues/161)
+
+Two shipped modules have no `_test.py` sibling, against `AGENTS.md` rule 9. This
+is a test-only change: no runtime behaviour is altered. Both new files pin
+*current* behaviour, including the sharp edges, so that a future change to
+either module is a deliberate decision rather than an accident.
+
+## `braintrace/_typing_test.py`
+
+`_typing.py` is mostly `TypeAlias` declarations, which have no runtime contract
+worth testing, plus one executable function: `as_size_tuple`. Its job is to turn
+the broad `Size` union (`int | np.integer | Sequence[int] | Sequence[np.integer]`)
+into a concrete `tuple[int, ...]` so that `self.in_size = ...` assignment and
+`size[-1]` lookups both type-check. Every RNN cell and the readout layer call it
+on their constructor arguments, so it is on the hot path of the public layer API.
+
+Pinned contracts:
+
+1. **Normalisation.** Scalar `int` and numpy integer scalars become a 1-tuple;
+   sequences become a tuple with order preserved. The result is always a `tuple`
+   whose elements are exactly `int` — never `np.integer`, which matters because
+   the values are used as shape components and in error messages.
+2. **Union coverage.** Every arm of the declared `Size` union is accepted.
+3. **Idempotence.** `as_size_tuple(as_size_tuple(x)) == as_size_tuple(x)`; the
+   function is safe to apply to a value that already went through it, which is
+   exactly what `_rnn.py` does (`_as_size_tuple(self.out_size)[-1]` on a size
+   that the setter already normalised).
+4. **Round-trip.** The result is assignable to `brainstate` `in_size` /
+   `out_size` and survives the setter unchanged — the function's stated reason
+   to exist.
+5. **No validation.** Zero, negative values and the empty sequence are accepted
+   and returned as-is. `as_size_tuple` normalises; it does not police shapes.
+   Pinned so that adding validation later is a visible change.
+6. **Rejections, by exception type.** `float` / `None` scalars and a 0-d numpy
+   array raise `TypeError` (not iterable / not indexable); a nested sequence
+   raises `TypeError` from `int()`; a non-numeric string raises `ValueError`
+   from `int()`. The function does not normalise these into a single custom
+   error, and callers see the raw builtin exception.
+7. **Two sharp edges, pinned as facts rather than endorsed.**
+   - A float *inside* a sequence is silently truncated toward zero:
+     `as_size_tuple((2.7,)) == (2,)`. There is no "integral float" check.
+   - A `str` is a `Sequence`, so a numeric string is iterated character by
+     character: `as_size_tuple('12') == (1, 2)`, not `(12,)`.
+8. **Alias identity.** `ArrayLike`, `DType`, `DTypeLike` and `Size` are the
+   `brainstate.typing` objects themselves, not re-declarations that could drift.
+
+Known divergence, deliberately not changed: `brainstate`'s own
+`nn._module._format_size_arg` accepts a 0-d integer `np.ndarray`
+(`np.array(3)` → `(3,)`), while `as_size_tuple` raises `TypeError` on it. A 0-d
+array is not a member of the declared `Size` union, and the `brainstate` layers
+that consume such a size fail the same way (verified against
+`brainstate.nn.LeakyRateReadout`), so this is out of scope for a test-only
+change. The test pins the current `TypeError`.
+
+## `braintrace/nn/__init___test.py`
+
+`braintrace/nn/__init__.py` is a deprecation dispatcher: 8 names forward to
+`brainpy.state`, 40 to `brainstate.nn`, each with a `DeprecationWarning` naming
+the replacement. `braintrace/__init___test.py` already touches `__dir__` and two
+sample forwards from the package-root side; this file owns the dispatcher
+itself.
+
+Pinned contracts:
+
+1. **Every** deprecated name resolves — all 48, parametrised, not a sample — and
+   resolves to the *same object* the target package exports.
+2. The warning is a `DeprecationWarning` whose message names both the old path
+   and the exact replacement path (`Use brainstate.nn.X instead.`).
+3. `stacklevel=2`: the warning is attributed to the caller's file, so a user
+   sees their own line, not `braintrace/nn/__init__.py`.
+4. The forward is not memoised — a second access warns again, and the name never
+   lands in the module `__dict__`. A dispatcher that cached would warn once per
+   process and go silent for every later caller.
+5. Real exports (`__all__`) resolve through normal attribute lookup and never
+   reach `__getattr__`, so they emit no warning.
+6. `__dir__` is sorted, duplicate-free, and is exactly the union of `__all__`
+   and the two deprecated tuples.
+7. The two tuples are disjoint from each other and from `__all__`. An overlap
+   would make a tuple entry dead code that never dispatches.
+8. **The fallthrough** (`__init__.py` L119). A module-level `__getattr__` that
+   falls off the end returns `None`, so `braintrace.nn.Typo` would silently be
+   `None` and fail much later with an unrelated error. The explicit `raise` is
+   what makes it fail at the access:
+   - an unknown name raises `AttributeError`, and never returns `None`;
+   - the message names both the module and the attribute;
+   - it raises without warning — the fallthrough is not a deprecation path;
+   - `hasattr` is `False` and `from braintrace.nn import Nope` raises
+     `ImportError`, both of which depend on the raise;
+   - dunder/private probes (`__wrapped__`, `_ipython_canary_method_should_not_exist_`)
+     raise too, which is what keeps `inspect`, `copy` and REPL completion from
+     seeing a bogus `None` attribute.
+9. **Allowlist, not blanket forwarder.** A name that exists in `brainstate.nn`
+   but is not listed (e.g. `Sequential`) still raises `AttributeError`. The
+   dispatcher forwards a fixed, reviewed set.
+
+### A correction to the issue text
+
+Issue #161 describes the fallthrough as "what makes a removed name fail with a
+message naming its replacement". That is not what L119 does. Names with a
+replacement never reach L119 — they are handled by the two branches above it,
+which *succeed* with a warning naming the replacement. L119 is the case with no
+replacement, and its message is the standard
+`module 'braintrace.nn' has no attribute 'X'`. Its value is that it raises at
+all rather than yielding `None`. The tests pin that reading.
+
+## Out of scope
+
+Changing any behaviour of either module, including the `as_size_tuple`
+rejections and the 0-d-array divergence above.


### PR DESCRIPTION
Two shipped modules had no `_test.py` sibling, against `AGENTS.md` rule 9. This
is a **test-only** change: no runtime behaviour is altered. Spec:
`docs/specs/2026-08-07-e06-colocated-tests.md`.

## `braintrace/_typing_test.py`

`_typing.py` is mostly `TypeAlias` declarations plus one executable function,
`as_size_tuple`, which every RNN cell and `LeakyRateReadout` call on their
constructor arguments. Pinned:

- **Normalisation** — scalar `int` / numpy integer to a 1-tuple, sequence to a
  tuple in order, result elements exactly `int` and never `np.integer`.
- **Union coverage** — every arm of the declared `Size` union is accepted, with
  a guard test on the union's own definition so widening `Size` upstream cannot
  silently narrow that coverage.
- **Idempotence** and the **round-trip** through a `brainstate` size setter —
  the helper's stated reason to exist.
- **No validation** — zero, negative and the empty sequence are accepted, so
  adding a check later is a visible change.
- **Rejections by exception type** — `TypeError` for a bare float (including an
  *integral* one, `3.0`), `None`, a 0-d array, a nested sequence, a 2-d array;
  `ValueError` for a non-numeric string.
- **Two sharp edges, pinned as facts rather than endorsed** — a float inside a
  sequence is silently truncated toward zero (`(2.7,)` → `(2,)`), and a `str` is
  a `Sequence`, so `'12'` → `(1, 2)` rather than `(12,)`.
- **Alias identity** — `ArrayLike` / `DType` / `DTypeLike` / `Size` are the
  `brainstate.typing` objects, not local re-declarations that could drift.

## `braintrace/nn/__init___test.py`

The dispatcher forwards 8 names to `brainpy.state` and 40 to `brainstate.nn`.
Pinned:

- **All 48** forwarded names — parametrised, not a sample — resolve to the same
  object the target package exports, with a `DeprecationWarning` naming the
  exact replacement path.
- `stacklevel=2` — the warning is attributed to the caller's file.
- **Non-memoisation** — a second access warns again and the name never lands in
  the module `__dict__`; a caching dispatcher would warn once per process and go
  silent for every later caller.
- Real `__all__` exports resolve without ever reaching `__getattr__`.
- The two dispatch tuples are disjoint from each other and from `__all__` (an
  overlap would be unreachable, misleading dead code).
- `__dir__` is sorted, duplicate-free, exactly the union, and every name it
  advertises is gettable.
- **The fallthrough** — a module-level `__getattr__` that falls off the end
  returns `None`, so without the explicit `raise`, `braintrace.nn.Typo` would
  silently *be* `None`. Pinned: `AttributeError` with a message naming module
  and attribute, no warning on that path, `hasattr` false, `from ... import`
  raising `ImportError`, protocol probes (`__wrapped__`, `__deepcopy__`,
  `__setstate__`, the IPython canary) raising rather than yielding a bogus
  non-callable hook, and unlisted `brainstate.nn` names (`Sequential`, `Module`)
  raising — the dispatcher is an allowlist, not a blanket proxy. The
  `getattr(nn, name, sentinel) is sentinel` assertion is the one that actually
  distinguishes "raises" from "never had a `__getattr__`".

## Notes

- **No bug found.** One documented divergence, deliberately left alone:
  `brainstate.nn._module._format_size_arg` accepts a 0-d integer `np.ndarray`
  (`np.array(3)` → `(3,)`) while `as_size_tuple` raises `TypeError`. A 0-d array
  is not in the declared `Size` union, and `brainstate`'s own layers fail
  identically on it (verified against `brainstate.nn.LeakyRateReadout`), so the
  test pins the current `TypeError`.
- **Correction to the issue text.** #161 describes the L119 fallthrough as
  "what makes a removed name fail with a message naming its replacement". It is
  not — names *with* a replacement never reach L119; they succeed via the two
  branches above it, which emit the naming warning. L119 is the no-replacement
  case, and its value is that it raises at all instead of yielding `None`. The
  tests pin that reading.

## Verification

```
$ python -m pytest braintrace/_typing_test.py braintrace/nn/__init___test.py -q
........................................................................ [ 47%]
........................................................................ [ 94%]
.........                                                                [100%]
153 passed in 4.86s

$ python -m mypy
Success: no issues found in 62 source files
```

`braintrace/__init___test.py` still passes (57 passed).

Wheel/sdist split confirmed against the `build_py` subclass in `setup.py`: both
new files end in `_test`, so `find_package_modules` drops them. Built both
artifacts — the wheel contains zero `*_test.py` entries (and still ships
`braintrace/_typing.py` and `braintrace/nn/__init__.py`), while the sdist
carries all 77, including the two new ones.

Closes #161

## Summary by Sourcery

Add co-located tests and accompanying spec documentation for braintrace typing utilities and nn package deprecation dispatcher.

Documentation:
- Add E-06 spec documenting the intent and pinned behaviour of new co-located tests for braintrace/_typing.py and braintrace/nn/__init__.py.

Tests:
- Add comprehensive tests for braintrace._typing.as_size_tuple covering normalisation, union coverage, idempotence, sharp edges, and alias identity with brainstate.typing.
- Add exhaustive tests for braintrace.nn package-level deprecation dispatcher, including forwarding behaviour, warnings, __dir__ contract, and fallthrough handling for unknown attributes.