### PR TITLE
Bring `_compiler` and `_legacy` inside the typing gate (E-09)

### DIFF
--- a/braintrace/_compiler/base.py
+++ b/braintrace/_compiler/base.py
@@ -17,6 +17,7 @@ from typing import Container, Dict, Sequence, Set, List
 
 from braintrace._compatible_imports import (
     Var,
+    Jaxpr,
     JaxprEqn,
     is_jit_primitive,
     is_scan_primitive,
@@ -89,10 +90,10 @@ def find_element_exist_in_the_set(
 
 
 def check_unsupported_op(
-    self,
+    self: 'JaxprEvaluation',
     eqn: JaxprEqn,
     op_name: str
-):
+) -> None:
     """
     Checks for unsupported operations involving weight or hidden state variables in the given equation.
 
@@ -275,7 +276,7 @@ class JaxprEvaluation(object):
         outvar_to_hidden_path: Dict[Var, Path],
         *,
         control_flow: ControlFlowPolicy = DEFAULT_CONTROL_FLOW_POLICY,
-    ):
+    ) -> None:
         self.weight_invars = weight_invars
         self.hidden_invars = hidden_invars
         self.hidden_outvars = hidden_outvars
@@ -283,7 +284,7 @@ class JaxprEvaluation(object):
         self.outvar_to_hidden_path = outvar_to_hidden_path
         self.control_flow = control_flow
 
-    def _eval_jaxpr(self, jaxpr) -> None:
+    def _eval_jaxpr(self, jaxpr: Jaxpr) -> None:
         """
         Evaluating the jaxpr for extracting the etrace relationships.
 
@@ -369,7 +370,7 @@ class JaxprEvaluation(object):
         check_unsupported_op(self, eqn, 'cond')
         self._eval_eqn(eqn)
 
-    def _eval_eqn(self, eqn):
+    def _eval_eqn(self, eqn: JaxprEqn) -> None:
         """
         Evaluate a single JAX equation.
 

--- a/braintrace/_compiler/canonicalize.py
+++ b/braintrace/_compiler/canonicalize.py
@@ -49,7 +49,7 @@ equations rather than spinning forever.
 """
 
 from dataclasses import dataclass
-from typing import Any, Callable, Container, Dict, Iterable, List, Optional, Set
+from typing import Any, Callable, Container, Dict, Iterable, List, Optional, Sequence, Set, Tuple
 
 import jax
 
@@ -68,7 +68,7 @@ from braintrace._compatible_imports import (
 from braintrace._misc import CompilationError
 from braintrace._op import is_etp_primitive
 from .diagnostics import DiagnosticKind, DiagnosticLevel, emit
-from .jaxpr_graph import build_producer_map, inline_jit_calls
+from .jaxpr_graph import Atom, build_producer_map, inline_jit_calls
 
 __all__ = [
     'ControlFlowPolicy',
@@ -186,7 +186,7 @@ class ControlFlowPolicy:
     scan_descent: str = 'auto'
     fixpoint_iteration_limit: int = 64
 
-    def __post_init__(self):
+    def __post_init__(self) -> None:
         if self.scan_descent not in ('auto', 'off'):
             raise ValueError(
                 f"ControlFlowPolicy.scan_descent must be 'auto' or 'off', "
@@ -458,7 +458,7 @@ def _convert_conds_once(
     hidden_outvars: Container[Var],
     policy: ControlFlowPolicy = DEFAULT_CONTROL_FLOW_POLICY,
     converted_log: Optional[List[JaxprEqn]] = None,
-):
+) -> Tuple[ClosedJaxpr, int, List[_PendingDiagnostic]]:
     """One conversion sweep over the top-level equations.
 
     Returns ``(closed_jaxpr, n_converted, pending)``; the input object itself
@@ -481,7 +481,11 @@ def _convert_conds_once(
     def fresh_like(v: Var) -> Var:
         return new_var('', v.aval)
 
-    def relevance_reason(resolved_invars, outvars, branches) -> Optional[str]:
+    def relevance_reason(
+        resolved_invars: Sequence[Atom],
+        outvars: Sequence[Var],
+        branches: Sequence[Any],
+    ) -> Optional[str]:
         for v in resolved_invars:
             if isinstance(v, Var):
                 if v in weight_invars:
@@ -521,7 +525,7 @@ def _convert_conds_once(
                         )
         return None
 
-    def inline_branch(branch_closed, operand_atoms) -> List[Any]:
+    def inline_branch(branch_closed: Any, operand_atoms: Sequence[Atom]) -> List[Any]:
         """Splice one branch body into ``new_eqns`` with every internal var
         freshened; return the branch's output atoms."""
         br = getattr(branch_closed, 'jaxpr', branch_closed)
@@ -538,7 +542,7 @@ def _convert_conds_once(
         for iv, atom in zip(br.invars, operand_atoms):
             subst[iv] = atom
 
-        def resolve(atom):
+        def resolve(atom: Atom) -> Atom:
             if isinstance(atom, Var):
                 return subst.get(atom, atom)
             return atom
@@ -547,7 +551,11 @@ def _convert_conds_once(
             handle_eqn(sub_eqn, resolve, subst)
         return [resolve(v) for v in br.outvars]
 
-    def handle_eqn(eqn: JaxprEqn, resolve, subst: Optional[Dict[Var, Any]]) -> None:
+    def handle_eqn(
+        eqn: JaxprEqn,
+        resolve: Callable[[Atom], Atom],
+        subst: Optional[Dict[Var, Any]],
+    ) -> None:
         """Process one equation. ``subst`` is ``None`` at the top level (the
         equation's vars are kept); inside a branch, invars are resolved and
         outvars freshened into ``subst``."""
@@ -800,7 +808,7 @@ def _unroll_scans_once(
     hidden_outvars: Container[Var],
     policy: ControlFlowPolicy,
     converted_log: Optional[List[JaxprEqn]] = None,
-):
+) -> Tuple[ClosedJaxpr, int, List[_PendingDiagnostic]]:
     """One unrolling sweep over the top-level equations.
 
     Returns ``(closed_jaxpr, n_unrolled, pending)``; the input object itself

--- a/braintrace/_compiler/graph.py
+++ b/braintrace/_compiler/graph.py
@@ -16,7 +16,7 @@
 
 import threading
 from contextlib import contextmanager
-from typing import Dict, Sequence, Tuple, Optional, NamedTuple
+from typing import Dict, Iterator, List, Sequence, Tuple, Optional, NamedTuple
 
 import brainstate
 import jax
@@ -24,8 +24,12 @@ import numpy as np
 
 from braintrace._misc import NotSupportedError
 from braintrace._typing import (
+    ETraceVals,
     Inputs,
+    Outputs,
     Path,
+    StateVals,
+    TempData,
 )
 from .canonicalize import ControlFlowPolicy
 from .diagnostics import (
@@ -60,7 +64,7 @@ __all__ = [
 
 def order_hidden_group_index(
     hidden_groups: Sequence[HiddenGroup],
-):
+) -> None:
     """
     Verifies that hidden group indices match their positions in the sequence.
 
@@ -178,7 +182,7 @@ class ETraceGraph(NamedTuple):
         args: Inputs,
         perturb_data: Sequence[jax.Array],
         old_state_vals: Optional[Sequence[jax.Array]] = None,
-    ):
+    ) -> Tuple[Outputs, ETraceVals, StateVals, TempData]:
         r"""Run the forward pass with additive perturbations injected at the hidden states.
 
         Evaluates the perturbed-forward jaxpr built during compilation, which is
@@ -200,9 +204,10 @@ class ETraceGraph(NamedTuple):
 
         Returns
         -------
-        object
-            The processed model outputs, in the same structure produced by a
-            normal forward call.
+        tuple
+            ``(outputs, etrace_state_vals, other_state_vals, temp_data)`` --
+            the same four-element structure produced by a normal forward call
+            through :meth:`ModuleInfo.jaxpr_call`.
         """
         # state checking
         if old_state_vals is None:
@@ -243,10 +248,10 @@ class CONTEXT(threading.local):
     for the eligibility trace.
     """
 
-    def __init__(self):
-        self.compilers = []
+    def __init__(self) -> None:
+        self.compilers: List[str] = []
 
-    def add_compiler(self, name: str):
+    def add_compiler(self, name: str) -> None:
         self.compilers.append(name)
 
 
@@ -254,7 +259,7 @@ context = CONTEXT()
 
 
 @contextmanager
-def compiler_context(name: str):
+def compiler_context(name: str) -> Iterator[None]:
     """
     Provides a context manager for managing the eligibility trace compiler context.
 

--- a/braintrace/_compiler/hid_param_op.py
+++ b/braintrace/_compiler/hid_param_op.py
@@ -210,18 +210,23 @@ class HiddenParamOpRelation(NamedTuple):
 
     # backward compat aliases
     @property
-    def x(self):
+    def x(self) -> Optional[Var]:
         return self.x_var
 
     @property
-    def y(self):
+    def y(self) -> Var:
         return self.y_var
 
     @property
-    def path(self):
+    def path(self) -> Optional[Path]:
         return next(iter(self.trainable_paths.values()), None)
 
-    def y_to_hidden_groups(self, y_val, const_vals, concat_hidden_vals=True):
+    def y_to_hidden_groups(
+        self,
+        y_val: jax.Array,
+        const_vals: Dict[Var, jax.Array],
+        concat_hidden_vals: bool = True,
+    ) -> List[Any]:
         """Evaluate the transition jaxprs mapping ``y`` to hidden-group values.
 
         Parameters
@@ -244,7 +249,8 @@ class HiddenParamOpRelation(NamedTuple):
         vals_of_hidden_groups = []
         for jaxpr, group in zip(self.y_to_hidden_group_jaxprs, self.hidden_groups):
             consts = [const_vals[var] for var in jaxpr.constvars]
-            hidden_vals = jax.core.eval_jaxpr(jaxpr, consts, y_val)
+            # ``list[Array]`` before concatenation, a single ``Array`` after.
+            hidden_vals: Any = jax.core.eval_jaxpr(jaxpr, consts, y_val)
             if concat_hidden_vals:
                 hidden_vals = group.concat_hidden(hidden_vals)
             vals_of_hidden_groups.append(hidden_vals)
@@ -811,7 +817,7 @@ def find_hidden_param_op_relations_from_jaxpr(
     weight_path_to_invars: Optional[Dict[Path, List[Var]]] = None,
     control_flow: ControlFlowPolicy = DEFAULT_CONTROL_FLOW_POLICY,
     descended_scan_eqn_ids: FrozenSet[int] = frozenset(),
-    **_ignored,
+    **_ignored: Any,
 ) -> Sequence[HiddenParamOpRelation]:
     """Find all ETP-primitive-to-hidden-state relations in *jaxpr*."""
     producers = build_producer_map(jaxpr)
@@ -1165,8 +1171,8 @@ def find_hidden_param_op_relations_from_minfo(
 
 def find_hidden_param_op_relations_from_module(
     model: brainstate.nn.Module,
-    *model_args,
-    **model_kwargs,
+    *model_args: Any,
+    **model_kwargs: Any,
 ) -> Sequence[HiddenParamOpRelation]:
     """Find ETP relations from a model.
 

--- a/braintrace/_compiler/hidden_group.py
+++ b/braintrace/_compiler/hidden_group.py
@@ -46,7 +46,7 @@
 
 from itertools import combinations
 from typing import TYPE_CHECKING
-from typing import List, Dict, FrozenSet, Sequence, Tuple, Set, Optional, Callable, NamedTuple, Any, cast
+from typing import List, Dict, FrozenSet, Iterable, Sequence, Tuple, Set, Optional, Callable, NamedTuple, Any, cast
 
 import brainstate
 import brainunit as u
@@ -273,7 +273,7 @@ class HiddenGroup(NamedTuple):
             return self.num_state
         return int(self.snap.num_neighbour) * self.num_state
 
-    def check_consistent_varshape(self):
+    def check_consistent_varshape(self) -> None:
         """Check whether the shapes of the hidden states are consistent.
 
         Raises
@@ -320,7 +320,7 @@ class HiddenGroup(NamedTuple):
         self,
         hidden_vals: Sequence[jax.Array],
         input_vals: PyTree,
-    ):
+    ) -> jax.Array:
         """Compute the diagonal Jacobian matrix along the last dimension.
 
         Parameters
@@ -378,7 +378,7 @@ class HiddenGroup(NamedTuple):
         self,
         hidden_vals: Sequence[jax.Array],
         input_vals: PyTree,
-    ):
+    ) -> jax.Array:
         """Compute the complete within-group hidden-to-hidden Jacobian.
 
         The sibling of :meth:`diagonal_jacobian` that keeps the cross-position
@@ -419,7 +419,7 @@ class HiddenGroup(NamedTuple):
         needs_fwd = _transition_contains_while(self.transition_jaxpr)
         return full_position_jacobian(fn, concat_hid, use_forward_mode=needs_fwd)
 
-    def concat_hidden(self, splitted_hid_vals: Sequence[jax.Array]):
+    def concat_hidden(self, splitted_hid_vals: Sequence[jax.Array]) -> jax.Array:
         """Concatenate split hidden-state values into a single array.
 
         Concatenates a sequence of split hidden-state values along the last
