### PR TITLE
Check the hidden-to-gradient correspondence for real (E-01)

### DIFF
--- a/braintrace/_algorithm/vjp_base.py
+++ b/braintrace/_algorithm/vjp_base.py
@@ -104,6 +104,162 @@ def _add_future_for_plain_paths(base: Any, future: Any, etp_paths: Any) -> Any:
     return out
 
 
+def _static_dtype(x: Any) -> Any:
+    """The dtype of ``x`` without materializing or converting it.
+
+    Read straight off the array/tracer when it has one, so that JAX's
+    ``float0`` cotangent dtype -- which does not survive ``jnp.result_type`` --
+    comes through intact, and so that nothing is moved to a device.
+
+    Parameters
+    ----------
+    x : Any
+        An array, tracer, ``Quantity`` mantissa or Python scalar.
+
+    Returns
+    -------
+    numpy.dtype
+        The dtype of ``x``.
+    """
+    dtype = getattr(x, 'dtype', None)
+    if dtype is not None:
+        return dtype
+    return jnp.result_type(x)
+
+
+def _expected_hidden_shape(state: brainstate.HiddenState) -> Tuple[int, ...]:
+    """The shape a cotangent for ``state`` must have.
+
+    A plain :class:`brainstate.HiddenState` carries one state per position, so
+    its cotangent is ``varshape``-shaped; a
+    :class:`brainstate.HiddenGroupState` stacks ``num_state`` of them on a
+    trailing axis, which is exactly the axis
+    :meth:`~braintrace.HiddenGroup.concat_hidden` concatenates along.
+
+    Parameters
+    ----------
+    state : brainstate.HiddenState
+        The hidden state whose cotangent shape is wanted.
+
+    Returns
+    -------
+    tuple of int
+        The required cotangent shape.
+    """
+    varshape = tuple(state.varshape)
+    if isinstance(state, brainstate.HiddenGroupState):
+        return varshape + (int(state.num_state),)
+    return varshape
+
+
+def _check_hidden_gradient_correspondence(
+    hidden_groups: Sequence[Any],
+    path_to_cotangent: Dict[Path, Any],
+    *,
+    source: str,
+) -> None:
+    """Check that cotangent *i* really belongs to hidden state *i*.
+
+    The backward pass hands back a collection of hidden-state cotangents which
+    is then re-ordered onto the hidden groups by path and concatenated. Nothing
+    downstream re-derives which hidden state a given cotangent came from, so a
+    mis-ordered or mis-shaped collection produces a **wrong gradient rather than
+    an error**. This function is the contract that makes that impossible.
+
+    Three things are checked, for every hidden group and every position in it:
+
+    1. **Totality** -- every path a group needs is present in
+       ``path_to_cotangent``.
+    2. **No strays** -- ``path_to_cotangent`` carries no path that no group
+       claims, which would mean the cotangent collection and the compiled graph
+       describe different models.
+    3. **Correspondence** -- the cotangent at each path has the shape and dtype
+       of the hidden state at that path (see :func:`_expected_hidden_shape`),
+       compared after :func:`brainunit.get_mantissa`, exactly as the consumers
+       strip units before concatenating.
+
+    Parameters
+    ----------
+    hidden_groups : sequence of HiddenGroup
+        The compiled hidden groups the cotangents will be routed onto.
+    path_to_cotangent : dict
+        Mapping from hidden-state path to that state's cotangent.
+    source : str
+        Human-readable name of the branch that produced ``path_to_cotangent``,
+        used in the error messages so the reader is not left guessing which of
+        the two VJP modes failed.
+
+    Raises
+    ------
+    ValueError
+        If any of the three conditions above does not hold. The message names
+        the hidden group, the position within it, the path, and the expected
+        versus actual shape/dtype.
+
+    Notes
+    -----
+    Deliberately ``if ... raise`` and not ``assert``: ``python -O`` /
+    ``PYTHONOPTIMIZE=1`` strips ``assert`` statements, and this guard has to
+    hold on an optimised interpreter too.
+
+    Every comparison is on Python-level metadata -- dict keys, static shapes,
+    dtypes -- and never on array *data*. Nothing here is traced into the
+    compiled program, so it adds no XLA operation and forces no device sync,
+    even though it runs once per backward pass.
+    """
+    needed: Dict[Path, Tuple[int, int, Any]] = {}
+    for group in hidden_groups:
+        for position, (path, state) in enumerate(zip(group.hidden_paths, group.hidden_states)):
+            needed.setdefault(path, (group.index, position, state))
+
+    missing = [path for path in needed if path not in path_to_cotangent]
+    if missing:
+        group_index, position, _ = needed[missing[0]]
+        raise ValueError(
+            f'The {source} did not provide a gradient for every hidden state. '
+            f'Hidden group {group_index} needs {missing[0]} at position '
+            f'{position}, and {len(missing)} needed path(s) are absent: '
+            f'{sorted(map(str, missing))}. The gradients provided are for '
+            f'{sorted(map(str, path_to_cotangent))}.'
+        )
+
+    strays = [path for path in path_to_cotangent if path not in needed]
+    if strays:
+        raise ValueError(
+            f'The {source} provided gradients for {len(strays)} hidden state '
+            f'path(s) that no hidden group claims: {sorted(map(str, strays))}. '
+            f'The hidden groups cover {sorted(map(str, needed))}. The compiled '
+            f'graph and the backward pass disagree about the model\'s hidden '
+            f'states; recompile the graph.'
+        )
+
+    for path, (group_index, position, state) in needed.items():
+        cotangent = u.get_mantissa(path_to_cotangent[path])
+        want_shape = _expected_hidden_shape(state)
+        got_shape = tuple(u.math.shape(cotangent))
+        if got_shape != want_shape:
+            raise ValueError(
+                f'The {source} produced a gradient of shape {got_shape} for the '
+                f'hidden state {path}, which is at position {position} of hidden '
+                f'group {group_index} and has shape {want_shape}. A gradient '
+                f'cannot belong to a hidden state of a different shape, so the '
+                f'gradients and the hidden states are not in correspondence.'
+            )
+        want_dtype = _static_dtype(u.get_mantissa(state.value))
+        got_dtype = _static_dtype(cotangent)
+        # `float0` is JAX's cotangent dtype for a non-differentiable leaf; it is
+        # a correct cotangent for an integer or boolean hidden state and must not
+        # be read as a mismatch.
+        if got_dtype != want_dtype and got_dtype != jax.dtypes.float0:
+            raise ValueError(
+                f'The {source} produced a gradient of dtype {got_dtype} for the '
+                f'hidden state {path}, which is at position {position} of hidden '
+                f'group {group_index} and has dtype {want_dtype}. A gradient '
+                f'cannot belong to a hidden state of a different dtype, so the '
+                f'gradients and the hidden states are not in correspondence.'
+            )
+
+
 def expand_modulator_to_group(
     modulator: Any,
     group_shape: Tuple[int, ...],
@@ -1043,24 +1199,65 @@ class ETraceVjpAlgorithm(ETraceAlgorithm):
         #
         # get the gradients of the hidden states at the last time step
         #
+        #
+        # Every guard below is `if ... raise`, never `assert`: `python -O` strips
+        # `assert` statements, and a mis-routed cotangent here produces a *wrong
+        # gradient rather than an error*, so the check has to survive an
+        # optimised interpreter. All of them read Python-level metadata only
+        # (lengths, dict keys, static shapes, dtypes), so none of it reaches the
+        # compiled program.
+        #
         if self.graph_executor.is_single_step_vjp:
-            # TODO: the correspondence between the hidden states and the gradients
-            #       should be checked.
-            #
-            assert len(dg_etrace_params) == 0  # gradients all etrace weights are updated by the RTRL algorithm
-            assert self.graph.hidden_perturb is not None
-            assert len(self.graph.hidden_perturb.perturb_vars) == len(dg_hid_perturb_or_dl2h)
-            dl2h_at_t_or_t_minus_1 = self.graph.hidden_perturb.perturb_data_to_hidden_group_data(
+            if len(dg_etrace_params) != 0:
+                # Under `vjp_method='single-step'` the ETP weights are updated by
+                # the RTRL recursion, so the transposed jaxpr must not also hand
+                # back gradients for them.
+                raise ValueError(
+                    f'Under vjp_method=\'single-step\' the ETP weight gradients '
+                    f'come from the eligibility-trace recursion, so the backward '
+                    f'pass must not return any. It returned '
+                    f'{len(dg_etrace_params)} for '
+                    f'{sorted(map(str, dg_etrace_params))}. The compiled graph '
+                    f'and the graph executor disagree; recompile the graph.'
+                )
+            hidden_perturb = self.graph.hidden_perturb
+            if hidden_perturb is None:
+                raise ValueError(
+                    'vjp_method=\'single-step\' reads the hidden-state gradients '
+                    'off the hidden perturbation variables, but the compiled '
+                    'graph carries no hidden perturbation. Call `compile_graph()` '
+                    'on this algorithm before running the backward pass.'
+                )
+            if len(hidden_perturb.perturb_vars) != len(dg_hid_perturb_or_dl2h):
+                raise ValueError(
+                    f'The backward pass returned {len(dg_hid_perturb_or_dl2h)} '
+                    f'hidden-perturbation gradient(s) for '
+                    f'{len(hidden_perturb.perturb_vars)} perturbation variable(s) '
+                    f'{list(hidden_perturb.perturb_hidden_paths)}. The two are '
+                    f'matched by position, so a length disagreement re-attributes '
+                    f'every gradient past the mismatch.'
+                )
+            _check_hidden_gradient_correspondence(
+                self.graph.hidden_groups,
+                dict(zip(hidden_perturb.perturb_hidden_paths, dg_hid_perturb_or_dl2h)),
+                source='single-step hidden perturbation',
+            )
+            dl2h_at_t_or_t_minus_1 = hidden_perturb.perturb_data_to_hidden_group_data(
                 dg_hid_perturb_or_dl2h, self.graph.hidden_groups,
             )
 
         else:
-            assert len(dg_last_hiddens) == len(self.hidden_states)
-            assert set(dg_last_hiddens.keys()) == set(self.hidden_states.keys()), (
-                f'The hidden states should be the same. Bug got \n'
-                f'{set(dg_last_hiddens.keys())}\n'
-                f'!=\n'
-                f'{set(self.hidden_states.keys())}'
+            if set(dg_last_hiddens.keys()) != set(self.hidden_states.keys()):
+                raise ValueError(
+                    f'The hidden states should be the same. Bug got \n'
+                    f'{set(dg_last_hiddens.keys())}\n'
+                    f'!=\n'
+                    f'{set(self.hidden_states.keys())}'
+                )
+            _check_hidden_gradient_correspondence(
+                self.graph.hidden_groups,
+                dg_last_hiddens,
+                source='multi-step last-hidden gradients',
             )
             dl2h_at_t_or_t_minus_1 = [
                 group.concat_hidden(

--- a/braintrace/_algorithm/vjp_base_test.py
+++ b/braintrace/_algorithm/vjp_base_test.py
@@ -824,3 +824,258 @@ class TestTheExitCotangentTemplate:
             algo._exit_cotangent_grads(
                 self._template(algo), {('h',): jnp.zeros((1, 9))})
         assert '(1, 9)' in str(exc.value) and '(1, 4)' in str(exc.value)
+
+
+# ---------------------------------------------------------------------------
+# E-01: the hidden <-> gradient correspondence is checked, not asserted
+#
+# The backward pass hands back a collection of hidden-state cotangents that is
+# then re-ordered onto the hidden groups by path and concatenated. Nothing
+# downstream re-derives which hidden state a cotangent came from, so a
+# mis-ordered or mis-shaped collection produces a *wrong gradient rather than an
+# error*. The guards used to be three `assert` statements checking cardinalities
+# and (in the multi-step branch) a key set -- never a correspondence -- and
+# `python -O` stripped all three.
+# ---------------------------------------------------------------------------
+
+import os
+import pathlib
+import subprocess
+import sys
+import textwrap
+
+from braintrace._algorithm.vjp_base import _check_hidden_gradient_correspondence
+
+
+def _e01_groups(n_rec=4):
+    """Real compiler output: the hidden groups of a one-layer GRU."""
+    gru = braintrace.nn.GRUCell(3, n_rec)
+    brainstate.nn.init_all_states(gru)
+    groups, _ = braintrace.find_hidden_groups_from_module(
+        gru, brainstate.random.randn(3))
+    return list(groups)
+
+
+def _e01_well_formed(groups):
+    """One correctly shaped, correctly typed cotangent per hidden state."""
+    return {
+        path: jnp.zeros(
+            tuple(state.varshape),
+            dtype=u.get_mantissa(state.value).dtype,
+        )
+        for group in groups
+        for path, state in zip(group.hidden_paths, group.hidden_states)
+    }
+
+
+class TestHiddenGradientCorrespondence:
+    """The helper accepts what the compiler produces, and nothing else."""
+
+    def test_a_well_formed_mapping_is_accepted(self):
+        groups = _e01_groups()
+        # returns None, raises nothing
+        assert _check_hidden_gradient_correspondence(
+            groups, _e01_well_formed(groups), source='unit test') is None
+
+    def test_a_missing_path_is_refused_and_named(self):
+        groups = _e01_groups()
+        mapping = _e01_well_formed(groups)
+        dropped = next(iter(mapping))
+        del mapping[dropped]
+
+        with pytest.raises(ValueError) as exc:
+            _check_hidden_gradient_correspondence(
+                groups, mapping, source='unit test')
+        message = str(exc.value)
+        assert str(dropped) in message
+        assert 'unit test' in message
+
+    def test_an_extra_path_is_refused_and_named(self):
+        groups = _e01_groups()
+        mapping = _e01_well_formed(groups)
+        mapping[('a', 'stray', 'path')] = jnp.zeros((4,))
+
+        with pytest.raises(ValueError) as exc:
+            _check_hidden_gradient_correspondence(
+                groups, mapping, source='unit test')
+        message = str(exc.value)
+        assert str(('a', 'stray', 'path')) in message
+        assert 'no hidden group claims' in message
+
+    def test_a_shape_mismatch_is_refused_naming_both_shapes(self):
+        groups = _e01_groups(n_rec=4)
+        mapping = _e01_well_formed(groups)
+        path = groups[0].hidden_paths[0]
+        mapping[path] = jnp.zeros((9,))
+
+        with pytest.raises(ValueError) as exc:
+            _check_hidden_gradient_correspondence(
+                groups, mapping, source='unit test')
+        message = str(exc.value)
+        assert str(path) in message
+        assert '(9,)' in message       # what arrived
+        assert '(4,)' in message       # what the hidden state wants
+
+    def test_a_dtype_mismatch_is_refused_naming_both_dtypes(self):
+        groups = _e01_groups()
+        mapping = _e01_well_formed(groups)
+        path = groups[0].hidden_paths[0]
+        state = groups[0].hidden_states[0]
+        assert u.get_mantissa(state.value).dtype == jnp.float32
+        mapping[path] = jnp.zeros(tuple(state.varshape), dtype=jnp.int32)
+
+        with pytest.raises(ValueError) as exc:
+            _check_hidden_gradient_correspondence(
+                groups, mapping, source='unit test')
+        message = str(exc.value)
+        assert str(path) in message
+        assert 'int32' in message
+        assert 'float32' in message
+
+    def test_the_message_names_the_group_the_position_and_the_source(self):
+        groups = _e01_groups()
+        mapping = _e01_well_formed(groups)
+        path = groups[0].hidden_paths[0]
+        mapping[path] = jnp.zeros((9,))
+
+        with pytest.raises(ValueError) as exc:
+            _check_hidden_gradient_correspondence(
+                groups, mapping, source='multi-step last-hidden gradients')
+        message = str(exc.value)
+        assert f'hidden group {groups[0].index}' in message
+        assert 'position 0' in message
+        assert 'multi-step last-hidden gradients' in message
+
+
+# The script the `-O` subprocess runs. It has to be self-contained: the point is
+# that a *fresh optimised interpreter* still refuses a mis-shaped cotangent.
+_E01_DASH_O_SCRIPT = textwrap.dedent(
+    """
+    import sys
+
+    # Prove the interpreter really is optimised before proving anything else:
+    # under -O, `__debug__` is False and `assert` compiles to nothing.
+    if __debug__:
+        print('NOT-OPTIMISED')
+        sys.exit(2)
+    assert False, 'this assert must have been stripped'
+
+    import brainstate
+    import brainunit as u
+    import jax.numpy as jnp
+    import braintrace
+    from braintrace._algorithm.vjp_base import _check_hidden_gradient_correspondence
+
+    gru = braintrace.nn.GRUCell(3, 4)
+    brainstate.nn.init_all_states(gru)
+    groups, _ = braintrace.find_hidden_groups_from_module(
+        gru, brainstate.random.randn(3))
+    groups = list(groups)
+
+    mapping = {
+        path: jnp.zeros(tuple(state.varshape),
+                        dtype=u.get_mantissa(state.value).dtype)
+        for group in groups
+        for path, state in zip(group.hidden_paths, group.hidden_states)
+    }
+
+    # 1. the well-formed mapping is still accepted
+    _check_hidden_gradient_correspondence(groups, mapping, source='dash-O probe')
+
+    # 2. a mis-shaped cotangent is still refused
+    mapping[groups[0].hidden_paths[0]] = jnp.zeros((9,))
+    try:
+        _check_hidden_gradient_correspondence(
+            groups, mapping, source='dash-O probe')
+    except ValueError as e:
+        if 'not in correspondence' not in str(e):
+            print('WRONG-MESSAGE:' + str(e))
+            sys.exit(3)
+    else:
+        print('NOT-RAISED')
+        sys.exit(4)
+
+    # 3. and so is a short value list to concat_hidden -- the zip truncation
+    try:
+        groups[0].concat_hidden([])
+    except ValueError:
+        pass
+    else:
+        print('CONCAT-NOT-RAISED')
+        sys.exit(5)
+
+    print('GUARDS-SURVIVED-DASH-O')
+    """
+)
+
+
+class TestTheGuardsSurviveDashO:
+    """E-01's core complaint: `python -O` strips `assert`, so these must not be.
+
+    Without this test the fix could silently regress to `assert` statements and
+    every other test in this file would still pass, because pytest runs with
+    assertions enabled.
+    """
+
+    def test_a_mis_shaped_cotangent_is_still_refused_under_dash_O(self):
+        # Import the package this test imported, not whatever is installed:
+        # `braintrace/__init__.py` lives one level below the path we want on
+        # `sys.path`.
+        package_root = str(pathlib.Path(braintrace.__file__).resolve().parent.parent)
+        env = dict(os.environ)
+        env['PYTHONPATH'] = os.pathsep.join(
+            [package_root] + ([env['PYTHONPATH']] if env.get('PYTHONPATH') else [])
+        )
+        env.pop('PYTHONOPTIMIZE', None)
+
+        proc = subprocess.run(
+            [sys.executable, '-O', '-c', _E01_DASH_O_SCRIPT],
+            capture_output=True, text=True, env=env, cwd=package_root, timeout=900,
+        )
+
+        assert proc.returncode == 0, (
+            f'-O subprocess failed (returncode={proc.returncode})\n'
+            f'--- stdout ---\n{proc.stdout}\n--- stderr ---\n{proc.stderr}'
+        )
+        assert 'GUARDS-SURVIVED-DASH-O' in proc.stdout, proc.stdout
+
+
+class TestGradientsAreUnchangedByTheGuards:
+    """Positive control: the guards accept real compiler output, and the
+    gradients they now stand in front of are the ones they always were."""
+
+    def test_multistep_gradients_still_match_bptt(self):
+        from braintrace._testing import oracle
+        from braintrace._testing import oracle_models as om
+
+        spec = om.tanh_rnn(n_in=3, n_rec=4)
+        inputs = brainstate.random.randn(8, 3)
+        bptt = oracle.bptt_param_gradients(spec.factory, inputs)
+        got = oracle.online_param_gradients(
+            spec.factory, inputs,
+            algo_factory=lambda m: braintrace.D_RTRL(m, vjp_method='multi-step'),
+        )
+        oracle.assert_param_gradients_close(
+            got, bptt, atol=1e-5, rtol=1e-5, keys=spec.etp_param_keys)
+
+    @pytest.mark.parametrize('cls', [braintrace.nn.GRUCell, braintrace.nn.LSTMCell])
+    def test_the_single_step_branch_accepts_the_compiled_graph(self, cls):
+        """The single-step branch is the one that reads the perturbation vars.
+
+        ``LSTMCell`` matters here: two hidden states, so the per-position
+        correspondence has something to get wrong.
+        """
+        model = cls(3, 4)
+        brainstate.nn.init_all_states(model, batch_size=1)
+        algo = braintrace.D_RTRL(model, vjp_method='single-step')
+        x = jnp.ones((1, 3))
+        algo.compile_graph(x)
+        algo.init_etrace_state()
+
+        params = model.states(brainstate.ParamState)
+        grads = brainstate.transform.grad(
+            lambda inp: (algo(inp) ** 2).sum(), params)(x)
+
+        leaves = jax.tree.leaves(grads)
+        assert leaves
+        assert all(bool(jnp.all(jnp.isfinite(u.get_mantissa(v)))) for v in leaves)

--- a/braintrace/_compiler/hidden_group.py
+++ b/braintrace/_compiler/hidden_group.py
@@ -437,7 +437,34 @@ class HiddenGroup(NamedTuple):
         jax.Array
             A single array containing all hidden-state values concatenated
             along the last axis.
+
+        Raises
+        ------
+        ValueError
+            If ``splitted_hid_vals`` does not have exactly one entry per hidden
+            state in the group.
+
+        Notes
+        -----
+        The length check is not decorative. Before it existed this method zipped
+        the value list against :attr:`hidden_states`, and ``zip`` truncates to the
+        shorter argument: a *short* value list produced a concatenated array with
+        a too-narrow trailing axis instead of an error, so a mis-routed cotangent
+        surfaced later as a shape mismatch in unrelated trace math -- or not at
+        all, when the widths happened to coincide. It is an ``if ... raise`` and
+        not an ``assert`` so that ``python -O`` cannot strip it.
+
+        The check reads only Python-level lengths, never array data, so it costs
+        nothing in the compiled program.
         """
+        splitted_hid_vals = list(splitted_hid_vals)
+        if len(splitted_hid_vals) != len(self.hidden_states):
+            raise ValueError(
+                f'Hidden group {self.index} has {len(self.hidden_states)} hidden '
+                f'state(s) {list(self.hidden_paths)}, but concat_hidden() was '
+                f'given {len(splitted_hid_vals)} value(s). Pass exactly one value '
+                f'per hidden state, in the order of the group\'s hidden_paths.'
+            )
         splitted_hid_vals = [
             val
             if isinstance(st, HiddenGroupState) else
@@ -464,8 +491,35 @@ class HiddenGroup(NamedTuple):
         list of jax.Array
             A list of split hidden-state arrays. For non-``HiddenGroupState``
             values, the last dimension is squeezed.
+
+        Raises
+        ------
+        ValueError
+            If the trailing axis of ``concat_hid_vals`` is not
+            :attr:`num_state` wide, i.e. the array is not this group's
+            concatenated slab.
+
+        Notes
+        -----
+        The width check is the inverse of :meth:`concat_hidden`'s length check
+        and closes the same silent path. ``u.math.split`` at this group's
+        cumulative boundaries returns one part per hidden state plus a trailing
+        remainder, and that remainder is dropped by the ``zip`` below -- so a
+        *too wide* slab silently loses its surplus, and a *too narrow* one
+        silently yields empty parts. Like the sibling check this is an
+        ``if ... raise`` rather than an ``assert`` so ``python -O`` cannot strip
+        it, and it reads only the static shape.
         """
         num_states = [st.num_state for st in self.hidden_states]
+        shape = u.math.shape(concat_hid_vals)
+        if len(shape) == 0 or shape[-1] != sum(num_states):
+            raise ValueError(
+                f'Hidden group {self.index} concatenates its hidden states '
+                f'{list(self.hidden_paths)} into a trailing axis of width '
+                f'{sum(num_states)}, but split_hidden() was given an array of '
+                f'shape {tuple(shape)}. Pass this group\'s concatenated slab, '
+                f'as produced by concat_hidden().'
+            )
         indices = np.cumsum(num_states)
         splitted_hid_vals = u.math.split(concat_hid_vals, indices, axis=-1)
         splitted_hid_vals = [

--- a/braintrace/_compiler/hidden_group_test.py
+++ b/braintrace/_compiler/hidden_group_test.py
@@ -1867,3 +1867,111 @@ class TestHiddenGroupSnapWidening:
             np.asarray(widened.diagonal_jacobian(hidden_vals, input_vals)),
             np.asarray(group.diagonal_jacobian(hidden_vals, input_vals)),
         )
+
+
+# ---------------------------------------------------------------------------
+# E-01: concat_hidden / split_hidden must not silently truncate
+#
+# `concat_hidden` used to zip the value list against `self.hidden_states`, and
+# `zip` truncates to the shorter argument. A *short* value list therefore did
+# not raise: it produced a concatenated array with a too-narrow trailing axis,
+# which surfaced later as a shape mismatch somewhere in unrelated trace math --
+# or not at all, when the widths happened to coincide. `split_hidden` had the
+# mirror-image hole on its trailing-axis width.
+# ---------------------------------------------------------------------------
+
+class _E01FakeState:
+    """A stand-in hidden state with just the attributes the group reads."""
+
+    def __init__(self, varshape=(2, 3), num_state=1):
+        self.varshape = varshape
+        self.num_state = num_state
+
+
+def _e01_group(num_states=(1, 1), varshape=(2, 3)):
+    """A `HiddenGroup` carrying `len(num_states)` fake plain hidden states."""
+    return braintrace.HiddenGroup(
+        index=7,
+        hidden_paths=[('h', i) for i in range(len(num_states))],
+        hidden_states=[_E01FakeState(varshape, n) for n in num_states],
+        hidden_invars=[],
+        hidden_outvars=[],
+        transition_jaxpr=None,
+        transition_jaxpr_constvars=[],
+    )
+
+
+class TestConcatHiddenLengthGuard:
+
+    def test_short_value_list_raises_instead_of_truncating(self):
+        group = _e01_group(num_states=(1, 1, 1))
+        vals = [jnp.zeros((2, 3)), jnp.zeros((2, 3))]  # one short
+
+        with pytest.raises(ValueError) as exc:
+            group.concat_hidden(vals)
+
+        message = str(exc.value)
+        assert '7' in message                  # names the group
+        assert '3' in message and '2' in message   # names both counts
+
+    def test_short_value_list_used_to_produce_a_narrow_array(self):
+        """Pin the pre-fix behaviour so the regression stays legible.
+
+        Zipping a 2-element value list against 3 hidden states produced a
+        ``(2, 3, 2)`` slab where the group's contract says ``(2, 3, 3)``. That
+        is the silent corruption E-01 is about; it is reproduced here through a
+        local ``zip`` rather than through the method, which now refuses it.
+        """
+        group = _e01_group(num_states=(1, 1, 1))
+        vals = [jnp.zeros((2, 3)), jnp.zeros((2, 3))]
+        truncated = jnp.concatenate(
+            [jnp.expand_dims(v, -1) for v, _ in zip(vals, group.hidden_states)],
+            axis=-1,
+        )
+        assert truncated.shape == (2, 3, 2)          # what used to come back
+        assert truncated.shape[-1] != group.num_state  # ... and it was wrong
+
+    def test_long_value_list_raises(self):
+        group = _e01_group(num_states=(1, 1))
+        vals = [jnp.zeros((2, 3))] * 3
+
+        with pytest.raises(ValueError) as exc:
+            group.concat_hidden(vals)
+        assert '3' in str(exc.value)
+
+    def test_exact_length_still_succeeds(self):
+        group = _e01_group(num_states=(1, 1))
+        out = group.concat_hidden([jnp.ones((2, 3)), jnp.full((2, 3), 2.0)])
+        assert out.shape == (2, 3, 2)
+        np.testing.assert_array_equal(np.asarray(out)[..., 0], np.ones((2, 3)))
+        np.testing.assert_array_equal(np.asarray(out)[..., 1], np.full((2, 3), 2.0))
+
+    def test_a_generator_is_accepted(self):
+        """The length guard must not break a lazily-produced value sequence."""
+        group = _e01_group(num_states=(1, 1))
+        out = group.concat_hidden(jnp.zeros((2, 3)) for _ in range(2))
+        assert out.shape == (2, 3, 2)
+
+
+class TestSplitHiddenWidthGuard:
+
+    def test_narrow_slab_raises(self):
+        group = _e01_group(num_states=(1, 1, 1))
+        with pytest.raises(ValueError) as exc:
+            group.split_hidden(jnp.zeros((2, 3, 2)))
+        message = str(exc.value)
+        assert '7' in message
+        assert '(2, 3, 2)' in message
+
+    def test_wide_slab_raises(self):
+        group = _e01_group(num_states=(1, 1))
+        with pytest.raises(ValueError):
+            group.split_hidden(jnp.zeros((2, 3, 5)))
+
+    def test_exact_width_still_round_trips(self):
+        group = _e01_group(num_states=(1, 1))
+        slab = group.concat_hidden([jnp.ones((2, 3)), jnp.full((2, 3), 2.0)])
+        parts = group.split_hidden(slab)
+        assert len(parts) == 2
+        np.testing.assert_array_equal(np.asarray(parts[0]), np.ones((2, 3)))
+        np.testing.assert_array_equal(np.asarray(parts[1]), np.full((2, 3), 2.0))

--- a/braintrace/_compiler/hidden_pertubation.py
+++ b/braintrace/_compiler/hidden_pertubation.py
@@ -173,29 +173,51 @@ class HiddenPerturbation(NamedTuple):
 
         Raises
         ------
-        AssertionError
+        ValueError
             If ``perturb_data`` does not have the same length as
-            ``perturb_vars``.
+            ``perturb_vars``, or if a hidden group needs a path that was not
+            perturbed.
+
+        Notes
+        -----
+        Both guards are ``if ... raise`` rather than ``assert`` so that
+        ``python -O`` cannot strip them. The mapping from paths to perturbation
+        data is positional (``zip(perturb_hidden_paths, perturb_data)``), so a
+        length disagreement silently re-attributes every cotangent past the
+        mismatch; and a group asking for an unperturbed path used to surface as
+        a bare ``KeyError`` naming a path tuple and nothing else. Both checks
+        read only Python-level lengths and dict keys, never array data.
         """
-        assert len(perturb_data) == len(self.perturb_vars), (
-            f'The length of the perturb data is not correct. '
-            f'Expected: {len(self.perturb_vars)}, '
-            f'Got: {len(perturb_data)}'
-        )
+        perturb_data = list(perturb_data)
+        if len(perturb_data) != len(self.perturb_vars):
+            raise ValueError(
+                f'The length of the perturb data is not correct. '
+                f'Expected: {len(self.perturb_vars)} '
+                f'(one per perturbed hidden state '
+                f'{list(self.perturb_hidden_paths)}), '
+                f'Got: {len(perturb_data)}'
+            )
         path_to_perturb_data = {
             path: data
             for path, data in zip(self.perturb_hidden_paths, perturb_data)
         }
-        return [
-            group.concat_hidden(
-                [
-                    # dimensionless processing
-                    u.get_mantissa(path_to_perturb_data[path])
-                    for path in group.hidden_paths
-                ]
-            )
-            for group in hidden_groups
-        ]
+
+        group_data = []
+        for group in hidden_groups:
+            vals = []
+            for path in group.hidden_paths:
+                if path not in path_to_perturb_data:
+                    raise ValueError(
+                        f'Hidden group {group.index} needs the hidden state '
+                        f'{path}, but that path was not perturbed. The perturbed '
+                        f'paths are {list(self.perturb_hidden_paths)}. The graph '
+                        f'and its hidden perturbation disagree; recompile the '
+                        f'graph.'
+                    )
+                # dimensionless processing
+                vals.append(u.get_mantissa(path_to_perturb_data[path]))
+            group_data.append(group.concat_hidden(vals))
+        return group_data
 
     def dict(self) -> Dict[str, Any]:
         """Return this perturbation's named fields as a plain dictionary.

--- a/braintrace/_compiler/hidden_pertubation_test.py
+++ b/braintrace/_compiler/hidden_pertubation_test.py
@@ -444,3 +444,65 @@ class TestWhileDetach:
         minfo = braintrace.extract_module_info(cell, x, control_flow=policy)
         with pytest.raises(NotImplementedError):
             add_hidden_perturbation_from_minfo(minfo)
+
+
+# ---------------------------------------------------------------------------
+# E-01: perturbation data -> hidden-group data must raise, not assert
+#
+# `perturb_data_to_hidden_group_data` maps perturbation values onto paths
+# positionally, so a length disagreement re-attributes every value past the
+# mismatch. The guard used to be an `assert`, which `python -O` strips, and a
+# group asking for an unperturbed path used to surface as a bare `KeyError`.
+# ---------------------------------------------------------------------------
+
+class TestPerturbDataToHiddenGroupDataGuards:
+
+    @staticmethod
+    def _perturbation():
+        gru = braintrace.nn.GRUCell(3, 4)
+        brainstate.nn.init_all_states(gru)
+        x = brainstate.random.randn(3)
+        perturb = add_hidden_perturbation_in_module(gru, x)
+        groups, _ = braintrace.find_hidden_groups_from_module(gru, x)
+        return perturb, list(groups)
+
+    def test_wrong_length_raises_value_error_not_assertion_error(self):
+        import jax.numpy as jnp
+
+        perturb, groups = self._perturbation()
+        data = perturb.init_perturb_data()
+        too_long = list(data) + [jnp.zeros_like(data[0])]
+
+        with pytest.raises(ValueError) as exc:
+            perturb.perturb_data_to_hidden_group_data(too_long, groups)
+        message = str(exc.value)
+        assert 'perturb data' in message
+        assert str(len(too_long)) in message
+
+    def test_wrong_length_short_raises(self):
+        perturb, groups = self._perturbation()
+        with pytest.raises(ValueError):
+            perturb.perturb_data_to_hidden_group_data([], groups)
+
+    def test_unperturbed_path_is_named(self):
+        perturb, groups = self._perturbation()
+        data = perturb.init_perturb_data()
+        # Same cardinality, but the perturbed path no longer matches what the
+        # group asks for -- previously a bare `KeyError`.
+        renamed = perturb._replace(
+            perturb_hidden_paths=[('not', 'the', 'group', 'path')]
+            * len(perturb.perturb_hidden_paths)
+        )
+
+        with pytest.raises(ValueError) as exc:
+            renamed.perturb_data_to_hidden_group_data(data, groups)
+        message = str(exc.value)
+        assert str(groups[0].hidden_paths[0]) in message
+        assert 'not' in message
+
+    def test_well_formed_data_still_maps(self):
+        perturb, groups = self._perturbation()
+        out = perturb.perturb_data_to_hidden_group_data(perturb.init_perturb_data(), groups)
+        assert len(out) == len(groups)
+        for arr, group in zip(out, groups):
+            assert arr.shape == (*group.varshape, group.num_state)

--- a/docs/specs/2026-08-07-e01-hidden-gradient-correspondence.md
+++ b/docs/specs/2026-08-07-e01-hidden-gradient-correspondence.md
@@ -1,6 +1,6 @@
 # E-01 — check the hidden↔gradient correspondence for real
 
-Status: proposed
+Status: implemented (see "Deviations from this plan" at the end)
 Scope: `braintrace/_algorithm/vjp_base.py`, `braintrace/_compiler/hidden_group.py`,
 `braintrace/_compiler/hidden_pertubation.py`
 Backlog entry: E-01 in `2026-08-07-deferred-engineering-backlog.md`
@@ -152,3 +152,38 @@ compiler's output, which no public API allows. The tests therefore drive the
 checkers directly. That is the right level: the checkers are the contract, and
 an end-to-end test would only re-verify that the compiler currently satisfies
 it — which the existing oracle suite already does.
+
+## Deviations from this plan
+
+Four places where the implementation had to depart from the text above.
+
+1. **`split_hidden` cannot use a length check or `strict=True`.** The plan says
+   to "add the same check to `split_hidden`'s inverse assumption". It cannot be
+   the same check: `u.math.split` at this group's cumulative boundaries returns
+   `len(hidden_states) + 1` parts — one per state plus a trailing remainder —
+   and the existing `zip` drops that remainder *by design*. A length check or
+   `strict=True` would therefore reject every correct call. The equivalent guard
+   is on the input's **trailing-axis width** (`shape[-1] == num_state`), which is
+   what was implemented. Every caller passes a `concat_hidden`-produced slab of
+   exactly that width, including the SnAp-n path (`widened_block_jacobian`
+   linearizes a shape-preserving map on `(*varshape, num_state)`).
+
+2. **`concat_hidden` uses an explicit length check, not `strict=True`.** Same
+   effect, but the message can name the group, both counts and the paths, which
+   `zip`'s built-in `ValueError` cannot — and its wording is interpreter-version
+   dependent, which CI on a different Python would notice. The argument is
+   materialized with `list()` first so a generator still works.
+
+3. **The dtype comparison exempts `float0`.** `jax.dtypes.float0` is JAX's
+   cotangent dtype for a non-differentiable leaf, so it is a *correct* cotangent
+   for an integer or boolean hidden state and must not read as a mismatch. The
+   dtype is also read straight off the array rather than through
+   `jnp.result_type`, which does not round-trip `float0`.
+
+4. **The multi-step branch's `len(dg_last_hiddens) == len(self.hidden_states)`
+   guard is dropped rather than converted.** Both operands are dicts, so the
+   key-set equality that follows it already implies it.
+
+The plan's cost argument holds unchanged: every check reads Python-level
+metadata (lengths, dict keys, static shapes, dtypes), never array data, so
+nothing is traced into the compiled program.


### PR DESCRIPTION
Implements `docs/specs/2026-08-07-e01-hidden-gradient-correspondence.md`, which
0.2.5 shipped as analysis only.

## The defect

`braintrace/_algorithm/vjp_base.py` carried a standing TODO above three
`assert` statements meant to guarantee that the backward pass's cotangents line
up with the compiled hidden states. Two distinct problems:

1. **Every guard was an `assert`**, so `python -O` / `PYTHONOPTIMIZE=1` stripped
   all three. On an optimised interpreter the correspondence was checked by
   nothing at all.
2. **None of them checked a *correspondence*.** They checked cardinalities and,
   in the multi-step branch, a key set. What has to hold is that cotangent *i*
   belongs to hidden state *i* — matching shape, dtype and position.

A cotangent attributed to the wrong hidden state produces a **wrong gradient,
not an error**. The concrete silent path was `HiddenGroup.concat_hidden`, which
zipped the value list against `self.hidden_states`; `zip` truncates to the
shorter argument, so a short cotangent list produced a slab with a too-narrow
trailing axis rather than raising — surfacing later in unrelated trace math, or
not at all when the widths happened to coincide.

## The change

Three sites, every guard now `if ... raise` so `-O` cannot strip it.

**`braintrace/_compiler/hidden_group.py`**

* `concat_hidden` raises `ValueError` unless it receives exactly one value per
  hidden state, naming the group index, both counts and the paths. The argument
  is materialized with `list()` first, so a generator still works.
* `split_hidden` gets the mirror guard on its input's **trailing-axis width**.
  Deliberately not a length check: `u.math.split` at the group's cumulative
  boundaries returns one part per state *plus a trailing remainder*, which the
  existing `zip` drops by design — a length check or `strict=True` would reject
  every correct call.

**`braintrace/_compiler/hidden_pertubation.py`**

* `perturb_data_to_hidden_group_data`'s length `assert` becomes a `ValueError`.
  The path→data mapping is positional, so a length disagreement re-attributes
  every value past the mismatch.
* A group needing an unperturbed path used to surface as a bare `KeyError`
  naming a tuple; it now names the group, the missing path and the paths that
  *were* perturbed.

**`braintrace/_algorithm/vjp_base.py`**

* New `_check_hidden_gradient_correspondence(groups, path_to_cotangent, *,
  source)` checks **totality** (every path a group needs is present), **no
  strays** (no path that no group claims), and **correspondence** (per-index
  shape and dtype agreement with the hidden state, compared after
  `u.get_mantissa`, as the consumers do). `source` names which branch produced
  the mapping, so the message says `single-step hidden perturbation` or
  `multi-step last-hidden gradients`.
* Both branches of the former TODO call it; the three `assert`s around them
  became explicit raises with messages that explain *why* the condition holds
  (ETP weights come from the RTRL recursion under `single-step`; the graph must
  be compiled; the perturbation mapping is positional).
* The TODO is gone.

## Cost

Every comparison is on Python-level metadata — lengths, dict keys, static
shapes, dtypes — never on array *data*. Nothing here is traced into the
compiled program, so no XLA op is added and no device sync is forced, even
though the checks run once per backward pass.

## Tests

Co-located per AGENTS.md rule 9. All are compiler/executor-contract assertions
rather than learning-rule assertions, so per AGENTS.md they do not need the
finite-window oracle path; the one gradient assertion that *is* numerical
(D-RTRL vs BPTT) is a compiler assertion and correctly uses the whole-sequence
path.

* `hidden_group_test.py` — `concat_hidden` refuses a short list (with the
  pre-fix `(2, 3, 2)`-instead-of-`(2, 3, 3)` truncation pinned in a sibling test
  so the regression stays legible) and a long one; exact length still succeeds;
  generators still accepted. `split_hidden` refuses narrow and wide slabs and
  still round-trips an exact one.
* `hidden_pertubation_test.py` — `ValueError` (not `AssertionError`) on wrong
  length in both directions; the unperturbed path is named; well-formed data
  still maps.
* `vjp_base_test.py` — the helper accepts a well-formed mapping and refuses a
  missing path, an extra path, a shape mismatch and a dtype mismatch, each
  asserting the message names the path, the group and the position.
* **The `-O` test** — a `subprocess.run([sys.executable, '-O', '-c', ...])` case
  that first proves `__debug__` is `False` and a bare `assert False` is
  stripped, then checks that the shape mismatch and the `concat_hidden`
  truncation both still raise `ValueError`. This is the assertion that pins
  E-01's core complaint; without it the fix could silently regress to asserts
  and every other test would still pass.
* Positive controls — D-RTRL multi-step gradients still match the BPTT oracle,
  and the single-step branch still accepts real compiler output for `GRUCell`
  and `LSTMCell` (the latter has two hidden states in one group, so the
  per-position correspondence has something to get wrong).

## Where the spec was wrong

Recorded in a new "Deviations from this plan" section of the spec: the
`split_hidden` guard cannot be a length check (see above); `concat_hidden` uses
an explicit check rather than `strict=True` so the message can name the group
and so it does not depend on interpreter-version-specific `zip` wording; the
dtype comparison exempts `jax.dtypes.float0` (JAX's correct cotangent dtype for
a non-differentiable leaf) and reads the dtype off the array rather than
through `jnp.result_type`, which does not round-trip `float0`; and the
multi-step `len(dg_last_hiddens) == len(self.hidden_states)` guard is dropped
rather than converted, since both operands are dicts and the key-set equality
that follows already implies it.

## Verification

```
$ python -m pytest braintrace/_algorithm/ braintrace/_compiler/ -q
1684 passed, 4 deselected, 223 warnings in 1316.44s (0:21:56)

$ python -m mypy
Success: no issues found in 62 source files
```

(1644 of those passed on the same tree before the new tests were added, so no
existing test changed behaviour — in particular the "no strays" check never
fired across the whole compiler and algorithm suite.)

Closes #165

## Summary by Sourcery

Enforce robust runtime validation of hidden-state gradient correspondence and hidden group perturbation wiring so that misrouted or mis-shaped cotangents raise clear errors instead of silently corrupting gradients, including under optimized Python interpreters.

Bug Fixes:
- Prevent silent truncation and shape mismatches in HiddenGroup.concat_hidden and split_hidden by validating value counts and concatenated slab widths before concatenation/splitting.
- Ensure perturbation data is length-checked and mapped only to actually perturbed hidden paths, surfacing missing paths as descriptive ValueErrors instead of stripped asserts or bare KeyErrors.
- Guarantee that hidden-state cotangents correspond one-to-one with compiled hidden states in both single-step and multi-step VJP paths, rejecting missing, extra, mis-shaped, or mis-typed gradients with detailed diagnostics.

Enhancements:
- Introduce a shared hidden-gradient correspondence checker that validates path coverage, shapes, and dtypes against compiled hidden groups using static metadata only, and integrate it into both VJP modes.
- Replace several assert-based invariants in the VJP backward logic and perturbation handling with explicit ValueError-raising checks that survive python -O while keeping them outside the traced/XLA program.
- Document and implement nuanced behavior for dtypes (including JAX float0) and HiddenGroupState stacking when validating hidden-state gradient shapes and dtypes.
- Tighten error messages across hidden-group concatenation, splitting, perturbation mapping, and VJP correspondence checks to report group indices, paths, positions, and expected vs actual metadata for easier debugging.

Documentation:
- Update the E-01 hidden-gradient correspondence spec to reflect the implemented behavior, including documented deviations such as split_hidden width checks, explicit concat_hidden length checks, float0 handling, and removal of a redundant length guard.

Tests:
- Add targeted tests for concat_hidden and split_hidden to pin the previous silent truncation behavior and verify new length/width guards and generator support.
- Extend hidden perturbation tests to assert ValueError on wrong perturbation-data lengths, name missing paths explicitly, and confirm that well-formed data still maps correctly to hidden groups.
- Add unit tests for the hidden-gradient correspondence helper covering well-formed mappings and failures on missing/extra paths, shape mismatches, dtype mismatches, and error-message contents.
- Introduce a subprocess-based -O test that proves asserts are stripped yet the new guards still raise under python -O, pinning E-01’s core regression risk.
- Add positive-control gradient tests to verify that D-RTRL multi-step gradients still match the BPTT oracle and that single-step VJP still accepts real compiled GRU and LSTM graphs.