@@ -473,7 +473,7 @@ class HiddenGroup(NamedTuple):
         ]
         return u.math.concatenate(splitted_hid_vals, axis=-1)
 
-    def split_hidden(self, concat_hid_vals: jax.Array):
+    def split_hidden(self, concat_hid_vals: jax.Array) -> List[jax.Array]:
         """Split a concatenated hidden-state array into individual arrays.
 
         Splits a concatenated array of hidden-state values into separate arrays,
@@ -624,7 +624,7 @@ def jacfwd_last_dim(
     varshape = hid_vals.shape[:-1]
     basis = u.math.broadcast_to(u.math.eye(num_state), (*varshape, num_state, num_state))
 
-    def _push(tangent):
+    def _push(tangent: jax.Array) -> jax.Array:
         out, tang = jax.jvp(fn, (hid_vals,), (tangent,))
         assert out.shape[-1] == num_state, 'Error: the number of input/output states should be the same.'
         return tang
@@ -1186,7 +1186,7 @@ def _simplify_hid2hid_tracer(
     hidden_invar_to_path: Dict[HiddenInVar, Path],
     hidden_outvar_to_path: Dict[HiddenOutVar, Path],
     path_to_state: Dict[Path, brainstate.HiddenState],
-    debug_info=None,
+    debug_info: Any = None,
 ) -> Optional[Hidden2GroupTransition]:
     """
     Simplifying the hidden-to-hidden state tracer.
@@ -1866,7 +1866,7 @@ def write_jaxpr_of_hidden_group_transition(
     hidden_invar_to_transition: Dict[HiddenInVar, Hidden2GroupTransition],
     hidden_invars: List[HiddenInVar],
     hidden_outvars: List[HiddenOutVar],
-    debug_info=None,
+    debug_info: Any = None,
 ) -> Jaxpr:
     assert len(hidden_invars) >= 1
 
@@ -1981,7 +1981,10 @@ def _merge_groups_ordered(groups: Sequence[Sequence[HiddenOutVar]]) -> List[List
     return [list(m) for m in merged]
 
 
-def group_merging(groups, version: int = 1) -> List[frozenset[HiddenOutVar]]:
+def group_merging(
+    groups: Iterable[Iterable[HiddenOutVar]],
+    version: int = 1,
+) -> List[frozenset[HiddenOutVar]]:
     """
     Merging the hidden groups using the intersection of the hidden states.
 
@@ -2170,7 +2173,7 @@ def find_hidden_groups_from_minfo(
     snap_max_jacobian_elements: int = DEFAULT_MAX_JACOBIAN_ELEMENTS,
     descended_scan_eqn_ids: FrozenSet[int] = frozenset(),
     descended_hidden_paths: FrozenSet[Path] = frozenset(),
-):
+) -> Tuple[Sequence[HiddenGroup], brainstate.util.PrettyDict]:
     """Find the hidden groups from the model information.
 
     Parameters
@@ -2225,11 +2228,11 @@ def find_hidden_groups_from_minfo(
 
 def find_hidden_groups_from_module(
     model: brainstate.nn.Module,
-    *model_args,
+    *model_args: Any,
     include_recurrent_mixing: bool = False,
     sparse_n: Optional[int] = None,
     snap_max_jacobian_elements: int = DEFAULT_MAX_JACOBIAN_ELEMENTS,
-    **model_kwargs,
+    **model_kwargs: Any,
 ) -> Tuple[Sequence[HiddenGroup], brainstate.util.PrettyDict]:
     """Find hidden groups from a model.
 

--- a/braintrace/_compiler/hidden_pertubation.py
+++ b/braintrace/_compiler/hidden_pertubation.py
@@ -485,7 +485,7 @@ class JaxprEvalForHiddenPerturbation(JaxprEvaluation):
         )
         return eqn.replace(invars=new_invars)
 
-    def _eval_eqn(self, eqn: JaxprEqn):
+    def _eval_eqn(self, eqn: JaxprEqn) -> None:
         # ------------------------------------------------
         #
         # For every hidden outvar the equation produces (any number, at any
@@ -528,7 +528,7 @@ class JaxprEvalForHiddenPerturbation(JaxprEvaluation):
                 )
             )
 
-    def _new_var_like(self, v):
+    def _new_var_like(self, v: Var) -> Var:
         return new_var('', jax.core.ShapedArray(v.aval.shape, v.aval.dtype))
 
 
@@ -625,8 +625,8 @@ def add_hidden_perturbation_from_minfo(
 
 def add_hidden_perturbation_in_module(
     model: brainstate.nn.Module,
-    *model_args,
-    **model_kwargs,
+    *model_args: Any,
+    **model_kwargs: Any,
 ) -> HiddenPerturbation:
     """Add hidden-state perturbations from a model.
 

--- a/braintrace/_compiler/jaxpr_graph.py
+++ b/braintrace/_compiler/jaxpr_graph.py
@@ -29,16 +29,23 @@ memory-address hashes for jaxpr ``Var`` objects).
 """
 
 from collections import deque
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, Iterator, List, Optional, Sequence, TypeAlias, Union
 
 from braintrace._compatible_imports import (
     ClosedJaxpr,
     Jaxpr,
     JaxprEqn,
+    Literal,
     Var,
     is_jit_primitive,
     new_var,
 )
+
+# A jaxpr equation input: either a variable or an inlined constant. JAX spells
+# this ``Atom``, but that name is private and has moved between releases, so the
+# union is written out here (mirroring ``_compatible_imports``' policy of not
+# depending on private JAX paths).
+Atom: TypeAlias = Union[Var, Literal]
 
 __all__ = [
     'build_producer_map',
@@ -128,7 +135,7 @@ def _contains_jit_eqn(jaxpr: Jaxpr) -> bool:
     return any(is_jit_primitive(eqn) for eqn in jaxpr.eqns)
 
 
-def _sub_closed_jaxprs(eqn: JaxprEqn):
+def _sub_closed_jaxprs(eqn: JaxprEqn) -> Iterator[ClosedJaxpr]:
     """Yield the ``ClosedJaxpr`` bodies of a control-flow equation.
 
     Covers ``scan`` (``jaxpr``), ``while`` (``cond_jaxpr``/``body_jaxpr``),
@@ -228,7 +235,7 @@ def inline_jit_calls(closed_jaxpr: ClosedJaxpr) -> ClosedJaxpr:
     # result see the same vars for untouched equations.
     top_subst: Dict[Var, Any] = {}  # Var -> Var | Literal
 
-    def resolve_top(atom):
+    def resolve_top(atom: Atom) -> Atom:
         if isinstance(atom, Var):
             return top_subst.get(atom, atom)
         return atom
@@ -237,7 +244,7 @@ def inline_jit_calls(closed_jaxpr: ClosedJaxpr) -> ClosedJaxpr:
     extra_consts: List[Any] = []
     new_eqns: List[JaxprEqn] = []
 
-    def splice(inner_closed, call_arg_atoms) -> List[Any]:
+    def splice(inner_closed: ClosedJaxpr, call_arg_atoms: Sequence[Atom]) -> List[Any]:
         """Inline one jit body with every internal var freshened; return the
         body's (resolved) output atoms.
 
@@ -257,7 +264,7 @@ def inline_jit_calls(closed_jaxpr: ClosedJaxpr) -> ClosedJaxpr:
         for iv, arg in zip(inner.invars, call_arg_atoms):
             local[iv] = arg
 
-        def res(atom):
+        def res(atom: Atom) -> Atom:
             if isinstance(atom, Var):
                 return local.get(atom, atom)
             return atom

--- a/braintrace/_compiler/module_info.py
+++ b/braintrace/_compiler/module_info.py
@@ -14,7 +14,7 @@
 # ==============================================================================
 
 import functools
-from typing import Dict, Sequence, List, Tuple, Optional, NamedTuple, Any
+from typing import Dict, Sequence, List, Tuple, Optional, NamedTuple, Any, cast
 
 import brainstate
 import jax
@@ -51,7 +51,11 @@ __all__ = [
 ]
 
 
-def _model_that_not_allow_param_assign(model, *args_, **kwargs_):
+def _model_that_not_allow_param_assign(
+    model: brainstate.nn.Module,
+    *args_: Any,
+    **kwargs_: Any,
+) -> Any:
     with brainstate.StateTraceStack() as trace:
         out = model(*args_, **kwargs_)
 
@@ -69,7 +73,7 @@ def _check_consistent_states_between_model_and_compiler(
     compiled_model_states: Sequence[brainstate.State],
     retrieved_model_states: Dict[Path, brainstate.State],
     verbose: bool = True,  # whether to print the information
-):
+) -> None:
     id_to_compiled_state = {
         id(st): st
         for st in compiled_model_states
@@ -119,10 +123,10 @@ def _check_consistent_states_between_model_and_compiler(
 
 
 def _check_in_out_consistent_units(
-    state_tree_invars,
-    state_tree_outvars,
-    state_tree_path,
-):
+    state_tree_invars: Sequence[PyTree],
+    state_tree_outvars: Sequence[PyTree],
+    state_tree_path: Sequence[Path],
+) -> None:
     assert len(state_tree_invars) == len(state_tree_outvars), 'The number of invars and outvars should be the same.'
     assert len(state_tree_invars) == len(state_tree_path), 'The number of invars and paths should be the same.'
     for invar, outvar, path in zip(state_tree_invars, state_tree_outvars, state_tree_path):
@@ -143,9 +147,9 @@ def _check_in_out_consistent_units(
 
 def abstractify_model(
     model: brainstate.nn.Module,
-    *model_args,
-    **model_kwargs
-):
+    *model_args: Any,
+    **model_kwargs: Any,
+) -> Tuple[brainstate.transform.StatefulFunction, brainstate.util.FlattedDict]:
     """
     Abstracts a model into a stateful representation suitable for compilation and state extraction.
 
@@ -174,7 +178,10 @@ def abstractify_model(
         "The model should be an instance of brainstate.nn.Module. "
         "Since it allows the explicit definition of the model structure."
     )
-    model_retrieved_states = brainstate.graph.states(model)
+    # ``brainstate.graph.states`` is declared as returning a ``FlattedDict`` *or*
+    # a tuple of them; the tuple form is only produced when ``*filters`` are
+    # passed, and none are here.
+    model_retrieved_states = cast(brainstate.util.FlattedDict, brainstate.graph.states(model))
 
     # --- stateful model, for extracting states, weights, and variables --- #
     #
@@ -369,7 +376,7 @@ class ModuleInfo(NamedTuple):
         items['closed_jaxpr'] = closed_jaxpr
         return ModuleInfo(**items)
 
-    def split_state_outvars(self):
+    def split_state_outvars(self) -> Tuple[PyTree, PyTree, PyTree]:
         """Split the state outvars into weight, hidden, and other states.
 
         Returns
@@ -381,11 +388,16 @@ class ModuleInfo(NamedTuple):
         other_state_jaxvar_tree : PyTree of Var
             The other-state tree of jaxpr variables.
         """
+        # ``sequence_split_state_values`` returns a 2-tuple when
+        # ``include_weight=False`` and a 3-tuple otherwise; the default (used
+        # here) is the 3-tuple form, which the union return type cannot express.
         (
             weight_jaxvar_tree,
             hidden_jaxvar,
             other_state_jaxvar_tree
-        ) = sequence_split_state_values(self.compiled_model_states, self.state_tree_outvars)
+        ) = sequence_split_state_values(  # type: ignore[misc]
+            self.compiled_model_states, self.state_tree_outvars
+        )
         return weight_jaxvar_tree, hidden_jaxvar, other_state_jaxvar_tree
 
     def jaxpr_call(
@@ -433,7 +445,11 @@ class ModuleInfo(NamedTuple):
 
         return self._process(*args, jaxpr_outs=jaxpr_outs)
 
-    def _process(self, *args, jaxpr_outs: Sequence[jax.Array]):
+    def _process(
+        self,
+        *args: Inputs,
+        jaxpr_outs: Sequence[jax.Array],
+    ) -> Tuple[Outputs, ETraceVals, StateVals, TempData]:
 
         # intermediate values contain three parts:
         #
@@ -504,9 +520,9 @@ ModuleInfo.__module__ = 'braintrace'
 
 def extract_module_info(
     model: brainstate.nn.Module,
-    *model_args,
+    *model_args: Any,
     control_flow: Optional[ControlFlowPolicy] = None,
-    **model_kwargs
+    **model_kwargs: Any,
 ) -> ModuleInfo:
     """Extract the model information for the ETrace compiler.
 
@@ -575,7 +591,7 @@ def extract_module_info(
 
     # state information
     cache_key = stateful_model.get_arg_cache_key(*model_args, **model_kwargs)
-    compiled_states = stateful_model.get_states_by_cache(cache_key)
+    compiled_states: Sequence[brainstate.State] = stateful_model.get_states_by_cache(cache_key)
     compiled_states = brainstate.util.PrettyList(compiled_states)
 
     state_id_to_path: Dict[StateID, Path] = {
@@ -594,7 +610,9 @@ def extract_module_info(
     jaxpr = closed_jaxpr.jaxpr
 
     # out information
-    out_shapes = stateful_model.get_out_shapes_by_cache(cache_key)[0]
+    # brainstate types the cached out-shapes as the broad ``PyTree``; at runtime
+    # it is the ``(out_shapes, state_shapes)`` pair the tracer recorded.
+    out_shapes = stateful_model.get_out_shapes_by_cache(cache_key)[0]  # type: ignore[index]
     state_vals = [state.value for state in compiled_states]
     in_avals, _ = jax.tree.flatten((model_args, model_kwargs))
     out_avals, _ = jax.tree.flatten(out_shapes)

--- a/braintrace/_compiler/position_graph.py
+++ b/braintrace/_compiler/position_graph.py
@@ -67,11 +67,11 @@ which condition failed otherwise:
 from __future__ import annotations
 
 import itertools
-from typing import List, NamedTuple, Optional, Sequence, Set, Tuple
+from typing import List, NamedTuple, Optional, Sequence, Set, Tuple, Union
 
 import numpy as np
 
-from braintrace._compatible_imports import Jaxpr, JaxprEqn, Var
+from braintrace._compatible_imports import Jaxpr, JaxprEqn, Literal, Var
 from braintrace._misc import NotSupportedError
 from braintrace._op import (
     get_snap_adjacency_rule,
@@ -258,7 +258,7 @@ def _is_position_preserving(eqn: JaxprEqn, varshape: Tuple[int, ...]) -> bool:
     return True
 
 
-def _aligned_shape(var, varshape: Tuple[int, ...]) -> bool:
+def _aligned_shape(var: Union[Var, Literal], varshape: Tuple[int, ...]) -> bool:
     """Whether *var* has exactly the group's position layout."""
     aval = getattr(var, 'aval', None)
     return tuple(getattr(aval, 'shape', ())) == varshape
@@ -381,7 +381,7 @@ def _mixing_axis_pattern(
     eqn: JaxprEqn,
     varshape: Tuple[int, ...],
     hit_positions: Set[int],
-):
+) -> Union[str, np.ndarray]:
     """The last-axis pattern of a mixing equation, or a reason string.
 
     Returns the boolean ``(d, d)`` pattern on success and a human-readable

--- a/braintrace/_compiler/report.py
+++ b/braintrace/_compiler/report.py
@@ -9,7 +9,7 @@ eligibility-trace compilation result. It is a pure view: it owns no state beyond
 the graph it wraps, and it is safe to build lazily whenever a graph is available.
 """
 
-from typing import Dict, List, Optional, Set, Tuple, cast
+from typing import IO, Dict, List, Optional, Set, Tuple, cast
 
 import brainstate
 from brainstate.util import FlattedDict
@@ -203,7 +203,7 @@ class CompilationReport:
 
         return msg
 
-    def show(self, level: int = 1, *, file=None) -> None:
+    def show(self, level: int = 1, *, file: Optional[IO[str]] = None) -> None:
         """Print :meth:`to_str` to ``file`` (stdout by default).
 
         Parameters

--- a/braintrace/_compiler/scan_descent.py
+++ b/braintrace/_compiler/scan_descent.py
@@ -299,7 +299,7 @@ class ScanDescentBundle(NamedTuple):
     hoist as jaxpr outputs."""
 
 
-def analyze_and_rewrite_scan(eqn: JaxprEqn, minfo) -> Optional[ScanDescentBundle]:
+def analyze_and_rewrite_scan(eqn: JaxprEqn, minfo: 'ModuleInfo') -> Optional[ScanDescentBundle]:
     """Analyze one descendable scan and rebuild it with stacked ys.
 
     Runs the flat hidden-group / relation finders on the scan *body* (with
@@ -497,7 +497,7 @@ def analyze_and_rewrite_scan(eqn: JaxprEqn, minfo) -> Optional[ScanDescentBundle
     )
 
 
-def apply_scan_descent(minfo) -> Tuple['ModuleInfo', List[ScanDescentBundle]]:
+def apply_scan_descent(minfo: 'ModuleInfo') -> Tuple['ModuleInfo', List[ScanDescentBundle]]:
     """Descend every eligible top-level scan in ``minfo`` and rewrite its jaxpr.
 
     Walks the top-level equations of ``minfo.jaxpr``; for each ETP-relevant

--- a/braintrace/_legacy/_ops.py
+++ b/braintrace/_legacy/_ops.py
@@ -26,7 +26,7 @@ the weight *out* of the ETP graph.
 
 import contextlib
 import threading
-from typing import Any, Callable, Optional, Sequence
+from typing import Any, Callable, Dict, Iterator, Optional, Sequence
 
 import jax
 import numpy as np
@@ -56,7 +56,7 @@ __all__ = [
 # ---------------------------------------------------------------------------
 
 class _OpContext(threading.local):
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
         self.stop = [False]
 
@@ -65,7 +65,7 @@ _ctx = _OpContext()
 
 
 @contextlib.contextmanager
-def stop_param_gradients(stop_or_not: bool = True):
+def stop_param_gradients(stop_or_not: bool = True) -> Iterator[None]:
     """Context manager — legacy compat shim. Pushes a flag onto a stack;
     has no effect in the new ETP primitive path (gradients flow through
     JAX autodiff on the primitive directly).
@@ -77,7 +77,7 @@ def stop_param_gradients(stop_or_not: bool = True):
         _ctx.stop.pop()
 
 
-def general_y2w(xw2y: Callable, x, y, w):
+def general_y2w(xw2y: Callable, x: Any, y: Any, w: Any) -> Any:
     """Legacy helper: VJP-based y→w pullback."""
     x = u.math.ones_like(x)
     primals, f_vjp = jax.vjp(lambda w_: u.get_mantissa(xw2y(x, w_)), w)
@@ -120,17 +120,17 @@ class ETraceOp:
         self,
         is_diagonal: Optional[bool] = False,
         name: Optional[str] = None,
-    ):
+    ) -> None:
         self.is_diagonal = is_diagonal
         self.name = name
 
-    def __call__(self, inputs, weights):
+    def __call__(self, inputs: Any, weights: Any) -> Any:
         return self.xw_to_y(inputs, weights)
 
-    def xw_to_y(self, inputs, weights):
+    def xw_to_y(self, inputs: Any, weights: Any) -> Any:
         raise NotImplementedError
 
-    def raw_xw_to_y(self, inputs, weights):
+    def raw_xw_to_y(self, inputs: Any, weights: Any) -> Any:
         """Compute the forward map without emitting an ETP primitive.
 
         Plain-JAX variant of :meth:`xw_to_y`, used by
@@ -153,10 +153,10 @@ class ETraceOp:
         """
         return self.xw_to_y(inputs, weights)
 
-    def dt_to_t(self, hidden_dim_arr, weight_dim_tree):
+    def dt_to_t(self, hidden_dim_arr: Any, weight_dim_tree: Any) -> Any:
         raise NotImplementedError
 
-    def xy_to_dw(self, input_dim_arr, hidden_dim_arr, weights):
+    def xy_to_dw(self, input_dim_arr: Any, hidden_dim_arr: Any, weights: Any) -> Any:
         primals, f_vjp = jax.vjp(
             lambda w: u.get_mantissa(self.xw_to_y(input_dim_arr, w)),
             weights,
@@ -203,7 +203,7 @@ class MatMulOp(ETraceOp):
         weight_mask: Optional[Any] = None,
         weight_fn: Callable = lambda w: w,
         apply_weight_fn_before_mask: bool = False,
-    ):
+    ) -> None:
         super().__init__(is_diagonal=False)
         if weight_mask is None:
             pass
@@ -219,13 +219,13 @@ class MatMulOp(ETraceOp):
         assert isinstance(apply_weight_fn_before_mask, bool)
         self.apply_weight_fn_before_mask = apply_weight_fn_before_mask
 
-    def _check(self, w):
+    def _check(self, w: Dict[str, Any]) -> None:
         if not isinstance(w, dict):
             raise TypeError(f'MatMulOp weight must be dict, got {type(w)}')
         if 'weight' not in w:
             raise ValueError("MatMulOp weight dict must contain 'weight'")
 
-    def _process_weight(self, w):
+    def _process_weight(self, w: Dict[str, Any]) -> Any:
         if self.apply_weight_fn_before_mask:
             W = self.weight_fn(w['weight'])
             if self.weight_mask is not None:
@@ -237,11 +237,11 @@ class MatMulOp(ETraceOp):
             W = self.weight_fn(W)
         return W
 
-    def xw_to_y(self, x, w):
+    def xw_to_y(self, x: Any, w: Dict[str, Any]) -> Any:
         self._check(w)
         return _new_matmul(x, self._process_weight(w), bias=w.get('bias'))
 
-    def raw_xw_to_y(self, x, w):
+    def raw_xw_to_y(self, x: Any, w: Dict[str, Any]) -> Any:
         self._check(w)
         y = u.math.matmul(x, self._process_weight(w))
         if 'bias' in w:
@@ -274,17 +274,17 @@ class ElemWiseOp(ETraceOp):
     """
     __module__ = 'braintrace'
 
-    def __init__(self, fn: Callable = lambda w: w):
+    def __init__(self, fn: Callable = lambda w: w) -> None:
         super().__init__(is_diagonal=True)
         self._raw_fn = fn
 
-    def __call__(self, weights):
+    def __call__(self, weights: Any) -> Any:  # type: ignore[override]
         return self.xw_to_y(None, weights)
 
-    def xw_to_y(self, inputs, weights):
+    def xw_to_y(self, inputs: Any, weights: Any) -> Any:
         return _new_element_wise(weights, weight_fn=self._raw_fn)
 
-    def raw_xw_to_y(self, inputs, weights):
+    def raw_xw_to_y(self, inputs: Any, weights: Any) -> Any:
         return self._raw_fn(weights)
 
 
@@ -336,7 +336,7 @@ class ConvOp(ETraceOp):
         self,
         xinfo: jax.ShapeDtypeStruct,
         window_strides: Sequence[int],
-        padding,
+        padding: Any,
         lhs_dilation: Optional[Sequence[int]] = None,
         rhs_dilation: Optional[Sequence[int]] = None,
         feature_group_count: int = 1,
@@ -344,7 +344,7 @@ class ConvOp(ETraceOp):
         dimension_numbers: Any = None,
         weight_mask: Optional[Any] = None,
         weight_fn: Callable = lambda w: w,
-    ):
+    ) -> None:
         super().__init__(is_diagonal=False)
         self.xinfo = xinfo
         self.window_strides = window_strides
@@ -366,19 +366,19 @@ class ConvOp(ETraceOp):
         assert callable(weight_fn)
         self.weight_fn = weight_fn
 
-    def _check(self, w):
+    def _check(self, w: Dict[str, Any]) -> None:
         if not isinstance(w, dict):
             raise TypeError(f'ConvOp weight must be dict, got {type(w)}')
         if 'weight' not in w:
             raise ValueError("ConvOp weight dict must contain 'weight'")
 
-    def _process_weight(self, w):
+    def _process_weight(self, w: Dict[str, Any]) -> Any:
         W = w['weight']
         if self.weight_mask is not None:
             W = W * self.weight_mask
         return self.weight_fn(W)
 
-    def _conv_kwargs(self):
+    def _conv_kwargs(self) -> Dict[str, Any]:
         return dict(
             strides=self.window_strides,
             padding=self.padding,
@@ -389,13 +389,13 @@ class ConvOp(ETraceOp):
             dimension_numbers=self.dimension_numbers,
         )
 
-    def xw_to_y(self, x, w):
+    def xw_to_y(self, x: Any, w: Dict[str, Any]) -> Any:
         self._check(w)
         return _new_conv(
             x, self._process_weight(w), bias=w.get('bias'), **self._conv_kwargs()
         )
 
-    def raw_xw_to_y(self, x, w):
+    def raw_xw_to_y(self, x: Any, w: Dict[str, Any]) -> Any:
         self._check(w)
         W = self._process_weight(w)
         y = jax.lax.conv_general_dilated(
@@ -445,9 +445,9 @@ class SpMatMulOp(ETraceOp):
 
     def __init__(
         self,
-        sparse_mat,
+        sparse_mat: Any,
         weight_fn: Callable = lambda w: w,
-    ):
+    ) -> None:
         super().__init__(is_diagonal=False)
         if not isinstance(sparse_mat, u.sparse.SparseMatrix):
             raise TypeError(
@@ -457,20 +457,20 @@ class SpMatMulOp(ETraceOp):
         assert callable(weight_fn)
         self.weight_fn = weight_fn
 
-    def _check(self, w):
+    def _check(self, w: Dict[str, Any]) -> None:
         if not isinstance(w, dict):
             raise TypeError(f'SpMatMulOp weight must be dict, got {type(w)}')
         if 'weight' not in w:
             raise ValueError("SpMatMulOp weight dict must contain 'weight'")
 
-    def xw_to_y(self, x, w):
+    def xw_to_y(self, x: Any, w: Dict[str, Any]) -> Any:
         self._check(w)
         data = self.weight_fn(w['weight'])
         return _new_sparse_matmul(
             x, data, sparse_mat=self.sparse_mat, bias=w.get('bias')
         )
 
-    def raw_xw_to_y(self, x, w):
+    def raw_xw_to_y(self, x: Any, w: Dict[str, Any]) -> Any:
         self._check(w)
         data = self.weight_fn(w['weight'])
         mat = self.sparse_mat.with_data(data)
@@ -506,24 +506,24 @@ class LoraOp(ETraceOp):
     """
     __module__ = 'braintrace'
 
-    def __init__(self, alpha: Optional[Any] = None):
+    def __init__(self, alpha: Optional[Any] = None) -> None:
         super().__init__(is_diagonal=False)
         if alpha is not None:
             alpha = u.math.asarray(alpha)
         self.alpha = alpha
 
-    def _check(self, w):
+    def _check(self, w: Dict[str, Any]) -> None:
         if not isinstance(w, dict):
             raise TypeError(f'LoraOp weight must be dict, got {type(w)}')
         if 'B' not in w or 'A' not in w:
             raise ValueError("LoraOp weight dict must contain 'B' and 'A'")
 
-    def xw_to_y(self, x, w):
+    def xw_to_y(self, x: Any, w: Dict[str, Any]) -> Any:
         self._check(w)
         alpha = 1.0 if self.alpha is None else self.alpha
         return _new_lora_matmul(x, w['B'], w['A'], alpha=alpha, bias=w.get('bias'))
 
-    def raw_xw_to_y(self, x, w):
+    def raw_xw_to_y(self, x: Any, w: Dict[str, Any]) -> Any:
         self._check(w)
         if self.alpha is not None:
             x = self.alpha * x

--- a/braintrace/_legacy/_params.py
+++ b/braintrace/_legacy/_params.py
@@ -28,7 +28,7 @@
 
 
 from enum import Enum
-from typing import Optional
+from typing import Any, Callable, Optional, Union
 
 import brainstate
 
@@ -90,11 +90,11 @@ class ETraceParam(brainstate.ParamState):
 
     def __init__(
         self,
-        weight,
+        weight: Any,
         op: ETraceOp,
         grad: Optional[object] = None,
         name: Optional[str] = None,
-    ):
+    ) -> None:
         super().__init__(weight, name=name)
         if not isinstance(op, ETraceOp):
             raise TypeError(f'op must be ETraceOp, got {type(op)}')
@@ -106,7 +106,7 @@ class ETraceParam(brainstate.ParamState):
         self.gradient = grad
         self.is_etrace = True
 
-    def execute(self, x):
+    def execute(self, x: Any) -> Any:
         return self.op(x, self.value)
 
 
@@ -142,17 +142,22 @@ class ElemWiseParam(ETraceParam):
     """
     __module__ = 'braintrace'
 
+    # Narrows the inherited ``ETraceParam.op`` for type checking only: the
+    # constructor below guarantees an ``ElemWiseOp``, whose ``__call__`` takes
+    # the weight alone. A bare annotation creates no class attribute at runtime.
+    op: ElemWiseOp
+
     def __init__(
         self,
-        weight,
-        op=(lambda w: w),
+        weight: Any,
+        op: Union[ElemWiseOp, Callable] = (lambda w: w),
         name: Optional[str] = None,
-    ):
+    ) -> None:
         if not isinstance(op, ElemWiseOp):
             op = ElemWiseOp(op)
         super().__init__(weight, op=op, grad=ETraceGrad.full, name=name)
 
-    def execute(self):  # type: ignore[override]
+    def execute(self) -> Any:  # type: ignore[override]
         return self.op(self.value)
 
 
@@ -192,11 +197,11 @@ class NonTempParam(brainstate.ParamState):
 
     def __init__(
         self,
-        value,
-        op,
+        value: Any,
+        op: Union[ETraceOp, Callable],
         name: Optional[str] = None,
-        **_kwargs,
-    ):
+        **_kwargs: Any,
+    ) -> None:
         super().__init__(value, name=name)
         if isinstance(op, ETraceOp):
             self._op: Optional[ETraceOp] = op
@@ -207,7 +212,7 @@ class NonTempParam(brainstate.ParamState):
             self._op = None
             self.op = op
 
-    def execute(self, x):
+    def execute(self, x: Any) -> Any:
         return self.op(x, self.value)
 
 
@@ -243,10 +248,10 @@ class FakeETraceParam(object):
     """
     __module__ = 'braintrace'
 
-    def __init__(self, value, op):
+    def __init__(self, value: Any, op: Union[ETraceOp, Callable]) -> None:
         self.value = value
         if isinstance(op, ETraceOp):
-            self._op = op
+            self._op: Optional[ETraceOp] = op
             self.op = op.raw_xw_to_y
         else:
             if not callable(op):
@@ -254,7 +259,7 @@ class FakeETraceParam(object):
             self._op = None
             self.op = op
 
-    def execute(self, x):
+    def execute(self, x: Any) -> Any:
         return self.op(x, self.value)
 
 
@@ -292,10 +297,10 @@ class FakeElemWiseParam(object):
 
     def __init__(
         self,
-        weight,
-        op=(lambda w: w),
+        weight: Any,
+        op: Union[ETraceOp, Callable] = (lambda w: w),
         name: Optional[str] = None,
-    ):
+    ) -> None:
         self._is_etrace_op = False
         if isinstance(op, ETraceOp):
             if not isinstance(op, ElemWiseOp):
@@ -303,7 +308,9 @@ class FakeElemWiseParam(object):
                     f'op must be ElemWiseOp when an ETraceOp is supplied, got {type(op)}'
                 )
             self._op: Optional[ElemWiseOp] = op
-            self.op = op.raw_xw_to_y
+            # ``Callable`` (i.e. ``Callable[..., Any]``): the two branches bind
+            # callables of different arity, matched by ``execute`` below.
+            self.op: Callable = op.raw_xw_to_y
             self._is_etrace_op = True
         else:
             if not callable(op):
@@ -313,7 +320,7 @@ class FakeElemWiseParam(object):
         self.value = weight
         self.name = name
 
-    def execute(self):
+    def execute(self) -> Any:
         if self._is_etrace_op:
             return self.op(None, self.value)
         return self.op(self.value)

--- a/changelog.md
+++ b/changelog.md
@@ -48,6 +48,22 @@
   Resolves [#162](https://github.com/chaobrain/braintrace/issues/162); see
   `docs/specs/2026-08-07-e07-state-management-rename.md`.
 
+### Internal
+
+- **`braintrace._compiler` and `braintrace._legacy` are now inside the typing
+  gate.** The `disallow_untyped_defs` module list in `pyproject.toml` is what
+  makes "every shipped def is annotated" a property `mypy` enforces rather than a
+  convention. Two packages were still outside it — the whole jaxpr-analysis layer
+  that every algorithm depends on, and the frozen v0.1.x back-compat shim. Both
+  are now listed and fully annotated: 93 `no-untyped-def` errors cleared (54 in
+  `_compiler`, 39 in `_legacy`). No runtime behaviour changed; the only
+  non-annotation edit is a corrected `Returns` docstring on
+  `ETraceGraph.call_hidden_perturb`, which claimed to return the model outputs
+  when it returns the same four-element tuple as a normal forward call.
+
+  Resolves [#164](https://github.com/chaobrain/braintrace/issues/164); see
+  `docs/specs/2026-08-07-e09-type-gate-compiler-legacy.md`.
+
 
 ## Version 0.2.5
 

--- a/docs/specs/2026-08-07-deferred-engineering-backlog.md
+++ b/docs/specs/2026-08-07-deferred-engineering-backlog.md
@@ -138,6 +138,13 @@ nothing but does change what a shallow clone gets, so it is a maintainer call.
 ## E-09 — the `_compiler` and `_legacy` packages are outside the typing gate
 
 Tracked as [#164](https://github.com/chaobrain/braintrace/issues/164).
+**Resolved** — both packages are now in the `disallow_untyped_defs` module list
+and fully annotated (93 `no-untyped-def` errors cleared: 54 in `_compiler`, 39 in
+`_legacy`). The baseline, the annotation categories, and every place precision
+was deliberately given up are recorded in
+[`2026-08-07-e09-type-gate-compiler-legacy.md`](2026-08-07-e09-type-gate-compiler-legacy.md).
+The paragraph below is left in its original wording as the record of the state
+this audit found.
 
 `pyproject.toml`'s `disallow_untyped_defs` list was extended in 0.2.5 to cover
 every module owning a public symbol. Two packages remain outside it:

--- a/docs/specs/2026-08-07-e09-type-gate-compiler-legacy.md
+++ b/docs/specs/2026-08-07-e09-type-gate-compiler-legacy.md
@@ -1,0 +1,213 @@
+# E-09 — bring `braintrace._compiler` and `braintrace._legacy` into the typing gate
+
+Status: implemented
+Scope: `pyproject.toml` (`[[tool.mypy.overrides]]` `disallow_untyped_defs` list),
+`braintrace/_compiler/*.py`, `braintrace/_legacy/*.py`
+Backlog entry: E-09 in `2026-08-07-deferred-engineering-backlog.md`
+Issue: [#164](https://github.com/chaobrain/braintrace/issues/164)
+
+## The defect
+
+`pyproject.toml` carries one `[[tool.mypy.overrides]]` block whose job is to make
+"every public API is typed" a property mypy enforces rather than a convention
+people remember. In 0.2.5 that block's module list was extended to cover every
+module owning a name in `braintrace.__all__`. Two whole packages stayed outside
+it:
+
+- `braintrace._compiler` — the jaxpr-analysis layer (Layer 2 of the architecture
+  in `AGENTS.md`), 13 modules.
+- `braintrace._legacy` — the frozen v0.1.x back-compat shim, 3 modules.
+
+Neither owns a public symbol, which is the letter of the rule the 0.2.5 list was
+written against. But `_compiler` is the layer *every* algorithm depends on, and
+an ungated package is not merely "currently unannotated" — it is a place where an
+untyped def can silently reappear at any time. The gate is only as strong as its
+weakest package.
+
+## Baseline
+
+Measured by adding both packages to the `disallow_untyped_defs` module list
+*first*, then running `python -m mypy` (mypy 2.1.0) with no source change:
+
+```
+Found 93 errors in 13 files (checked 62 source files)
+```
+
+All 93 are `[no-untyped-def]`. Per package:
+
+| package | errors |
+| --- | --- |
+| `braintrace._compiler` | 54 |
+| `braintrace._legacy` | 39 |
+
+Per file:
+
+| file | errors |
+| --- | --- |
+| `_legacy/_ops.py` | 29 |
+| `_compiler/hidden_group.py` | 11 |
+| `_legacy/_params.py` | 10 |
+| `_compiler/module_info.py` | 9 |
+| `_compiler/canonicalize.py` | 7 |
+| `_compiler/hid_param_op.py` | 6 |
+| `_compiler/graph.py` | 5 |
+| `_compiler/base.py` | 4 |
+| `_compiler/jaxpr_graph.py` | 4 |
+| `_compiler/hidden_pertubation.py` | 3 |
+| `_compiler/position_graph.py` | 2 |
+| `_compiler/scan_descent.py` | 2 |
+| `_compiler/report.py` | 1 |
+
+By mypy's own phrasing: 35 "missing a type annotation" (neither params nor
+return), 31 "missing a return type annotation", 27 "missing a type annotation for
+one or more parameters".
+
+These match the counts quoted in the issue (~54 / ~39) exactly.
+
+## Constraints this sweep worked under
+
+1. **Typing-only.** No runtime behaviour changes. Where an annotation appeared to
+   demand a code change, the annotation was the thing that got revised, not the
+   code. See "What the sweep exposed" below for the one place where the
+   annotation revealed a real (pre-existing, benign) inconsistency.
+2. **The explicit-module-list style is preserved.** The existing block's comment
+   says "Explicit module list (no wildcards) so internal / test-helper modules
+   are not dragged in", so both packages are listed module by module rather than
+   as `braintrace._compiler.*`. The `_compiler/tests/` subpackage is left out for
+   that reason (its three files are all `*_test.py` and already fall under the
+   top-level `exclude`, but the explicit list means a future non-test helper
+   dropped in there would not be gated by accident).
+3. **Python floor is 3.11.** `requires-python >= 3.11`, so no PEP 695 generics
+   and no `type X = ...` alias statements. Everything uses `typing.TypeAlias` /
+   `typing.TypeVar`, matching `braintrace/_typing.py`.
+4. **`_legacy` is frozen.** Annotated to satisfy the gate and nothing else: no
+   refactor, no style update, no docstring rewrite.
+5. **PR #174's guards are untouched.** `_compiler/hidden_group.py`,
+   `_compiler/hidden_pertubation.py` and `_algorithm/vjp_base.py` carry explicit
+   `if ... raise` shape/dtype correspondence checks that must survive `python
+   -O`. None of them were weakened, removed, or converted to `assert`.
+
+## Categories of annotation added
+
+**A. Jaxpr plumbing.** The recurring types come from
+`braintrace._compatible_imports` (`Jaxpr`, `ClosedJaxpr`, `JaxprEqn`, `Var`,
+`Literal`, `Primitive`), imported there rather than from `jax.core` /
+`jax.extend.core` so the version-compat indirection stays in one place — this is
+what the already-gated modules do. A jaxpr *atom* (an equation input, which is
+either a `Var` or a `Literal`) has no single JAX-side type, so it is spelled
+`Union[Var, Literal]` where the code really accepts both.
+
+**B. Existing `_typing.py` aliases.** `Path`, `PyTree`, `Inputs`, `HiddenInVar`,
+`HiddenOutVar`, `VarID` and friends were used wherever they already describe the
+value, rather than re-spelling `Tuple[str, ...]` etc. at each site.
+
+**C. Nested closures.** A large share of the baseline errors are inner helper
+functions (`resolve`, `res`, `splice`, `inline_branch`, `_push`, …) defined
+inside an already-annotated outer function. `disallow_untyped_defs` applies to
+these too. They are annotated in place; none of them is part of any interface.
+
+**D. `__init__` / dunder returns.** `-> None` on constructors and
+`__post_init__`.
+
+**E. Legacy op/param shims.** The `_legacy` weight pytrees are dicts keyed by
+`'weight'` / `'bias'` / `'A'` / `'B'`, so the recurring parameter type is
+`Dict[str, Any]`, and the arrays flowing through them are `Any` (see below).
+
+**F. One shared alias.** `jaxpr_graph.Atom = Union[Var, Literal]` is introduced
+and reused by `canonicalize.py`, which already imports from `jaxpr_graph`. It is
+a `typing.TypeAlias` assignment, not a PEP 695 `type` statement, so it works on
+the declared 3.11 floor.
+
+**G. Downstream body checks.** Annotating a def also switches mypy's body
+checking on for it. Five errors surfaced that way, all at the `brainstate`
+boundary and all resolved without touching runtime behaviour — three narrowing
+annotations on local bindings, one `cast`, two `# type: ignore[...]` with error
+codes and an explanatory comment (the pattern `module_info.py` already used for
+its `get_out_treedef_by_cache(...).unflatten` call).
+
+## Where precision was deliberately given up
+
+These are the interesting cases — every place the sweep settled for `Any`,
+a `Union`, or a broad container instead of asserting a precise type, and why.
+
+| Site | Chosen type | Why not something tighter |
+| --- | --- | --- |
+| `_compiler/*` — every `debug_info` parameter (`hidden_group.py` `_simplify_hid2hid_tracer` / `write_jaxpr_of_hidden_group_transition`, `hidden_pertubation.py`) | `Any` | The value is JAX's `core.DebugInfo`, whose import path has moved between JAX versions (`jax.core` → `jax._src.core` → `jax.api_util`). `_compatible_imports` deliberately does not re-export it, and pinning a private JAX path in a signature is exactly the version coupling that module exists to prevent. The value is only ever passed straight back into a JAX constructor. |
+| `_compiler/jaxpr_graph.py` `splice` / `resolve_top` / `res`, `canonicalize.py` `resolve` / `inline_branch` / `handle_eqn` — the "atom" parameters | `Union[Var, Literal]` (returns `List[Any]` where the list is a jaxpr atom list) | A jaxpr equation's `invars` are typed `list[Atom]` in recent JAX but `Atom` is a private alias that is not re-exported and has changed shape across versions. The union spells the same thing without importing a private name. The `List[Any]` returns are lists that JAX itself types loosely at the boundary. |
+| `_compiler/module_info.py` `_model_that_not_allow_param_assign(model, *args_, **kwargs_)` | `model: brainstate.nn.Module`, `*args_: Any`, `**kwargs_: Any`, `-> Any` | It is a pass-through that calls the model and returns whatever the model returns; the model's return type is by construction unknown (any user pytree). |
+| `_compiler/module_info.py` `_check_in_out_consistent_units` | `Sequence[PyTree]` for the invar/outvar trees | These are `jax.tree`-shaped mirrors of the state list whose leaves are `Var`. `PyTree` (itself `Any`) is the alias the codebase already uses for exactly this, so it is at least a *named* imprecision. |
+| `_compiler/module_info.py` `ModuleInfo.split_state_outvars` | `Tuple[PyTree, PyTree, PyTree]` | Same: three `jax.tree`-shaped `Var` trees, whose structure mirrors the model's state pytree and is not statically knowable. |
+| `_compiler/graph.py` `compiler_context` | returns `Iterator[None]` under `@contextlib.contextmanager` | Precise, listed here only because it is the one place where the *decorated* type and the *def* type differ and a reader may expect `ContextManager`. |
+| `_compiler/report.py` `show(file=...)` | `Optional[IO[str]]` | The parameter is forwarded verbatim to `print`, whose stub wants `SupportsWrite[str]`. That protocol lives in `_typeshed` and is not importable at runtime, so `IO[str]` is the closest importable supertype. |
+| `_compiler/hid_param_op.py` `HiddenParamOpRelation.y_to_hidden_groups` | returns `List[Any]`; local `hidden_vals: Any` | The list holds a `list[Array]` per group when `concat_hidden_vals=False` and a single `Array` when `True` — the return type is switched by an argument value, which only an `@overload` pair could express, and the method has one internal caller. The local annotation exists because the same name is rebound from list to array. |
+| `_compiler/module_info.py` `abstractify_model` second return | `brainstate.util.FlattedDict` via `cast` | `brainstate.graph.states()` is declared `FlattedDict | tuple[FlattedDict, ...]`; the tuple form only occurs when `*filters` are passed, and none are. `cast` is a runtime identity, so this stays typing-only. |
+| `_compiler/module_info.py` `split_state_outvars` unpack | `# type: ignore[misc]` | `_state_management.sequence_split_state_values` returns a 2-tuple when `include_weight=False` and a 3-tuple otherwise. Expressing that needs `@overload` on a module outside this issue's scope, so the call site suppresses the unpack error with a comment naming the reason. |
+| `_compiler/module_info.py` `get_out_shapes_by_cache(...)[0]` | `# type: ignore[index]` | `brainstate` types the cached out-shapes as its opaque `PyTree` class, which mypy does not consider indexable; at runtime it is the `(out_shapes, state_shapes)` pair. Mirrors the pre-existing `# type: ignore[attr-defined]` on the sibling `get_out_treedef_by_cache(...).unflatten` call. |
+| `_legacy/_ops.py` — every `w` / `weights` parameter | `Dict[str, Any]` | The values are weight pytrees whose leaves may be `jax.Array`, numpy arrays or `brainunit.Quantity`. `brainunit` is configured `follow_imports = "skip"` in `pyproject.toml`, so `Quantity` is `Any` to mypy anyway and a narrower leaf type would be a fiction. |
+| `_legacy/_ops.py` `general_y2w`, `ETraceOp.xy_to_dw` and every `xw_to_y` / `raw_xw_to_y` return | `Any` | Same reason: the return is produced by `brainunit`/`jax` calls that mypy already sees as `Any`, and the legacy op contract genuinely allows a `Quantity` or a bare array. Declaring `jax.Array` would be a false promise. |
+| `_legacy/_ops.py` `ConvOp.__init__(padding=...)`, `dimension_numbers=...` | `Any` | Forwarded to `jax.lax.conv_general_dilated`, which accepts a string, an int, a sequence of pairs, or a `ConvDimensionNumbers`. The pre-existing docstring already says "Padding specification passed to the convolution". |
+| `_legacy/_ops.py` `SpMatMulOp.__init__(sparse_mat=...)` | `Any` | The declared type is `brainunit.sparse.SparseMatrix`, which is `Any` under `follow_imports = "skip"`. The `isinstance` check in the body is the real contract and is untouched. |
+| `_legacy/_params.py` — every `weight` / `value` parameter and every `execute` return | `Any` | Same weight-pytree reasoning; the values are arbitrary pytrees whose leaves may be `Quantity`. |
+| `_legacy/_params.py` `NonTempParam.__init__(**_kwargs)` | `Any` | Deliberately-ignored legacy kwargs; the name already says so. |
+| `_legacy/_params.py` `FakeElemWiseParam.op` | `Callable` (i.e. `Callable[..., Any]`) | The attribute is bound either to `ElemWiseOp.raw_xw_to_y` (two arguments) or to a user callable (one), and `execute` dispatches between the two on `self._is_etrace_op`. A precise arity would make one of the two live call sites a type error. |
+
+One extra annotation is *narrowing* rather than widening and is worth naming for
+the same reason: `_legacy/_params.py` adds a bare class-level `op: ElemWiseOp` to
+`ElemWiseParam`, narrowing the `op: ETraceOp` it inherits from `ETraceParam`. The
+constructor already guarantees an `ElemWiseOp`, whose `__call__` takes the weight
+alone, and without the narrowing `execute`'s one-argument call is a `call-arg`
+error. A bare annotation creates no class attribute at runtime.
+
+The pattern across most of these is the same: `brainunit` is configured
+`follow_imports = "skip"` in `pyproject.toml`, so every value that originates
+from it — which is every array in the legacy op path, because those paths call
+`u.math.*` — is `Any` regardless of what a signature claims. Annotating those
+boundaries as `jax.Array` would look more precise while checking nothing, and
+would be actively wrong for the `Quantity` paths. Where a value is genuinely
+ours — jaxpr vars, paths, hidden groups, relations, diagnostics — a precise type
+is asserted.
+
+## What the sweep exposed
+
+No runtime bug: the ETP graph, its Jacobians and its gradients are byte-identical
+before and after. Two things are worth recording, because they are the kind of
+thing this gate exists to surface.
+
+**1. `ETraceGraph.call_hidden_perturb` documented the wrong return value.** Its
+docstring said it returns "the processed model outputs, in the same structure
+produced by a normal forward call". It actually returns the four-element
+`(outputs, etrace_state_vals, other_state_vals, temp_data)` tuple that
+`ModuleInfo._process` produces — which is what its one caller,
+`_algorithm/vjp_graph_executor.py`, unpacks. Writing the annotation is what made
+the mismatch visible. The annotation is the four-tuple and the docstring's
+`Returns` section was corrected to match; no code changed. This is a
+documentation defect rather than a behaviour defect, so it is fixed in place.
+
+**2. `_legacy` overrides rename their parameters.** `ETraceOp.xw_to_y(self,
+inputs, weights)` is overridden by every concrete subclass as `xw_to_y(self, x,
+w)`. The parameter *names* differ, so a keyword call `op.xw_to_y(inputs=...,
+weights=...)` works on the base class and raises `TypeError` on every subclass.
+mypy does not check parameter-name compatibility on overrides, so the gate does
+not flag it, and renaming is exactly the kind of "improvement" constraint 4 above
+forbids in a frozen shim. It is recorded here and left alone: no caller in the
+package, in the tests, or in the docs uses the keyword form.
+
+Separately, `ElemWiseOp.__call__(self, weights)` drops an argument relative to
+`ETraceOp.__call__(self, inputs, weights)`. That *is* a Liskov violation mypy
+reports, and it is pre-existing and load-bearing (the element-wise op has no
+input). It carries a `# type: ignore[override]`, matching the one
+`ElemWiseParam.execute` already had for the identical reason.
+
+## Verification
+
+- `python -m mypy` (mypy 2.1.0, local Python 3.13, `python_version = "3.14"` in
+  config) → `Success: no issues found in 62 source files`.
+- `python -m pytest braintrace/_compiler/ braintrace/_legacy/ -q` →
+  `618 passed`. Both packages have co-located tests: `_compiler` has 12
+  `*_test.py` siblings plus the three files in `_compiler/tests/`, and `_legacy`
+  has `_ops_test.py` and `_params_test.py`.
+- `python -m pytest braintrace/ -q` (the whole suite, which includes
+  `braintrace/_algorithm/` — the primary consumer of the annotated compiler
+  layer) → `2902 passed, 4 deselected` in 35 min.
+- Every changed file re-parsed with `ast.parse(..., feature_version=(3, 11))` to
+  confirm nothing depends on syntax newer than the `requires-python` floor.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -248,6 +248,28 @@ module = [
     "braintrace.nn._embedding",
     "braintrace._state_management",
     "braintrace._compatible_imports",
+    # Added for 0.2.6 (issue #164). Neither package owns a name in
+    # `braintrace.__all__`, which is why they were skipped in 0.2.5, but leaving
+    # whole packages outside the gate meant an untyped def could reappear
+    # anywhere in the compiler -- the layer every algorithm depends on. Both are
+    # now fully annotated; the sweep is recorded in
+    # `docs/specs/2026-08-07-e09-type-gate-compiler-legacy.md`.
+    "braintrace._compiler",
+    "braintrace._compiler.base",
+    "braintrace._compiler.canonicalize",
+    "braintrace._compiler.diagnostics",
+    "braintrace._compiler.graph",
+    "braintrace._compiler.hid_param_op",
+    "braintrace._compiler.hidden_group",
+    "braintrace._compiler.hidden_pertubation",
+    "braintrace._compiler.jaxpr_graph",
+    "braintrace._compiler.module_info",
+    "braintrace._compiler.position_graph",
+    "braintrace._compiler.report",
+    "braintrace._compiler.scan_descent",
+    "braintrace._legacy",
+    "braintrace._legacy._ops",
+    "braintrace._legacy._params",
 ]
 disallow_untyped_defs = true
 


### PR DESCRIPTION
`pyproject.toml`'s `[[tool.mypy.overrides]]` `disallow_untyped_defs` module list
is what makes *"every shipped def is annotated"* a property mypy enforces rather
than a convention people remember. Two packages were still outside it:

- `braintrace._compiler` — the jaxpr-analysis layer every algorithm depends on
- `braintrace._legacy` — the frozen v0.1.x back-compat shim

Neither owns a name in `braintrace.__all__`, which is the letter of the rule the
0.2.5 list was written against. But an ungated package is not merely "currently
unannotated" — it is a place where an untyped def can silently reappear at any
time. The gate is only as strong as its weakest package.

Both are now listed **module by module** (matching the block's existing
no-wildcards style, so a future non-test helper dropped into `_compiler/tests/`
is not gated by accident) and fully annotated.

## Baseline

Measured by adding both packages to the gate *first* and running `python -m mypy`
(2.1.0) with no source change:

```
Found 93 errors in 13 files (checked 62 source files)
```

All 93 `[no-untyped-def]`. **54 in `_compiler`, 39 in `_legacy`** — matching the
issue's estimate exactly.

| file | errors |
| --- | --- |
| `_legacy/_ops.py` | 29 |
| `_compiler/hidden_group.py` | 11 |
| `_legacy/_params.py` | 10 |
| `_compiler/module_info.py` | 9 |
| `_compiler/canonicalize.py` | 7 |
| `_compiler/hid_param_op.py` | 6 |
| `_compiler/graph.py` | 5 |
| `_compiler/base.py` | 4 |
| `_compiler/jaxpr_graph.py` | 4 |
| `_compiler/hidden_pertubation.py` | 3 |
| `_compiler/position_graph.py` | 2 |
| `_compiler/scan_descent.py` | 2 |
| `_compiler/report.py` | 1 |

## Typing-only

The one non-annotation edit in the diff is a **corrected docstring**:
`ETraceGraph.call_hidden_perturb` documented its return as *"the processed model
outputs, in the same structure produced by a normal forward call"*, when it
actually returns the four-element `(outputs, etrace_state_vals,
other_state_vals, temp_data)` tuple that `ModuleInfo._process` produces — which
is what its one caller, `_algorithm/vjp_graph_executor.py`, unpacks. Writing the
annotation is what made the mismatch visible. Documentation defect, not a
behaviour defect; no code changed.

Everything else is signature annotations plus, at the `brainstate` boundary,
three narrowing annotations on local bindings, one `cast` (a runtime identity),
and two `# type: ignore[...]` with error codes and explanatory comments — the
pattern `module_info.py` already used for its `get_out_treedef_by_cache(...)
.unflatten` call.

## Constraints respected

- **`_legacy` is frozen.** Annotated to satisfy the gate and nothing else: no
  refactor, no style update, no docstring rewrite. The pre-existing parameter-
  name divergence between `ETraceOp.xw_to_y(inputs, weights)` and every
  subclass's `(x, w)` is recorded in the spec and deliberately left alone.
- **The `python -O`-surviving guards from #174 are untouched.** The explicit
  `if ... raise` shape/dtype correspondence checks in
  `_compiler/hidden_group.py` and `_compiler/hidden_pertubation.py` are
  unchanged — not weakened, not converted to `assert`.
- **Python 3.11 floor.** No PEP 695 generics and no `type` alias statements: the
  one new alias, `jaxpr_graph.Atom = Union[Var, Literal]`, is a
  `typing.TypeAlias` assignment. Verified by re-parsing every changed file with
  `ast.parse(..., feature_version=(3, 11))`.

Every place the sweep settled for `Any`, a `Union`, or a `type: ignore` instead
of asserting a precise type is enumerated with its reason in the spec — the
recurring one being that `brainunit` is configured `follow_imports = "skip"`, so
every array in the legacy op path is `Any` to mypy no matter what the signature
claims.

## Verification

- `python -m mypy` → `Success: no issues found in 62 source files`
- `python -m pytest braintrace/_compiler/ braintrace/_legacy/ -q` → `618 passed`
- `python -m pytest braintrace/ -q` (full suite) → `2902 passed, 4 deselected`

Spec: `docs/specs/2026-08-07-e09-type-gate-compiler-legacy.md`. Backlog entry
E-09 and `changelog.md` updated.

Closes #164

## Summary by Sourcery

Bring the `_compiler` and `_legacy` packages under the `disallow_untyped_defs` typing gate and fully annotate their public and internal APIs without changing runtime behavior.

Enhancements:
- Add precise type annotations across `braintrace._compiler` and `braintrace._legacy`, covering jaxpr plumbing, hidden-group analysis, and legacy op/param shims while preserving existing runtime guards and behavior.
- Introduce shared typing aliases (e.g., `Atom`) and local helper annotations to make jaxpr graph and canonicalization logic type-checked end to end.
- Tighten context and state-handling utilities with explicit iterator/sequence and IO types to support stricter mypy checking.

Build:
- Extend `pyproject.toml`'s `[[tool.mypy.overrides]]` `disallow_untyped_defs` module list to include all `_compiler` and `_legacy` modules explicitly, aligning with the no-wildcard gating policy.

Documentation:
- Add a new spec documenting the E-09 typing-gate sweep for `_compiler` and `_legacy`, including baseline error counts and rationale for any remaining imprecision.
- Correct the `ETraceGraph.call_hidden_perturb` docstring to describe its four-tuple return value accurately and update backlog and changelog entries to record the change.